### PR TITLE
[dyninst] Support line probes

### DIFF
--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -10,7 +10,7 @@
 	Call dc 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
-	PrepareEventRoot b2 00 00 00 09 00 00 00 
+	PrepareEventRoot b8 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6046.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
@@ -20,21 +20,21 @@
 	Call ee 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
-	PrepareEventRoot b3 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6090.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e7 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 1c 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
-	PrepareEventRoot aa 00 00 00 09 00 00 00 
+	PrepareEventRoot b0 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6553.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a65de]
-	PrepareEventRoot ab 00 00 00 00 00 00 00 
+	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@4a5e0e]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	PrepareEventRoot b6 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@4a642a]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	PrepareEventRoot b6 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a646a]
-	PrepareEventRoot b1 00 00 00 00 00 00 00 
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
 	ExprPrepare 
@@ -63,11 +63,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xef: ProcessEvent[Probe[main.intArg]@4a610a]
-	PrepareEventRoot 9b 00 00 00 09 00 00 00 
+	PrepareEventRoot a1 00 00 00 09 00 00 00 
 	Call d9 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a610a.expr[0]]
 	Return 
 // 0xfe: ProcessEvent[Probe[main.intArg]Return@4a614a]
-	PrepareEventRoot 9c 00 00 00 00 00 00 00 
+	PrepareEventRoot a2 00 00 00 00 00 00 00 
 	Return 
 // 0x108: ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@4a628a]
-	PrepareEventRoot a1 00 00 00 19 00 00 00 
+	PrepareEventRoot a7 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a628a.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@4a62d6]
-	PrepareEventRoot a2 00 00 00 00 00 00 00 
+	PrepareEventRoot a8 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[[3]string]
+	Call be 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
-	PrepareEventRoot a7 00 00 00 31 00 00 00 
+	PrepareEventRoot ad 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6400.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
@@ -97,60 +97,60 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call f8 03 00 00 // ProcessType[[]int]
+	Call 0a 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a620a]
-	PrepareEventRoot 9f 00 00 00 19 00 00 00 
+	PrepareEventRoot a5 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a620a.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@4a624f]
-	PrepareEventRoot a0 00 00 00 00 00 00 00 
+	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 04 00 00 // ProcessType[map[string]int]
+	Call 16 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a64ea]
-	PrepareEventRoot a8 00 00 00 09 00 00 00 
+	PrepareEventRoot ae 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a64ea.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@4a651f]
-	PrepareEventRoot a9 00 00 00 00 00 00 00 
+	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@4a660a]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@4a6646]
-	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a618a]
-	PrepareEventRoot 9d 00 00 00 11 00 00 00 
+	PrepareEventRoot a3 00 00 00 11 00 00 00 
 	Call f7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a618a.expr[0]]
 	Return 
 // 0x228: ProcessEvent[Probe[main.stringArg]Return@4a61cf]
-	PrepareEventRoot 9e 00 00 00 00 00 00 00 
+	PrepareEventRoot a4 00 00 00 00 00 00 00 
 	Return 
 // 0x232: ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[[3]string]
+	Call be 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
-	PrepareEventRoot a5 00 00 00 31 00 00 00 
+	PrepareEventRoot ab 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a638a.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@4a63d6]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	ExprPrepare 
@@ -158,36 +158,36 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 12 04 00 00 // ProcessType[[]string]
+	Call 24 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
-	PrepareEventRoot a3 00 00 00 19 00 00 00 
+	PrepareEventRoot a9 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a630a.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@4a634f]
-	PrepareEventRoot a4 00 00 00 00 00 00 00 
+	PrepareEventRoot aa 00 00 00 00 00 00 00 
 	Return 
 // 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a6676]
-	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ed 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 28 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
 // 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
-	PrepareEventRoot af 00 00 00 09 00 00 00 
+	PrepareEventRoot b5 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
 // 0x2dc: ProcessType[*****int]
-	ProcessPointer 79 00 00 00 
+	ProcessPointer 7e 00 00 00 
 	Return 
 // 0x2e2: ProcessType[****int]
-	ProcessPointer 99 00 00 00 
+	ProcessPointer 9f 00 00 00 
 	Return 
 // 0x2e8: ProcessType[***int]
-	ProcessPointer 7a 00 00 00 
+	ProcessPointer 7f 00 00 00 
 	Return 
 // 0x2ee: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
@@ -199,7 +199,7 @@
 	ProcessPointer 04 00 00 00 
 	Return 
 // 0x300: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 93 00 00 00 
+	ProcessPointer 98 00 00 00 
 	Return 
 // 0x306: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
@@ -207,243 +207,263 @@
 // 0x30c: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x312: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 7c 00 00 00 
+	Return 
+// 0x318: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x318: ProcessType[*error]
+// 0x31e: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x31e: ProcessType[*float32]
+// 0x324: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x324: ProcessType[*float64]
+// 0x32a: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x32a: ProcessType[*int]
+// 0x330: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x330: ProcessType[*int32]
+// 0x336: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x336: ProcessType[*int64]
+// 0x33c: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x33c: ProcessType[*main.bigStruct]
-	ProcessPointer 8b 00 00 00 
+// 0x342: ProcessType[*main.bigStruct]
+	ProcessPointer 90 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime._defer]
+// 0x348: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime._panic]
+// 0x34e: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.cgoCallers]
+// 0x354: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.coro]
+// 0x35a: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.g]
+// 0x360: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.m]
+// 0x366: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.mapextra]
+// 0x36c: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.sudog]
+// 0x372: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.timer]
+// 0x378: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.traceBuf]
+// 0x37e: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x37e: ProcessType[*string]
+// 0x384: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x384: ProcessType[*uint]
+// 0x38a: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint16]
+// 0x390: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint32]
+// 0x396: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint64]
+// 0x39c: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint8]
+// 0x3a2: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uintptr]
+// 0x3a8: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3a8: ProcessType[[2]*runtime.traceBuf]
+// 0x3ae: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 7e 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3b8: ProcessType[[3]string]
+// 0x3be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3c8: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3ce: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5c 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 6e 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<string,int>.array]
+// 0x3da: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 67 04 00 00 // ProcessType[bucket<string,int>]
+	Call 79 04 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3e6: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 8e 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x3f2: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 91 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a3 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]int]
-	ProcessSlice 81 00 00 00 08 00 00 00 
+// 0x3fe: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call b8 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]key<string>]
+// 0x40a: ProcessType[[]int]
+	ProcessSlice 86 00 00 00 08 00 00 00 
+	Return 
+// 0x414: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x412: ProcessType[[]string]
-	ProcessSlice 83 00 00 00 10 00 00 00 
+// 0x424: ProcessType[[]string]
+	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x41c: ProcessType[[]string.array]
+// 0x42e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x428: ProcessType[[]uint8]
-	ProcessSlice 7d 00 00 00 01 00 00 00 
+// 0x43a: ProcessType[[]uint8]
+	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x432: ProcessType[[]uintptr]
-	ProcessSlice 7f 00 00 00 08 00 00 00 
+// 0x444: ProcessType[[]uintptr]
+	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]val<main.bigStruct>]
+// 0x44e: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*main.bigStruct]
+	Call 42 03 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x45e: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call db 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 10 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x45c: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x46e: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
 	Call 00 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x467: ProcessType[bucket<string,int>]
+// 0x479: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[[]key<string>]
+	Call 14 04 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
 	Call 06 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x47c: ProcessType[bucket<string,main.bigStruct>]
+// 0x48e: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[[]key<string>]
-	Call 3c 04 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 4e 04 00 00 // ProcessType[[]val<main.bigStruct>]
 	Call 0c 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x491: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 4c 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 12 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a3: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 12 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4a1: ProcessType[error]
+// 0x4b8: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 18 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x4c8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4a3: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 98 00 00 00 90 00 00 00 08 09 10 18 
+// 0x4ca: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4b1: ProcessType[hash<string,int>]
-	ProcessGoHmap 88 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x4d8: ProcessType[hash<string,int>]
+	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4bf: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 8c 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x4e6: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4cd: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 94 00 00 00 58 00 00 00 08 09 10 18 
+// 0x4f4: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4db: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 91 00 00 00 
+// 0x502: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x4e1: ProcessType[map[string]int]
+// 0x510: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 96 00 00 00 
+	Return 
+// 0x516: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x4e7: ProcessType[map[string]main.bigStruct]
+// 0x51c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x4ed: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x522: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7a 00 00 00 
+	Return 
+// 0x528: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x4f3: ProcessType[runtime.g]
+// 0x52e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime._panic]
+	Call 4e 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime._defer]
+	Call 48 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 28 04 00 00 // ProcessType[[]uint8]
+	Call 3a 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.sudog]
+	Call 72 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 72 03 00 00 // ProcessType[*runtime.timer]
+	Call 78 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.coro]
+	Call 5a 03 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x54e: ProcessType[runtime.m]
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+// 0x589: ProcessType[runtime.m]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 54 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ae 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call e9 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b9 05 00 00 // ProcessType[runtime.mTraceState]
+	Call f4 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ae: ProcessType[runtime.mLockProfile]
+// 0x5e9: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5b9: ProcessType[runtime.mTraceState]
+// 0x5f4: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call a8 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x5c9: ProcessType[string]
-	ProcessString 7b 00 00 00 
+// 0x604: ProcessType[string]
+	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -465,11 +485,11 @@ ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
 ID: 5 Len: 8 Enqueue: 762
-ID: 6 Len: 8 Enqueue: 924
+ID: 6 Len: 8 Enqueue: 930
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 930
+ID: 8 Len: 8 Enqueue: 936
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1481
+ID: 10 Len: 16 Enqueue: 1540
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -477,18 +497,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1185
+ID: 18 Len: 16 Enqueue: 1224
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 816
-ID: 21 Len: 8 Enqueue: 912
-ID: 22 Len: 432 Enqueue: 1267
+ID: 20 Len: 8 Enqueue: 822
+ID: 21 Len: 8 Enqueue: 918
+ID: 22 Len: 432 Enqueue: 1326
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 840
+ID: 24 Len: 8 Enqueue: 846
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 834
+ID: 26 Len: 8 Enqueue: 840
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 864
-ID: 29 Len: 1760 Enqueue: 1358
+ID: 28 Len: 8 Enqueue: 870
+ID: 29 Len: 1760 Enqueue: 1417
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -497,41 +517,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1064
+ID: 38 Len: 24 Enqueue: 1082
 ID: 39 Len: 8 Enqueue: 756
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 876
+ID: 41 Len: 8 Enqueue: 882
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1074
-ID: 44 Len: 8 Enqueue: 882
+ID: 43 Len: 24 Enqueue: 1092
+ID: 44 Len: 8 Enqueue: 888
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 852
+ID: 47 Len: 8 Enqueue: 858
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 858
+ID: 53 Len: 8 Enqueue: 864
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 846
+ID: 60 Len: 8 Enqueue: 852
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1454
+ID: 64 Len: 64 Enqueue: 1513
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1465
+ID: 69 Len: 32 Enqueue: 1524
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 936
-ID: 72 Len: 8 Enqueue: 888
+ID: 71 Len: 16 Enqueue: 942
+ID: 72 Len: 8 Enqueue: 894
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -547,95 +567,101 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 894
+ID: 88 Len: 8 Enqueue: 900
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 804
-ID: 92 Len: 8 Enqueue: 822
-ID: 93 Len: 8 Enqueue: 810
-ID: 94 Len: 8 Enqueue: 918
-ID: 95 Len: 8 Enqueue: 792
-ID: 96 Len: 8 Enqueue: 798
-ID: 97 Len: 8 Enqueue: 900
-ID: 98 Len: 8 Enqueue: 906
-ID: 99 Len: 24 Enqueue: 1016
+ID: 91 Len: 8 Enqueue: 810
+ID: 92 Len: 8 Enqueue: 828
+ID: 93 Len: 8 Enqueue: 816
+ID: 94 Len: 8 Enqueue: 924
+ID: 95 Len: 8 Enqueue: 798
+ID: 96 Len: 8 Enqueue: 804
+ID: 97 Len: 8 Enqueue: 906
+ID: 98 Len: 8 Enqueue: 912
+ID: 99 Len: 24 Enqueue: 1034
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1042
-ID: 102 Len: 48 Enqueue: 952
-ID: 103 Len: 8 Enqueue: 1249
+ID: 101 Len: 24 Enqueue: 1060
+ID: 102 Len: 48 Enqueue: 958
+ID: 103 Len: 8 Enqueue: 1302
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1201
+ID: 105 Len: 48 Enqueue: 1240
 ID: 106 Len: 8 Enqueue: 774
-ID: 107 Len: 208 Enqueue: 1127
-ID: 108 Len: 8 Enqueue: 870
+ID: 107 Len: 208 Enqueue: 1145
+ID: 108 Len: 8 Enqueue: 876
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1255
+ID: 110 Len: 8 Enqueue: 1308
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1215
+ID: 112 Len: 48 Enqueue: 1254
 ID: 113 Len: 8 Enqueue: 780
-ID: 114 Len: 208 Enqueue: 1148
-ID: 115 Len: 8 Enqueue: 1261
+ID: 114 Len: 208 Enqueue: 1166
+ID: 115 Len: 8 Enqueue: 1320
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1229
-ID: 118 Len: 8 Enqueue: 786
-ID: 119 Len: 88 Enqueue: 1169
-ID: 120 Len: 8 Enqueue: 732
-ID: 121 Len: 8 Enqueue: 738
-ID: 122 Len: 8 Enqueue: 750
-ID: 123 Len: 1 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 1 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 0
+ID: 117 Len: 48 Enqueue: 1282
+ID: 118 Len: 8 Enqueue: 792
+ID: 119 Len: 88 Enqueue: 1208
+ID: 120 Len: 8 Enqueue: 1314
+ID: 121 Len: 8 Enqueue: 0
+ID: 122 Len: 48 Enqueue: 1268
+ID: 123 Len: 8 Enqueue: 786
+ID: 124 Len: 208 Enqueue: 1187
+ID: 125 Len: 8 Enqueue: 732
+ID: 126 Len: 8 Enqueue: 738
+ID: 127 Len: 8 Enqueue: 750
+ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
-ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 16 Enqueue: 1052
+ID: 130 Len: 1 Enqueue: 0
+ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 128 Enqueue: 1026
-ID: 135 Len: 64 Enqueue: 0
-ID: 136 Len: 208 Enqueue: 980
-ID: 137 Len: 64 Enqueue: 1084
-ID: 138 Len: 8 Enqueue: 828
-ID: 139 Len: 184 Enqueue: 0
-ID: 140 Len: 208 Enqueue: 992
-ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 64 Enqueue: 1100
-ID: 143 Len: 8 Enqueue: 1243
-ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 48 Enqueue: 1187
-ID: 146 Len: 8 Enqueue: 768
-ID: 147 Len: 144 Enqueue: 1116
-ID: 148 Len: 88 Enqueue: 1004
-ID: 149 Len: 64 Enqueue: 0
-ID: 150 Len: 64 Enqueue: 0
-ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 144 Enqueue: 968
-ID: 153 Len: 8 Enqueue: 744
-ID: 154 Len: 128 Enqueue: 0
-ID: 155 Len: 9 Enqueue: 0
-ID: 156 Len: 0 Enqueue: 0
-ID: 157 Len: 17 Enqueue: 0
-ID: 158 Len: 0 Enqueue: 0
-ID: 159 Len: 25 Enqueue: 0
-ID: 160 Len: 0 Enqueue: 0
-ID: 161 Len: 25 Enqueue: 0
+ID: 134 Len: 8 Enqueue: 0
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 16 Enqueue: 1070
+ID: 137 Len: 8 Enqueue: 0
+ID: 138 Len: 8 Enqueue: 0
+ID: 139 Len: 128 Enqueue: 1044
+ID: 140 Len: 64 Enqueue: 0
+ID: 141 Len: 208 Enqueue: 986
+ID: 142 Len: 64 Enqueue: 1102
+ID: 143 Len: 8 Enqueue: 834
+ID: 144 Len: 184 Enqueue: 0
+ID: 145 Len: 208 Enqueue: 998
+ID: 146 Len: 8 Enqueue: 0
+ID: 147 Len: 64 Enqueue: 1118
+ID: 148 Len: 8 Enqueue: 1296
+ID: 149 Len: 8 Enqueue: 0
+ID: 150 Len: 48 Enqueue: 1226
+ID: 151 Len: 8 Enqueue: 768
+ID: 152 Len: 144 Enqueue: 1134
+ID: 153 Len: 88 Enqueue: 1022
+ID: 154 Len: 208 Enqueue: 1010
+ID: 155 Len: 64 Enqueue: 0
+ID: 156 Len: 64 Enqueue: 0
+ID: 157 Len: 8 Enqueue: 0
+ID: 158 Len: 144 Enqueue: 974
+ID: 159 Len: 8 Enqueue: 744
+ID: 160 Len: 128 Enqueue: 0
+ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0
-ID: 163 Len: 25 Enqueue: 0
+ID: 163 Len: 17 Enqueue: 0
 ID: 164 Len: 0 Enqueue: 0
-ID: 165 Len: 49 Enqueue: 0
+ID: 165 Len: 25 Enqueue: 0
 ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 49 Enqueue: 0
-ID: 168 Len: 9 Enqueue: 0
-ID: 169 Len: 0 Enqueue: 0
-ID: 170 Len: 9 Enqueue: 0
-ID: 171 Len: 0 Enqueue: 0
+ID: 167 Len: 25 Enqueue: 0
+ID: 168 Len: 0 Enqueue: 0
+ID: 169 Len: 25 Enqueue: 0
+ID: 170 Len: 0 Enqueue: 0
+ID: 171 Len: 49 Enqueue: 0
 ID: 172 Len: 0 Enqueue: 0
-ID: 173 Len: 0 Enqueue: 0
-ID: 174 Len: 0 Enqueue: 0
-ID: 175 Len: 9 Enqueue: 0
+ID: 173 Len: 49 Enqueue: 0
+ID: 174 Len: 9 Enqueue: 0
+ID: 175 Len: 0 Enqueue: 0
 ID: 176 Len: 9 Enqueue: 0
 ID: 177 Len: 0 Enqueue: 0
-ID: 178 Len: 9 Enqueue: 0
-ID: 179 Len: 9 Enqueue: 0
+ID: 178 Len: 0 Enqueue: 0
+ID: 179 Len: 0 Enqueue: 0
+ID: 180 Len: 0 Enqueue: 0
+ID: 181 Len: 9 Enqueue: 0
+ID: 182 Len: 9 Enqueue: 0
+ID: 183 Len: 0 Enqueue: 0
+ID: 184 Len: 9 Enqueue: 0
+ID: 185 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a65de]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@4a5e0e]
+	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@4a642a]
+// 0xc0: ProcessEvent[Probe[main.inlined]@4a642a]
 	PrepareEventRoot b0 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@4a5e0e]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5e0e.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a642a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a646a]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4a85de]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@4a7e0e]
+	PrepareEventRoot c7 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@4a842a]
+// 0xc0: ProcessEvent[Probe[main.inlined]@4a842a]
 	PrepareEventRoot c7 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@4a7e0e]
-	PrepareEventRoot c7 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7e0e.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a842a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4a846a]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@4aebde]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@4ae40e]
+	PrepareEventRoot cc 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@4aea2a]
+// 0xc0: ProcessEvent[Probe[main.inlined]@4aea2a]
 	PrepareEventRoot cc 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@4ae40e]
-	PrepareEventRoot cc 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae40e.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4aea2a.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@4aea6a]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -10,7 +10,7 @@
 	Call dc 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
-	PrepareEventRoot b3 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5388.expr[0]]
 	Return 
 // 0x2d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
@@ -20,21 +20,21 @@
 	Call ee 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
-	PrepareEventRoot b4 00 00 00 09 00 00 00 
+	PrepareEventRoot ba 00 00 00 09 00 00 00 
 	Call 2d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb53c0.expr[0]]
 	Return 
 // 0x57: ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e7 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 1c 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5880]
-	PrepareEventRoot ab 00 00 00 09 00 00 00 
+	PrepareEventRoot b1 00 00 00 09 00 00 00 
 	Call 57 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5880.expr[0]]
 	Return 
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b58f4]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
 // 0x8b: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	ExprPrepare 
@@ -42,7 +42,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x9b: ProcessEvent[Probe[main.inlined]@b519c]
-	PrepareEventRoot b1 00 00 00 09 00 00 00 
+	PrepareEventRoot b7 00 00 00 09 00 00 00 
 	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
 	Return 
 // 0xaa: ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
@@ -51,11 +51,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc0: ProcessEvent[Probe[main.inlined]@b5748]
-	PrepareEventRoot b1 00 00 00 09 00 00 00 
+	PrepareEventRoot b7 00 00 00 09 00 00 00 
 	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b5780]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+	PrepareEventRoot b8 00 00 00 00 00 00 00 
 	Return 
 // 0xd9: ProcessExpression[Probe[main.intArg]@0xb5428.expr[0]]
 	ExprPrepare 
@@ -63,11 +63,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xef: ProcessEvent[Probe[main.intArg]@b5428]
-	PrepareEventRoot 9c 00 00 00 09 00 00 00 
+	PrepareEventRoot a2 00 00 00 09 00 00 00 
 	Call d9 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb5428.expr[0]]
 	Return 
 // 0xfe: ProcessEvent[Probe[main.intArg]Return@b5460]
-	PrepareEventRoot 9d 00 00 00 00 00 00 00 
+	PrepareEventRoot a3 00 00 00 00 00 00 00 
 	Return 
 // 0x108: ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	ExprPrepare 
@@ -75,20 +75,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x124: ProcessEvent[Probe[main.intArrayArg]@b55a8]
-	PrepareEventRoot a2 00 00 00 19 00 00 00 
+	PrepareEventRoot a8 00 00 00 19 00 00 00 
 	Call 08 01 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb55a8.expr[0]]
 	Return 
 // 0x133: ProcessEvent[Probe[main.intArrayArg]Return@b55ec]
-	PrepareEventRoot a3 00 00 00 00 00 00 00 
+	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
 // 0x13d: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[[3]string]
+	Call be 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
-	PrepareEventRoot a8 00 00 00 31 00 00 00 
+	PrepareEventRoot ae 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5720.expr[0]]
 	Return 
 // 0x16d: ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
@@ -97,60 +97,60 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call f8 03 00 00 // ProcessType[[]int]
+	Call 0a 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b5518]
-	PrepareEventRoot a0 00 00 00 19 00 00 00 
+	PrepareEventRoot a6 00 00 00 19 00 00 00 
 	Call 6d 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5518.expr[0]]
 	Return 
 // 0x1a5: ProcessEvent[Probe[main.intSliceArg]Return@b5554]
-	PrepareEventRoot a1 00 00 00 00 00 00 00 
+	PrepareEventRoot a7 00 00 00 00 00 00 00 
 	Return 
 // 0x1af: ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 04 00 00 // ProcessType[map[string]int]
+	Call 16 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5808]
-	PrepareEventRoot a9 00 00 00 09 00 00 00 
+	PrepareEventRoot af 00 00 00 09 00 00 00 
 	Call af 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5808.expr[0]]
 	Return 
 // 0x1d9: ProcessEvent[Probe[main.mapArg]Return@b5838]
-	PrepareEventRoot aa 00 00 00 00 00 00 00 
+	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
 // 0x1e3: ProcessEvent[Probe[main.noArgs]@b5938]
-	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x1ed: ProcessEvent[Probe[main.noArgs]Return@b5970]
-	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
 // 0x1f7: ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5498]
-	PrepareEventRoot 9e 00 00 00 11 00 00 00 
+	PrepareEventRoot a4 00 00 00 11 00 00 00 
 	Call f7 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5498.expr[0]]
 	Return 
 // 0x228: ProcessEvent[Probe[main.stringArg]Return@b54d4]
-	PrepareEventRoot 9f 00 00 00 00 00 00 00 
+	PrepareEventRoot a5 00 00 00 00 00 00 00 
 	Return 
 // 0x232: ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call b8 03 00 00 // ProcessType[[3]string]
+	Call be 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
-	PrepareEventRoot a6 00 00 00 31 00 00 00 
+	PrepareEventRoot ac 00 00 00 31 00 00 00 
 	Call 32 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb56b8.expr[0]]
 	Return 
 // 0x262: ProcessEvent[Probe[main.stringArrayArg]Return@b56fc]
-	PrepareEventRoot a7 00 00 00 00 00 00 00 
+	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
 // 0x26c: ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	ExprPrepare 
@@ -158,36 +158,36 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 12 04 00 00 // ProcessType[[]string]
+	Call 24 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b5628]
-	PrepareEventRoot a4 00 00 00 19 00 00 00 
+	PrepareEventRoot aa 00 00 00 19 00 00 00 
 	Call 6c 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5628.expr[0]]
 	Return 
 // 0x2a4: ProcessEvent[Probe[main.stringSliceArg]Return@b5664]
-	PrepareEventRoot a5 00 00 00 00 00 00 00 
+	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
 // 0x2ae: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b59b0]
-	PrepareEventRoot af 00 00 00 00 00 00 00 
+	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ed 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 28 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
 // 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
-	PrepareEventRoot b0 00 00 00 09 00 00 00 
+	PrepareEventRoot b6 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
 // 0x2dc: ProcessType[*****int]
-	ProcessPointer 7a 00 00 00 
+	ProcessPointer 7f 00 00 00 
 	Return 
 // 0x2e2: ProcessType[****int]
-	ProcessPointer 9a 00 00 00 
+	ProcessPointer a0 00 00 00 
 	Return 
 // 0x2e8: ProcessType[***int]
-	ProcessPointer 7b 00 00 00 
+	ProcessPointer 80 00 00 00 
 	Return 
 // 0x2ee: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
@@ -199,7 +199,7 @@
 	ProcessPointer 04 00 00 00 
 	Return 
 // 0x300: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 94 00 00 00 
+	ProcessPointer 99 00 00 00 
 	Return 
 // 0x306: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
@@ -207,243 +207,263 @@
 // 0x30c: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x312: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 7d 00 00 00 
+	Return 
+// 0x318: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x318: ProcessType[*error]
+// 0x31e: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x31e: ProcessType[*float32]
+// 0x324: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x324: ProcessType[*float64]
+// 0x32a: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x32a: ProcessType[*int]
+// 0x330: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x330: ProcessType[*int32]
+// 0x336: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x336: ProcessType[*int64]
+// 0x33c: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x33c: ProcessType[*main.bigStruct]
-	ProcessPointer 8c 00 00 00 
+// 0x342: ProcessType[*main.bigStruct]
+	ProcessPointer 91 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime._defer]
+// 0x348: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime._panic]
+// 0x34e: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.cgoCallers]
+// 0x354: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.coro]
+// 0x35a: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.g]
+// 0x360: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.m]
+// 0x366: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.mapextra]
+// 0x36c: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.sudog]
+// 0x372: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.timer]
+// 0x378: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.traceBuf]
+// 0x37e: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x37e: ProcessType[*string]
+// 0x384: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x384: ProcessType[*uint]
+// 0x38a: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint16]
+// 0x390: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint32]
+// 0x396: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint64]
+// 0x39c: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint8]
+// 0x3a2: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uintptr]
+// 0x3a8: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3a8: ProcessType[[2]*runtime.traceBuf]
+// 0x3ae: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 7e 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3b8: ProcessType[[3]string]
+// 0x3be: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3c8: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3ce: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 5c 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 6e 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3d4: ProcessType[[]bucket<string,int>.array]
+// 0x3da: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 67 04 00 00 // ProcessType[bucket<string,int>]
+	Call 79 04 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e0: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3e6: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7c 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 8e 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3ec: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x3f2: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 91 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a3 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f8: ProcessType[[]int]
-	ProcessSlice 82 00 00 00 08 00 00 00 
+// 0x3fe: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call b8 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x402: ProcessType[[]key<string>]
+// 0x40a: ProcessType[[]int]
+	ProcessSlice 87 00 00 00 08 00 00 00 
+	Return 
+// 0x414: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x412: ProcessType[[]string]
-	ProcessSlice 84 00 00 00 10 00 00 00 
+// 0x424: ProcessType[[]string]
+	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x41c: ProcessType[[]string.array]
+// 0x42e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x428: ProcessType[[]uint8]
-	ProcessSlice 7e 00 00 00 01 00 00 00 
+// 0x43a: ProcessType[[]uint8]
+	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x432: ProcessType[[]uintptr]
-	ProcessSlice 80 00 00 00 08 00 00 00 
+// 0x444: ProcessType[[]uintptr]
+	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x43c: ProcessType[[]val<main.bigStruct>]
+// 0x44e: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*main.bigStruct]
+	Call 42 03 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x45e: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call db 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 10 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x45c: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x46e: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
 	Call 00 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x467: ProcessType[bucket<string,int>]
+// 0x479: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[[]key<string>]
+	Call 14 04 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
 	Call 06 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x47c: ProcessType[bucket<string,main.bigStruct>]
+// 0x48e: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 04 00 00 // ProcessType[[]key<string>]
-	Call 3c 04 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 4e 04 00 00 // ProcessType[[]val<main.bigStruct>]
 	Call 0c 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x491: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 4c 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 12 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a3: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 12 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4a1: ProcessType[error]
+// 0x4b8: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 18 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x4c8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4a3: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 99 00 00 00 90 00 00 00 08 09 10 18 
+// 0x4ca: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4b1: ProcessType[hash<string,int>]
-	ProcessGoHmap 89 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x4d8: ProcessType[hash<string,int>]
+	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4bf: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x4e6: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4cd: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 95 00 00 00 58 00 00 00 08 09 10 18 
+// 0x4f4: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4db: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 92 00 00 00 
+// 0x502: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x4e1: ProcessType[map[string]int]
+// 0x510: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 97 00 00 00 
+	Return 
+// 0x516: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x4e7: ProcessType[map[string]main.bigStruct]
+// 0x51c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x4ed: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x522: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7b 00 00 00 
+	Return 
+// 0x528: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x4f3: ProcessType[runtime.g]
+// 0x52e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime._panic]
+	Call 4e 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime._defer]
+	Call 48 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 28 04 00 00 // ProcessType[[]uint8]
+	Call 3a 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
 	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 6c 03 00 00 // ProcessType[*runtime.sudog]
+	Call 72 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 72 03 00 00 // ProcessType[*runtime.timer]
+	Call 78 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.coro]
+	Call 5a 03 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x54e: ProcessType[runtime.m]
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+// 0x589: ProcessType[runtime.m]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.g]
+	Call 60 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c9 05 00 00 // ProcessType[string]
+	Call 04 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 54 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ae 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call e9 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b9 05 00 00 // ProcessType[runtime.mTraceState]
+	Call f4 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5ae: ProcessType[runtime.mLockProfile]
+// 0x5e9: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 04 00 00 // ProcessType[[]uintptr]
+	Call 44 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5b9: ProcessType[runtime.mTraceState]
+// 0x5f4: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call a8 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 60 03 00 00 // ProcessType[*runtime.m]
+	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 66 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x5c9: ProcessType[string]
-	ProcessString 7c 00 00 00 
+// 0x604: ProcessType[string]
+	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -465,11 +485,11 @@ ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
 ID: 5 Len: 8 Enqueue: 762
-ID: 6 Len: 8 Enqueue: 924
+ID: 6 Len: 8 Enqueue: 930
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 930
+ID: 8 Len: 8 Enqueue: 936
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1481
+ID: 10 Len: 16 Enqueue: 1540
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -477,18 +497,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1185
+ID: 18 Len: 16 Enqueue: 1224
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 816
-ID: 21 Len: 8 Enqueue: 912
-ID: 22 Len: 432 Enqueue: 1267
+ID: 20 Len: 8 Enqueue: 822
+ID: 21 Len: 8 Enqueue: 918
+ID: 22 Len: 432 Enqueue: 1326
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 840
+ID: 24 Len: 8 Enqueue: 846
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 834
+ID: 26 Len: 8 Enqueue: 840
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 864
-ID: 29 Len: 1760 Enqueue: 1358
+ID: 28 Len: 8 Enqueue: 870
+ID: 29 Len: 1760 Enqueue: 1417
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -497,41 +517,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1064
+ID: 38 Len: 24 Enqueue: 1082
 ID: 39 Len: 8 Enqueue: 756
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 876
+ID: 41 Len: 8 Enqueue: 882
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1074
-ID: 44 Len: 8 Enqueue: 882
+ID: 43 Len: 24 Enqueue: 1092
+ID: 44 Len: 8 Enqueue: 888
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 852
+ID: 47 Len: 8 Enqueue: 858
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 858
+ID: 53 Len: 8 Enqueue: 864
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 846
+ID: 60 Len: 8 Enqueue: 852
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1454
+ID: 64 Len: 64 Enqueue: 1513
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1465
+ID: 69 Len: 32 Enqueue: 1524
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 936
-ID: 72 Len: 8 Enqueue: 888
+ID: 71 Len: 16 Enqueue: 942
+ID: 72 Len: 8 Enqueue: 894
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -547,96 +567,102 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 894
+ID: 88 Len: 8 Enqueue: 900
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 804
-ID: 93 Len: 8 Enqueue: 822
-ID: 94 Len: 8 Enqueue: 810
-ID: 95 Len: 8 Enqueue: 918
-ID: 96 Len: 8 Enqueue: 792
-ID: 97 Len: 8 Enqueue: 798
-ID: 98 Len: 8 Enqueue: 900
-ID: 99 Len: 8 Enqueue: 906
-ID: 100 Len: 24 Enqueue: 1016
+ID: 92 Len: 8 Enqueue: 810
+ID: 93 Len: 8 Enqueue: 828
+ID: 94 Len: 8 Enqueue: 816
+ID: 95 Len: 8 Enqueue: 924
+ID: 96 Len: 8 Enqueue: 798
+ID: 97 Len: 8 Enqueue: 804
+ID: 98 Len: 8 Enqueue: 906
+ID: 99 Len: 8 Enqueue: 912
+ID: 100 Len: 24 Enqueue: 1034
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1042
-ID: 103 Len: 48 Enqueue: 952
-ID: 104 Len: 8 Enqueue: 1249
+ID: 102 Len: 24 Enqueue: 1060
+ID: 103 Len: 48 Enqueue: 958
+ID: 104 Len: 8 Enqueue: 1302
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1201
+ID: 106 Len: 48 Enqueue: 1240
 ID: 107 Len: 8 Enqueue: 774
-ID: 108 Len: 208 Enqueue: 1127
-ID: 109 Len: 8 Enqueue: 870
+ID: 108 Len: 208 Enqueue: 1145
+ID: 109 Len: 8 Enqueue: 876
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1255
+ID: 111 Len: 8 Enqueue: 1308
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1215
+ID: 113 Len: 48 Enqueue: 1254
 ID: 114 Len: 8 Enqueue: 780
-ID: 115 Len: 208 Enqueue: 1148
-ID: 116 Len: 8 Enqueue: 1261
+ID: 115 Len: 208 Enqueue: 1166
+ID: 116 Len: 8 Enqueue: 1320
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1229
-ID: 119 Len: 8 Enqueue: 786
-ID: 120 Len: 88 Enqueue: 1169
-ID: 121 Len: 8 Enqueue: 732
-ID: 122 Len: 8 Enqueue: 738
-ID: 123 Len: 8 Enqueue: 750
-ID: 124 Len: 1 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 1 Enqueue: 0
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 0
+ID: 118 Len: 48 Enqueue: 1282
+ID: 119 Len: 8 Enqueue: 792
+ID: 120 Len: 88 Enqueue: 1208
+ID: 121 Len: 8 Enqueue: 1314
+ID: 122 Len: 8 Enqueue: 0
+ID: 123 Len: 48 Enqueue: 1268
+ID: 124 Len: 8 Enqueue: 786
+ID: 125 Len: 208 Enqueue: 1187
+ID: 126 Len: 8 Enqueue: 732
+ID: 127 Len: 8 Enqueue: 738
+ID: 128 Len: 8 Enqueue: 750
+ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 0
-ID: 132 Len: 16 Enqueue: 1052
+ID: 131 Len: 1 Enqueue: 0
+ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 128 Enqueue: 1026
-ID: 136 Len: 64 Enqueue: 0
-ID: 137 Len: 208 Enqueue: 980
-ID: 138 Len: 64 Enqueue: 1084
-ID: 139 Len: 8 Enqueue: 828
-ID: 140 Len: 184 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 992
-ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 64 Enqueue: 1100
-ID: 144 Len: 8 Enqueue: 1243
-ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 48 Enqueue: 1187
-ID: 147 Len: 8 Enqueue: 768
-ID: 148 Len: 144 Enqueue: 1116
-ID: 149 Len: 88 Enqueue: 1004
-ID: 150 Len: 64 Enqueue: 0
-ID: 151 Len: 64 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 144 Enqueue: 968
-ID: 154 Len: 8 Enqueue: 744
-ID: 155 Len: 128 Enqueue: 0
-ID: 156 Len: 9 Enqueue: 0
-ID: 157 Len: 0 Enqueue: 0
-ID: 158 Len: 17 Enqueue: 0
-ID: 159 Len: 0 Enqueue: 0
-ID: 160 Len: 25 Enqueue: 0
-ID: 161 Len: 0 Enqueue: 0
-ID: 162 Len: 25 Enqueue: 0
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 8 Enqueue: 0
+ID: 137 Len: 16 Enqueue: 1070
+ID: 138 Len: 8 Enqueue: 0
+ID: 139 Len: 8 Enqueue: 0
+ID: 140 Len: 128 Enqueue: 1044
+ID: 141 Len: 64 Enqueue: 0
+ID: 142 Len: 208 Enqueue: 986
+ID: 143 Len: 64 Enqueue: 1102
+ID: 144 Len: 8 Enqueue: 834
+ID: 145 Len: 184 Enqueue: 0
+ID: 146 Len: 208 Enqueue: 998
+ID: 147 Len: 8 Enqueue: 0
+ID: 148 Len: 64 Enqueue: 1118
+ID: 149 Len: 8 Enqueue: 1296
+ID: 150 Len: 8 Enqueue: 0
+ID: 151 Len: 48 Enqueue: 1226
+ID: 152 Len: 8 Enqueue: 768
+ID: 153 Len: 144 Enqueue: 1134
+ID: 154 Len: 88 Enqueue: 1022
+ID: 155 Len: 208 Enqueue: 1010
+ID: 156 Len: 64 Enqueue: 0
+ID: 157 Len: 64 Enqueue: 0
+ID: 158 Len: 8 Enqueue: 0
+ID: 159 Len: 144 Enqueue: 974
+ID: 160 Len: 8 Enqueue: 744
+ID: 161 Len: 128 Enqueue: 0
+ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0
-ID: 164 Len: 25 Enqueue: 0
+ID: 164 Len: 17 Enqueue: 0
 ID: 165 Len: 0 Enqueue: 0
-ID: 166 Len: 49 Enqueue: 0
+ID: 166 Len: 25 Enqueue: 0
 ID: 167 Len: 0 Enqueue: 0
-ID: 168 Len: 49 Enqueue: 0
-ID: 169 Len: 9 Enqueue: 0
-ID: 170 Len: 0 Enqueue: 0
-ID: 171 Len: 9 Enqueue: 0
-ID: 172 Len: 0 Enqueue: 0
+ID: 168 Len: 25 Enqueue: 0
+ID: 169 Len: 0 Enqueue: 0
+ID: 170 Len: 25 Enqueue: 0
+ID: 171 Len: 0 Enqueue: 0
+ID: 172 Len: 49 Enqueue: 0
 ID: 173 Len: 0 Enqueue: 0
-ID: 174 Len: 0 Enqueue: 0
-ID: 175 Len: 0 Enqueue: 0
-ID: 176 Len: 9 Enqueue: 0
+ID: 174 Len: 49 Enqueue: 0
+ID: 175 Len: 9 Enqueue: 0
+ID: 176 Len: 0 Enqueue: 0
 ID: 177 Len: 9 Enqueue: 0
 ID: 178 Len: 0 Enqueue: 0
-ID: 179 Len: 9 Enqueue: 0
-ID: 180 Len: 9 Enqueue: 0
+ID: 179 Len: 0 Enqueue: 0
+ID: 180 Len: 0 Enqueue: 0
+ID: 181 Len: 0 Enqueue: 0
+ID: 182 Len: 9 Enqueue: 0
+ID: 183 Len: 9 Enqueue: 0
+ID: 184 Len: 0 Enqueue: 0
+ID: 185 Len: 9 Enqueue: 0
+ID: 186 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b58f4]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@b519c]
+	PrepareEventRoot b1 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@b5748]
+// 0xc0: ProcessEvent[Probe[main.inlined]@b5748]
 	PrepareEventRoot b1 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@b519c]
-	PrepareEventRoot b1 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb519c.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb5748.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b5780]
 	PrepareEventRoot b2 00 00 00 00 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b5764]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@b502c]
+	PrepareEventRoot c8 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@b55b8]
+// 0xc0: ProcessEvent[Probe[main.inlined]@b55b8]
 	PrepareEventRoot c8 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@b502c]
-	PrepareEventRoot c8 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb502c.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb55b8.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b55f0]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -36,23 +36,23 @@
 // 0x81: ProcessEvent[Probe[main.bigMapArg]Return@b82b0]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x8b: ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
+// 0x8b: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	ExprPrepare 
+	Return 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x9b: ProcessEvent[Probe[main.inlined]@b7bc8]
+	PrepareEventRoot cd 00 00 00 09 00 00 00 
+	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	Return 
+// 0xaa: ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xa1: ProcessEvent[Probe[main.inlined]@b8108]
+// 0xc0: ProcessEvent[Probe[main.inlined]@b8108]
 	PrepareEventRoot cd 00 00 00 09 00 00 00 
-	Call 8b 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
-	Return 
-// 0xb0: ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
-	ExprPrepare 
-	Return 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0xc0: ProcessEvent[Probe[main.inlined]@b7bc8]
-	PrepareEventRoot cd 00 00 00 09 00 00 00 
-	Call b0 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb7bc8.expr[0]]
+	Call aa 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb8108.expr[0]]
 	Return 
 // 0xcf: ProcessEvent[Probe[main.inlined]Return@b813c]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/go-json-experiment/json"
@@ -286,6 +287,16 @@ func (s *snapshotMessage) init(
 	case ir.FunctionWhere:
 		s.Debugger.Snapshot.Probe.Location.Method = where.Location()
 		s.Logger.Method = where.Location()
+	case ir.LineWhere:
+		function, file, lineStr := where.Line()
+		line, err := strconv.Atoi(lineStr)
+		if err != nil {
+			return probe, fmt.Errorf("invalid line number: %v", lineStr)
+		}
+		s.Debugger.Snapshot.Probe.Location.Method = function
+		s.Debugger.Snapshot.Probe.Location.File = file
+		s.Debugger.Snapshot.Probe.Location.Line = line
+		s.Logger.Method = function
 	default:
 		return probe, fmt.Errorf(
 			"probe %s is not on a supported location: %T",

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -172,6 +172,9 @@ func (d *Decoder) Decode(
 	var numExpressions int
 	if d.snapshotMessage.Debugger.Snapshot.Captures.Entry != nil {
 		numExpressions = len(d.snapshotMessage.Debugger.Snapshot.Captures.Entry.rootType.Expressions)
+		if d.snapshotMessage.Debugger.Snapshot.Captures.Return != nil {
+			numExpressions += len(d.snapshotMessage.Debugger.Snapshot.Captures.Return.rootType.Expressions)
+		}
 	} else if d.snapshotMessage.Debugger.Snapshot.Captures.Lines != nil {
 		numExpressions = len(d.snapshotMessage.Debugger.Snapshot.Captures.Lines.capture.rootType.Expressions)
 	}
@@ -195,6 +198,7 @@ func (d *Decoder) resetForNextMessage() {
 	clear(d.entry.dataItems)
 	d.entry.clear()
 	d.line.clear()
+	d._return.clear()
 	d.snapshotMessage = snapshotMessage{}
 }
 

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -41,7 +41,7 @@ func FuzzDecoder(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, item []byte) {
 		_, _, _ = decoder.Decode(Event{
-			Entry:       output.Event(item),
+			EntryOrLine: output.Event(item),
 			ServiceName: "foo",
 		}, &noopSymbolicator{}, []byte{})
 		require.Empty(t, decoder.entry.dataItems)
@@ -64,7 +64,7 @@ func TestDecoderManually(t *testing.T) {
 			decoder, err := NewDecoder(irProg, &noopTypeNameResolver{}, time.Now())
 			require.NoError(t, err)
 			buf, probe, err := decoder.Decode(Event{
-				Entry:       output.Event(item),
+				EntryOrLine: output.Event(item),
 				ServiceName: "foo",
 			}, &noopSymbolicator{}, []byte{})
 			require.NoError(t, err)
@@ -90,7 +90,7 @@ func BenchmarkDecoder(b *testing.B) {
 			require.NoError(b, err)
 			symbolicator := &noopSymbolicator{}
 			event := Event{
-				Entry:       output.Event(c.eventConstructor(b, irProg)),
+				EntryOrLine: output.Event(c.eventConstructor(b, irProg)),
 				ServiceName: "foo",
 			}
 			b.ResetTimer()
@@ -771,7 +771,7 @@ func TestDecoderPanics(t *testing.T) {
 	stringID := stringType.GetID()
 	decoder.decoderTypes[stringID] = &panicDecoderType{decoder.decoderTypes[stringID]}
 	_, _, err = decoder.Decode(Event{
-		Entry:       output.Event(input),
+		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
 		[]byte{},
@@ -800,7 +800,7 @@ func TestDecoderFailsOnEvaluationError(t *testing.T) {
 	stringID := stringType.GetID()
 	delete(decoder.decoderTypes, stringID)
 	out, _, err := decoder.Decode(Event{
-		Entry:       output.Event(input),
+		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
 		[]byte{},
@@ -840,7 +840,7 @@ func TestDecoderFailsOnEvaluationErrorAndRetainsPassedBuffer(t *testing.T) {
 	// by each iteration of the loop. It's expected/possible that consumers
 	// of the decoder API will call Decode every time with the same buffer.
 	out, _, err := decoder.Decode(Event{
-		Entry:       output.Event(input),
+		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
 		buf,

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -59,8 +59,35 @@ type locationData struct {
 }
 
 type captureData struct {
-	Entry  *captureEvent `json:"entry,omitempty"`
-	Return *captureEvent `json:"return,omitempty"`
+	Entry  *captureEvent    `json:"entry,omitempty"`
+	Return *captureEvent    `json:"return,omitempty"`
+	Lines  *lineCaptureData `json:"lines,omitempty"`
+}
+
+type lineCaptureData struct {
+	sourceLine string
+	capture    *captureEvent
+}
+
+func (l *lineCaptureData) clear() {
+	l.sourceLine = ""
+	l.capture = nil
+}
+
+func (l *lineCaptureData) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if err := writeTokens(enc,
+		jsontext.BeginObject,
+		jsontext.String(l.sourceLine)); err != nil {
+		return err
+	}
+	if err := json.MarshalEncode(enc, l.capture); err != nil {
+		return err
+	}
+	if err := writeTokens(enc, jsontext.EndObject); err != nil {
+		return err
+	}
+	return nil
+
 }
 
 type captureEvent struct {

--- a/pkg/dyninst/ir/event_kind.go
+++ b/pkg/dyninst/ir/event_kind.go
@@ -17,6 +17,8 @@ const (
 	EventKindEntry
 	// EventKindReturn is an event that emits a return.
 	EventKindReturn
+	// EventKindLine is an event that emits a line.
+	EventKindLine
 
 	maxEventKind uint8 = iota
 )

--- a/pkg/dyninst/ir/event_kind_string.go
+++ b/pkg/dyninst/ir/event_kind_string.go
@@ -10,11 +10,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[EventKindEntry-1]
 	_ = x[EventKindReturn-2]
+	_ = x[EventKindLine-3]
 }
 
-const _EventKind_name = "EntryReturn"
+const _EventKind_name = "EntryReturnLine"
 
-var _EventKind_index = [...]uint8{0, 5, 11}
+var _EventKind_index = [...]uint8{0, 5, 11, 15}
 
 func (i EventKind) String() string {
 	i -= 1

--- a/pkg/dyninst/ir/probe_definition.go
+++ b/pkg/dyninst/ir/probe_definition.go
@@ -49,6 +49,12 @@ type FunctionWhere interface {
 	Location() (functionName string)
 }
 
+// LineWhere is a where clause of a probe that is a line within a function.
+type LineWhere interface {
+	Where
+	Line() (functionName string, sourceFile string, lineNumber string)
+}
+
 // CaptureConfig is the capture configuration of a probe.
 type CaptureConfig interface {
 	GetMaxReferenceDepth() uint32

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -108,6 +108,8 @@ type Variable struct {
 	// Type is the type of the variable.
 	Type Type
 	// Locations are the locations of the variable in the subprogram.
+	// Sorted by low limit of their ranges. Note the ranges might overlap,
+	// in case of variables inlined multiple times in the same parent subprogram.
 	Locations []Location
 	// IsParameter is true if the variable is a parameter.
 	IsParameter bool
@@ -138,7 +140,7 @@ type Event struct {
 	Kind EventKind
 	// The datatype of the event.
 	Type *EventRootType
-	// The PC values at which the event should be injected.
+	// The PC values at which the event should be injected. Sorted by PC.
 	InjectionPoints []InjectionPoint
 	// The condition that must be met for the event to be injected.
 	Condition *Expression

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -139,7 +139,7 @@ type Event struct {
 	// Kind is the kind of event.
 	Kind EventKind
 	// SourceLine for line events, empty otherwise.
-	SourceLine string
+	SourceLine string `json:"-"`
 	// The datatype of the event.
 	Type *EventRootType
 	// The PC values at which the event should be injected. Sorted by PC.

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -77,7 +77,9 @@ type CommonTypes struct {
 // subprogram A, that has been inlined into subprogram B, and subprogram B has been inlined
 // to a subprogram C, and C is not inlined, then these are pc ranges of C.
 type InlinePCRanges struct {
-	Ranges     []PCRange
+	// Non-overlapping and sorted.
+	Ranges []PCRange
+	// Non-overlapping and sorted.
 	RootRanges []PCRange
 }
 

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -138,6 +138,8 @@ type Event struct {
 	ID EventID
 	// Kind is the kind of event.
 	Kind EventKind
+	// SourceLine for line events, empty otherwise.
+	SourceLine string
 	// The datatype of the event.
 	Type *EventRootType
 	// The PC values at which the event should be injected. Sorted by PC.

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -749,7 +749,6 @@ func materializePending(
 						baseVar.Locations = append(baseVar.Locations, locs...)
 					}
 				} else {
-
 					// Fully defined var in the inlined instance.
 					v, err := processVariable(
 						p.unit, inlVar, isParameter,
@@ -762,6 +761,11 @@ func materializePending(
 					sp.Variables = append(sp.Variables, v)
 				}
 			}
+		}
+		for _, v := range sp.Variables {
+			slices.SortFunc(v.Locations, func(a, b ir.Location) int {
+				return cmp.Compare(a.Range[0], b.Range[0])
+			})
 		}
 		subprograms = append(subprograms, sp)
 	}
@@ -1872,6 +1876,9 @@ func newProbe(
 			return nil, issue, err
 		}
 	}
+	slices.SortFunc(injectionPoints, func(a, b ir.InjectionPoint) int {
+		return cmp.Compare(a.PC, b.PC)
+	})
 	events := []*ir.Event{
 		{
 			ID:              eventIDAlloc.next(),
@@ -2451,6 +2458,9 @@ func processVariable(
 				pointerSize,
 			)
 		}
+		slices.SortFunc(locations, func(a, b ir.Location) int {
+			return cmp.Compare(a.Range[0], b.Range[0])
+		})
 	}
 	isReturn, _, err := maybeGetAttr[bool](entry, dwarf.AttrVarParam)
 	if err != nil {

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1898,11 +1898,13 @@ func newProbe(
 		return cmp.Compare(a.PC, b.PC)
 	})
 	var eventKind ir.EventKind
-	switch probeCfg.GetWhere().(type) {
+	var sourceLine string
+	switch where := probeCfg.GetWhere().(type) {
 	case ir.FunctionWhere:
 		eventKind = ir.EventKindEntry
 	case ir.LineWhere:
 		eventKind = ir.EventKindLine
+		_, _, sourceLine = where.Line()
 	}
 	events := []*ir.Event{
 		{
@@ -1910,6 +1912,7 @@ func newProbe(
 			InjectionPoints: injectionPoints,
 			Condition:       nil,
 			Kind:            eventKind,
+			SourceLine:      sourceLine,
 			// Will be populated after all the types have been resolved
 			// and placeholders have been filled in.
 			Type: nil,

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 105 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 105 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 110 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a7fe0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 110 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a7fe0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 115 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4ae5e0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 115 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4ae5e0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 106 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5290", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 106 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5290", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 111 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5170", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 111 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb5170", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,6 +11,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 116 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb7d10", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 116 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0xb7d10", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 105 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4a804e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 106 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4a80f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 105 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4a804e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 106 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4a80f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 105 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4a804e", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 106 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4a80f2", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 110 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4aa26e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 111 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4aa312", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 110 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4aa26e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 111 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4aa312", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 110 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4aa26e", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 111 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4aa312", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 115 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4b094e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 116 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4b09f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 115 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4b094e", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 116 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4b09f2", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 115 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0x4b094e", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 116 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0x4b09f2", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 106 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7508", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 107 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb7588", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 106 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7508", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 107 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb7588", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 106 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7508", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 107 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb7588", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 111 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7538", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 112 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb75b8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 111 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7538", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 112 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb75b8", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 111 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xb7538", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 112 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xb75b8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 116 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xba068", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 117 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xba0dc", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 116 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xba068", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 117 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xba0dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 116 EventRootType Probe[main.callMe]
           InjectionPoints: [{PC: "0xba068", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 117 EventRootType Probe[main.callMe]Return
           InjectionPoints: [{PC: "0xba0dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd59a14"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd59bbd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 189 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 190 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd59bbd", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 188 EventRootType Probe[main.HandleHTTP]
+          Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 189 EventRootType Probe[main.HandleHTTP]Return
+          Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd59a14"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 190 EventRootType Probe[main.LookAtTheRequest]
+          Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd59bbd", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0xd59848..0xd59881
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 107 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd59958..0xd5997a
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd5997a..0xd59a5c
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd59b20..0xd59be5]
@@ -100,6 +116,16 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
+      ID: 220
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
@@ -107,20 +133,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 185
+      ID: 189
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 188 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 108
+      ID: 112
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 111 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 110
+      ID: 114
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 109 GoSliceDataType []uintptr.array
+      Pointee: 113 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -129,22 +155,44 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 224
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 161
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,[]string>
+      Pointee: 162 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 204
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 205 GoHMapBucketType bucket<string,float64>
+    - __kind: PointerType
+      ID: 199
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 200 GoHMapBucketType bucket<string,interface {}>
+    - __kind: PointerType
+      ID: 182
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 179 GoHMapBucketType bucket<string,string>
+      Pointee: 183 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 167
+      ID: 107
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.17632e+06
+      GoKind: 22
+      Pointee: 108 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 171
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 172 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -167,22 +215,72 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 111
+      ID: 105
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.187104e+06
+      GoKind: 22
+      Pointee: 106 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 212
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.916704e+06
+      GoKind: 22
+      Pointee: 213 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 207
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.129216e+06
+      GoKind: 22
+      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 210
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.129344e+06
+      GoKind: 22
+      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 230
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130112e+06
+      GoKind: 22
+      Pointee: 231 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 115
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.396768e+06
       GoKind: 22
-      Pointee: 112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 116 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 155
+      ID: 222
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 223 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 159
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,[]string>
+      Pointee: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 176
+      ID: 202
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 203 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 197
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 180
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 177 GoHMapHeaderType hash<string,string>
+      Pointee: 181 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -219,12 +317,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 169
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 170 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -233,40 +331,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 170
+      ID: 174
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType net/http.Response
+      Pointee: 175 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.876224e+06
       GoKind: 22
-      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 153 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.pattern
+      Pointee: 178 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.117184e+06
       GoKind: 22
-      Pointee: 151 UnresolvedPointeeType net/http.response
+      Pointee: 155 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 152
+      ID: 156
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 153 UnresolvedPointeeType net/url.URL
+      Pointee: 157 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -310,12 +408,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 159
+      ID: 163
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType runtime.mapextra
+      Pointee: 164 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -345,115 +443,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 106
+      ID: 110
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 105 GoStringDataType string.str
+      Pointee: 109 GoStringDataType string.str
     - __kind: PointerType
-      ID: 117
+      ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 131
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532032e+06
       GoKind: 22
-      Pointee: 114 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 123
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.655968e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726624e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65616e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.655776e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726176e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.794496e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7264e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532224e+06
       GoKind: 22
-      Pointee: 116 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 127
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 139
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726848e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -497,12 +595,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 169
+      ID: 173
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: EventRootType
-      ID: 188
+      ID: 234
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -528,10 +626,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 189
+      ID: 235
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 236
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -547,7 +645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 237
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 85
@@ -640,7 +738,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 180
+      ID: 184
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
@@ -649,19 +747,83 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 232
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 187
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 158 GoHMapBucketType bucket<string,[]string>
+      Element: 162 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 218
+      Name: '[]bucket<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 205 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: '[]bucket<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 272
+      Element: 200 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 191
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 179 GoHMapBucketType bucket<string,string>
+      Element: 183 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 206
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463424
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 209
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463616
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 181
+      ID: 185
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -672,7 +834,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 167
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -687,9 +849,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 188 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 188
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -710,9 +872,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
+      Data: 111 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 111
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -733,22 +895,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 109 GoSliceDataType []uintptr.array
+      Data: 113 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 113
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 182
+      ID: 229
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 186
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 163 GoSliceHeaderType []string
+      Element: 167 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 186
+      ID: 217
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 17 BaseType float64
+    - __kind: ArrayType
+      ID: 214
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 215 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 190
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -761,43 +944,122 @@ Types:
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 225
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 229 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoHMapBucketType
+      ID: 162
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 185 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 182 ArrayType []val<[]string>
+          Type: 186 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 163 GoSliceHeaderType []string
+      ValueType: 167 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 179
+      ID: 205
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 217 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 204 PointerType *bucket<string,float64>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 17 BaseType float64
+    - __kind: GoHMapBucketType
+      ID: 200
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 214 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 199 PointerType *bucket<string,interface {}>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 215 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 183
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 185 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<string>
+          Type: 190 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 108
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.450816e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 233 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 233
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541536
+      GoKind: 3
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -811,7 +1073,7 @@ Types:
       GoRuntimeType: 543072
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 176
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
@@ -824,7 +1086,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 168
+      ID: 172
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -859,7 +1121,7 @@ Types:
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 162
+      ID: 166
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
@@ -870,8 +1132,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 798176
       GoKind: 19
+    - __kind: StructureType
+      ID: 106
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.251424e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 192 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 11 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 11 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 11 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 11 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 13 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 179 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 196 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 201 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 10 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 10 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 10 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 12 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 206 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 209 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 11 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 176 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 176 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 57 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 213
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 208
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.822016e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 10 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 10 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 179 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 196
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.007296e+06
+      GoKind: 21
+      HeaderType: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: StructureType
+      ID: 211
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.663808e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 10 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 221 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 226 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 231
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.265696e+06
@@ -884,11 +1287,45 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 112
+      ID: 116
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 223
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 232 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: GoHMapHeaderType
+      ID: 160
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -909,20 +1346,88 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 162 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 187 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 177
+      ID: 203
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 204 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 204 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 205 GoHMapBucketType bucket<string,float64>
+      BucketsType: 218 GoSliceDataType []bucket<string,float64>.array
+    - __kind: GoHMapHeaderType
+      ID: 198
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 199 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 199 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 200 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 216 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 181
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -943,18 +1448,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 179 GoHMapBucketType bucket<string,string>
-      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 183 GoHMapBucketType bucket<string,string>
+      BucketsType: 191 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -985,6 +1490,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 542368
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 215
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 797888
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
@@ -1085,7 +1603,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 165
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
@@ -1098,18 +1616,39 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 175
+      ID: 221
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 904992
+      GoKind: 21
+      HeaderType: 223 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 201
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 904896
+      GoKind: 21
+      HeaderType: 203 GoHMapHeaderType hash<string,float64>
+    - __kind: GoMapType
+      ID: 226
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896352
+      GoKind: 21
+      HeaderType: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoMapType
+      ID: 179
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 177 GoHMapHeaderType hash<string,string>
+      HeaderType: 181 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 170
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 150
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006528e+06
@@ -1122,7 +1661,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 144
+      ID: 148
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.00512e+06
@@ -1135,14 +1674,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 154
+      ID: 158
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 151
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005248e+06
@@ -1155,7 +1694,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 149
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005504e+06
@@ -1179,7 +1718,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 152 PointerType *net/url.URL
+          Type: 156 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1191,19 +1730,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 154 GoMapType net/http.Header
+          Type: 158 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 161 GoInterfaceType io.ReadCloser
+          Type: 165 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 166 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 163 GoSliceHeaderType []string
+          Type: 167 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1212,16 +1751,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 164 GoMapType net/url.Values
+          Type: 168 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 164 GoMapType net/url.Values
+          Type: 168 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 165 PointerType *mime/multipart.Form
+          Type: 169 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 154 GoMapType net/http.Header
+          Type: 158 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1230,30 +1769,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 167 PointerType *crypto/tls.ConnectionState
+          Type: 171 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 169 GoChannelType <-chan struct {}
+          Type: 173 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 170 PointerType *net/http.Response
+          Type: 174 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 172 GoInterfaceType context.Context
+          Type: 176 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 173 PointerType *net/http.pattern
+          Type: 177 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 163 GoSliceHeaderType []string
+          Type: 167 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 175 GoMapType map[string]string
+          Type: 179 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 175
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1270,28 +1809,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 149
+      ID: 153
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 151
+      ID: 155
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 153
+      ID: 157
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 164
+      ID: 168
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1887,7 +2426,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 164
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2021,18 +2560,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 106 PointerType *string.str
+          Type: 110 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 105 GoStringDataType string.str
+      Data: 109 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 105
+      ID: 109
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 118
+      ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.855808e+06
@@ -2040,12 +2579,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 132
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -2053,15 +2592,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855296e+06
@@ -2069,12 +2608,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 124
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.929952e+06
@@ -2082,15 +2621,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999552e+06
@@ -2098,18 +2637,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -2117,15 +2656,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.929664e+06
@@ -2133,15 +2672,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.998912e+06
@@ -2149,18 +2688,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.058656e+06
@@ -2168,21 +2707,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999232e+06
@@ -2190,18 +2729,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.856064e+06
@@ -2209,12 +2748,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 116
+      ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.855552e+06
@@ -2222,12 +2761,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 128
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -2235,15 +2774,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 140
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999872e+06
@@ -2251,18 +2790,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -2270,13 +2809,67 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 193
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.313984e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
+    - __kind: StructureType
+      ID: 192
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.750592e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 193 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 194 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 194 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 194
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315424e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 195 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 12 BaseType int32
+    - __kind: StructureType
+      ID: 195
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 965792
+      GoKind: 25
+      RawFields: []
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2319,7 +2912,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
-MaxTypeID: 191
+MaxTypeID: 237
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd59a14"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd59bbd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 201 EventRootType Probe[main.HandleHTTP]
+          Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 202 EventRootType Probe[main.HandleHTTP]Return
+          Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd315af"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 203 EventRootType Probe[main.LookAtTheRequest]
+          Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3175d", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0xd313e8..0xd31421
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 112 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd314f7..0xd31512
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd31512..0xd315f9
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd316c0..0xd31785]
@@ -100,15 +116,40 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 162
+      ID: 251
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 252 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 166
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,[]string>
+      Pointee: 167 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 219
+      Name: '**table<string,float64>'
+      ByteSize: 8
+      Pointee: 220 PointerType *table<string,float64>
+    - __kind: PointerType
+      ID: 214
+      Name: '**table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 215 PointerType *table<string,interface {}>
+    - __kind: PointerType
+      ID: 185
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,string>
+      Pointee: 186 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 247
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 246 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -117,20 +158,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 192
+      ID: 196
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []string.array
+      Pointee: 195 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 116 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 118 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -139,12 +180,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 170
+      ID: 112
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.316768e+06
+      GoKind: 22
+      Pointee: 113 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 174
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 175 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -167,12 +215,47 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 110
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.32752e+06
+      GoKind: 22
+      Pointee: 111 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 227
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.046208e+06
+      GoKind: 22
+      Pointee: 228 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 222
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.210688e+06
+      GoKind: 22
+      Pointee: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 225
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.210816e+06
+      GoKind: 22
+      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 262
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.211584e+06
+      GoKind: 22
+      Pointee: 263 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.577632e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 121 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -209,22 +292,37 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 160
+      ID: 249
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 250 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 164
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 217
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 218 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 212
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 183
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,string>
+      Pointee: 184 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 168
+      ID: 172
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 173 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -233,50 +331,65 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.Response
+      Pointee: 178 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 157
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.045344e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 158 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 176
+      ID: 180
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.pattern
+      Pointee: 181 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 159
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.254144e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 160 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 161
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 162 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 185
+      ID: 258
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 189
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[string][]string
+      Pointee: 190 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 195
+      ID: 240
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 241 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 231
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 199
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]string
+      Pointee: 200 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -355,125 +468,140 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 115
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 114 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716704e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774624e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.71632e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773856e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845888e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774048e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773664e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.84544e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 150
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.918112e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845664e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716896e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716512e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.77424e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 148
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.846112e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774432e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 163
+      ID: 252
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 256 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 167
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 183 StructureType table<string,[]string>
+      Pointee: 187 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 220
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 238 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 215
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 229 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 186
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 193 StructureType table<string,string>
+      Pointee: 197 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -517,12 +645,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 172
+      ID: 176
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: EventRootType
-      ID: 201
+      ID: 267
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -548,10 +676,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 268
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 269
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -567,7 +695,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 270
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -676,35 +804,117 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 264
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 252 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 193
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,[]string>
+      Element: 167 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 244
+      Name: '[]*table<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 220 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]*table<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 215 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 203
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,string>
+      Element: 186 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 221
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 491520
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 246 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 246
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 224
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 491712
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 194
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 186 StructureType noalg.map.group[string][]string
+      Element: 190 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 245
+      Name: '[]noalg.map.group[string]float64.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 241 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]noalg.map.group[string]interface {}.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 264
+      Element: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 204
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 196 StructureType noalg.map.group[string]string
+      Element: 200 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 170
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -719,9 +929,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []string.array
+      Data: 195 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 195
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -742,9 +952,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 116 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 116
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -765,9 +975,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 118 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 118
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -778,6 +988,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
+    - __kind: StructureType
+      ID: 113
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.635488e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 266 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 266
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 589536
+      GoKind: 3
     - __kind: BaseType
       ID: 95
       Name: complex128
@@ -791,7 +1023,7 @@ Types:
       GoRuntimeType: 591136
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 175
+      ID: 179
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
@@ -804,7 +1036,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 175
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -839,7 +1071,7 @@ Types:
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 165
+      ID: 169
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
@@ -850,8 +1082,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 863936
       GoKind: 19
+    - __kind: StructureType
+      ID: 111
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.39312e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 205 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 9 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 9 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 9 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 12 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 12 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 182 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 211 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 216 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 8 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 8 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 8 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 10 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 221 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 224 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 227 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 9 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 179 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 179 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 59 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 228
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 223
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.947136e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 8 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 182 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 211
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.299968e+06
+      GoKind: 21
+      HeaderType: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: StructureType
+      ID: 226
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.781696e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 248 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 253 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 263
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.440512e+06
@@ -864,37 +1237,79 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 121
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 257
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 258 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 188
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[string][]string
+          Type: 189 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[string][]string
-      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 190 StructureType noalg.map.group[string][]string
+      GroupSliceType: 194 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 239
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 240 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 241 StructureType noalg.map.group[string]float64
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 230
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 231 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 198
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]string
+          Type: 199 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]string
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 200 StructureType noalg.map.group[string]string
+      GroupSliceType: 204 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -925,6 +1340,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 590432
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 235
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 863648
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
@@ -1024,8 +1452,21 @@ Types:
       GoRuntimeType: 1.007872e+06
       GoKind: 25
       RawFields: []
+    - __kind: StructureType
+      ID: 208
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.512992e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 10 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 168
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
@@ -1038,7 +1479,39 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 250
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 251 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 165
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1051,7 +1524,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,[]string>
+          Type: 166 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1067,10 +1540,74 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 186 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 193 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 190 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 218
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 219 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 213
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 214 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 184
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1083,7 +1620,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,string>
+          Type: 185 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1099,21 +1636,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
-      GroupType: 196 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 203 GoSliceDataType []*table<string,string>.array
+      GroupType: 200 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 178
+      ID: 248
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.153728e+06
+      GoKind: 21
+      HeaderType: 250 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 216
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.1536e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 253
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.146944e+06
+      GoKind: 21
+      HeaderType: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 182
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,string>
+      HeaderType: 184 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 169
+      ID: 173
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 155
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.04576e+06
@@ -1126,7 +1684,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 153
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.044352e+06
@@ -1139,14 +1697,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 163
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 156
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.04448e+06
@@ -1159,7 +1717,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 154
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044736e+06
@@ -1183,7 +1741,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 161 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1195,19 +1753,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 163 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 164 GoInterfaceType io.ReadCloser
+          Type: 168 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 169 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1216,16 +1774,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 167 GoMapType net/url.Values
+          Type: 171 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 167 GoMapType net/url.Values
+          Type: 171 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 168 PointerType *mime/multipart.Form
+          Type: 172 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 163 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1234,30 +1792,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 170 PointerType *crypto/tls.ConnectionState
+          Type: 174 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 172 GoChannelType <-chan struct {}
+          Type: 176 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 173 PointerType *net/http.Response
+          Type: 177 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 175 GoInterfaceType context.Context
+          Type: 179 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 176 PointerType *net/http.pattern
+          Type: 180 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 178 GoMapType map[string]string
+          Type: 182 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1274,48 +1832,88 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 158
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 181
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 160
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 162
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 167
+      ID: 171
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 187
+      ID: 260
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 711904
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 261 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 191
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key string; elem []string }
+      Element: 192 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 197
+      ID: 242
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 711808
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 243 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 233
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 688768
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 234 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 201
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem string }
+      Element: 202 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 186
+      ID: 259
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.327872e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 260 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 190
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -1326,9 +1924,35 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 191 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 196
+      ID: 241
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.327616e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 232
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.309568e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 200
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -1339,9 +1963,22 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 201 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 188
+      ID: 261
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.327744e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 262 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 192
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -1352,9 +1989,35 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 198
+      ID: 243
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.327488e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 18 BaseType float64
+    - __kind: StructureType
+      ID: 234
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.30944e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 235 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 202
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -2129,18 +2792,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 115 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 114 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 114
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.982976e+06
@@ -2148,12 +2811,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06032e+06
@@ -2161,15 +2824,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.982464e+06
@@ -2177,12 +2840,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059168e+06
@@ -2190,15 +2853,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129376e+06
@@ -2206,18 +2869,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059456e+06
@@ -2225,15 +2888,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.05888e+06
@@ -2241,15 +2904,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128736e+06
@@ -2257,18 +2920,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 151
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.191008e+06
@@ -2276,21 +2939,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129056e+06
@@ -2298,18 +2961,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.983232e+06
@@ -2317,12 +2980,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.98272e+06
@@ -2330,12 +2993,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059744e+06
@@ -2343,15 +3006,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 149
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.129696e+06
@@ -2359,18 +3022,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.060032e+06
@@ -2378,15 +3041,99 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 183
+      ID: 206
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.489632e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 207 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 208 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 205
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.872192e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 206 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 209 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 209 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 207
+      Name: sync.noCopy
+      GoRuntimeType: 1.003072e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 209
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.490912e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 210 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 10 BaseType int32
+    - __kind: StructureType
+      ID: 210
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.003168e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 256
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 257 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 187
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2408,9 +3155,57 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 188 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 193
+      ID: 238
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 229
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 197
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2432,7 +3227,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,string>
+          Type: 198 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2475,7 +3270,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 270
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd315af"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3175d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 202 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 203 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3175d", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd315af"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3175d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 207 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 208 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3673d", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd3658f"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3673d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd3658f"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3673d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd36353", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 207 EventRootType Probe[main.HandleHTTP]Return
+          Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd3658f"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd366ae", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd3673d", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0xd363c8..0xd36401
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 114 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd364d7..0xd364f2
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd364f2..0xd365d9
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd366a0..0xd36765]
@@ -106,20 +122,45 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 167
+      ID: 256
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 257 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 171
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 172 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 224
+      Name: '**table<string,float64>'
+      ByteSize: 8
+      Pointee: 225 PointerType *table<string,float64>
+    - __kind: PointerType
+      ID: 219
+      Name: '**table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 220 PointerType *table<string,interface {}>
+    - __kind: PointerType
+      ID: 190
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 191 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*runtime.p.array
+      Pointee: 123 GoSliceDataType []*runtime.p.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +169,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 201
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 200 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uint8.array
+      Pointee: 118 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 117
+      ID: 121
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []uintptr.array
+      Pointee: 120 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,12 +191,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 114
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.321376e+06
+      GoKind: 22
+      Pointee: 115 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 179
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 180 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -178,12 +226,47 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 112
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.33264e+06
+      GoKind: 22
+      Pointee: 113 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 232
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.054336e+06
+      GoKind: 22
+      Pointee: 233 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 227
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.21456e+06
+      GoKind: 22
+      Pointee: 228 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 230
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.214688e+06
+      GoKind: 22
+      Pointee: 231 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 267
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.215456e+06
+      GoKind: 22
+      Pointee: 268 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 125
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582816e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -220,22 +303,37 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 254
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 255 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 169
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 222
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 223 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 217
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 188
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 189 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 178 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -244,50 +342,65 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 182
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.7584e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 183 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 162
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.053472e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 185
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642688e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 186 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 164
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.27712e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 165 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 166
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.167328e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 167 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 263
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 194
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 195 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 245
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 246 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 236
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 204
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 205 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -336,7 +449,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.055968e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType runtime.p
+      Pointee: 122 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -373,125 +486,140 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 112 GoStringDataType string.str
+      Pointee: 116 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.722368e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781632e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.721984e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780864e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853888e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781056e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780672e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.85344e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925792e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853664e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72256e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.722176e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.781248e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.854112e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.78144e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 257
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 261 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 172
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 192 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 225
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 243 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 220
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 234 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 191
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 202 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -535,12 +663,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 181
       Name: <-chan struct {}
       GoRuntimeType: 607264
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 272
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -566,10 +694,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 273
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 274
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -585,7 +713,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 209
+      ID: 275
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -702,43 +830,125 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*runtime.p.array
+      Data: 123 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 123
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 269
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 257 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 172 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 249
+      Name: '[]*table<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 225 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*table<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 220 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 208
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 191 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 226
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 494784
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 227 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 251 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 251
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 228 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 229
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 494976
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 231 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 199
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 195 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 250
+      Name: '[]noalg.map.group[string]float64.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 246 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]noalg.map.group[string]interface {}.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 264
+      Element: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 209
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 205 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 175
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501440
@@ -753,9 +963,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 200 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 200
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -776,9 +986,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uint8.array
+      Data: 118 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 118
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -799,9 +1009,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 116 GoSliceDataType []uintptr.array
+      Data: 120 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 120
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -812,6 +1022,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595232
       GoKind: 1
+    - __kind: StructureType
+      ID: 115
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.640384e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 271 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 271
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 593440
+      GoKind: 3
     - __kind: BaseType
       ID: 97
       Name: complex128
@@ -825,7 +1057,7 @@ Types:
       GoRuntimeType: 594976
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 184
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.3032e+06
@@ -838,7 +1070,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 180
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -873,7 +1105,7 @@ Types:
       GoRuntimeType: 484960
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 174
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 705088
@@ -884,8 +1116,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 867392
       GoKind: 19
+    - __kind: StructureType
+      ID: 113
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.3976e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 210 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 9 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 9 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 9 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 12 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 12 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 187 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 216 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 221 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 8 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 8 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 8 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 10 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 226 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 229 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 232 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 9 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 184 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 184 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 59 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 233
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 228
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.955616e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 8 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 187 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 216
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.30448e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: StructureType
+      ID: 231
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.789664e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 253 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 258 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 268
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.445024e+06
@@ -898,37 +1271,79 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 126
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 262
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 263 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 270 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 193
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 194 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 195 StructureType noalg.map.group[string][]string
+      GroupSliceType: 199 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 244
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 245 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 246 StructureType noalg.map.group[string]float64
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 235
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 236 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 237 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 203
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 204 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 205 StructureType noalg.map.group[string]string
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -959,6 +1374,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 594272
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 240
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 867104
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
@@ -1058,8 +1486,21 @@ Types:
       GoRuntimeType: 1.012288e+06
       GoKind: 25
       RawFields: []
+    - __kind: StructureType
+      ID: 213
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.518176e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 10 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 173
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.135168e+06
@@ -1072,7 +1513,42 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 255
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 256 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 269 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 170
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1085,7 +1561,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 171 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1104,10 +1580,80 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 198 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 195 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 223
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 224 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 249 GoSliceDataType []*table<string,float64>.array
+      GroupType: 246 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 218
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 219 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 241 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 189
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1120,7 +1666,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 190 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1139,21 +1685,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,string>.array
+      GroupType: 205 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 253
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.158336e+06
+      GoKind: 21
+      HeaderType: 255 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 221
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.158208e+06
+      GoKind: 21
+      HeaderType: 223 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 258
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.151808e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 187
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.15424e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 189 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 160
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.05008e+06
@@ -1166,7 +1733,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 158
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.048544e+06
@@ -1179,14 +1746,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 168
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.15504e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 161
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.048672e+06
@@ -1199,7 +1766,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 159
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048928e+06
@@ -1223,7 +1790,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 166 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1235,19 +1802,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 168 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 173 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 174 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1256,16 +1823,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 176 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 176 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 177 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 168 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1274,30 +1841,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 179 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 181 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 182 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 184 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 185 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 187 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 183
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1314,48 +1881,88 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 163
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 186
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 165
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 167
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 176
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.92848e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 265
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 715328
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 266 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 196
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 701120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 197 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 247
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 715232
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 248 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 238
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 692576
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 239 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 206
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 207 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 264
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.332e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 265 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 195
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.31664e+06
@@ -1366,9 +1973,35 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 196 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 246
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.331744e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 247 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 237
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.31408e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 238 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 205
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.319072e+06
@@ -1379,9 +2012,22 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 266
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.331872e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 267 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 197
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.316512e+06
@@ -1392,9 +2038,35 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 248
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.331616e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 15 BaseType float64
+    - __kind: StructureType
+      ID: 239
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.313952e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 240 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 207
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.318944e+06
@@ -2051,7 +2723,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 122
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2176,18 +2848,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 113 PointerType *string.str
+          Type: 117 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 112 GoStringDataType string.str
+      Data: 116 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 112
+      ID: 116
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.991456e+06
@@ -2195,12 +2867,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067584e+06
@@ -2208,15 +2880,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -2224,12 +2896,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.066432e+06
@@ -2237,15 +2909,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137312e+06
@@ -2253,18 +2925,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.06672e+06
@@ -2272,15 +2944,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.066144e+06
@@ -2288,15 +2960,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.136672e+06
@@ -2304,18 +2976,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.199296e+06
@@ -2323,21 +2995,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136992e+06
@@ -2345,18 +3017,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.991712e+06
@@ -2364,12 +3036,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9912e+06
@@ -2377,12 +3049,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.067008e+06
@@ -2390,15 +3062,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.137632e+06
@@ -2406,18 +3078,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.067296e+06
@@ -2425,15 +3097,99 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 211
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.494336e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 212 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 213 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 210
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.88144e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 211 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 214 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 214 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 212
+      Name: sync.noCopy
+      GoRuntimeType: 1.007392e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 214
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.495616e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 215 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 10 BaseType int32
+    - __kind: StructureType
+      ID: 215
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.007488e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 261
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 262 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 192
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2455,9 +3211,57 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 193 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 243
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 244 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 234
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 235 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 202
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2479,7 +3283,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 203 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2522,7 +3326,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595296
       GoKind: 26
-MaxTypeID: 209
+MaxTypeID: 275
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18bb880", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff50", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 189 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 190 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e0268", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8e02dc", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff50", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8e0124"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e0268", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8e02dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff50", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8e0124"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e0268", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8e02dc", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 188 EventRootType Probe[main.HandleHTTP]
+          Type: 234 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff50", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 189 EventRootType Probe[main.HandleHTTP]Return
+          Type: 235 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8e0124"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 190 EventRootType Probe[main.LookAtTheRequest]
+          Type: 236 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e0268", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 237 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8e02dc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0x8dffa8..0x8dffd8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 107 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x8e007c..0x8e0098
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8e0098..0x8e0170
+              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8e0250..0x8e0310]
@@ -100,6 +116,16 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
+      ID: 220
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 228
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
@@ -107,20 +133,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 185
+      ID: 189
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 188 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 108
+      ID: 112
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 111 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 110
+      ID: 114
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 109 GoSliceDataType []uintptr.array
+      Pointee: 113 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -129,22 +155,44 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 224
+      Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 161
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,[]string>
+      Pointee: 162 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 204
+      Name: '*bucket<string,float64>'
+      ByteSize: 8
+      Pointee: 205 GoHMapBucketType bucket<string,float64>
+    - __kind: PointerType
+      ID: 199
+      Name: '*bucket<string,interface {}>'
+      ByteSize: 8
+      Pointee: 200 GoHMapBucketType bucket<string,interface {}>
+    - __kind: PointerType
+      ID: 182
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 179 GoHMapBucketType bucket<string,string>
+      Pointee: 183 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 167
+      ID: 107
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.176896e+06
+      GoKind: 22
+      Pointee: 108 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 171
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 172 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -167,22 +215,72 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 111
+      ID: 105
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.18768e+06
+      GoKind: 22
+      Pointee: 106 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 212
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 1.91728e+06
+      GoKind: 22
+      Pointee: 213 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 207
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.12944e+06
+      GoKind: 22
+      Pointee: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 210
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.129568e+06
+      GoKind: 22
+      Pointee: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 230
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.130336e+06
+      GoKind: 22
+      Pointee: 231 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 115
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.397152e+06
       GoKind: 22
-      Pointee: 112 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 116 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
-      ID: 155
+      ID: 222
+      Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 223 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 159
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,[]string>
+      Pointee: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 176
+      ID: 202
+      Name: '*hash<string,float64>'
+      ByteSize: 8
+      Pointee: 203 GoHMapHeaderType hash<string,float64>
+    - __kind: PointerType
+      ID: 197
+      Name: '*hash<string,interface {}>'
+      ByteSize: 8
+      Pointee: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: PointerType
+      ID: 180
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 177 GoHMapHeaderType hash<string,string>
+      Pointee: 181 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -219,12 +317,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 169
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 170 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -233,40 +331,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 170
+      ID: 174
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType net/http.Response
+      Pointee: 175 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 148
+      ID: 152
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.8768e+06
       GoKind: 22
-      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 153 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.pattern
+      Pointee: 178 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 150
+      ID: 154
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.11776e+06
       GoKind: 22
-      Pointee: 151 UnresolvedPointeeType net/http.response
+      Pointee: 155 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 152
+      ID: 156
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 153 UnresolvedPointeeType net/url.URL
+      Pointee: 157 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -310,12 +408,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 159
+      ID: 163
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType runtime.mapextra
+      Pointee: 164 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -345,115 +443,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 106
+      ID: 110
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 105 GoStringDataType string.str
+      Pointee: 109 GoStringDataType string.str
     - __kind: PointerType
-      ID: 117
+      ID: 121
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.5328e+06
       GoKind: 22
-      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 131
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.657312e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.532416e+06
       GoKind: 22
-      Pointee: 114 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 118 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 123
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656544e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.7272e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.656736e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 125
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.656352e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.726752e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.795072e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.726976e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 123
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.532992e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.532608e+06
       GoKind: 22
-      Pointee: 116 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 120 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 127
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.656928e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 139
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.727424e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.65712e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -497,12 +595,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 169
+      ID: 173
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: EventRootType
-      ID: 188
+      ID: 234
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -528,10 +626,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 189
+      ID: 235
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 236
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -547,7 +645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 237
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 85
@@ -640,7 +738,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 180
+      ID: 184
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
@@ -649,19 +747,83 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 232
+      Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 187
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 158 GoHMapBucketType bucket<string,[]string>
+      Element: 162 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 218
+      Name: '[]bucket<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 205 GoHMapBucketType bucket<string,float64>
+    - __kind: GoSliceDataType
+      ID: 216
+      Name: '[]bucket<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 272
+      Element: 200 GoHMapBucketType bucket<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 191
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 179 GoHMapBucketType bucket<string,string>
+      Element: 183 GoHMapBucketType bucket<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 206
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 463584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 207 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 219 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: GoSliceDataType
+      ID: 219
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 208 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 209
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 463776
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 210 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 9 BaseType int
+      Data: 227 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 227
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 211 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: ArrayType
-      ID: 181
+      ID: 185
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -672,7 +834,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 167
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -687,9 +849,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 188 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 188
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -710,9 +872,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
+      Data: 111 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 111
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -733,22 +895,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 109 GoSliceDataType []uintptr.array
+      Data: 113 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 113
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 182
+      ID: 229
+      Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: ArrayType
+      ID: 186
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 163 GoSliceHeaderType []string
+      Element: 167 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 186
+      ID: 217
+      Name: '[]val<float64>'
+      ByteSize: 64
+      Count: 8
+      HasCount: true
+      Element: 17 BaseType float64
+    - __kind: ArrayType
+      ID: 214
+      Name: '[]val<interface {}>'
+      ByteSize: 128
+      Count: 8
+      HasCount: true
+      Element: 215 GoEmptyInterfaceType interface {}
+    - __kind: ArrayType
+      ID: 190
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -761,43 +944,122 @@ Types:
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 225
+      Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 229 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: overflow
+          Offset: 200
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoHMapBucketType
+      ID: 162
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 185 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 182 ArrayType []val<[]string>
+          Type: 186 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 163 GoSliceHeaderType []string
+      ValueType: 167 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 179
+      ID: 205
+      Name: bucket<string,float64>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 217 ArrayType []val<float64>
+        - Name: overflow
+          Offset: 200
+          Type: 204 PointerType *bucket<string,float64>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 17 BaseType float64
+    - __kind: GoHMapBucketType
+      ID: 200
+      Name: bucket<string,interface {}>
+      ByteSize: 272
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 184 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 185 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 214 ArrayType []val<interface {}>
+        - Name: overflow
+          Offset: 264
+          Type: 199 PointerType *bucket<string,interface {}>
+      KeyType: 11 GoStringHeaderType string
+      ValueType: 215 GoEmptyInterfaceType interface {}
+    - __kind: GoHMapBucketType
+      ID: 183
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 184 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 185 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<string>
+          Type: 190 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 108
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.4512e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 233 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 233
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 541760
+      GoKind: 3
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -811,7 +1073,7 @@ Types:
       GoRuntimeType: 543296
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 176
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
@@ -824,7 +1086,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 168
+      ID: 172
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -859,7 +1121,7 @@ Types:
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 162
+      ID: 166
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
@@ -870,8 +1132,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 798304
       GoKind: 19
+    - __kind: StructureType
+      ID: 106
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.252e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 192 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 11 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 11 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 11 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 11 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 14 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 14 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 179 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 196 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 201 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 10 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 10 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 10 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 13 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 206 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 209 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 212 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 11 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 176 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 176 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 57 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 213
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 208
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.822592e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 10 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 10 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 10 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 179 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 11 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 196
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.00752e+06
+      GoKind: 21
+      HeaderType: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: StructureType
+      ID: 211
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.664384e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 11 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 10 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 221 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 226 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 231
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 147
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.26592e+06
@@ -884,11 +1287,45 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 112
+      ID: 116
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 223
+      Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 224 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 225 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 232 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+    - __kind: GoHMapHeaderType
+      ID: 160
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -909,20 +1346,88 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 161 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 162 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 187 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 177
+      ID: 203
+      Name: hash<string,float64>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 204 PointerType *bucket<string,float64>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 204 PointerType *bucket<string,float64>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 205 GoHMapBucketType bucket<string,float64>
+      BucketsType: 218 GoSliceDataType []bucket<string,float64>.array
+    - __kind: GoHMapHeaderType
+      ID: 198
+      Name: hash<string,interface {}>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 199 PointerType *bucket<string,interface {}>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 199 PointerType *bucket<string,interface {}>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 200 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 216 GoSliceDataType []bucket<string,interface {}>.array
+    - __kind: GoHMapHeaderType
+      ID: 181
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -943,18 +1448,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 178 PointerType *bucket<string,string>
+          Type: 182 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 179 GoHMapBucketType bucket<string,string>
-      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
+          Type: 163 PointerType *runtime.mapextra
+      BucketType: 183 GoHMapBucketType bucket<string,string>
+      BucketsType: 191 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -985,6 +1490,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 542592
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 215
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 798016
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
@@ -1085,7 +1603,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 165
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
@@ -1098,18 +1616,39 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 175
+      ID: 221
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 905120
+      GoKind: 21
+      HeaderType: 223 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 201
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 905024
+      GoKind: 21
+      HeaderType: 203 GoHMapHeaderType hash<string,float64>
+    - __kind: GoMapType
+      ID: 226
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 896480
+      GoKind: 21
+      HeaderType: 198 GoHMapHeaderType hash<string,interface {}>
+    - __kind: GoMapType
+      ID: 179
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 177 GoHMapHeaderType hash<string,string>
+      HeaderType: 181 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 170
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 150
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.006752e+06
@@ -1122,7 +1661,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 144
+      ID: 148
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.005344e+06
@@ -1135,14 +1674,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 154
+      ID: 158
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 151
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.005472e+06
@@ -1155,7 +1694,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 149
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.005728e+06
@@ -1179,7 +1718,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 152 PointerType *net/url.URL
+          Type: 156 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1191,19 +1730,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 154 GoMapType net/http.Header
+          Type: 158 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 161 GoInterfaceType io.ReadCloser
+          Type: 165 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 166 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 163 GoSliceHeaderType []string
+          Type: 167 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1212,16 +1751,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 164 GoMapType net/url.Values
+          Type: 168 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 164 GoMapType net/url.Values
+          Type: 168 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 165 PointerType *mime/multipart.Form
+          Type: 169 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 154 GoMapType net/http.Header
+          Type: 158 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1230,30 +1769,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 167 PointerType *crypto/tls.ConnectionState
+          Type: 171 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 169 GoChannelType <-chan struct {}
+          Type: 173 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 170 PointerType *net/http.Response
+          Type: 174 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 172 GoInterfaceType context.Context
+          Type: 176 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 173 PointerType *net/http.pattern
+          Type: 177 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 163 GoSliceHeaderType []string
+          Type: 167 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 175 GoMapType map[string]string
+          Type: 179 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 175
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1270,28 +1809,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 149
+      ID: 153
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 151
+      ID: 155
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 153
+      ID: 157
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 164
+      ID: 168
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 160 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1887,7 +2426,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 164
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2021,18 +2560,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 106 PointerType *string.str
+          Type: 110 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 105 GoStringDataType string.str
+      Data: 109 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 105
+      ID: 109
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 118
+      ID: 122
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.856384e+06
@@ -2040,12 +2579,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 132
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.93168e+06
@@ -2053,15 +2592,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 118
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.855872e+06
@@ -2069,12 +2608,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 124
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.930528e+06
@@ -2082,15 +2621,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000128e+06
@@ -2098,18 +2637,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.930816e+06
@@ -2117,15 +2656,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 126
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.93024e+06
@@ -2133,15 +2672,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.999488e+06
@@ -2149,18 +2688,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.059232e+06
@@ -2168,21 +2707,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.999808e+06
@@ -2190,18 +2729,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 148 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 124
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.85664e+06
@@ -2209,12 +2748,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 116
+      ID: 120
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.856128e+06
@@ -2222,12 +2761,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 128
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.931104e+06
@@ -2235,15 +2774,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 140
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.000448e+06
@@ -2251,18 +2790,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 150 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.931392e+06
@@ -2270,13 +2809,67 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 147 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 149 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 151 GoInterfaceType net/http.Hijacker
+    - __kind: StructureType
+      ID: 193
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.314208e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 13 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
+    - __kind: StructureType
+      ID: 192
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.751168e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 193 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 194 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 194 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 194
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.315648e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 195 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 13 BaseType int32
+    - __kind: StructureType
+      ID: 195
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 966016
+      GoKind: 25
+      RawFields: []
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2319,7 +2912,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
-MaxTypeID: 191
+MaxTypeID: 237
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0cb0", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8a0e80"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0fa8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8a101c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 201 EventRootType Probe[main.HandleHTTP]
+          Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0cb0", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 202 EventRootType Probe[main.HandleHTTP]Return
+          Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8a0e80"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 203 EventRootType Probe[main.LookAtTheRequest]
+          Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0fa8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8a101c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0x8a0d08..0x8a0d38
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 112 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x8a0ddc..0x8a0df0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8a0df0..0x8a0ec0
+              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8a0f90..0x8a1040]
@@ -100,15 +116,40 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 162
+      ID: 251
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 252 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 166
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,[]string>
+      Pointee: 167 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 219
+      Name: '**table<string,float64>'
+      ByteSize: 8
+      Pointee: 220 PointerType *table<string,float64>
+    - __kind: PointerType
+      ID: 214
+      Name: '**table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 215 PointerType *table<string,interface {}>
+    - __kind: PointerType
+      ID: 185
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,string>
+      Pointee: 186 PointerType *table<string,string>
+    - __kind: PointerType
+      ID: 247
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 246 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 255
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -117,20 +158,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 192
+      ID: 196
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []string.array
+      Pointee: 195 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 116 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 118 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -139,12 +180,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 170
+      ID: 112
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.316032e+06
+      GoKind: 22
+      Pointee: 113 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 174
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 175 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -167,12 +215,47 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 110
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.326784e+06
+      GoKind: 22
+      Pointee: 111 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 227
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.045472e+06
+      GoKind: 22
+      Pointee: 228 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 222
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.210016e+06
+      GoKind: 22
+      Pointee: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 225
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.210144e+06
+      GoKind: 22
+      Pointee: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 262
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.210912e+06
+      GoKind: 22
+      Pointee: 263 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 120
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.57712e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 121 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -209,22 +292,37 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 160
+      ID: 249
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 250 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 164
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 217
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 218 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 212
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 183
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,string>
+      Pointee: 184 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 168
+      ID: 172
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 173 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -233,50 +331,65 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.Response
+      Pointee: 178 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 157
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.044608e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 158 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 176
+      ID: 180
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.pattern
+      Pointee: 181 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 159
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.253408e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 160 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 161
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 162 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 185
+      ID: 258
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 189
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[string][]string
+      Pointee: 190 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 195
+      ID: 240
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 241 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 231
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 199
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]string
+      Pointee: 200 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -355,125 +468,140 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 115
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 114 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 126
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.716192e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 140
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.774112e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 122
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.715808e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 123 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 132
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773344e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 146
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845376e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 134
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.773536e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 130
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.773152e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 131 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 142
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.844928e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 143 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 150
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.917376e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 151 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 144
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.845152e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 128
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.716384e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 129 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.716e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 125 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 136
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.773728e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 148
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.8456e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 149 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 138
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.77392e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 163
+      ID: 252
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 256 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 167
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 183 StructureType table<string,[]string>
+      Pointee: 187 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 220
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 238 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 215
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 229 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 186
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 193 StructureType table<string,string>
+      Pointee: 197 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -517,12 +645,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 172
+      ID: 176
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: EventRootType
-      ID: 201
+      ID: 267
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -548,10 +676,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 268
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 269
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -567,7 +695,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 270
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -676,35 +804,117 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 264
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 252 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 193
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,[]string>
+      Element: 167 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 244
+      Name: '[]*table<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 220 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 236
+      Name: '[]*table<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 215 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 203
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,string>
+      Element: 186 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 221
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 491392
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 222 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 246 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 246
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 223 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 224
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 491584
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 225 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 254 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 254
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 226 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceDataType
+      ID: 265
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 194
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 186 StructureType noalg.map.group[string][]string
+      Element: 190 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 245
+      Name: '[]noalg.map.group[string]float64.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 241 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 237
+      Name: '[]noalg.map.group[string]interface {}.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 264
+      Element: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 204
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 196 StructureType noalg.map.group[string]string
+      Element: 200 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 170
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -719,9 +929,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []string.array
+      Data: 195 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 195
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -742,9 +952,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 116 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 116
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -765,9 +975,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 118 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 118
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -778,6 +988,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
+    - __kind: StructureType
+      ID: 113
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.634976e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 266 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 266
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 589344
+      GoKind: 3
     - __kind: BaseType
       ID: 96
       Name: complex128
@@ -791,7 +1023,7 @@ Types:
       GoRuntimeType: 590944
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 175
+      ID: 179
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
@@ -804,7 +1036,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 175
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -839,7 +1071,7 @@ Types:
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 165
+      ID: 169
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
@@ -850,8 +1082,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 863360
       GoKind: 19
+    - __kind: StructureType
+      ID: 111
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.392384e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 205 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 9 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 9 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 9 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 13 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 182 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 211 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 216 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 8 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 8 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 8 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 12 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 221 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 224 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 227 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 9 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 179 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 179 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 59 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 228
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 223
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.9464e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 8 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 182 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 211
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.299296e+06
+      GoKind: 21
+      HeaderType: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: StructureType
+      ID: 226
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.781184e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 248 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 253 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 263
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 152
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.43984e+06
@@ -864,37 +1237,79 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 121
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 257
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 258 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 188
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[string][]string
+          Type: 189 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[string][]string
-      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 190 StructureType noalg.map.group[string][]string
+      GroupSliceType: 194 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 239
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 240 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 241 StructureType noalg.map.group[string]float64
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 230
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 231 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 237 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 198
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]string
+          Type: 199 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]string
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 200 StructureType noalg.map.group[string]string
+      GroupSliceType: 204 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -925,6 +1340,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 590240
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 235
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 863072
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
@@ -1024,8 +1452,21 @@ Types:
       GoRuntimeType: 1.0072e+06
       GoKind: 25
       RawFields: []
+    - __kind: StructureType
+      ID: 208
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.51232e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 168
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
@@ -1038,7 +1479,39 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 250
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 251 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 264 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 259 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 165
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1051,7 +1524,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,[]string>
+          Type: 166 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1067,10 +1540,74 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 186 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 193 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 190 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 218
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 219 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,float64>.array
+      GroupType: 241 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 213
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 214 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 236 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 232 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 184
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1083,7 +1620,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,string>
+          Type: 185 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1099,21 +1636,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
-      GroupType: 196 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 203 GoSliceDataType []*table<string,string>.array
+      GroupType: 200 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 178
+      ID: 248
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.153056e+06
+      GoKind: 21
+      HeaderType: 250 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 216
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.152928e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 253
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.146272e+06
+      GoKind: 21
+      HeaderType: 213 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 182
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,string>
+      HeaderType: 184 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 169
+      ID: 173
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 155
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.045088e+06
@@ -1126,7 +1684,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 153
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04368e+06
@@ -1139,14 +1697,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 163
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 156
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.043808e+06
@@ -1159,7 +1717,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 154
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.044064e+06
@@ -1183,7 +1741,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 161 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1195,19 +1753,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 163 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 164 GoInterfaceType io.ReadCloser
+          Type: 168 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 169 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1216,16 +1774,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 167 GoMapType net/url.Values
+          Type: 171 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 167 GoMapType net/url.Values
+          Type: 171 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 168 PointerType *mime/multipart.Form
+          Type: 172 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 163 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1234,30 +1792,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 170 PointerType *crypto/tls.ConnectionState
+          Type: 174 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 172 GoChannelType <-chan struct {}
+          Type: 176 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 173 PointerType *net/http.Response
+          Type: 177 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 175 GoInterfaceType context.Context
+          Type: 179 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 176 PointerType *net/http.pattern
+          Type: 180 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 178 GoMapType map[string]string
+          Type: 182 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1274,48 +1832,88 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 158
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 181
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 160
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 162
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 167
+      ID: 171
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 165 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 187
+      ID: 260
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 711712
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 261 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 191
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key string; elem []string }
+      Element: 192 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 197
+      ID: 242
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 711616
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 243 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 233
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 688576
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 234 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 201
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem string }
+      Element: 202 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 186
+      ID: 259
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.3272e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 260 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 190
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -1326,9 +1924,35 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 191 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 196
+      ID: 241
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.326944e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 242 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 232
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.308896e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 233 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 200
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -1339,9 +1963,22 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 201 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 188
+      ID: 261
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.327072e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 262 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 192
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -1352,9 +1989,35 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 GoSliceHeaderType []string
+          Type: 170 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 198
+      ID: 243
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.326816e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 18 BaseType float64
+    - __kind: StructureType
+      ID: 234
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.308768e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 235 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 202
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -2129,18 +2792,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 115 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 114 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 114
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 127
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.98224e+06
@@ -2148,12 +2811,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 141
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059584e+06
@@ -2161,15 +2824,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 123
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.981728e+06
@@ -2177,12 +2840,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 133
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.058432e+06
@@ -2190,15 +2853,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 147
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12864e+06
@@ -2206,18 +2869,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 135
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.05872e+06
@@ -2225,15 +2888,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 131
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.058144e+06
@@ -2241,15 +2904,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 143
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.128e+06
@@ -2257,18 +2920,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 151
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.190272e+06
@@ -2276,21 +2939,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 145
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12832e+06
@@ -2298,18 +2961,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 153 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 129
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.982496e+06
@@ -2317,12 +2980,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 125
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.981984e+06
@@ -2330,12 +2993,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 137
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.059008e+06
@@ -2343,15 +3006,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 149
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.12896e+06
@@ -2359,18 +3022,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 155 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 139
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.059296e+06
@@ -2378,15 +3041,99 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 152 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 154 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 156 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 183
+      ID: 206
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.48896e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 207 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 208 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 205
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.87168e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 206 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 209 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 209 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 207
+      Name: sync.noCopy
+      GoRuntimeType: 1.0024e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 209
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.49024e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 210 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 12 BaseType int32
+    - __kind: StructureType
+      ID: 210
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.002496e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 256
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 257 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 187
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2408,9 +3155,57 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 188 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 193
+      ID: 238
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 239 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 229
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 230 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 197
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2432,7 +3227,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,string>
+          Type: 198 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2475,7 +3270,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 270
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0cb0", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 268 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8a0e80"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 269 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0fa8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 270 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8a101c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0cb0", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 202 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 203 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0fa8", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8a101c", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859990", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 207 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 208 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c68", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x859cd0", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859990", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x859b34"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c68", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x859cd0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859990", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x859b34"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c68", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x859cd0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 272 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x859990", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 207 EventRootType Probe[main.HandleHTTP]Return
+          Type: 273 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x859b34"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 274 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x859c68", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 275 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x859cd0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,22 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: span
+          Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Locations:
+            - Range: 0x8599e4..0x859a14
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&buf'
+          Type: 114 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x859aa0..0x859ab8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x859ab8..0x859b80
+              Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x859c50..0x859cf0]
@@ -106,20 +122,45 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 167
+      ID: 256
+      Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 257 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 171
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 172 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 224
+      Name: '**table<string,float64>'
+      ByteSize: 8
+      Pointee: 225 PointerType *table<string,float64>
+    - __kind: PointerType
+      ID: 219
+      Name: '**table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 220 PointerType *table<string,interface {}>
+    - __kind: PointerType
+      ID: 190
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 191 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 124
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*runtime.p.array
+      Pointee: 123 GoSliceDataType []*runtime.p.array
+    - __kind: PointerType
+      ID: 252
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      ByteSize: 8
+      Pointee: 251 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+    - __kind: PointerType
+      ID: 260
+      Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      ByteSize: 8
+      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +169,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 201
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 200 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 115
+      ID: 119
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uint8.array
+      Pointee: 118 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 117
+      ID: 121
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []uintptr.array
+      Pointee: 120 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,12 +191,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 114
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.320608e+06
+      GoKind: 22
+      Pointee: 115 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 179
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 923424
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 180 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -178,12 +226,47 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 112
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
+      ByteSize: 8
+      GoRuntimeType: 2.331872e+06
+      GoKind: 22
+      Pointee: 113 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+    - __kind: PointerType
+      ID: 232
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
+      ByteSize: 8
+      GoRuntimeType: 2.053568e+06
+      GoKind: 22
+      Pointee: 233 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+    - __kind: PointerType
+      ID: 227
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 8
+      GoRuntimeType: 1.213856e+06
+      GoKind: 22
+      Pointee: 228 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: PointerType
+      ID: 230
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.213984e+06
+      GoKind: 22
+      Pointee: 231 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: PointerType
+      ID: 267
+      Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      GoRuntimeType: 1.214752e+06
+      GoKind: 22
+      Pointee: 268 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 125
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.582272e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
+      Pointee: 126 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -220,22 +303,37 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 254
+      Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 255 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 169
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 222
+      Name: '*map<string,float64>'
+      ByteSize: 8
+      Pointee: 223 GoSwissMapHeaderType map<string,float64>
+    - __kind: PointerType
+      ID: 217
+      Name: '*map<string,interface {}>'
+      ByteSize: 8
+      Pointee: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: PointerType
+      ID: 188
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 189 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 177
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 925056
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 178 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -244,50 +342,65 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 182
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.757856e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 183 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 162
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.052704e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 163 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 185
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.642144e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 186 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 164
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.276352e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 165 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 166
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16656e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 167 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 263
+      Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
+      ByteSize: 8
+      Pointee: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: PointerType
+      ID: 194
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 195 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 245
+      Name: '*noalg.map.group[string]float64'
+      ByteSize: 8
+      Pointee: 246 StructureType noalg.map.group[string]float64
+    - __kind: PointerType
+      ID: 236
+      Name: '*noalg.map.group[string]interface {}'
+      ByteSize: 8
+      Pointee: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: PointerType
+      ID: 204
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 205 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -336,7 +449,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.055264e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType runtime.p
+      Pointee: 122 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -373,125 +486,140 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 113
+      ID: 117
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 112 GoStringDataType string.str
+      Pointee: 116 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 131
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.721824e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 145
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.781088e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 127
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.72144e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 128 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 137
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.78032e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 151
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853344e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 139
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780512e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 135
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.780128e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 136 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 147
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.852896e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 148 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 155
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.925024e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 156 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 149
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.85312e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 133
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.722016e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 134 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 129
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.721632e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 130 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 141
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.780704e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 142 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 153
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.853568e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 154 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 143
       Name: '*struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.780896e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 144 StructureType struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 257
+      Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
+      ByteSize: 8
+      Pointee: 261 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: PointerType
+      ID: 172
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 192 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 225
+      Name: '*table<string,float64>'
+      ByteSize: 8
+      Pointee: 243 StructureType table<string,float64>
+    - __kind: PointerType
+      ID: 220
+      Name: '*table<string,interface {}>'
+      ByteSize: 8
+      Pointee: 234 StructureType table<string,interface {}>
+    - __kind: PointerType
+      ID: 191
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 202 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -535,12 +663,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 181
       Name: <-chan struct {}
       GoRuntimeType: 607040
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 272
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -566,10 +694,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 273
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 274
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -585,7 +713,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 209
+      ID: 275
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -702,43 +830,125 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*runtime.p.array
+      Data: 123 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 123
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 269
+      Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 257 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoSliceDataType
+      ID: 198
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 172 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 249
+      Name: '[]*table<string,float64>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 225 PointerType *table<string,float64>
+    - __kind: GoSliceDataType
+      ID: 241
+      Name: '[]*table<string,interface {}>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 8
+      Element: 220 PointerType *table<string,interface {}>
+    - __kind: GoSliceDataType
+      ID: 208
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 191 PointerType *table<string,string>
+    - __kind: GoSliceHeaderType
+      ID: 226
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
+      ByteSize: 24
+      GoRuntimeType: 494624
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 227 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 251 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 251
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
+      DynamicSizeClass: slice
+      ByteSize: 56
+      Element: 228 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+    - __kind: GoSliceHeaderType
+      ID: 229
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
+      ByteSize: 24
+      GoRuntimeType: 494816
+      GoKind: 23
+      RawFields:
+        - Name: array
+          Offset: 0
+          Type: 230 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: cap
+          Offset: 16
+          Type: 7 BaseType int
+      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+    - __kind: GoSliceDataType
+      ID: 259
+      Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
+      DynamicSizeClass: slice
+      ByteSize: 40
+      Element: 231 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+    - __kind: GoSliceDataType
+      ID: 270
+      Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSliceDataType
+      ID: 199
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 195 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 250
+      Name: '[]noalg.map.group[string]float64.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 200
+      Element: 246 StructureType noalg.map.group[string]float64
+    - __kind: GoSliceDataType
+      ID: 242
+      Name: '[]noalg.map.group[string]interface {}.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 264
+      Element: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSliceDataType
+      ID: 209
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 205 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 175
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 501280
@@ -753,9 +963,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 200 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 200
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -776,9 +986,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uint8.array
+      Data: 118 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 118
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -799,9 +1009,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 116 GoSliceDataType []uintptr.array
+      Data: 120 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 120
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -812,6 +1022,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 595008
       GoKind: 1
+    - __kind: StructureType
+      ID: 115
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.63984e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 271 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 271
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 593216
+      GoKind: 3
     - __kind: BaseType
       ID: 98
       Name: complex128
@@ -825,7 +1057,7 @@ Types:
       GoRuntimeType: 594752
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 184
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.302496e+06
@@ -838,7 +1070,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 180
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -873,7 +1105,7 @@ Types:
       GoRuntimeType: 484800
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 174
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 704864
@@ -884,8 +1116,149 @@ Types:
       ByteSize: 8
       GoRuntimeType: 866784
       GoKind: 19
+    - __kind: StructureType
+      ID: 113
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      ByteSize: 288
+      GoRuntimeType: 2.396832e+06
+      GoKind: 25
+      RawFields:
+        - Name: mu
+          Offset: 0
+          Type: 210 StructureType sync.RWMutex
+        - Name: name
+          Offset: 24
+          Type: 9 GoStringHeaderType string
+        - Name: service
+          Offset: 40
+          Type: 9 GoStringHeaderType string
+        - Name: resource
+          Offset: 56
+          Type: 9 GoStringHeaderType string
+        - Name: spanType
+          Offset: 72
+          Type: 9 GoStringHeaderType string
+        - Name: start
+          Offset: 88
+          Type: 13 BaseType int64
+        - Name: duration
+          Offset: 96
+          Type: 13 BaseType int64
+        - Name: meta
+          Offset: 104
+          Type: 187 GoMapType map[string]string
+        - Name: metaStruct
+          Offset: 112
+          Type: 216 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+        - Name: metrics
+          Offset: 120
+          Type: 221 GoMapType map[string]float64
+        - Name: spanID
+          Offset: 128
+          Type: 8 BaseType uint64
+        - Name: traceID
+          Offset: 136
+          Type: 8 BaseType uint64
+        - Name: parentID
+          Offset: 144
+          Type: 8 BaseType uint64
+        - Name: error
+          Offset: 152
+          Type: 12 BaseType int32
+        - Name: spanLinks
+          Offset: 160
+          Type: 226 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+        - Name: spanEvents
+          Offset: 184
+          Type: 229 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+        - Name: goExecTraced
+          Offset: 208
+          Type: 4 BaseType bool
+        - Name: noDebugStack
+          Offset: 209
+          Type: 4 BaseType bool
+        - Name: finished
+          Offset: 210
+          Type: 4 BaseType bool
+        - Name: context
+          Offset: 216
+          Type: 232 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+        - Name: integration
+          Offset: 224
+          Type: 9 GoStringHeaderType string
+        - Name: supportsEvents
+          Offset: 240
+          Type: 4 BaseType bool
+        - Name: pprofCtxActive
+          Offset: 248
+          Type: 184 GoInterfaceType context.Context
+        - Name: pprofCtxRestore
+          Offset: 264
+          Type: 184 GoInterfaceType context.Context
+        - Name: taskEnd
+          Offset: 280
+          Type: 59 GoSubroutineType func()
+    - __kind: UnresolvedPointeeType
+      ID: 233
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      ByteSize: 8
+    - __kind: StructureType
+      ID: 228
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      ByteSize: 56
+      GoRuntimeType: 1.954848e+06
+      GoKind: 25
+      RawFields:
+        - Name: TraceID
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: TraceIDHigh
+          Offset: 8
+          Type: 8 BaseType uint64
+        - Name: SpanID
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 187 GoMapType map[string]string
+        - Name: Tracestate
+          Offset: 32
+          Type: 9 GoStringHeaderType string
+        - Name: Flags
+          Offset: 48
+          Type: 2 BaseType uint32
+    - __kind: GoMapType
+      ID: 216
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+      ByteSize: 8
+      GoRuntimeType: 1.303776e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: StructureType
+      ID: 231
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      ByteSize: 40
+      GoRuntimeType: 1.78912e+06
+      GoKind: 25
+      RawFields:
+        - Name: Name
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: TimeUnixNano
+          Offset: 16
+          Type: 8 BaseType uint64
+        - Name: Attributes
+          Offset: 24
+          Type: 253 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: RawAttributes
+          Offset: 32
+          Type: 258 GoMapType map[string]interface {}
+    - __kind: UnresolvedPointeeType
+      ID: 268
+      Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 157
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.44432e+06
@@ -898,37 +1271,79 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 126
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.responseWriter
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 262
+      Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 263 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 270 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+    - __kind: GoSwissMapGroupsType
+      ID: 193
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 194 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 195 StructureType noalg.map.group[string][]string
+      GroupSliceType: 199 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 244
+      Name: groupReference<string,float64>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 245 PointerType *noalg.map.group[string]float64
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 246 StructureType noalg.map.group[string]float64
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[string]float64.array
+    - __kind: GoSwissMapGroupsType
+      ID: 235
+      Name: groupReference<string,interface {}>
+      ByteSize: 16
+      GoKind: 25
+      RawFields:
+        - Name: data
+          Offset: 0
+          Type: 236 PointerType *noalg.map.group[string]interface {}
+        - Name: lengthMask
+          Offset: 8
+          Type: 8 BaseType uint64
+      GroupType: 237 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string]interface {}.array
+    - __kind: GoSwissMapGroupsType
+      ID: 203
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 204 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 205 StructureType noalg.map.group[string]string
+      GroupSliceType: 209 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -959,6 +1374,19 @@ Types:
       ByteSize: 1
       GoRuntimeType: 594048
       GoKind: 3
+    - __kind: GoEmptyInterfaceType
+      ID: 240
+      Name: interface {}
+      ByteSize: 16
+      GoRuntimeType: 866496
+      GoKind: 20
+      RawFields:
+        - Name: _type
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
@@ -1058,8 +1486,21 @@ Types:
       GoRuntimeType: 1.011584e+06
       GoKind: 25
       RawFields: []
+    - __kind: StructureType
+      ID: 213
+      Name: internal/sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.517472e+06
+      GoKind: 25
+      RawFields:
+        - Name: state
+          Offset: 0
+          Type: 12 BaseType int32
+        - Name: sema
+          Offset: 4
+          Type: 2 BaseType uint32
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 173
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.134464e+06
@@ -1072,7 +1513,42 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 255
+      Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 256 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 269 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 264 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: GoSwissMapHeaderType
+      ID: 170
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1085,7 +1561,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 171 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1104,10 +1580,80 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 198 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 195 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 223
+      Name: map<string,float64>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 224 PointerType **table<string,float64>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 249 GoSliceDataType []*table<string,float64>.array
+      GroupType: 246 StructureType noalg.map.group[string]float64
+    - __kind: GoSwissMapHeaderType
+      ID: 218
+      Name: map<string,interface {}>
+      ByteSize: 48
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: seed
+          Offset: 8
+          Type: 1 BaseType uintptr
+        - Name: dirPtr
+          Offset: 16
+          Type: 219 PointerType **table<string,interface {}>
+        - Name: dirLen
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: globalDepth
+          Offset: 32
+          Type: 3 BaseType uint8
+        - Name: globalShift
+          Offset: 33
+          Type: 3 BaseType uint8
+        - Name: writing
+          Offset: 34
+          Type: 3 BaseType uint8
+        - Name: tombstonePossible
+          Offset: 35
+          Type: 4 BaseType bool
+        - Name: clearSeq
+          Offset: 40
+          Type: 8 BaseType uint64
+      TablePtrSliceType: 241 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 237 StructureType noalg.map.group[string]interface {}
+    - __kind: GoSwissMapHeaderType
+      ID: 189
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1120,7 +1666,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 190 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1139,21 +1685,42 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 208 GoSliceDataType []*table<string,string>.array
+      GroupType: 205 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 253
+      Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 8
+      GoRuntimeType: 1.157632e+06
+      GoKind: 21
+      HeaderType: 255 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: GoMapType
+      ID: 221
+      Name: map[string]float64
+      ByteSize: 8
+      GoRuntimeType: 1.157504e+06
+      GoKind: 21
+      HeaderType: 223 GoSwissMapHeaderType map<string,float64>
+    - __kind: GoMapType
+      ID: 258
+      Name: map[string]interface {}
+      ByteSize: 8
+      GoRuntimeType: 1.151104e+06
+      GoKind: 21
+      HeaderType: 218 GoSwissMapHeaderType map<string,interface {}>
+    - __kind: GoMapType
+      ID: 187
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.153536e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 189 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 178
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 160
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.049376e+06
@@ -1166,7 +1733,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 158
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.04784e+06
@@ -1179,14 +1746,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 168
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.154272e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 161
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.047968e+06
@@ -1199,7 +1766,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 159
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.048224e+06
@@ -1223,7 +1790,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 166 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1235,19 +1802,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 168 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 173 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 174 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1256,16 +1823,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 176 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 176 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 177 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 168 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1274,30 +1841,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 179 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 181 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 182 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 184 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 185 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 187 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 183
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1314,48 +1881,88 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 163
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 186
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 165
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 167
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 176
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.927712e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 170 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 265
+      Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 192
+      GoRuntimeType: 715104
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 266 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: ArrayType
+      ID: 196
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 700896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 197 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 247
+      Name: noalg.[8]struct { key string; elem float64 }
+      ByteSize: 192
+      GoRuntimeType: 715008
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 248 StructureType noalg.struct { key string; elem float64 }
+    - __kind: ArrayType
+      ID: 238
+      Name: noalg.[8]struct { key string; elem interface {} }
+      ByteSize: 256
+      GoRuntimeType: 692352
+      GoKind: 17
+      Count: 8
+      HasCount: true
+      Element: 239 StructureType noalg.struct { key string; elem interface {} }
+    - __kind: ArrayType
+      ID: 206
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 705056
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 207 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 264
+      Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      ByteSize: 200
+      GoRuntimeType: 1.331296e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 265 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+    - __kind: StructureType
+      ID: 195
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.315936e+06
@@ -1366,9 +1973,35 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 196 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 246
+      Name: noalg.map.group[string]float64
+      ByteSize: 200
+      GoRuntimeType: 1.33104e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 247 ArrayType noalg.[8]struct { key string; elem float64 }
+    - __kind: StructureType
+      ID: 237
+      Name: noalg.map.group[string]interface {}
+      ByteSize: 264
+      GoRuntimeType: 1.313376e+06
+      GoKind: 25
+      RawFields:
+        - Name: ctrl
+          Offset: 0
+          Type: 8 BaseType uint64
+        - Name: slots
+          Offset: 8
+          Type: 238 ArrayType noalg.[8]struct { key string; elem interface {} }
+    - __kind: StructureType
+      ID: 205
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.318368e+06
@@ -1379,9 +2012,22 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 206 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 266
+      Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      ByteSize: 24
+      GoRuntimeType: 1.331168e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 267 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+    - __kind: StructureType
+      ID: 197
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.315808e+06
@@ -1392,9 +2038,35 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 175 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 248
+      Name: noalg.struct { key string; elem float64 }
+      ByteSize: 24
+      GoRuntimeType: 1.330912e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 16 BaseType float64
+    - __kind: StructureType
+      ID: 239
+      Name: noalg.struct { key string; elem interface {} }
+      ByteSize: 32
+      GoRuntimeType: 1.313248e+06
+      GoKind: 25
+      RawFields:
+        - Name: key
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: elem
+          Offset: 16
+          Type: 240 GoEmptyInterfaceType interface {}
+    - __kind: StructureType
+      ID: 207
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.31824e+06
@@ -2051,7 +2723,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 122
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2176,18 +2848,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 113 PointerType *string.str
+          Type: 117 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 112 GoStringDataType string.str
+      Data: 116 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 112
+      ID: 116
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 132
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.990688e+06
@@ -2195,12 +2867,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 146
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066816e+06
@@ -2208,15 +2880,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 128
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.990176e+06
@@ -2224,12 +2896,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 138
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.065664e+06
@@ -2237,15 +2909,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 152
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136544e+06
@@ -2253,18 +2925,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 140
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.065952e+06
@@ -2272,15 +2944,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 136
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.065376e+06
@@ -2288,15 +2960,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 148
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.135904e+06
@@ -2304,18 +2976,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 156
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.198528e+06
@@ -2323,21 +2995,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 150
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136224e+06
@@ -2345,18 +3017,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 158 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 134
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.990944e+06
@@ -2364,12 +3036,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 130
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.990432e+06
@@ -2377,12 +3049,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 142
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.06624e+06
@@ -2390,15 +3062,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 154
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.136864e+06
@@ -2406,18 +3078,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 160 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 144
       Name: struct { github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter = github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.066528e+06
@@ -2425,15 +3097,99 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
+          Type: 157 GoInterfaceType github.com/DataDog/dd-trace-go/v2/instrumentation/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 159 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 161 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 211
+      Name: sync.Mutex
+      ByteSize: 8
+      GoRuntimeType: 1.493632e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 212 StructureType sync.noCopy
+        - Name: mu
+          Offset: 0
+          Type: 213 StructureType internal/sync.Mutex
+    - __kind: StructureType
+      ID: 210
+      Name: sync.RWMutex
+      ByteSize: 24
+      GoRuntimeType: 1.880896e+06
+      GoKind: 25
+      RawFields:
+        - Name: w
+          Offset: 0
+          Type: 211 StructureType sync.Mutex
+        - Name: writerSem
+          Offset: 8
+          Type: 2 BaseType uint32
+        - Name: readerSem
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: readerCount
+          Offset: 16
+          Type: 214 StructureType sync/atomic.Int32
+        - Name: readerWait
+          Offset: 20
+          Type: 214 StructureType sync/atomic.Int32
+    - __kind: StructureType
+      ID: 212
+      Name: sync.noCopy
+      GoRuntimeType: 1.006688e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 214
+      Name: sync/atomic.Int32
+      ByteSize: 4
+      GoRuntimeType: 1.494912e+06
+      GoKind: 25
+      RawFields:
+        - Name: _
+          Offset: 0
+          Type: 215 StructureType sync/atomic.noCopy
+        - Name: v
+          Offset: 0
+          Type: 12 BaseType int32
+    - __kind: StructureType
+      ID: 215
+      Name: sync/atomic.noCopy
+      GoRuntimeType: 1.006784e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: StructureType
+      ID: 261
+      Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 262 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+    - __kind: StructureType
+      ID: 192
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2455,9 +3211,57 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 193 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 243
+      Name: table<string,float64>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 244 GoSwissMapGroupsType groupReference<string,float64>
+    - __kind: StructureType
+      ID: 234
+      Name: table<string,interface {}>
+      ByteSize: 32
+      GoKind: 25
+      RawFields:
+        - Name: used
+          Offset: 0
+          Type: 6 BaseType uint16
+        - Name: capacity
+          Offset: 2
+          Type: 6 BaseType uint16
+        - Name: growthLeft
+          Offset: 4
+          Type: 6 BaseType uint16
+        - Name: localDepth
+          Offset: 6
+          Type: 3 BaseType uint8
+        - Name: index
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: groups
+          Offset: 16
+          Type: 235 GoSwissMapGroupsType groupReference<string,interface {}>
+    - __kind: StructureType
+      ID: 202
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2479,7 +3283,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 203 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2522,7 +3326,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 595072
       GoKind: 26
-MaxTypeID: 209
+MaxTypeID: 275
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x139d860", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd28c4b"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd28dfd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 188 EventRootType Probe[main.HandleHTTP]
+          Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 189 EventRootType Probe[main.HandleHTTP]Return
+          Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd28c4b"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 190 EventRootType Probe[main.LookAtTheRequest]
+          Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd28dfd", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,38 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 105 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd28b8f..0xd28bb1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd28bb1..0xd28c90
+              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0xd28a68..0xd28a68
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd28a68..0xd28aa8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd28aa8..0xd28aac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd28d60..0xd28e25]
@@ -107,20 +139,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 185
+      ID: 188
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 187 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 108
+      ID: 111
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 110 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 110
+      ID: 113
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 109 GoSliceDataType []uintptr.array
+      Pointee: 112 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -129,22 +161,29 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 160
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,[]string>
+      Pointee: 161 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 179 GoHMapBucketType bucket<string,string>
+      Pointee: 182 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 167
+      ID: 105
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.114976e+06
+      GoKind: 22
+      Pointee: 106 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -167,22 +206,43 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.361664e+06
       GoKind: 22
-      Pointee: 112 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 115 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 155
+      ID: 192
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.59648e+06
+      GoKind: 22
+      Pointee: 193 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 194
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.705376e+06
+      GoKind: 22
+      Pointee: 195 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 196
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.158432e+06
+      GoKind: 22
+      Pointee: 197 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+    - __kind: PointerType
+      ID: 158
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,[]string>
+      Pointee: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 176
+      ID: 179
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 177 GoHMapHeaderType hash<string,string>
+      Pointee: 180 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -219,12 +279,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -233,40 +293,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 170
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 148
+      ID: 151
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.832832e+06
       GoKind: 22
-      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 152 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 150
+      ID: 153
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059008e+06
       GoKind: 22
-      Pointee: 151 UnresolvedPointeeType net/http.response
+      Pointee: 154 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 152
+      ID: 155
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 153 UnresolvedPointeeType net/url.URL
+      Pointee: 156 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -310,12 +370,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 159
+      ID: 162
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType runtime.mapextra
+      Pointee: 163 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -345,115 +405,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 106
+      ID: 109
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 105 GoStringDataType string.str
+      Pointee: 108 GoStringDataType string.str
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.495904e+06
       GoKind: 22
-      Pointee: 118 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.61568e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.49552e+06
       GoKind: 22
-      Pointee: 114 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 117 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.614912e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684896e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615104e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.61472e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684448e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.750176e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.684672e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496096e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.495712e+06
       GoKind: 22
-      Pointee: 116 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615296e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68512e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615488e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -497,12 +557,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 169
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -528,10 +588,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -547,7 +607,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 85
@@ -640,7 +700,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
@@ -649,19 +709,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 186
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 158 GoHMapBucketType bucket<string,[]string>
+      Element: 161 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 190
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 179 GoHMapBucketType bucket<string,string>
+      Element: 182 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 181
+      ID: 184
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -672,7 +732,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -687,9 +747,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 187 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 187
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -710,9 +770,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
+      Data: 110 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 110
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -733,22 +793,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 109 GoSliceDataType []uintptr.array
+      Data: 112 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 112
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 182
+      ID: 185
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 163 GoSliceHeaderType []string
+      Element: 166 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 186
+      ID: 189
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -761,43 +821,65 @@ Types:
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 161
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 184 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 182 ArrayType []val<[]string>
+          Type: 185 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 163 GoSliceHeaderType []string
+      ValueType: 166 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 179
+      ID: 182
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 184 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<string>
+          Type: 189 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 106
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.41392e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 191 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 191
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532800
+      GoKind: 3
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -811,7 +893,7 @@ Types:
       GoRuntimeType: 534336
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
@@ -824,7 +906,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 168
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -859,7 +941,7 @@ Types:
       GoRuntimeType: 451168
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 162
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
@@ -871,7 +953,7 @@ Types:
       GoRuntimeType: 785664
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 146
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.235648e+06
@@ -884,11 +966,38 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 112
+      ID: 115
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 107
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.295936e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 193
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.691968e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 195
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 197
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 159
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -909,20 +1018,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+          Type: 162 PointerType *runtime.mapextra
+      BucketType: 161 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 186 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 177
+      ID: 180
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -943,18 +1052,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 179 GoHMapBucketType bucket<string,string>
-      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
+          Type: 162 PointerType *runtime.mapextra
+      BucketType: 182 GoHMapBucketType bucket<string,string>
+      BucketsType: 190 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1085,7 +1194,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
@@ -1098,18 +1207,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 175
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 177 GoHMapHeaderType hash<string,string>
+      HeaderType: 180 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 149
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983104
@@ -1122,7 +1231,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 144
+      ID: 147
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981696
@@ -1135,14 +1244,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 154
+      ID: 157
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 150
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 981824
@@ -1155,7 +1264,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 148
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982080
@@ -1179,7 +1288,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 152 PointerType *net/url.URL
+          Type: 155 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1191,19 +1300,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 154 GoMapType net/http.Header
+          Type: 157 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 161 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 163 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1212,16 +1321,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 164 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 164 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 165 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 154 GoMapType net/http.Header
+          Type: 157 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1230,30 +1339,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 167 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 169 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 170 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 172 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 173 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 163 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 175 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1270,28 +1379,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 149
+      ID: 152
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 151
+      ID: 154
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 153
+      ID: 156
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1887,7 +1996,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 163
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2021,18 +2130,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 106 PointerType *string.str
+          Type: 109 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 105 GoStringDataType string.str
+      Data: 108 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 105
+      ID: 108
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 118
+      ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810144e+06
@@ -2040,12 +2149,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 132
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885248e+06
@@ -2053,15 +2162,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 117
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.809632e+06
@@ -2069,12 +2178,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 124
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884096e+06
@@ -2082,15 +2191,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.9472e+06
@@ -2098,18 +2207,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884384e+06
@@ -2117,15 +2226,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.883808e+06
@@ -2133,15 +2242,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.94656e+06
@@ -2149,18 +2258,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005088e+06
@@ -2168,21 +2277,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94688e+06
@@ -2190,18 +2299,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.8104e+06
@@ -2209,12 +2318,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 116
+      ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.809888e+06
@@ -2222,12 +2331,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 128
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.884672e+06
@@ -2235,15 +2344,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.94752e+06
@@ -2251,18 +2360,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.88496e+06
@@ -2270,13 +2379,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 15
       Name: uint
@@ -2319,7 +2428,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
-MaxTypeID: 191
+MaxTypeID: 201
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd28c4b"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd28dfd", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 189 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 190 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd28dfd", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xcfc8ab"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xcfca5d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 202 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 203 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xcfca5d", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 201 EventRootType Probe[main.HandleHTTP]
+          Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 202 EventRootType Probe[main.HandleHTTP]Return
+          Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xcfc8ab"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 203 EventRootType Probe[main.LookAtTheRequest]
+          Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xcfca5d", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,38 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 110 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xcfc7ee..0xcfc809
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcfc809..0xcfc8f0
+              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0xcfc6c8..0xcfc6c8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xcfc6c8..0xcfc708
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcfc708..0xcfc70c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xcfc9c0..0xcfca85]
@@ -100,15 +132,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 162
+      ID: 165
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,[]string>
+      Pointee: 166 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,string>
+      Pointee: 185 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -117,20 +149,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 192
+      ID: 195
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []string.array
+      Pointee: 194 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 115 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 117 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -139,12 +171,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 170
+      ID: 110
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.245824e+06
+      GoKind: 22
+      Pointee: 111 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 173
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 174 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -167,12 +206,33 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 119
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.539904e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 120 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 205
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.710848e+06
+      GoKind: 22
+      Pointee: 206 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 207
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.822688e+06
+      GoKind: 22
+      Pointee: 208 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 209
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.289216e+06
+      GoKind: 22
+      Pointee: 210 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -209,22 +269,22 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 182
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,string>
+      Pointee: 183 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 172 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -233,50 +293,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.Response
+      Pointee: 177 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 156
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.99632e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 157 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 176
+      ID: 179
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.pattern
+      Pointee: 180 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189984e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 159 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 160
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 161 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 185
+      ID: 188
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[string][]string
+      Pointee: 189 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 195
+      ID: 198
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]string
+      Pointee: 199 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -355,125 +415,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 113 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.677056e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.729472e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676672e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728704e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.800096e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728896e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.728512e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799648e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.869504e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799872e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.677248e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.676864e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.729088e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.80032e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.72928e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 163
+      ID: 166
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 183 StructureType table<string,[]string>
+      Pointee: 186 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 185
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 193 StructureType table<string,string>
+      Pointee: 196 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -517,12 +577,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 172
+      ID: 175
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -548,10 +608,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -567,7 +627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -676,35 +736,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 192
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,[]string>
+      Element: 166 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 202
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,string>
+      Element: 185 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 193
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 186 StructureType noalg.map.group[string][]string
+      Element: 189 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 203
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 196 StructureType noalg.map.group[string]string
+      Element: 199 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 169
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -719,9 +779,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []string.array
+      Data: 194 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 194
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -742,9 +802,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 115 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 115
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -765,9 +825,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 117 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 117
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -778,6 +838,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
+    - __kind: StructureType
+      ID: 111
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.595648e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 204 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 204
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 578816
+      GoKind: 3
     - __kind: BaseType
       ID: 95
       Name: complex128
@@ -791,7 +873,7 @@ Types:
       GoRuntimeType: 580416
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 175
+      ID: 178
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
@@ -804,7 +886,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 174
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -839,7 +921,7 @@ Types:
       GoRuntimeType: 476896
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 165
+      ID: 168
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
@@ -851,7 +933,7 @@ Types:
       GoRuntimeType: 849568
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -864,37 +946,64 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 120
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 112
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.469568e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 206
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.809056e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 208
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 210
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 187
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[string][]string
+          Type: 188 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[string][]string
-      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 189 StructureType noalg.map.group[string][]string
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 197
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]string
+          Type: 198 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]string
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 199 StructureType noalg.map.group[string]string
+      GroupSliceType: 203 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1025,7 +1134,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 167
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
@@ -1038,7 +1147,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 164
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1051,7 +1160,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,[]string>
+          Type: 165 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1067,10 +1176,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 186 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 192 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 189 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 183
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1083,7 +1192,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,string>
+          Type: 184 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1099,21 +1208,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
-      GroupType: 196 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 202 GoSliceDataType []*table<string,string>.array
+      GroupType: 199 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 178
+      ID: 181
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,string>
+      HeaderType: 183 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 169
+      ID: 172
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 154
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.019104e+06
@@ -1126,7 +1235,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 152
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.017696e+06
@@ -1139,14 +1248,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 162
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 155
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.017824e+06
@@ -1159,7 +1268,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 153
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.01808e+06
@@ -1183,7 +1292,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 160 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1195,19 +1304,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 162 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 164 GoInterfaceType io.ReadCloser
+          Type: 167 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 168 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1216,16 +1325,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 167 GoMapType net/url.Values
+          Type: 170 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 167 GoMapType net/url.Values
+          Type: 170 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 168 PointerType *mime/multipart.Form
+          Type: 171 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 162 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1234,30 +1343,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 170 PointerType *crypto/tls.ConnectionState
+          Type: 173 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 172 GoChannelType <-chan struct {}
+          Type: 175 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 173 PointerType *net/http.Response
+          Type: 176 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 175 GoInterfaceType context.Context
+          Type: 178 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 176 PointerType *net/http.pattern
+          Type: 179 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 178 GoMapType map[string]string
+          Type: 181 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1274,48 +1383,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 157
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 180
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 159
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 161
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 167
+      ID: 170
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 187
+      ID: 190
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key string; elem []string }
+      Element: 191 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 197
+      ID: 200
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem string }
+      Element: 201 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 186
+      ID: 189
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -1326,9 +1435,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 190 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 196
+      ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -1339,9 +1448,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 188
+      ID: 191
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -1352,9 +1461,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 198
+      ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2129,18 +2238,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 114 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 113 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 113
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.9328e+06
@@ -2148,12 +2257,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010432e+06
@@ -2161,15 +2270,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -2177,12 +2286,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.00928e+06
@@ -2190,15 +2299,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071712e+06
@@ -2206,18 +2315,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009568e+06
@@ -2225,15 +2334,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008992e+06
@@ -2241,15 +2350,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.071072e+06
@@ -2257,18 +2366,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.131456e+06
@@ -2276,21 +2385,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071392e+06
@@ -2298,18 +2407,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.933056e+06
@@ -2317,12 +2426,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.932544e+06
@@ -2330,12 +2439,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009856e+06
@@ -2343,15 +2452,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.072032e+06
@@ -2359,18 +2468,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.010144e+06
@@ -2378,15 +2487,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 183
+      ID: 186
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2408,9 +2517,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 187 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 193
+      ID: 196
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2432,7 +2541,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,string>
+          Type: 197 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -2475,7 +2584,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 214
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xcfc8ab"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xcfca5d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 207 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 208 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd0527d", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd050cb"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd0527d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd050cb"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd0527d", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd04e73", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 207 EventRootType Probe[main.HandleHTTP]Return
+          Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0xd050cb"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd051ee", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0xd0527d", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,38 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 112 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0xd0500e..0xd05029
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd05029..0xd05110
+              Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0xd04ee8..0xd04ee8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0xd04ee8..0xd04f28
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04f28..0xd04f2c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd051e0..0xd052a5]
@@ -106,20 +138,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 167
+      ID: 170
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 171 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 189
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 190 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*runtime.p.array
+      Pointee: 122 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +160,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 200
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 199 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uint8.array
+      Pointee: 117 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []uintptr.array
+      Pointee: 119 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,12 +182,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 112
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.260704e+06
+      GoKind: 22
+      Pointee: 113 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 178
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 179 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -178,12 +217,33 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 124
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.550528e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 210
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.723616e+06
+      GoKind: 22
+      Pointee: 211 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 212
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.837664e+06
+      GoKind: 22
+      Pointee: 213 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 214
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.304608e+06
+      GoKind: 22
+      Pointee: 215 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -220,22 +280,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 187
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 188 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 177 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -244,50 +304,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718816e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 182 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 161
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.010368e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608608e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 185 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.218272e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 164 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 165
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.1136e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 166 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 193
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 194 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 203
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 204 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -336,7 +396,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.03344e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType runtime.p
+      Pointee: 121 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -373,125 +433,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 112 GoStringDataType string.str
+      Pointee: 115 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.68848e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74224e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.688096e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741472e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814048e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741664e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.74128e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.8136e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882912e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813824e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688672e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.688288e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741856e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.814272e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.742048e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 191 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 190
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 201 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -535,12 +595,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 180
       Name: <-chan struct {}
       GoRuntimeType: 597696
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -566,10 +626,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 218
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -585,7 +645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 209
+      ID: 219
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -702,43 +762,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*runtime.p.array
+      Data: 122 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 122
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 197
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 171 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 207
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 190 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 198
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 194 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 208
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 204 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 174
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496448
@@ -753,9 +813,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 199 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 199
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -776,9 +836,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uint8.array
+      Data: 117 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 117
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -799,9 +859,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 116 GoSliceDataType []uintptr.array
+      Data: 119 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 119
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -812,6 +872,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585472
       GoKind: 1
+    - __kind: StructureType
+      ID: 113
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.606304e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 209 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 209
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 583680
+      GoKind: 3
     - __kind: BaseType
       ID: 97
       Name: complex128
@@ -825,7 +907,7 @@ Types:
       GoRuntimeType: 585216
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 183
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276992e+06
@@ -838,7 +920,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 179
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -873,7 +955,7 @@ Types:
       GoRuntimeType: 480064
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 173
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693344
@@ -885,7 +967,7 @@ Types:
       GoRuntimeType: 855136
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417952e+06
@@ -898,37 +980,64 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 125
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.479712e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 211
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.823808e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 213
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 215
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 192
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 193 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 194 StructureType noalg.map.group[string][]string
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 202
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 203 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 204 StructureType noalg.map.group[string]string
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1059,7 +1168,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 172
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.110464e+06
@@ -1072,7 +1181,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 169
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1085,7 +1194,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 170 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1104,10 +1213,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 194 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 188
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1120,7 +1229,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 189 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1139,21 +1248,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
+      GroupType: 204 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 186
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.129024e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 188 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 159
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.027552e+06
@@ -1166,7 +1275,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 157
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.026016e+06
@@ -1179,14 +1288,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.101632e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 160
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.026144e+06
@@ -1199,7 +1308,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 158
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.0264e+06
@@ -1223,7 +1332,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 165 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1235,19 +1344,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 167 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 172 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 173 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 12 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1256,16 +1365,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 175 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 175 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 176 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 167 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1274,30 +1383,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 178 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 180 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 181 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 183 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 184 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 186 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 182
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1314,48 +1423,48 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 162
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 185
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 164
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 166
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 175
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.885152e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 195
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 196 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 205
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 206 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 194
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.290432e+06
@@ -1366,9 +1475,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.292864e+06
@@ -1379,9 +1488,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 196
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.290304e+06
@@ -1392,9 +1501,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292736e+06
@@ -2051,7 +2160,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 121
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2176,18 +2285,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 113 PointerType *string.str
+          Type: 116 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 112 GoStringDataType string.str
+      Data: 115 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 112
+      ID: 115
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.947456e+06
@@ -2195,12 +2304,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023616e+06
@@ -2208,15 +2317,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -2224,12 +2333,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022464e+06
@@ -2237,15 +2346,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085568e+06
@@ -2253,18 +2362,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022752e+06
@@ -2272,15 +2381,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.022176e+06
@@ -2288,15 +2397,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.084928e+06
@@ -2304,18 +2413,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.1464e+06
@@ -2323,21 +2432,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085248e+06
@@ -2345,18 +2454,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.947712e+06
@@ -2364,12 +2473,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.9472e+06
@@ -2377,12 +2486,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.02304e+06
@@ -2390,15 +2499,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.085888e+06
@@ -2406,18 +2515,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.023328e+06
@@ -2425,15 +2534,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 191
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2455,9 +2564,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 192 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 201
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2479,7 +2588,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 202 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -2522,7 +2631,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585536
       GoKind: 26
-MaxTypeID: 209
+MaxTypeID: 219
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x182c9a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 188 EventRootType Probe[main.HandleHTTP]
+          Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad880", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 189 EventRootType Probe[main.HandleHTTP]Return
+          Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8ada5c"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 190 EventRootType Probe[main.LookAtTheRequest]
+          Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adba8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8adc1c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,38 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 105 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x8ad9b4..0x8ad9d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8ad9d0..0x8adab0
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0x8ad8d8..0x8ad8d8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x8ad8d8..0x8ad910
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8ad910..0x8ad914
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8adb90..0x8adc50]
@@ -107,20 +139,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 185
+      ID: 188
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 187 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 108
+      ID: 111
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 107 GoSliceDataType []uint8.array
+      Pointee: 110 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 110
+      ID: 113
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 109 GoSliceDataType []uintptr.array
+      Pointee: 112 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -129,22 +161,29 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 157
+      ID: 160
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 158 GoHMapBucketType bucket<string,[]string>
+      Pointee: 161 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 179 GoHMapBucketType bucket<string,string>
+      Pointee: 182 GoHMapBucketType bucket<string,string>
     - __kind: PointerType
-      ID: 167
+      ID: 105
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.11552e+06
+      GoKind: 22
+      Pointee: 106 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 170
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 168 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -167,22 +206,43 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.362016e+06
       GoKind: 22
-      Pointee: 112 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 115 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
     - __kind: PointerType
-      ID: 155
+      ID: 192
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.597024e+06
+      GoKind: 22
+      Pointee: 193 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 194
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.70592e+06
+      GoKind: 22
+      Pointee: 195 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 196
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.158976e+06
+      GoKind: 22
+      Pointee: 197 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+    - __kind: PointerType
+      ID: 158
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 156 GoHMapHeaderType hash<string,[]string>
+      Pointee: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 176
+      ID: 179
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 177 GoHMapHeaderType hash<string,string>
+      Pointee: 180 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -219,12 +279,12 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 166 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 103
       Name: '*net/http.Request'
@@ -233,40 +293,40 @@ Types:
       GoKind: 22
       Pointee: 104 StructureType net/http.Request
     - __kind: PointerType
-      ID: 170
+      ID: 173
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType net/http.Response
+      Pointee: 174 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 148
+      ID: 151
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.833376e+06
       GoKind: 22
-      Pointee: 149 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 152 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.pattern
+      Pointee: 177 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 150
+      ID: 153
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.059552e+06
       GoKind: 22
-      Pointee: 151 UnresolvedPointeeType net/http.response
+      Pointee: 154 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 152
+      ID: 155
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 153 UnresolvedPointeeType net/url.URL
+      Pointee: 156 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -310,12 +370,12 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 159
+      ID: 162
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 160 UnresolvedPointeeType runtime.mapextra
+      Pointee: 163 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -345,115 +405,115 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 106
+      ID: 109
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 105 GoStringDataType string.str
+      Pointee: 108 GoStringDataType string.str
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.496256e+06
       GoKind: 22
-      Pointee: 118 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616224e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.495872e+06
       GoKind: 22
-      Pointee: 114 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 117 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.615456e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.68544e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.615648e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 121
+      ID: 124
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.615264e+06
       GoKind: 22
-      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.684992e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.75072e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685216e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 119
+      ID: 122
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.496448e+06
       GoKind: 22
-      Pointee: 120 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.496064e+06
       GoKind: 22
-      Pointee: 116 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.61584e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.685664e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.616032e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -497,12 +557,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 169
+      ID: 172
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: EventRootType
-      ID: 188
+      ID: 198
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -528,10 +588,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 189
+      ID: 199
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 200
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -547,7 +607,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 201
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 85
@@ -640,7 +700,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
@@ -649,19 +709,19 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 186
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 158 GoHMapBucketType bucket<string,[]string>
+      Element: 161 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 190
       Name: '[]bucket<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 272
-      Element: 179 GoHMapBucketType bucket<string,string>
+      Element: 182 GoHMapBucketType bucket<string,string>
     - __kind: ArrayType
-      ID: 181
+      ID: 184
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
@@ -672,7 +732,7 @@ Types:
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 163
+      ID: 166
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -687,9 +747,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 187 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 187
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -710,9 +770,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 107 GoSliceDataType []uint8.array
+      Data: 110 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 107
+      ID: 110
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -733,22 +793,22 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 109 GoSliceDataType []uintptr.array
+      Data: 112 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 109
+      ID: 112
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 182
+      ID: 185
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 163 GoSliceHeaderType []string
+      Element: 166 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 186
+      ID: 189
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
@@ -761,43 +821,65 @@ Types:
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 158
+      ID: 161
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 184 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 182 ArrayType []val<[]string>
+          Type: 185 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 163 GoSliceHeaderType []string
+      ValueType: 166 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 179
+      ID: 182
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 180 ArrayType [8]uint8
+          Type: 183 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 181 ArrayType []key<string>
+          Type: 184 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 186 ArrayType []val<string>
+          Type: 189 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
       KeyType: 11 GoStringHeaderType string
       ValueType: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 106
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.414272e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 191 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 191
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 532992
+      GoKind: 3
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -811,7 +893,7 @@ Types:
       GoRuntimeType: 534528
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 172
+      ID: 175
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
@@ -824,7 +906,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 168
+      ID: 171
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -859,7 +941,7 @@ Types:
       GoRuntimeType: 451296
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 162
+      ID: 165
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
@@ -871,7 +953,7 @@ Types:
       GoRuntimeType: 785760
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 143
+      ID: 146
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.23584e+06
@@ -884,11 +966,38 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 112
+      ID: 115
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 107
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.296128e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 193
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.692512e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 195
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 197
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoHMapHeaderType
-      ID: 156
+      ID: 159
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -909,20 +1018,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 157 PointerType *bucket<string,[]string>
+          Type: 160 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 158 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+          Type: 162 PointerType *runtime.mapextra
+      BucketType: 161 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 186 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 177
+      ID: 180
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
@@ -943,18 +1052,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 178 PointerType *bucket<string,string>
+          Type: 181 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 159 PointerType *runtime.mapextra
-      BucketType: 179 GoHMapBucketType bucket<string,string>
-      BucketsType: 187 GoSliceDataType []bucket<string,string>.array
+          Type: 162 PointerType *runtime.mapextra
+      BucketType: 182 GoHMapBucketType bucket<string,string>
+      BucketsType: 190 GoSliceDataType []bucket<string,string>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1085,7 +1194,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 161
+      ID: 164
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
@@ -1098,18 +1207,18 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 175
+      ID: 178
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 177 GoHMapHeaderType hash<string,string>
+      HeaderType: 180 GoHMapHeaderType hash<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 166
+      ID: 169
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 146
+      ID: 149
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 983296
@@ -1122,7 +1231,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 144
+      ID: 147
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 981888
@@ -1135,14 +1244,14 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 154
+      ID: 157
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 150
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 982016
@@ -1155,7 +1264,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 145
+      ID: 148
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 982272
@@ -1179,7 +1288,7 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 152 PointerType *net/url.URL
+          Type: 155 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 11 GoStringHeaderType string
@@ -1191,19 +1300,19 @@ Types:
           Type: 9 BaseType int
         - Name: Header
           Offset: 56
-          Type: 154 GoMapType net/http.Header
+          Type: 157 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 161 GoInterfaceType io.ReadCloser
+          Type: 164 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 162 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 14 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 163 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1212,16 +1321,16 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 164 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 164 GoMapType net/url.Values
+          Type: 167 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 165 PointerType *mime/multipart.Form
+          Type: 168 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 154 GoMapType net/http.Header
+          Type: 157 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 11 GoStringHeaderType string
@@ -1230,30 +1339,30 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 167 PointerType *crypto/tls.ConnectionState
+          Type: 170 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 169 GoChannelType <-chan struct {}
+          Type: 172 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 170 PointerType *net/http.Response
+          Type: 173 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 11 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 172 GoInterfaceType context.Context
+          Type: 175 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 173 PointerType *net/http.pattern
+          Type: 176 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 163 GoSliceHeaderType []string
+          Type: 166 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 175 GoMapType map[string]string
+          Type: 178 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 174
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1270,28 +1379,28 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 149
+      ID: 152
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 151
+      ID: 154
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 153
+      ID: 156
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 156 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 159 GoHMapHeaderType hash<string,[]string>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -1887,7 +1996,7 @@ Types:
           Offset: 24
           Type: 28 PointerType *runtime.m
     - __kind: UnresolvedPointeeType
-      ID: 160
+      ID: 163
       Name: runtime.mapextra
       ByteSize: 8
     - __kind: BaseType
@@ -2021,18 +2130,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 106 PointerType *string.str
+          Type: 109 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 105 GoStringDataType string.str
+      Data: 108 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 105
+      ID: 108
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 118
+      ID: 121
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.810688e+06
@@ -2040,12 +2149,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 132
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885792e+06
@@ -2053,15 +2162,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 114
+      ID: 117
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.810176e+06
@@ -2069,12 +2178,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 124
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.88464e+06
@@ -2082,15 +2191,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 138
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947744e+06
@@ -2098,18 +2207,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.884928e+06
@@ -2117,15 +2226,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 122
+      ID: 125
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 1.884352e+06
@@ -2133,15 +2242,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 134
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 1.947104e+06
@@ -2149,18 +2258,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.005632e+06
@@ -2168,21 +2277,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.947424e+06
@@ -2190,18 +2299,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 144 GoInterfaceType net/http.Flusher
+          Type: 147 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 120
+      ID: 123
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.810944e+06
@@ -2209,12 +2318,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 116
+      ID: 119
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.810432e+06
@@ -2222,12 +2331,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 128
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 1.885216e+06
@@ -2235,15 +2344,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 1.948064e+06
@@ -2251,18 +2360,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 146 GoInterfaceType net/http.CloseNotifier
+          Type: 149 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 1.885504e+06
@@ -2270,13 +2379,13 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 143 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 146 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 145 GoInterfaceType net/http.Pusher
+          Type: 148 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 147 GoInterfaceType net/http.Hijacker
+          Type: 150 GoInterfaceType net/http.Hijacker
     - __kind: BaseType
       ID: 12
       Name: uint
@@ -2319,7 +2428,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
-MaxTypeID: 191
+MaxTypeID: 201
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 188 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad880", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 189 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 190 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adba8", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 191 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8adc1c", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad880", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8ada5c"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adba8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8adc1c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad880", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x8ada5c"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adba8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x8adc1c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 201 EventRootType Probe[main.HandleHTTP]
+          Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c120", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 202 EventRootType Probe[main.HandleHTTP]Return
+          Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x86c2f8"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 203 EventRootType Probe[main.LookAtTheRequest]
+          Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c428", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x86c49c", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,38 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 110 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x86c254..0x86c268
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x86c268..0x86c340
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0x86c178..0x86c178
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x86c178..0x86c1b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x86c1b0..0x86c1b4
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x86c410..0x86c4c0]
@@ -100,15 +132,15 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 162
+      ID: 165
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 163 PointerType *table<string,[]string>
+      Pointee: 166 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 182 PointerType *table<string,string>
+      Pointee: 185 PointerType *table<string,string>
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -117,20 +149,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 192
+      ID: 195
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []string.array
+      Pointee: 194 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 112 GoSliceDataType []uint8.array
+      Pointee: 115 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uintptr.array
+      Pointee: 117 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -139,12 +171,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 170
+      ID: 110
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.245056e+06
+      GoKind: 22
+      Pointee: 111 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 173
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 171 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 174 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -167,12 +206,33 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 116
+      ID: 119
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.53936e+06
       GoKind: 22
-      Pointee: 117 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 120 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 205
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.710304e+06
+      GoKind: 22
+      Pointee: 206 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 207
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.822144e+06
+      GoKind: 22
+      Pointee: 208 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 209
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.288448e+06
+      GoKind: 22
+      Pointee: 210 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -209,22 +269,22 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType int8
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 161 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 179
+      ID: 182
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 180 GoSwissMapHeaderType map<string,string>
+      Pointee: 183 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 169 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 172 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 108
       Name: '*net/http.Request'
@@ -233,50 +293,50 @@ Types:
       GoKind: 22
       Pointee: 109 StructureType net/http.Request
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType net/http.Response
+      Pointee: 177 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 153
+      ID: 156
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.995552e+06
       GoKind: 22
-      Pointee: 154 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 157 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 176
+      ID: 179
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 177 UnresolvedPointeeType net/http.pattern
+      Pointee: 180 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.189216e+06
       GoKind: 22
-      Pointee: 156 UnresolvedPointeeType net/http.response
+      Pointee: 159 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 157
+      ID: 160
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 158 UnresolvedPointeeType net/url.URL
+      Pointee: 161 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 185
+      ID: 188
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 186 StructureType noalg.map.group[string][]string
+      Pointee: 189 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 195
+      ID: 198
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 196 StructureType noalg.map.group[string]string
+      Pointee: 199 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -355,125 +415,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 111
+      ID: 114
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 110 GoStringDataType string.str
+      Pointee: 113 GoStringDataType string.str
     - __kind: PointerType
-      ID: 122
+      ID: 125
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.676512e+06
       GoKind: 22
-      Pointee: 123 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 136
+      ID: 139
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728928e+06
       GoKind: 22
-      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 118
+      ID: 121
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.676128e+06
       GoKind: 22
-      Pointee: 119 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 122 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.72816e+06
       GoKind: 22
-      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799552e+06
       GoKind: 22
-      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728352e+06
       GoKind: 22
-      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 126
+      ID: 129
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.727968e+06
       GoKind: 22
-      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 138
+      ID: 141
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.799104e+06
       GoKind: 22
-      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 146
+      ID: 149
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.868736e+06
       GoKind: 22
-      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799328e+06
       GoKind: 22
-      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 124
+      ID: 127
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.676704e+06
       GoKind: 22
-      Pointee: 125 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.67632e+06
       GoKind: 22
-      Pointee: 121 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 132
+      ID: 135
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.728544e+06
       GoKind: 22
-      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 144
+      ID: 147
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.799776e+06
       GoKind: 22
-      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 134
+      ID: 137
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.728736e+06
       GoKind: 22
-      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 163
+      ID: 166
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 183 StructureType table<string,[]string>
+      Pointee: 186 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 182
+      ID: 185
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 193 StructureType table<string,string>
+      Pointee: 196 StructureType table<string,string>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -517,12 +577,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 172
+      ID: 175
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: EventRootType
-      ID: 201
+      ID: 211
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -548,10 +608,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 212
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 213
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -567,7 +627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 214
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -676,35 +736,35 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 192
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 163 PointerType *table<string,[]string>
+      Element: 166 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 202
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 182 PointerType *table<string,string>
+      Element: 185 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 193
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 186 StructureType noalg.map.group[string][]string
+      Element: 189 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 203
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 196 StructureType noalg.map.group[string]string
+      Element: 199 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 166
+      ID: 169
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -719,9 +779,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 191 GoSliceDataType []string.array
+      Data: 194 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 194
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -742,9 +802,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 112 GoSliceDataType []uint8.array
+      Data: 115 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 112
+      ID: 115
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -765,9 +825,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uintptr.array
+      Data: 117 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 117
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -778,6 +838,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
+    - __kind: StructureType
+      ID: 111
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.595104e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 204 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 204
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 578592
+      GoKind: 3
     - __kind: BaseType
       ID: 96
       Name: complex128
@@ -791,7 +873,7 @@ Types:
       GoRuntimeType: 580192
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 175
+      ID: 178
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
@@ -804,7 +886,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 171
+      ID: 174
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -839,7 +921,7 @@ Types:
       GoRuntimeType: 476736
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 165
+      ID: 168
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
@@ -851,7 +933,7 @@ Types:
       GoRuntimeType: 848960
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 148
+      ID: 151
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.407616e+06
@@ -864,37 +946,64 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 117
+      ID: 120
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 112
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.468864e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 206
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.808512e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 208
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 210
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 184
+      ID: 187
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 185 PointerType *noalg.map.group[string][]string
+          Type: 188 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 186 StructureType noalg.map.group[string][]string
-      GroupSliceType: 190 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 189 StructureType noalg.map.group[string][]string
+      GroupSliceType: 193 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 194
+      ID: 197
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 195 PointerType *noalg.map.group[string]string
+          Type: 198 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 196 StructureType noalg.map.group[string]string
-      GroupSliceType: 200 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 199 StructureType noalg.map.group[string]string
+      GroupSliceType: 203 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1025,7 +1134,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 164
+      ID: 167
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
@@ -1038,7 +1147,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 161
+      ID: 164
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1051,7 +1160,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 162 PointerType **table<string,[]string>
+          Type: 165 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1067,10 +1176,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 189 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 186 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 192 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 189 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 180
+      ID: 183
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1083,7 +1192,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 181 PointerType **table<string,string>
+          Type: 184 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1099,21 +1208,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 199 GoSliceDataType []*table<string,string>.array
-      GroupType: 196 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 202 GoSliceDataType []*table<string,string>.array
+      GroupType: 199 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 178
+      ID: 181
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 180 GoSwissMapHeaderType map<string,string>
+      HeaderType: 183 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 169
+      ID: 172
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 151
+      ID: 154
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.0184e+06
@@ -1126,7 +1235,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 149
+      ID: 152
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.016992e+06
@@ -1139,14 +1248,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 159
+      ID: 162
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 152
+      ID: 155
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.01712e+06
@@ -1159,7 +1268,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 150
+      ID: 153
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.017376e+06
@@ -1183,7 +1292,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 157 PointerType *net/url.URL
+          Type: 160 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1195,19 +1304,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 159 GoMapType net/http.Header
+          Type: 162 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 164 GoInterfaceType io.ReadCloser
+          Type: 167 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 165 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 168 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1216,16 +1325,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 167 GoMapType net/url.Values
+          Type: 170 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 167 GoMapType net/url.Values
+          Type: 170 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 168 PointerType *mime/multipart.Form
+          Type: 171 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 159 GoMapType net/http.Header
+          Type: 162 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1234,30 +1343,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 170 PointerType *crypto/tls.ConnectionState
+          Type: 173 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 172 GoChannelType <-chan struct {}
+          Type: 175 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 173 PointerType *net/http.Response
+          Type: 176 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 175 GoInterfaceType context.Context
+          Type: 178 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 176 PointerType *net/http.pattern
+          Type: 179 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 178 GoMapType map[string]string
+          Type: 181 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1274,48 +1383,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 154
+      ID: 157
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 177
+      ID: 180
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 156
+      ID: 159
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 158
+      ID: 161
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 167
+      ID: 170
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 161 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 164 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 187
+      ID: 190
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 188 StructureType noalg.struct { key string; elem []string }
+      Element: 191 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 197
+      ID: 200
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 198 StructureType noalg.struct { key string; elem string }
+      Element: 201 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 186
+      ID: 189
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -1326,9 +1435,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 187 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 190 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 196
+      ID: 199
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -1339,9 +1448,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 197 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 200 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 188
+      ID: 191
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -1352,9 +1461,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 166 GoSliceHeaderType []string
+          Type: 169 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 198
+      ID: 201
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2129,18 +2238,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 111 PointerType *string.str
+          Type: 114 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 110 GoStringDataType string.str
+      Data: 113 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 110
+      ID: 113
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 123
+      ID: 126
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.932032e+06
@@ -2148,12 +2257,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 137
+      ID: 140
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009664e+06
@@ -2161,15 +2270,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 119
+      ID: 122
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.93152e+06
@@ -2177,12 +2286,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 129
+      ID: 132
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.008512e+06
@@ -2190,15 +2299,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 143
+      ID: 146
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070944e+06
@@ -2206,18 +2315,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 131
+      ID: 134
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.0088e+06
@@ -2225,15 +2334,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 127
+      ID: 130
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.008224e+06
@@ -2241,15 +2350,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 139
+      ID: 142
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.070304e+06
@@ -2257,18 +2366,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 147
+      ID: 150
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.130688e+06
@@ -2276,21 +2385,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 141
+      ID: 144
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.070624e+06
@@ -2298,18 +2407,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 149 GoInterfaceType net/http.Flusher
+          Type: 152 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 125
+      ID: 128
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.932288e+06
@@ -2317,12 +2426,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 121
+      ID: 124
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.931776e+06
@@ -2330,12 +2439,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 133
+      ID: 136
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.009088e+06
@@ -2343,15 +2452,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.071264e+06
@@ -2359,18 +2468,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 151 GoInterfaceType net/http.CloseNotifier
+          Type: 154 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 135
+      ID: 138
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.009376e+06
@@ -2378,15 +2487,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 148 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 151 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 150 GoInterfaceType net/http.Pusher
+          Type: 153 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 152 GoInterfaceType net/http.Hijacker
+          Type: 155 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 183
+      ID: 186
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2408,9 +2517,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 184 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 187 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 193
+      ID: 196
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2432,7 +2541,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 194 GoSwissMapGroupsType groupReference<string,string>
+          Type: 197 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2475,7 +2584,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
-MaxTypeID: 204
+MaxTypeID: 214
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c120", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x86c2f8"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c428", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x86c49c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 201 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c120", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 202 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 203 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c428", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 204 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x86c49c", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 211 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c120", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 212 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x86c2f8"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 213 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c428", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 214 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x86c49c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b110", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 207 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
@@ -34,12 +34,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 208 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b408", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x82b470", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b110", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x82b2d8"
@@ -36,11 +38,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b408", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x82b470", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,12 +12,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 206 EventRootType Probe[main.HandleHTTP]
+          Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b110", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 207 EventRootType Probe[main.HandleHTTP]Return
+          Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x82b2d8"
               Frameless: false
@@ -36,12 +36,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 208 EventRootType Probe[main.LookAtTheRequest]
+          Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b408", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 209 EventRootType Probe[main.LookAtTheRequest]Return
+          Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x82b470", Frameless: false}]
           Condition: null
 Subprograms:
@@ -82,6 +82,32 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           IsParameter: true
           IsReturn: false
+        - Name: '&buf'
+          Type: 112 PointerType *bytes.Buffer
+          Locations:
+            - Range: 0x82b23c..0x82b258
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x82b258..0x82b320
+              Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: span
+          Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Locations:
+            - Range: 0x82b164..0x82b164
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x82b164..0x82b1a4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: false
+          IsReturn: false
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x82b3f0..0x82b490]
@@ -106,20 +132,20 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 167
+      ID: 170
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<string,[]string>
+      Pointee: 171 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 186
+      ID: 189
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 187 PointerType *table<string,string>
+      Pointee: 190 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 119 GoSliceDataType []*runtime.p.array
+      Pointee: 122 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -128,20 +154,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 197
+      ID: 200
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType []string.array
+      Pointee: 199 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 115
+      ID: 118
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 114 GoSliceDataType []uint8.array
+      Pointee: 117 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 117
+      ID: 120
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 116 GoSliceDataType []uintptr.array
+      Pointee: 119 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -150,12 +176,19 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 175
+      ID: 112
+      Name: '*bytes.Buffer'
+      ByteSize: 8
+      GoRuntimeType: 2.259936e+06
+      GoKind: 22
+      Pointee: 113 StructureType bytes.Buffer
+    - __kind: PointerType
+      ID: 178
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 907744
       GoKind: 22
-      Pointee: 176 UnresolvedPointeeType crypto/tls.ConnectionState
+      Pointee: 179 UnresolvedPointeeType crypto/tls.ConnectionState
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -178,12 +211,33 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 121
+      ID: 124
       Name: '*gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter'
       ByteSize: 8
       GoRuntimeType: 1.549984e+06
       GoKind: 22
-      Pointee: 122 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+      Pointee: 125 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
+    - __kind: PointerType
+      ID: 210
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan'
+      ByteSize: 8
+      GoRuntimeType: 1.723072e+06
+      GoKind: 22
+      Pointee: 211 StructureType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+    - __kind: PointerType
+      ID: 212
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent'
+      ByteSize: 8
+      GoRuntimeType: 1.83712e+06
+      GoKind: 22
+      Pointee: 213 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+    - __kind: PointerType
+      ID: 214
+      Name: '*gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span'
+      ByteSize: 8
+      GoRuntimeType: 2.30384e+06
+      GoKind: 22
+      Pointee: 215 UnresolvedPointeeType gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -220,22 +274,22 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType int8
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 184
+      ID: 187
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 185 GoSwissMapHeaderType map<string,string>
+      Pointee: 188 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 909376
       GoKind: 22
-      Pointee: 174 UnresolvedPointeeType mime/multipart.Form
+      Pointee: 177 UnresolvedPointeeType mime/multipart.Form
     - __kind: PointerType
       ID: 110
       Name: '*net/http.Request'
@@ -244,50 +298,50 @@ Types:
       GoKind: 22
       Pointee: 111 StructureType net/http.Request
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.718272e+06
       GoKind: 22
-      Pointee: 179 UnresolvedPointeeType net/http.Response
+      Pointee: 182 UnresolvedPointeeType net/http.Response
     - __kind: PointerType
-      ID: 158
+      ID: 161
       Name: '*net/http.http2responseWriter'
       ByteSize: 8
       GoRuntimeType: 2.0096e+06
       GoKind: 22
-      Pointee: 159 UnresolvedPointeeType net/http.http2responseWriter
+      Pointee: 162 UnresolvedPointeeType net/http.http2responseWriter
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.608064e+06
       GoKind: 22
-      Pointee: 182 UnresolvedPointeeType net/http.pattern
+      Pointee: 185 UnresolvedPointeeType net/http.pattern
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*net/http.response'
       ByteSize: 8
       GoRuntimeType: 2.217504e+06
       GoKind: 22
-      Pointee: 161 UnresolvedPointeeType net/http.response
+      Pointee: 164 UnresolvedPointeeType net/http.response
     - __kind: PointerType
-      ID: 162
+      ID: 165
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.112832e+06
       GoKind: 22
-      Pointee: 163 UnresolvedPointeeType net/url.URL
+      Pointee: 166 UnresolvedPointeeType net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 193
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 191 StructureType noalg.map.group[string][]string
+      Pointee: 194 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 200
+      ID: 203
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 201 StructureType noalg.map.group[string]string
+      Pointee: 204 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -336,7 +390,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.032736e+06
       GoKind: 22
-      Pointee: 118 UnresolvedPointeeType runtime.p
+      Pointee: 121 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -373,125 +427,125 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 113
+      ID: 116
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 112 GoStringDataType string.str
+      Pointee: 115 GoStringDataType string.str
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.687936e+06
       GoKind: 22
-      Pointee: 128 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
+      Pointee: 131 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741696e+06
       GoKind: 22
-      Pointee: 142 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 145 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }'
       ByteSize: 8
       GoRuntimeType: 1.687552e+06
       GoKind: 22
-      Pointee: 124 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
+      Pointee: 127 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.740928e+06
       GoKind: 22
-      Pointee: 134 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
+      Pointee: 137 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813504e+06
       GoKind: 22
-      Pointee: 148 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 151 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.74112e+06
       GoKind: 22
-      Pointee: 136 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
+      Pointee: 139 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.740736e+06
       GoKind: 22
-      Pointee: 132 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
+      Pointee: 135 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
     - __kind: PointerType
-      ID: 143
+      ID: 146
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.813056e+06
       GoKind: 22
-      Pointee: 144 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 147 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 151
+      ID: 154
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.882144e+06
       GoKind: 22
-      Pointee: 152 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 155 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 145
+      ID: 148
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.81328e+06
       GoKind: 22
-      Pointee: 146 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
+      Pointee: 149 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.688128e+06
       GoKind: 22
-      Pointee: 130 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
+      Pointee: 133 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }'
       ByteSize: 8
       GoRuntimeType: 1.687744e+06
       GoKind: 22
-      Pointee: 126 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
+      Pointee: 129 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }'
       ByteSize: 8
       GoRuntimeType: 1.741312e+06
       GoKind: 22
-      Pointee: 138 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
+      Pointee: 141 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
     - __kind: PointerType
-      ID: 149
+      ID: 152
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.813728e+06
       GoKind: 22
-      Pointee: 150 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
+      Pointee: 153 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }'
       ByteSize: 8
       GoRuntimeType: 1.741504e+06
       GoKind: 22
-      Pointee: 140 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
+      Pointee: 143 StructureType struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 188 StructureType table<string,[]string>
+      Pointee: 191 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 187
+      ID: 190
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 198 StructureType table<string,string>
+      Pointee: 201 StructureType table<string,string>
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -535,12 +589,12 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: GoChannelType
-      ID: 177
+      ID: 180
       Name: <-chan struct {}
       GoRuntimeType: 597472
       GoKind: 18
     - __kind: EventRootType
-      ID: 206
+      ID: 216
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -566,10 +620,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 217
       Name: Probe[main.HandleHTTP]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 218
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -585,7 +639,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 209
+      ID: 219
       Name: Probe[main.LookAtTheRequest]Return
     - __kind: ArrayType
       ID: 92
@@ -702,43 +756,43 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 119 GoSliceDataType []*runtime.p.array
+      Data: 122 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 119
+      ID: 122
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 197
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<string,[]string>
+      Element: 171 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 207
       Name: '[]*table<string,string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 187 PointerType *table<string,string>
+      Element: 190 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 198
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 191 StructureType noalg.map.group[string][]string
+      Element: 194 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 208
       Name: '[]noalg.map.group[string]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 264
-      Element: 201 StructureType noalg.map.group[string]string
+      Element: 204 StructureType noalg.map.group[string]string
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 171
+      ID: 174
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 496288
@@ -753,9 +807,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 196 GoSliceDataType []string.array
+      Data: 199 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 199
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -776,9 +830,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 114 GoSliceDataType []uint8.array
+      Data: 117 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 114
+      ID: 117
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -799,9 +853,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 116 GoSliceDataType []uintptr.array
+      Data: 119 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 116
+      ID: 119
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -812,6 +866,28 @@ Types:
       ByteSize: 1
       GoRuntimeType: 585248
       GoKind: 1
+    - __kind: StructureType
+      ID: 113
+      Name: bytes.Buffer
+      ByteSize: 40
+      GoRuntimeType: 1.60576e+06
+      GoKind: 25
+      RawFields:
+        - Name: buf
+          Offset: 0
+          Type: 38 GoSliceHeaderType []uint8
+        - Name: off
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: lastRead
+          Offset: 32
+          Type: 209 BaseType bytes.readOp
+    - __kind: BaseType
+      ID: 209
+      Name: bytes.readOp
+      ByteSize: 1
+      GoRuntimeType: 583456
+      GoKind: 3
     - __kind: BaseType
       ID: 98
       Name: complex128
@@ -825,7 +901,7 @@ Types:
       GoRuntimeType: 584992
       GoKind: 15
     - __kind: GoInterfaceType
-      ID: 180
+      ID: 183
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.276288e+06
@@ -838,7 +914,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 176
+      ID: 179
       Name: crypto/tls.ConnectionState
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -873,7 +949,7 @@ Types:
       GoRuntimeType: 479904
       GoKind: 19
     - __kind: GoSubroutineType
-      ID: 170
+      ID: 173
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 693216
@@ -885,7 +961,7 @@ Types:
       GoRuntimeType: 854528
       GoKind: 19
     - __kind: GoInterfaceType
-      ID: 153
+      ID: 156
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
       ByteSize: 16
       GoRuntimeType: 1.417248e+06
@@ -898,37 +974,64 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 122
+      ID: 125
       Name: gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.responseWriter
       ByteSize: 8
+    - __kind: GoInterfaceType
+      ID: 114
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+      ByteSize: 16
+      GoRuntimeType: 1.479008e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: StructureType
+      ID: 211
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/internal.NoopSpan
+      GoRuntimeType: 1.823264e+06
+      GoKind: 25
+      RawFields: []
+    - __kind: UnresolvedPointeeType
+      ID: 213
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.ciVisibilityEvent
+      ByteSize: 8
+    - __kind: UnresolvedPointeeType
+      ID: 215
+      Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.span
+      ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 189
+      ID: 192
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 190 PointerType *noalg.map.group[string][]string
+          Type: 193 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 191 StructureType noalg.map.group[string][]string
-      GroupSliceType: 195 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 194 StructureType noalg.map.group[string][]string
+      GroupSliceType: 198 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 199
+      ID: 202
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 200 PointerType *noalg.map.group[string]string
+          Type: 203 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 201 StructureType noalg.map.group[string]string
-      GroupSliceType: 205 GoSliceDataType []noalg.map.group[string]string.array
+      GroupType: 204 StructureType noalg.map.group[string]string
+      GroupSliceType: 208 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -1059,7 +1162,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoInterfaceType
-      ID: 169
+      ID: 172
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10976e+06
@@ -1072,7 +1175,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 169
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -1085,7 +1188,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<string,[]string>
+          Type: 170 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1104,10 +1207,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 194 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 191 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 197 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 194 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 185
+      ID: 188
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
@@ -1120,7 +1223,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 186 PointerType **table<string,string>
+          Type: 189 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -1139,21 +1242,21 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 204 GoSliceDataType []*table<string,string>.array
-      GroupType: 201 StructureType noalg.map.group[string]string
+      TablePtrSliceType: 207 GoSliceDataType []*table<string,string>.array
+      GroupType: 204 StructureType noalg.map.group[string]string
     - __kind: GoMapType
-      ID: 183
+      ID: 186
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.12832e+06
       GoKind: 21
-      HeaderType: 185 GoSwissMapHeaderType map<string,string>
+      HeaderType: 188 GoSwissMapHeaderType map<string,string>
     - __kind: UnresolvedPointeeType
-      ID: 174
+      ID: 177
       Name: mime/multipart.Form
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 159
       Name: net/http.CloseNotifier
       ByteSize: 16
       GoRuntimeType: 1.026848e+06
@@ -1166,7 +1269,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 154
+      ID: 157
       Name: net/http.Flusher
       ByteSize: 16
       GoRuntimeType: 1.025312e+06
@@ -1179,14 +1282,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.100864e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoInterfaceType
-      ID: 157
+      ID: 160
       Name: net/http.Hijacker
       ByteSize: 16
       GoRuntimeType: 1.02544e+06
@@ -1199,7 +1302,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 155
+      ID: 158
       Name: net/http.Pusher
       ByteSize: 16
       GoRuntimeType: 1.025696e+06
@@ -1223,7 +1326,7 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 162 PointerType *net/url.URL
+          Type: 165 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
           Type: 9 GoStringHeaderType string
@@ -1235,19 +1338,19 @@ Types:
           Type: 7 BaseType int
         - Name: Header
           Offset: 56
-          Type: 164 GoMapType net/http.Header
+          Type: 167 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 169 GoInterfaceType io.ReadCloser
+          Type: 172 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 170 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 173 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
           Type: 13 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
           Type: 4 BaseType bool
@@ -1256,16 +1359,16 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 172 GoMapType net/url.Values
+          Type: 175 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 172 GoMapType net/url.Values
+          Type: 175 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 173 PointerType *mime/multipart.Form
+          Type: 176 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 164 GoMapType net/http.Header
+          Type: 167 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
           Type: 9 GoStringHeaderType string
@@ -1274,30 +1377,30 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 175 PointerType *crypto/tls.ConnectionState
+          Type: 178 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 177 GoChannelType <-chan struct {}
+          Type: 180 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 178 PointerType *net/http.Response
+          Type: 181 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
           Type: 9 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 180 GoInterfaceType context.Context
+          Type: 183 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 181 PointerType *net/http.pattern
+          Type: 184 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 183 GoMapType map[string]string
+          Type: 186 GoMapType map[string]string
     - __kind: UnresolvedPointeeType
-      ID: 179
+      ID: 182
       Name: net/http.Response
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -1314,48 +1417,48 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 159
+      ID: 162
       Name: net/http.http2responseWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 182
+      ID: 185
       Name: net/http.pattern
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 161
+      ID: 164
       Name: net/http.response
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 163
+      ID: 166
       Name: net/url.URL
       ByteSize: 8
     - __kind: GoMapType
-      ID: 172
+      ID: 175
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.884384e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 169 GoSwissMapHeaderType map<string,[]string>
     - __kind: ArrayType
-      ID: 192
+      ID: 195
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 689248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 193 StructureType noalg.struct { key string; elem []string }
+      Element: 196 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 202
+      ID: 205
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 693408
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 203 StructureType noalg.struct { key string; elem string }
+      Element: 206 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 191
+      ID: 194
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.289728e+06
@@ -1366,9 +1469,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 192 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 195 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 201
+      ID: 204
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.29216e+06
@@ -1379,9 +1482,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 202 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 205 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: StructureType
-      ID: 193
+      ID: 196
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.2896e+06
@@ -1392,9 +1495,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 171 GoSliceHeaderType []string
+          Type: 174 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 203
+      ID: 206
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.292032e+06
@@ -2051,7 +2154,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 118
+      ID: 121
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -2176,18 +2279,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 113 PointerType *string.str
+          Type: 116 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 112 GoStringDataType string.str
+      Data: 115 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 112
+      ID: 115
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 128
+      ID: 131
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier }
       ByteSize: 32
       GoRuntimeType: 1.946688e+06
@@ -2195,12 +2298,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 142
+      ID: 145
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.022848e+06
@@ -2208,15 +2311,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: CloseNotifier
           Offset: 16
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 124
+      ID: 127
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher }
       ByteSize: 32
       GoRuntimeType: 1.946176e+06
@@ -2224,12 +2327,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
     - __kind: StructureType
-      ID: 134
+      ID: 137
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.021696e+06
@@ -2237,15 +2340,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.0848e+06
@@ -2253,18 +2356,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 136
+      ID: 139
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.021984e+06
@@ -2272,15 +2375,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 132
+      ID: 135
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher }
       ByteSize: 48
       GoRuntimeType: 2.021408e+06
@@ -2288,15 +2391,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 144
+      ID: 147
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 64
       GoRuntimeType: 2.08416e+06
@@ -2304,18 +2407,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 152
+      ID: 155
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 80
       GoRuntimeType: 2.145632e+06
@@ -2323,21 +2426,21 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 48
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 64
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 146
+      ID: 149
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Flusher; net/http.Pusher; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08448e+06
@@ -2345,18 +2448,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Flusher
           Offset: 16
-          Type: 154 GoInterfaceType net/http.Flusher
+          Type: 157 GoInterfaceType net/http.Flusher
         - Name: Pusher
           Offset: 32
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 130
+      ID: 133
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Hijacker }
       ByteSize: 32
       GoRuntimeType: 1.946944e+06
@@ -2364,12 +2467,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Hijacker
           Offset: 16
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 126
+      ID: 129
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher }
       ByteSize: 32
       GoRuntimeType: 1.946432e+06
@@ -2377,12 +2480,12 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
     - __kind: StructureType
-      ID: 138
+      ID: 141
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier }
       ByteSize: 48
       GoRuntimeType: 2.022272e+06
@@ -2390,15 +2493,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.CloseNotifier; net/http.Hijacker }
       ByteSize: 64
       GoRuntimeType: 2.08512e+06
@@ -2406,18 +2509,18 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: CloseNotifier
           Offset: 32
-          Type: 156 GoInterfaceType net/http.CloseNotifier
+          Type: 159 GoInterfaceType net/http.CloseNotifier
         - Name: Hijacker
           Offset: 48
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: struct { gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter = gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1; net/http.Pusher; net/http.Hijacker }
       ByteSize: 48
       GoRuntimeType: 2.02256e+06
@@ -2425,15 +2528,15 @@ Types:
       RawFields:
         - Name: monitoredResponseWriter
           Offset: 0
-          Type: 153 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
+          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace.monitoredResponseWriter·1
         - Name: Pusher
           Offset: 16
-          Type: 155 GoInterfaceType net/http.Pusher
+          Type: 158 GoInterfaceType net/http.Pusher
         - Name: Hijacker
           Offset: 32
-          Type: 157 GoInterfaceType net/http.Hijacker
+          Type: 160 GoInterfaceType net/http.Hijacker
     - __kind: StructureType
-      ID: 188
+      ID: 191
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -2455,9 +2558,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 189 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 192 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 198
+      ID: 201
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
@@ -2479,7 +2582,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 199 GoSwissMapGroupsType groupReference<string,string>
+          Type: 202 GoSwissMapGroupsType groupReference<string,string>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -2522,7 +2625,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 585312
       GoKind: 26
-MaxTypeID: 209
+MaxTypeID: 219
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x130d980", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 216 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x82b110", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 217 EventRootType Probe[main.HandleHTTP]Return
           InjectionPoints:
             - PC: "0x82b2d8"
@@ -38,13 +36,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 218 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x82b408", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 219 EventRootType Probe[main.LookAtTheRequest]Return
           InjectionPoints: [{PC: "0x82b470", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1222 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0856a", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1223 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd085a5", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1153 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1154 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04b85", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1156 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1157 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04c1d", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0371e", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1138 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1139 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd0410c", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1136 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1137 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd0403b", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1148 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1149 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04825", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1150 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04844", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1151 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd0487d", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1140 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1141 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd0456e", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1142 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1143 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd0463e", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1144 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1145 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd046cb", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1146 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1147 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd047fe", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1241 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0xd0468f"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1242 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd043aa", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1207 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd07cae", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1208 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd07d3e", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1205 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd07c0a", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1206 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd07c72", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1201 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07a4a", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1202 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xd07aa7", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1199 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd079ca", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1200 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1197 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd0796a", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1198 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1191 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd0776a", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1192 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd077b4", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1195 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd0788e", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1196 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07931", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1193 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd077ea", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1194 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07853", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1203 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd07aee", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1204 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1209 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd07d6e", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1210 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd07dff", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1237 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd08960", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1238 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd08982", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1235 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd08820", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1236 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0883e", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1226 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd08600", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1227 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0861e", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1226 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd087ca", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1227 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd08805", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1157 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04daa", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1158 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04de5", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1160 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04e4a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1161 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04e7d", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1106 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1108 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1169 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1107 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0371e", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1095 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1092 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1186 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1184 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06d20", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1194 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd074c0", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1132 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1133 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1128 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1129 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1130 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd03960", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1131 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1216 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd08380", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd083e0", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1237 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd08900", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1243 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd08d40", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd08d60", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1159 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e20", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1141 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0432a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd0436c", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1139 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0420e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1140 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd0429b", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1151 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1152 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04a85", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1153 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04aa4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1154 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04add", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1155 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04aa8", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1143 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0476a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1144 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd047ce", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1145 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1146 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd0489e", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1147 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd048ea", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0492b", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04866", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1149 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0496e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1150 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a5e", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04973", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1250 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd04973", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1252 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd045ca"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0460a", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1247 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd045ce"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1254 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04ac5"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1098 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1099 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1100 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1097 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1096 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1156 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04d80", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1188 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03b7a", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c2d", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03cf4", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1167 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1171 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1172 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1173 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1165 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1166 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1164 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05520", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1234 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1235 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd07f0e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd07f9e", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd06ee0", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1209 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd07e6a", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1210 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd07ed2", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1193 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd07480", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1223 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd08460", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd08400", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd08440", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd088a0", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1189 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07300", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1170 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd072c0", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1205 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1206 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xd07d07", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xd07c68"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1201 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07bfa"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1195 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd079ca", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1196 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07a14", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07aee", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07b91", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07a4a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07ab3", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1207 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xd07de8"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1093 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1112 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1110 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1123 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1124 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1113 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1115 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1116 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1117 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1114 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1111 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1228 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd08820", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1118 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1120 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1121 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1122 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1119 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1217 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd083a0", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1168 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd07fce", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0805f", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1094 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1192 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd07440", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1221 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd08420", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1134 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1135 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1241 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd08bc0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1242 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd08be2", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1218 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd083c0", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1162 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ea0", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd08a80", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd08a9e", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd08a60", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1163 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05500", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1229 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd08840", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd08860", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0887e", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd08880", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1125 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1103 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1104 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1105 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1102 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1101 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1191 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd07360", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1215 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd08360", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1236 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd088e0", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1190 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1109 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1226 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd087ca", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1227 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd08805", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1157 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04daa", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1158 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04de5", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1160 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04e4a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1161 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04e7d", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1106 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1108 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1169 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1107 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03700", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0371e", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1095 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1092 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02de0", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1186 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1184 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06d20", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1194 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd074c0", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1132 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03ae0", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1133 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b00", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1128 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd037c0", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1129 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd037e0", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1130 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd03960", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1131 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd03980", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1216 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd08380", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd083e0", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1237 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd08900", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1243 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd08d40", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd08d60", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1159 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e20", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1141 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0432a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd0436c", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1139 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0420e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1140 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd0429b", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1151 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1152 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04a85", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1153 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04aa4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1154 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04add", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1155 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1155 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04aa8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1143 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd0476a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1144 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd047ce", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1145 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1146 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd0489e", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1147 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd048ea", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0492b", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd04866", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1149 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd0496e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1150 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a5e", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd04973", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1250 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1250 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd04973", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1252 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1252 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd045ca"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0460a", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1247 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1247 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd045ce"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1254 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1254 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04ac5"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1098 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1099 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1100 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1097 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1096 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1156 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04d80", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1188 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03b7a", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c2d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03cf4", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1167 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1171 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1172 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1173 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1165 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1166 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1164 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05520", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1234 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1235 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd07f0e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd07f9e", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd06ee0", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1209 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd07e6a", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1210 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd07ed2", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1193 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd07480", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1223 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd08460", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd08400", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd08440", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd088a0", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1189 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07300", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1170 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd072c0", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1205 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1206 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xd07d07", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xd07c68"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1201 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07bfa"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1195 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd079ca", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1196 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07a14", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07aee", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07b91", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07a4a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07ab3", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1207 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xd07de8"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1093 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1112 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1110 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd033c0", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1123 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1124 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1113 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1115 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1116 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1117 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1114 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1111 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd033e0", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1228 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd08820", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1118 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1120 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1121 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1122 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1119 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1217 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd083a0", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1168 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd07fce", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0805f", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1094 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1192 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd07440", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1221 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd08420", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1134 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1135 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1241 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd08bc0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1242 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd08be2", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1218 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd083c0", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1162 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ea0", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd08a80", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd08a9e", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd08a60", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1163 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05500", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1229 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd08840", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd08860", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0887e", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd08880", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1125 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1103 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1104 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1105 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1102 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1101 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1191 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd07360", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1215 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd08360", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1236 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd088e0", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1190 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1109 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null
@@ -7833,7 +7997,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1155
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -7980,13 +8144,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1250
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1251
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1252
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1149
       Name: Probe[main.testInlinedBC]
@@ -8011,7 +8175,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1247
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8046,7 +8210,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1254
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8190,10 +8354,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1136
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1137
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8219,7 +8383,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1138
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd045b6..0xd045c7
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd045c7..0xd04665
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xd04680..0xd046e2]
@@ -2765,7 +2774,29 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xd04700..0xd0480e]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0475b..0xd04765
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xd04765..0xd04780
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xd04780..0xd04794
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd04756..0xd04760
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xd04760..0xd04780
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xd04780..0xd0478f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xd04820..0xd04826]
@@ -3357,6 +3388,15 @@ Subprograms:
           Locations: [{Range: 0xd077e0..0xd0786f, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 93 PointerType *int
+          Locations:
+            - Range: 0xd077ff..0xd07818
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07818..0xd0786f
+              Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xd07880..0xd0794f]
@@ -3381,6 +3421,15 @@ Subprograms:
           Locations: [{Range: 0xd07880..0xd0794f, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0xd0789f..0xd078d4
+              Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
+            - Range: 0xd078d4..0xd0794f
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xd07960..0xd079bb]
@@ -3509,6 +3558,45 @@ Subprograms:
           Locations: [{Range: 0xd07ae0..0xd07bf7, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 153 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xd07ae0..0xd07b18
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07b18..0xd07b69
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd07b69..0xd07b79
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd07b79..0xd07b8e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd07b8e..0xd07b90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd07b90..0xd07b92
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xd07b92..0xd07bf7
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xd07c00..0xd07c8f]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1222 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd0856a", Frameless: false}]
+          Type: 1226 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd087ca", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1223 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xd085a5", Frameless: false}]
+          Type: 1227 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xd08805", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1153 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xd04b4a", Frameless: false}]
+          Type: 1157 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xd04daa", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1154 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xd04b85", Frameless: false}]
+          Type: 1158 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xd04de5", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1156 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xd04bea", Frameless: false}]
+          Type: 1160 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xd04e4a", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1157 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xd04c1d", Frameless: false}]
+          Type: 1161 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xd04e7d", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1165 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd05360", Frameless: true}]
+          Type: 1169 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1182 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd06ea0", Frameless: true}]
+          Type: 1186 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1180 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
+          Type: 1184 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd06d20", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1190 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd07260", Frameless: true}]
+          Type: 1194 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd074c0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1212 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd08120", Frameless: true}]
+          Type: 1216 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd08380", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1215 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd08180", Frameless: true}]
+          Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd083e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1233 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd086a0", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd08900", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1239 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd08ae0", Frameless: true}]
+          Type: 1243 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd08d40", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1240 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd08b00", Frameless: true}]
+          Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd08d60", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1155 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xd04bc0", Frameless: true}]
+          Type: 1159 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xd04e20", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1138 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xd040ca", Frameless: false}]
+          Type: 1141 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xd0432a", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1139 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xd0410c", Frameless: false}]
+          Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xd0436c", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1136 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xd03fae", Frameless: false}]
+          Type: 1139 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xd0420e", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1137 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xd0403b", Frameless: false}]
+          Type: 1140 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xd0429b", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1148 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xd04820", Frameless: true}]
+          Type: 1151 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xd04a80", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1149 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xd04825", Frameless: true}]
+          Type: 1152 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xd04a85", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1150 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xd04844", Frameless: false}]
+          Type: 1153 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xd04aa4", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1151 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xd0487d", Frameless: false}]
+          Type: 1154 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xd04add", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1155 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0xd04aa8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1140 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xd0450a", Frameless: false}]
+          Type: 1143 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xd0476a", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1141 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xd0456e", Frameless: false}]
+          Type: 1144 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xd047ce", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1142 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xd045ae", Frameless: false}]
+          Type: 1145 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1143 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xd0463e", Frameless: false}]
+          Type: 1146 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xd0489e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1144 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xd0468a", Frameless: false}]
+          Type: 1147 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xd048ea", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1145 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xd046cb", Frameless: false}]
+          Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xd0492b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1243 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xd04606", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xd04866", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1146 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xd0470e", Frameless: false}]
+          Type: 1149 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xd0496e", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1147 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xd047fe", Frameless: false}]
+          Type: 1150 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xd04a5e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1244 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xd04713", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xd04973", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1250 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0xd04973", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1245 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xd047c6", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1252 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0xd04a26", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1241 EventRootType Probe[main.testInlinedPrint]
+          Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xd0436a"
+            - PC: "0xd045ca"
               Frameless: false
-            - PC: "0xd043f1"
+            - PC: "0xd04651"
               Frameless: false
-            - PC: "0xd04532"
+            - PC: "0xd04792"
               Frameless: false
-            - PC: "0xd045bc"
+            - PC: "0xd0481c"
               Frameless: false
-            - PC: "0xd0468f"
+            - PC: "0xd048ef"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1242 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xd043aa", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xd0460a", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1247 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0xd045ce"
+              Frameless: false
+            - PC: "0xd04651"
+              Frameless: false
+            - PC: "0xd04792"
+              Frameless: false
+            - PC: "0xd0481c"
+              Frameless: false
+            - PC: "0xd048ef"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1246 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xd04821", Frameless: true}]
+          Type: 1253 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1254 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0xd04a81", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1247 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xd04865"
+            - PC: "0xd04ac5"
               Frameless: false
-            - PC: "0xd04905"
+            - PC: "0xd04b65"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1152 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xd04b20", Frameless: true}]
+          Type: 1156 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xd04d80", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1184 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd07080", Frameless: true}]
+          Type: 1188 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xd03b7a", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xd03c2d", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xd03cf4", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1163 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd05320", Frameless: true}]
+          Type: 1167 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1170 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd053e0", Frameless: true}]
+          Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1167 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd053a0", Frameless: true}]
+          Type: 1171 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1179 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd05500", Frameless: true}]
+          Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1178 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd054e0", Frameless: true}]
+          Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1168 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
+          Type: 1172 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1169 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd053c0", Frameless: true}]
+          Type: 1173 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1177 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd054c0", Frameless: true}]
+          Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1176 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd054a0", Frameless: true}]
+          Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1161 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd052e0", Frameless: true}]
+          Type: 1165 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1162 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd05300", Frameless: true}]
+          Type: 1166 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1160 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd052c0", Frameless: true}]
+          Type: 1164 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd05520", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1171 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd05400", Frameless: true}]
+          Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1174 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd05460", Frameless: true}]
+          Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1175 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd05480", Frameless: true}]
+          Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1172 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd05420", Frameless: true}]
+          Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1173 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd05440", Frameless: true}]
+          Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1230 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd08660", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1231 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd08660", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd088c0", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1207 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd07cae", Frameless: false}]
+          Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd07f0e", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1208 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd07d3e", Frameless: false}]
+          Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd07f9e", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1181 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd06c80", Frameless: true}]
+          Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd06ee0", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1205 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd07c0a", Frameless: false}]
+          Type: 1209 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd07e6a", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1206 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd07c72", Frameless: false}]
+          Type: 1210 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd07ed2", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1189 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd07220", Frameless: true}]
+          Type: 1193 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd07480", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1219 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd08200", Frameless: true}]
+          Type: 1223 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd08460", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1216 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd081a0", Frameless: true}]
+          Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd08400", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1218 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd081e0", Frameless: true}]
+          Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd08440", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1229 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd08640", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd088a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1185 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd070a0", Frameless: true}]
+          Type: 1189 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd07300", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1166 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd05380", Frameless: true}]
+          Type: 1170 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1183 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd07060", Frameless: true}]
+          Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd072c0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1201 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xd07a4a", Frameless: false}]
+          Type: 1205 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1202 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xd07aa7", Frameless: false}]
+          Type: 1206 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0xd07d07", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1199 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xd079ca", Frameless: false}]
+          Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1200 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xd07a08"
+            - PC: "0xd07c68"
               Frameless: false
-            - PC: "0xd07a12"
+            - PC: "0xd07c72"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1197 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xd0796a", Frameless: false}]
+          Type: 1201 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xd07bca", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1198 EventRootType Probe[main.testReturnsError]Return
+          Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xd0799a"
+            - PC: "0xd07bfa"
               Frameless: false
-            - PC: "0xd079a5"
+            - PC: "0xd07c05"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1191 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xd0776a", Frameless: false}]
+          Type: 1195 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xd079ca", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1192 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xd077b4", Frameless: false}]
+          Type: 1196 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xd07a14", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1195 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xd0788e", Frameless: false}]
+          Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xd07aee", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1196 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xd07931", Frameless: false}]
+          Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xd07b91", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1193 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xd077ea", Frameless: false}]
+          Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xd07a4a", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1194 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xd07853", Frameless: false}]
+          Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xd07ab3", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1203 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xd07aee", Frameless: false}]
+          Type: 1207 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1204 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xd07b88"
+            - PC: "0xd07de8"
               Frameless: false
-            - PC: "0xd07b92"
+            - PC: "0xd07df2"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1224 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd085c0", Frameless: true}]
+          Type: 1228 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd08820", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1213 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd08140", Frameless: true}]
+          Type: 1217 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd083a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1164 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd05340", Frameless: true}]
+          Type: 1168 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1209 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xd07d6e", Frameless: false}]
+          Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xd07fce", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1210 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xd07dff", Frameless: false}]
+          Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0805f", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1188 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd071e0", Frameless: true}]
+          Type: 1192 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd07440", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1217 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd081c0", Frameless: true}]
+          Type: 1221 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd08420", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1237 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd08960", Frameless: true}]
+          Type: 1241 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd08bc0", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1238 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xd08982", Frameless: true}]
+          Type: 1242 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd08be2", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1214 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd08160", Frameless: true}]
+          Type: 1218 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd083c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1158 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xd04c40", Frameless: true}]
+          Type: 1162 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xd04ea0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1235 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xd08820", Frameless: true}]
+          Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xd08a80", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1236 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xd0883e", Frameless: true}]
+          Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xd08a9e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1234 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xd08800", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xd08a60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1159 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd052a0", Frameless: true}]
+          Type: 1163 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd05500", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1225 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd085e0", Frameless: true}]
+          Type: 1229 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd08840", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1226 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd08600", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd08860", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1227 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd0861e", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0887e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1228 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd08620", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd08880", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1187 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd07100", Frameless: true}]
+          Type: 1191 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd07360", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1211 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd08100", Frameless: true}]
+          Type: 1215 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd08360", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1232 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd08680", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd088e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1186 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd070c0", Frameless: true}]
+          Type: 1190 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1220 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd08220", Frameless: true}]
+          Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1221 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd08220", Frameless: true}]
+          Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd08480", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0xd03b60..0xd03daa]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd03c44..0xd03c65
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd03d18..0xd03d2f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd03c2d..0xd03c30
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd03c30..0xd03c65
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd03c65..0xd03d0b
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0xd03d0b..0xd03d18
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xd03d18..0xd03daa
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd03c2a..0xd03c30
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd03c30..0xd03c30
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd03c30..0xd03c65
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd03c65..0xd03d0b
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0xd03d0b..0xd03d10
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xd03d10..0xd03d18
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xd03d18..0xd03d2f
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xd03d2f..0xd03daa
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd03fa0..0xd040a5]
+      OutOfLinePCRanges: [0xd04200..0xd04305]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 146 StructureType main.esotericStack
           Locations:
-            - Range: 0xd03fa0..0xd03ff3
+            - Range: 0xd04200..0xd04253
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03ff3..0xd03ff8
+            - Range: 0xd04253..0xd04258
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03ff8..0xd03ffd
+            - Range: 0xd04258..0xd0425d
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,140 +2910,140 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd040c0..0xd04123]
+      OutOfLinePCRanges: [0xd04320..0xd04383]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd040c0..0xd040ed
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd04500..0xd04588]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04500..0xd04515
+            - Range: 0xd04320..0xd0434d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd045a0..0xd04665]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xd04760..0xd047e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd045a0..0xd045b6
+            - Range: 0xd04760..0xd04775
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xd04800..0xd048c5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd04800..0xd04816
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd045a0..0xd045c7
+            - Range: 0xd04800..0xd04827
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd045b6..0xd045c7
+            - Range: 0xd04816..0xd04827
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd045c7..0xd04665
+            - Range: 0xd04827..0xd048c5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd04680..0xd046e2]
+      OutOfLinePCRanges: [0xd048e0..0xd04942]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04680..0xd0469a
+            - Range: 0xd048e0..0xd048fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd04700..0xd0480e]
+      OutOfLinePCRanges: [0xd04960..0xd04a6e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0475b..0xd04765
+            - Range: 0xd049bb..0xd049c5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04765..0xd04780
+            - Range: 0xd049c5..0xd049e0
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd04780..0xd04794
+            - Range: 0xd049e0..0xd049f4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04756..0xd04760
+            - Range: 0xd049b6..0xd049c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04760..0xd04780
+            - Range: 0xd049c0..0xd049e0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd04780..0xd0478f
+            - Range: 0xd049e0..0xd049ef
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd04820..0xd04826]
+      OutOfLinePCRanges: [0xd04a80..0xd04a86]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04820..0xd04825
+            - Range: 0xd04a80..0xd04a85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04820..0xd04826, Pieces: []}]
+          Locations: [{Range: 0xd04a80..0xd04a86, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd04840..0xd04883]
+      OutOfLinePCRanges: [0xd04aa0..0xd04ae3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 ArrayType [5]int
           Locations:
-            - Range: 0xd04840..0xd04883
+            - Range: 0xd04aa0..0xd04ae3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04840..0xd04883, Pieces: []}]
+          Locations: [{Range: 0xd04aa0..0xd04ae3, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd04b20..0xd04b21]
+      OutOfLinePCRanges: [0xd04d80..0xd04d81]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 153 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd04b20..0xd04b21
+            - Range: 0xd04d80..0xd04d81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2847,21 +3051,21 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0xd04b40..0xd04ba6]
+      OutOfLinePCRanges: [0xd04da0..0xd04e06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd04b40..0xd04b69
+            - Range: 0xd04da0..0xd04dc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd04b69..0xd04b6e
+            - Range: 0xd04dc9..0xd04dce
               Pieces:
                 - Size: 8
                   Op: null
@@ -2871,18 +3075,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04b40..0xd04ba6, Pieces: []}]
+          Locations: [{Range: 0xd04da0..0xd04e06, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0xd04bc0..0xd04bc1]
+      OutOfLinePCRanges: [0xd04e20..0xd04e21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd04bc0..0xd04bc1
+            - Range: 0xd04e20..0xd04e21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,32 +3094,32 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xd04be0..0xd04c34]
+      OutOfLinePCRanges: [0xd04e40..0xd04e94]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType *interface {}
           Locations:
-            - Range: 0xd04be0..0xd04c06
+            - Range: 0xd04e40..0xd04e66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04be0..0xd04c34, Pieces: []}]
+          Locations: [{Range: 0xd04e40..0xd04e94, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xd04c40..0xd04c41]
+      OutOfLinePCRanges: [0xd04ea0..0xd04ea1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 155 StructureType main.structWithAny
           Locations:
-            - Range: 0xd04c40..0xd04c41
+            - Range: 0xd04ea0..0xd04ea1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2923,309 +3127,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd052a0..0xd052a1]
+      OutOfLinePCRanges: [0xd05500..0xd05501]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 156 StructureType main.structWithMap
           Locations:
-            - Range: 0xd052a0..0xd052a1
+            - Range: 0xd05500..0xd05501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd052c0..0xd052c1]
+      OutOfLinePCRanges: [0xd05520..0xd05521]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xd052c0..0xd052c1
+            - Range: 0xd05520..0xd05521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd052e0..0xd052e1]
+      OutOfLinePCRanges: [0xd05540..0xd05541]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]int
           Locations:
-            - Range: 0xd052e0..0xd052e1
+            - Range: 0xd05540..0xd05541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd05300..0xd05301]
+      OutOfLinePCRanges: [0xd05560..0xd05561]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string][]string
           Locations:
-            - Range: 0xd05300..0xd05301
+            - Range: 0xd05560..0xd05561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd05320..0xd05321]
+      OutOfLinePCRanges: [0xd05580..0xd05581]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xd05320..0xd05321
+            - Range: 0xd05580..0xd05581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xd05340..0xd05341]
+      OutOfLinePCRanges: [0xd055a0..0xd055a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]int
           Locations:
-            - Range: 0xd05340..0xd05341
+            - Range: 0xd055a0..0xd055a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xd05360..0xd05361]
+      OutOfLinePCRanges: [0xd055c0..0xd055c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xd05360..0xd05361
+            - Range: 0xd055c0..0xd055c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xd05380..0xd05381]
+      OutOfLinePCRanges: [0xd055e0..0xd055e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 PointerType *map[string]int
           Locations:
-            - Range: 0xd05380..0xd05381
+            - Range: 0xd055e0..0xd055e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xd053a0..0xd053a1]
+      OutOfLinePCRanges: [0xd05600..0xd05601]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 157 GoMapType map[int]int
           Locations:
-            - Range: 0xd053a0..0xd053a1
+            - Range: 0xd05600..0xd05601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xd053c0..0xd053c1]
+      OutOfLinePCRanges: [0xd05620..0xd05621]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 184 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd053c0..0xd053c1
+            - Range: 0xd05620..0xd05621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xd053e0..0xd053e1]
+      OutOfLinePCRanges: [0xd05640..0xd05641]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 184 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xd053e0..0xd053e1
+            - Range: 0xd05640..0xd05641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xd05400..0xd05401]
+      OutOfLinePCRanges: [0xd05660..0xd05661]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xd05400..0xd05401
+            - Range: 0xd05660..0xd05661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xd05420..0xd05421]
+      OutOfLinePCRanges: [0xd05680..0xd05681]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd05420..0xd05421
+            - Range: 0xd05680..0xd05681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xd05440..0xd05441]
+      OutOfLinePCRanges: [0xd056a0..0xd056a1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 194 GoMapType map[int]uint8
           Locations:
-            - Range: 0xd05440..0xd05441
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xd05460..0xd05461]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 199 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xd05460..0xd05461
+            - Range: 0xd056a0..0xd056a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xd05480..0xd05481]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xd056c0..0xd056c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd05480..0xd05481
+            - Range: 0xd056c0..0xd056c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xd054a0..0xd054a1]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xd056e0..0xd056e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xd054a0..0xd054a1
+            - Range: 0xd056e0..0xd056e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xd05700..0xd05701]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 199 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xd05700..0xd05701
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xd054c0..0xd054c1]
+      OutOfLinePCRanges: [0xd05720..0xd05721]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xd054c0..0xd054c1
+            - Range: 0xd05720..0xd05721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xd054e0..0xd054e1]
+      OutOfLinePCRanges: [0xd05740..0xd05741]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xd054e0..0xd054e1
+            - Range: 0xd05740..0xd05741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xd05500..0xd05501]
+      OutOfLinePCRanges: [0xd05760..0xd05761]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xd05500..0xd05501
+            - Range: 0xd05760..0xd05761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd06ac0..0xd06ac1]
+      OutOfLinePCRanges: [0xd06d20..0xd06d21]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06ac0..0xd06ac1
+            - Range: 0xd06d20..0xd06d21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06ac0..0xd06ac1
+            - Range: 0xd06d20..0xd06d21
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xd06ac0..0xd06ac1
+            - Range: 0xd06d20..0xd06d21
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd06c80..0xd06c81]
+      OutOfLinePCRanges: [0xd06ee0..0xd06ee1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06ee0..0xd06ee1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06ee0..0xd06ee1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06ee0..0xd06ee1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06ee0..0xd06ee1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd06c80..0xd06c81
+            - Range: 0xd06ee0..0xd06ee1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3233,39 +3437,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd06ea0..0xd06ea1]
+      OutOfLinePCRanges: [0xd07100..0xd07101]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 219 GoChannelType chan bool
           Locations:
-            - Range: 0xd06ea0..0xd06ea1
+            - Range: 0xd07100..0xd07101
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd07060..0xd07061]
+      OutOfLinePCRanges: [0xd072c0..0xd072c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 220 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd07060..0xd07061
+            - Range: 0xd072c0..0xd072c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd07080..0xd07081]
+      OutOfLinePCRanges: [0xd072e0..0xd072e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 222 StructureType main.node
           Locations:
-            - Range: 0xd07080..0xd07081
+            - Range: 0xd072e0..0xd072e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3273,195 +3477,195 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd070a0..0xd070a1]
+      OutOfLinePCRanges: [0xd07300..0xd07301]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 223 PointerType *main.node
           Locations:
-            - Range: 0xd070a0..0xd070a1
+            - Range: 0xd07300..0xd07301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd070c0..0xd070c1]
+      OutOfLinePCRanges: [0xd07320..0xd07321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd070c0..0xd070c1
+            - Range: 0xd07320..0xd07321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd07100..0xd07101]
+      OutOfLinePCRanges: [0xd07360..0xd07361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0xd07100..0xd07101
+            - Range: 0xd07360..0xd07361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd071e0..0xd071e1]
+      OutOfLinePCRanges: [0xd07440..0xd07441]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0xd071e0..0xd071e1
+            - Range: 0xd07440..0xd07441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd07220..0xd07221]
+      OutOfLinePCRanges: [0xd07480..0xd07481]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd07220..0xd07221
+            - Range: 0xd07480..0xd07481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd07220..0xd07221
+            - Range: 0xd07480..0xd07481
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd07260..0xd07261]
+      OutOfLinePCRanges: [0xd074c0..0xd074c1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 224 PointerType *main.t
           Locations:
-            - Range: 0xd07260..0xd07261
+            - Range: 0xd074c0..0xd074c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd07760..0xd077cc]
+      OutOfLinePCRanges: [0xd079c0..0xd07a2c]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07760..0xd0777e
+            - Range: 0xd079c0..0xd079de
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0777e..0xd077cc
+            - Range: 0xd079de..0xd07a2c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07760..0xd077cc, Pieces: []}]
+          Locations: [{Range: 0xd079c0..0xd07a2c, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd077e0..0xd0786f]
+      OutOfLinePCRanges: [0xd07a40..0xd07acf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd077e0..0xd077fa
+            - Range: 0xd07a40..0xd07a5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 93 PointerType *int
-          Locations: [{Range: 0xd077e0..0xd0786f, Pieces: []}]
+          Locations: [{Range: 0xd07a40..0xd07acf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd077ff..0xd07818
+            - Range: 0xd07a5f..0xd07a78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07818..0xd0786f
+            - Range: 0xd07a78..0xd07acf
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd07880..0xd0794f]
+      OutOfLinePCRanges: [0xd07ae0..0xd07baf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07880..0xd078d4
+            - Range: 0xd07ae0..0xd07b34
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd078d4..0xd0794f
+            - Range: 0xd07b34..0xd07baf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07880..0xd0794f, Pieces: []}]
+          Locations: [{Range: 0xd07ae0..0xd07baf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd07880..0xd0794f, Pieces: []}]
+          Locations: [{Range: 0xd07ae0..0xd07baf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd0789f..0xd078d4
+            - Range: 0xd07aff..0xd07b34
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd078d4..0xd0794f
+            - Range: 0xd07b34..0xd07baf
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd07960..0xd079bb]
+      OutOfLinePCRanges: [0xd07bc0..0xd07c1b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07960..0xd07979
+            - Range: 0xd07bc0..0xd07bd9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0xd07960..0xd079bb, Pieces: []}]
+          Locations: [{Range: 0xd07bc0..0xd07c1b, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd079c0..0xd07a3c]
+      OutOfLinePCRanges: [0xd07c20..0xd07c9c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd079c0..0xd079e3
+            - Range: 0xd07c20..0xd07c43
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd079e3..0xd079e8
+            - Range: 0xd07c43..0xd07c48
               Pieces:
                 - Size: 8
                   Op: null
@@ -3472,41 +3676,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd079c0..0xd079e8
+            - Range: 0xd07c20..0xd07c48
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 148 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xd079c0..0xd07a3c, Pieces: []}]
+          Locations: [{Range: 0xd07c20..0xd07c9c, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0xd079c0..0xd07a3c, Pieces: []}]
+          Locations: [{Range: 0xd07c20..0xd07c9c, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd07a40..0xd07acb]
+      OutOfLinePCRanges: [0xd07ca0..0xd07d2b]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07a40..0xd07a95
+            - Range: 0xd07ca0..0xd07cf5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07a95..0xd07a98
+            - Range: 0xd07cf5..0xd07cf8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07a98..0xd07acb
+            - Range: 0xd07cf8..0xd07d2b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -3516,186 +3720,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 148 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xd07a40..0xd07acb, Pieces: []}]
+          Locations: [{Range: 0xd07ca0..0xd07d2b, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd07ae0..0xd07bf7]
+      OutOfLinePCRanges: [0xd07d40..0xd07e57]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07ae0..0xd07b18
+            - Range: 0xd07d40..0xd07d78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07b18..0xd07b79
+            - Range: 0xd07d78..0xd07dd9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd07b79..0xd07b98
+            - Range: 0xd07dd9..0xd07df8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd07b98..0xd07bb8
+            - Range: 0xd07df8..0xd07e18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07bb8..0xd07bbf
+            - Range: 0xd07e18..0xd07e1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07bbf..0xd07bf7
+            - Range: 0xd07e1f..0xd07e57
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 153 GoInterfaceType main.behavior
-          Locations: [{Range: 0xd07ae0..0xd07bf7, Pieces: []}]
+          Locations: [{Range: 0xd07d40..0xd07e57, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 153 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd07ae0..0xd07b18
+            - Range: 0xd07d40..0xd07d78
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07b18..0xd07b69
+            - Range: 0xd07d78..0xd07dc9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07b69..0xd07b79
+            - Range: 0xd07dc9..0xd07dd9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07b79..0xd07b8e
+            - Range: 0xd07dd9..0xd07dee
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07b8e..0xd07b90
+            - Range: 0xd07dee..0xd07df0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07b90..0xd07b92
+            - Range: 0xd07df0..0xd07df2
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd07b92..0xd07bf7
+            - Range: 0xd07df2..0xd07e57
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd07c00..0xd07c8f]
+      OutOfLinePCRanges: [0xd07e60..0xd07eef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07c00..0xd07c3c
+            - Range: 0xd07e60..0xd07e9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c3c..0xd07c8f
+            - Range: 0xd07e9c..0xd07eef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07c00..0xd07c8f, Pieces: []}]
+          Locations: [{Range: 0xd07e60..0xd07eef, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd07ca0..0xd07d58]
+      OutOfLinePCRanges: [0xd07f00..0xd07fb8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07ca0..0xd07ce6
+            - Range: 0xd07f00..0xd07f46
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07ce6..0xd07d58
+            - Range: 0xd07f46..0xd07fb8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07ca0..0xd07d58, Pieces: []}]
+          Locations: [{Range: 0xd07f00..0xd07fb8, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07ca0..0xd07d58, Pieces: []}]
+          Locations: [{Range: 0xd07f00..0xd07fb8, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd07d60..0xd07e19]
+      OutOfLinePCRanges: [0xd07fc0..0xd08079]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d60..0xd07da5
+            - Range: 0xd07fc0..0xd08005
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07da5..0xd07e19
+            - Range: 0xd08005..0xd08079
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07d60..0xd07e19, Pieces: []}]
+          Locations: [{Range: 0xd07fc0..0xd08079, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07d60..0xd07e19, Pieces: []}]
+          Locations: [{Range: 0xd07fc0..0xd08079, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07d60..0xd07e19, Pieces: []}]
+          Locations: [{Range: 0xd07fc0..0xd08079, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd08100..0xd08101]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 226 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd08100..0xd08101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd08120..0xd08121]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd08360..0xd08361]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd08120..0xd08121
+            - Range: 0xd08360..0xd08361
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3706,14 +3892,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd08140..0xd08141]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd08380..0xd08381]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 227 GoSliceHeaderType [][]uint
+          Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd08140..0xd08141
+            - Range: 0xd08380..0xd08381
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3724,14 +3910,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd08160..0xd08161]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd083a0..0xd083a1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 229 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 227 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xd08160..0xd08161
+            - Range: 0xd083a0..0xd083a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3739,24 +3925,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd08160..0xd08161
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd08180..0xd08181]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xd083c0..0xd083c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd08180..0xd08181
+            - Range: 0xd083c0..0xd083c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3769,19 +3948,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08180..0xd08181
+            - Range: 0xd083c0..0xd083c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd081a0..0xd081a1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xd083e0..0xd083e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd081a0..0xd081a1
+            - Range: 0xd083e0..0xd083e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3794,19 +3973,44 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd081a0..0xd081a1
+            - Range: 0xd083e0..0xd083e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd08400..0xd08401]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 229 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd08400..0xd08401
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08400..0xd08401
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd081c0..0xd081c1]
+      OutOfLinePCRanges: [0xd08420..0xd08421]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 232 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd081c0..0xd081c1
+            - Range: 0xd08420..0xd08421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3816,22 +4020,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd081e0..0xd081e1]
+      OutOfLinePCRanges: [0xd08440..0xd08441]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd081e0..0xd081e1
+            - Range: 0xd08440..0xd08441
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 233 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd081e0..0xd081e1
+            - Range: 0xd08440..0xd08441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3844,37 +4048,19 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd081e0..0xd081e1
+            - Range: 0xd08440..0xd08441
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd08200..0xd08201]
+      OutOfLinePCRanges: [0xd08460..0xd08461]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd08200..0xd08201
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd08220..0xd08221]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 226 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd08220..0xd08221
+            - Range: 0xd08460..0xd08461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3885,24 +4071,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd08480..0xd08481]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 226 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd08480..0xd08481
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0xd08560..0xd085b2]
+      OutOfLinePCRanges: [0xd087c0..0xd08812]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd08560..0xd085b2, Pieces: []}]
+          Locations: [{Range: 0xd087c0..0xd08812, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd085c0..0xd085c1]
+      OutOfLinePCRanges: [0xd08820..0xd08821]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd085c0..0xd085c1
+            - Range: 0xd08820..0xd08821
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3910,15 +4114,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd085e0..0xd085e1]
+      OutOfLinePCRanges: [0xd08840..0xd08841]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd085e0..0xd085e1
+            - Range: 0xd08840..0xd08841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3929,7 +4133,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd085e0..0xd085e1
+            - Range: 0xd08840..0xd08841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3940,7 +4144,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd085e0..0xd085e1
+            - Range: 0xd08840..0xd08841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3948,15 +4152,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd08600..0xd0861f]
+      OutOfLinePCRanges: [0xd08860..0xd0887f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 235 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd08600..0xd0861f
+            - Range: 0xd08860..0xd0887f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3972,55 +4176,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd08620..0xd08621]
+      OutOfLinePCRanges: [0xd08880..0xd08881]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 236 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd08620..0xd08621
+            - Range: 0xd08880..0xd08881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd08640..0xd08641]
+      OutOfLinePCRanges: [0xd088a0..0xd088a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd08640..0xd08641
+            - Range: 0xd088a0..0xd088a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd08660..0xd08661]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd08660..0xd08661
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd08680..0xd08681]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd088c0..0xd088c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08680..0xd08681
+            - Range: 0xd088c0..0xd088c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4029,14 +4217,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd086a0..0xd086a1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd088e0..0xd088e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd086a0..0xd086a1
+            - Range: 0xd088e0..0xd088e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4045,26 +4233,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd08900..0xd08901]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd08900..0xd08901
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd08800..0xd08801]
+      OutOfLinePCRanges: [0xd08a60..0xd08a61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd08800..0xd08801
+            - Range: 0xd08a60..0xd08a61
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd08820..0xd0883f]
+      OutOfLinePCRanges: [0xd08a80..0xd08a9f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd08820..0xd0883f
+            - Range: 0xd08a80..0xd08a9f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4080,15 +4284,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd08960..0xd08983]
+      OutOfLinePCRanges: [0xd08bc0..0xd08be3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 283 StructureType main.aStruct
           Locations:
-            - Range: 0xd08960..0xd08983
+            - Range: 0xd08bc0..0xd08be3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4106,108 +4310,108 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd08ae0..0xd08ae1]
+      OutOfLinePCRanges: [0xd08d40..0xd08d41]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 285 StructureType main.emptyStruct
-          Locations: [{Range: 0xd08ae0..0xd08ae1, Pieces: []}]
+          Locations: [{Range: 0xd08d40..0xd08d41, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd08b00..0xd08b01]
+      OutOfLinePCRanges: [0xd08d60..0xd08d61]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 286 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd08b00..0xd08b01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd04360..0xd043c2]
-      InlinePCRanges:
-        - Ranges: [0xd043f1..0xd0442d]
-          RootRanges: [0xd043e0..0xd04451]
-        - Ranges: [0xd04532..0xd0456e]
-          RootRanges: [0xd04500..0xd04588]
-        - Ranges: [0xd045bc..0xd045f8]
-          RootRanges: [0xd045a0..0xd04665]
-        - Ranges: [0xd0468f..0xd046cb]
-          RootRanges: [0xd04680..0xd046e2]
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd04360..0xd04379
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd043f1..0xd043fc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd04532..0xd0453d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd045b6..0xd045c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd045c7..0xd04665
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd04680..0xd0469a
+            - Range: 0xd08d60..0xd08d61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xd045c0..0xd04622]
       InlinePCRanges:
-        - Ranges: [0xd04606..0xd0463e]
-          RootRanges: [0xd045a0..0xd04665]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd04713..0xd04751]
-          RootRanges: [0xd04700..0xd0480e]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd047c6..0xd047fe]
-          RootRanges: [0xd04700..0xd0480e]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xd04821..0xd04825]
-          RootRanges: [0xd04820..0xd04826]
+        - Ranges: [0xd04651..0xd0468d]
+          RootRanges: [0xd04640..0xd046b1]
+        - Ranges: [0xd04792..0xd047ce]
+          RootRanges: [0xd04760..0xd047e8]
+        - Ranges: [0xd0481c..0xd04858]
+          RootRanges: [0xd04800..0xd048c5]
+        - Ranges: [0xd048ef..0xd0492b]
+          RootRanges: [0xd048e0..0xd04942]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd04820..0xd04825
+            - Range: 0xd045c0..0xd045d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04651..0xd0465c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04792..0xd0479d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04816..0xd04827
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04827..0xd048c5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xd048e0..0xd048fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04866..0xd0489e]
+          RootRanges: [0xd04800..0xd048c5]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04973..0xd049b1]
+          RootRanges: [0xd04960..0xd04a6e]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04a26..0xd04a5e]
+          RootRanges: [0xd04960..0xd04a6e]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd04a81..0xd04a85]
+          RootRanges: [0xd04a80..0xd04a86]
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd04a80..0xd04a85
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd04865..0xd0487d]
-          RootRanges: [0xd04840..0xd04883]
-        - Ranges: [0xd04905..0xd04923]
-          RootRanges: [0xd048a0..0xd04a25]
+        - Ranges: [0xd04ac5..0xd04add]
+          RootRanges: [0xd04aa0..0xd04ae3]
+        - Ranges: [0xd04b65..0xd04b83]
+          RootRanges: [0xd04b00..0xd04c85]
       Variables:
         - Name: a
           Type: 152 ArrayType [5]int
           Locations:
-            - Range: 0xd0484d..0xd04883
+            - Range: 0xd04aad..0xd04ae3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd048ec..0xd04a25
+            - Range: 0xd04b4c..0xd04c85
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
@@ -5019,14 +5223,14 @@ Types:
       ID: 642
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 981504
+      GoRuntimeType: 979840
       GoKind: 22
       Pointee: 643 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 644
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 981632
+      GoRuntimeType: 979968
       GoKind: 22
       Pointee: 645 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -6024,21 +6228,21 @@ Types:
       ID: 870
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.103648e+06
+      GoRuntimeType: 1.103904e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 868
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.103264e+06
+      GoRuntimeType: 1.10352e+06
       GoKind: 22
       Pointee: 869 StructureType io.discard
     - __kind: PointerType
       ID: 842
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 979968
+      GoRuntimeType: 980736
       GoKind: 22
       Pointee: 843 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7106,10 +7310,10 @@ Types:
       GoKind: 22
       Pointee: 639 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1222
+      ID: 1226
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1223
+      ID: 1227
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7121,11 +7325,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1156
+      ID: 1160
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7137,11 +7341,11 @@ Types:
             Type: 154 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1161
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7153,11 +7357,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1153
+      ID: 1157
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7169,11 +7373,11 @@ Types:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1154
+      ID: 1158
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7185,7 +7389,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7221,7 +7425,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1165
+      ID: 1169
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7233,7 +7437,7 @@ Types:
             Type: 182 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7304,7 +7508,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1182
+      ID: 1186
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7316,11 +7520,11 @@ Types:
             Type: 219 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1180
+      ID: 1184
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7332,7 +7536,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7342,7 +7546,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7352,11 +7556,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1190
+      ID: 1194
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7368,7 +7572,7 @@ Types:
             Type: 224 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7468,7 +7672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1219
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7480,7 +7684,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7490,11 +7694,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1216
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7506,11 +7710,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1233
+      ID: 1237
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7522,11 +7726,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1240
+      ID: 1244
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7538,11 +7742,11 @@ Types:
             Type: 286 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1239
+      ID: 1243
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7554,11 +7758,11 @@ Types:
             Type: 285 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1155
+      ID: 1159
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7570,11 +7774,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1138
+      ID: 1141
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7586,14 +7790,14 @@ Types:
             Type: 150 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1142
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1136
+      ID: 1139
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7605,14 +7809,14 @@ Types:
             Type: 146 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1137
+      ID: 1140
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1150
+      ID: 1153
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7624,12 +7828,70 @@ Types:
             Type: 152 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1151
+      ID: 1155
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1154
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1151
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1152
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7644,82 +7906,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1148
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1149
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1140
+      ID: 1143
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1141
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1144
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1145
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1142
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -7732,6 +7921,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1144
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1147
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1148
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1145
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -7739,26 +7969,32 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1146
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1244
+      ID: 1249
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1245
+      ID: 1250
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1251
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1146
+      ID: 1252
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1149
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1147
+      ID: 1150
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1241
+      ID: 1245
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7770,14 +8006,30 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1247
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1246
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1253
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7789,11 +8041,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1247
+      ID: 1254
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1255
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7805,7 +8073,7 @@ Types:
             Type: 152 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -7889,7 +8157,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1156
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7901,11 +8169,11 @@ Types:
             Type: 153 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1184
+      ID: 1188
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7917,11 +8185,66 @@ Types:
             Type: 222 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1163
+      ID: 1136
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1137
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1138
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1167
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7933,11 +8256,11 @@ Types:
             Type: 177 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1170
+      ID: 1174
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7949,11 +8272,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1171
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7965,11 +8288,11 @@ Types:
             Type: 157 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1183
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7981,11 +8304,11 @@ Types:
             Type: 214 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1182
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7997,11 +8320,11 @@ Types:
             Type: 209 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1172
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8013,11 +8336,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1173
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8029,11 +8352,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1177
+      ID: 1181
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8045,12 +8368,92 @@ Types:
             Type: 204 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1180
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 199 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1176
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1165
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 167 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1166
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 172 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1164
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 162 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1175
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 189 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1179
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8065,72 +8468,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 167 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1162
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 172 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1160
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 162 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1171
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 189 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1175
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1178
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8145,23 +8484,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 199 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1173
+      ID: 1177
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8173,11 +8496,11 @@ Types:
             Type: 194 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1176
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8189,11 +8512,11 @@ Types:
             Type: 194 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1230
+      ID: 1234
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8205,11 +8528,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1231
+      ID: 1235
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8221,12 +8544,110 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1207
+      ID: 1211
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1212
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1185
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1209
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8241,9 +8662,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1208
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1210
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8256,106 +8677,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 15 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1205
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1206
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1189
+      ID: 1193
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8367,7 +8690,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8377,11 +8700,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1216
+      ID: 1220
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8393,7 +8716,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8403,11 +8726,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1218
+      ID: 1222
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8419,7 +8742,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8429,7 +8752,7 @@ Types:
             Type: 233 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8439,11 +8762,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1223
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8455,11 +8778,11 @@ Types:
             Type: 234 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1229
+      ID: 1233
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8471,11 +8794,11 @@ Types:
             Type: 237 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1189
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8487,11 +8810,11 @@ Types:
             Type: 223 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1166
+      ID: 1170
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8503,11 +8826,11 @@ Types:
             Type: 183 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1187
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8519,65 +8842,13 @@ Types:
             Type: 220 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1203
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 148 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1200
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 148 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1201
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8590,10 +8861,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1202
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1204
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8603,150 +8884,22 @@ Types:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1197
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1198
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1196
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1193
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1194
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 93 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1191
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1192
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1203
-      Name: Probe[main.testReturnsInterface]
+      ID: 1205
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8761,7 +8914,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1204
+      ID: 1206
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 148 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1201
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1202
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1199
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1200
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1197
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1198
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 93 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1195
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1196
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1207
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 148 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1208
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8773,7 +9096,7 @@ Types:
             Type: 153 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -8953,7 +9276,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1224
+      ID: 1228
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8965,7 +9288,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9049,7 +9372,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1217
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9061,11 +9384,11 @@ Types:
             Type: 227 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1164
+      ID: 1168
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9077,11 +9400,11 @@ Types:
             Type: 167 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1213
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9093,11 +9416,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1214
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9109,7 +9432,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9119,7 +9442,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9129,7 +9452,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9149,7 +9472,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1188
+      ID: 1192
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9161,11 +9484,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1221
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9177,7 +9500,7 @@ Types:
             Type: 232 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9213,7 +9536,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1214
+      ID: 1218
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9225,7 +9548,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9235,11 +9558,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1162
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9251,11 +9574,11 @@ Types:
             Type: 155 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1239
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9267,14 +9590,14 @@ Types:
             Type: 252 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1236
+      ID: 1240
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1234
+      ID: 1238
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9286,11 +9609,11 @@ Types:
             Type: 239 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1159
+      ID: 1163
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9302,11 +9625,11 @@ Types:
             Type: 156 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1237
+      ID: 1241
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9318,14 +9641,14 @@ Types:
             Type: 283 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1238
+      ID: 1242
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1228
+      ID: 1232
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9337,11 +9660,11 @@ Types:
             Type: 236 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1226
+      ID: 1230
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9353,14 +9676,14 @@ Types:
             Type: 235 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1227
+      ID: 1231
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1225
+      ID: 1229
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9372,7 +9695,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9382,7 +9705,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9392,7 +9715,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9492,7 +9815,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1187
+      ID: 1191
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9504,11 +9827,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1215
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9520,11 +9843,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1232
+      ID: 1236
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9536,11 +9859,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1186
+      ID: 1190
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9552,7 +9875,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9572,7 +9895,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1220
+      ID: 1224
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9584,11 +9907,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1221
+      ID: 1225
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9600,7 +9923,7 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13687,7 +14010,7 @@ Types:
       ID: 912
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.103392e+06
+      GoRuntimeType: 1.103648e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13700,7 +14023,7 @@ Types:
       ID: 943
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 980096
+      GoRuntimeType: 980864
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13726,7 +14049,7 @@ Types:
       ID: 120
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 979840
+      GoRuntimeType: 980608
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13738,7 +14061,7 @@ Types:
     - __kind: StructureType
       ID: 869
       Name: io.discard
-      GoRuntimeType: 1.280416e+06
+      GoRuntimeType: 1.280896e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -16263,7 +16586,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 951776
       GoKind: 5
-MaxTypeID: 1247
+MaxTypeID: 1255
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1758760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1377 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd996a", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1378 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcd99a5", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1308 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1309 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd5ea5", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1311 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1312 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd5f3d", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a3e", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1293 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1294 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd542c", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1291 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1292 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd535b", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1303 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1304 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5b45", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1305 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1306 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5b9d", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1295 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1296 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd588e", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1297 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1298 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd595e", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1299 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1300 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd59eb", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1301 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1302 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5b1e", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1396 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0xcd59af"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1397 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd56ca", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1362 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd90ae", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1363 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd913e", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1360 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd900a", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1361 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd9072", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1356 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1357 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcd8ea4", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1354 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd8dca", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1355 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1352 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd8d6a", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1353 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1346 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd8b6a", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1347 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd8bb4", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1350 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd8c8e", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1351 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd8d31", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1348 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd8bea", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1349 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd8c50", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1358 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd8eee", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1359 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1364 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd916e", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1365 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd91fb", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1392 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd9d60", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1393 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcd9d82", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1390 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcd9c20", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1391 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcd9c3e", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1381 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1382 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcd9a1e", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1381 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd9bca", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1382 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcd9c05", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1312 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd60ca", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6105", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd616a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd619d", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1261 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1263 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1262 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a3e", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1250 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1247 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd85a0", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd81c0", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8960", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd97e0", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd9d00", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcda140", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcda160", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6140", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd564a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd568c", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd552e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55bb", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5da5", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5dc4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5dfd", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1310 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5dc8", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd5a8a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5aee", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bbe", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd5c0a", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c4b", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5b86", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5c8e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5d7e", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1405 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1407 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd58ea"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd592a", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1402 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd58ee"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1409 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5de5"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1254 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1252 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1311 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60a0", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4e9a", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f4d", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5014", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6840", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd930e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd939e", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd8380", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd92d2", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8920", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd9800", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd9ca0", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd87a0", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd8760", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcd9104", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcd9068"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd8fca", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd8ffa"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd8dca", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd8e14", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd8eee", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd8f91", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd8eb0", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcd91e2"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1265 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd9c20", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd93ce", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd945b", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd88e0", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcd9fe2", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd97c0", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd61c0", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcd9e9e", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6820", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd9c40", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd9c60", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcd9c7e", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd9c80", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1258 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1259 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1260 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1257 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1256 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd9ce0", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd87c0", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1264 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd996a", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd9bca", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1378 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcd99a5", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcd9c05", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcd5e6a", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcd60ca", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1309 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xcd5ea5", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xcd6105", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xcd5f0a", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcd616a", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1312 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xcd5f3d", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xcd619d", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd6680", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd8340", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd85a0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd81c0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd8700", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd8960", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd9520", Frameless: true}]
+          Type: 1371 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
+          Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd97e0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd9aa0", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd9d00", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcda140", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcd9f00", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcda160", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd5ee0", Frameless: true}]
+          Type: 1314 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcd6140", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1293 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd53ea", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcd564a", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1294 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xcd542c", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xcd568c", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1291 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd52ce", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd552e", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1292 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xcd535b", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xcd55bb", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
+          Type: 1306 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1304 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xcd5b45", Frameless: true}]
+          Type: 1307 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xcd5da5", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcd5b64", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcd5dc4", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1306 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xcd5b9d", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xcd5dfd", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1310 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0xcd5dc8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1295 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcd582a", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcd5a8a", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1296 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xcd588e", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xcd5aee", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1297 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcd58ce", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1298 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xcd595e", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xcd5bbe", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1299 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcd59aa", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcd5c0a", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1300 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xcd59eb", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xcd5c4b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd5926", Frameless: false}]
+          Type: 1403 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcd5b86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcd5a2e", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcd5c8e", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1302 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xcd5b1e", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xcd5d7e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd5a33", Frameless: false}]
+          Type: 1404 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1405 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd5ae6", Frameless: false}]
+          Type: 1406 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1407 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testInlinedPrint]
+          Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd568a"
+            - PC: "0xcd58ea"
               Frameless: false
-            - PC: "0xcd5711"
+            - PC: "0xcd5971"
               Frameless: false
-            - PC: "0xcd5852"
+            - PC: "0xcd5ab2"
               Frameless: false
-            - PC: "0xcd58dc"
+            - PC: "0xcd5b3c"
               Frameless: false
-            - PC: "0xcd59af"
+            - PC: "0xcd5c0f"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1397 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xcd56ca", Frameless: false}]
+          Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xcd592a", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1402 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0xcd58ee"
+              Frameless: false
+            - PC: "0xcd5971"
+              Frameless: false
+            - PC: "0xcd5ab2"
+              Frameless: false
+            - PC: "0xcd5b3c"
+              Frameless: false
+            - PC: "0xcd5c0f"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1401 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd5b41", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1409 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcd5b85"
+            - PC: "0xcd5de5"
               Frameless: false
-            - PC: "0xcd5c25"
+            - PC: "0xcd5e85"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd5e40", Frameless: true}]
+          Type: 1311 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcd60a0", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd8520", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd4e9a", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd4f4d", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd5014", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd6640", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd6700", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd66c0", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd6820", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd6800", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd66e0", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd67e0", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd67c0", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd6600", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd6620", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd65e0", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd6840", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd6720", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd6780", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd67a0", Frameless: true}]
+          Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd6740", Frameless: true}]
+          Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd6760", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd90ae", Frameless: false}]
+          Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd930e", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd913e", Frameless: false}]
+          Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd939e", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd8120", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd8380", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd900a", Frameless: false}]
+          Type: 1364 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1361 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd9072", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd92d2", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd86c0", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd8920", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd9600", Frameless: true}]
+          Type: 1378 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
+          Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd9800", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
+          Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd9a40", Frameless: true}]
+          Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd9ca0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd8540", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd87a0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd66a0", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd8760", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
+          Type: 1360 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1357 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xcd8ea4", Frameless: false}]
+          Type: 1361 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0xcd9104", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcd8dca", Frameless: false}]
+          Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1355 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcd8e08"
+            - PC: "0xcd9068"
               Frameless: false
-            - PC: "0xcd8e12"
+            - PC: "0xcd9072"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcd8d6a", Frameless: false}]
+          Type: 1356 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcd8fca", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1353 EventRootType Probe[main.testReturnsError]Return
+          Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcd8d9a"
+            - PC: "0xcd8ffa"
               Frameless: false
-            - PC: "0xcd8da5"
+            - PC: "0xcd9005"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcd8b6a", Frameless: false}]
+          Type: 1350 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcd8dca", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1347 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcd8bb4", Frameless: false}]
+          Type: 1351 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcd8e14", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcd8c8e", Frameless: false}]
+          Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcd8eee", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1351 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcd8d31", Frameless: false}]
+          Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcd8f91", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1348 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcd8bea", Frameless: false}]
+          Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1349 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcd8c50", Frameless: false}]
+          Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcd8eb0", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcd8eee", Frameless: false}]
+          Type: 1362 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1359 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcd8f82"
+            - PC: "0xcd91e2"
               Frameless: false
-            - PC: "0xcd8f8c"
+            - PC: "0xcd91ec"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd99c0", Frameless: true}]
+          Type: 1383 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd9c20", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd9540", Frameless: true}]
+          Type: 1372 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd6660", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcd916e", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcd93ce", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1365 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd91fb", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd945b", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd8680", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd88e0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
+          Type: 1376 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd9d60", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1393 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcd9d82", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcd9fe2", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd9560", Frameless: true}]
+          Type: 1373 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd97c0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xcd5f60", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcd61c0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcd9c20", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1391 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcd9c3e", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xcd9e9e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcd9c00", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd65c0", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd6820", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
+          Type: 1384 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd9c40", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd9c60", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcd9a1e", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcd9c7e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd9a20", Frameless: true}]
+          Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd9c80", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd85a0", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd9500", Frameless: true}]
+          Type: 1370 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd9a80", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd9ce0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd8560", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd87c0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd9620", Frameless: true}]
+          Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1376 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd9620", Frameless: true}]
+          Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0xcd4e80..0xcd50ca]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd4f64..0xcd4f85
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5038..0xcd504f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd4f4d..0xcd4f50
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd4f50..0xcd4f85
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd4f85..0xcd502b
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0xcd502b..0xcd5038
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xcd5038..0xcd50ca
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd4f4a..0xcd4f50
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd4f50..0xcd4f50
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd4f50..0xcd4f85
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd4f85..0xcd502b
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0xcd502b..0xcd5030
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xcd5030..0xcd5038
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xcd5038..0xcd504f
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xcd504f..0xcd50ca
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd52c0..0xcd53c5]
+      OutOfLinePCRanges: [0xcd5520..0xcd5625]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 149 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd52c0..0xcd5313
+            - Range: 0xcd5520..0xcd5573
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd5313..0xcd5318
+            - Range: 0xcd5573..0xcd5578
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd5318..0xcd531d
+            - Range: 0xcd5578..0xcd557d
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,140 +2910,140 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd53e0..0xcd5443]
+      OutOfLinePCRanges: [0xcd5640..0xcd56a3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd53e0..0xcd540d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd5820..0xcd58a8]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5820..0xcd5835
+            - Range: 0xcd5640..0xcd566d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd58c0..0xcd5985]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xcd5a80..0xcd5b08]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd58c0..0xcd58d6
+            - Range: 0xcd5a80..0xcd5a95
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xcd5b20..0xcd5be5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5b20..0xcd5b36
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd58c0..0xcd58e7
+            - Range: 0xcd5b20..0xcd5b47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd58d6..0xcd58e7
+            - Range: 0xcd5b36..0xcd5b47
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd58e7..0xcd5985
+            - Range: 0xcd5b47..0xcd5be5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd59a0..0xcd5a02]
+      OutOfLinePCRanges: [0xcd5c00..0xcd5c62]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd59a0..0xcd59ba
+            - Range: 0xcd5c00..0xcd5c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd5a20..0xcd5b2e]
+      OutOfLinePCRanges: [0xcd5c80..0xcd5d8e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5a7b..0xcd5a85
+            - Range: 0xcd5cdb..0xcd5ce5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5a85..0xcd5aa0
+            - Range: 0xcd5ce5..0xcd5d00
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd5aa0..0xcd5ab4
+            - Range: 0xcd5d00..0xcd5d14
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5a76..0xcd5a80
+            - Range: 0xcd5cd6..0xcd5ce0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5a80..0xcd5aa0
+            - Range: 0xcd5ce0..0xcd5d00
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd5aa0..0xcd5aaf
+            - Range: 0xcd5d00..0xcd5d0f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd5b40..0xcd5b46]
+      OutOfLinePCRanges: [0xcd5da0..0xcd5da6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5b40..0xcd5b45
+            - Range: 0xcd5da0..0xcd5da5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5b40..0xcd5b46, Pieces: []}]
+          Locations: [{Range: 0xcd5da0..0xcd5da6, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd5b60..0xcd5ba3]
+      OutOfLinePCRanges: [0xcd5dc0..0xcd5e03]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 ArrayType [5]int
           Locations:
-            - Range: 0xcd5b60..0xcd5ba3
+            - Range: 0xcd5dc0..0xcd5e03
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5b60..0xcd5ba3, Pieces: []}]
+          Locations: [{Range: 0xcd5dc0..0xcd5e03, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd5e40..0xcd5e41]
+      OutOfLinePCRanges: [0xcd60a0..0xcd60a1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 156 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd5e40..0xcd5e41
+            - Range: 0xcd60a0..0xcd60a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2847,21 +3051,21 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0xcd5e60..0xcd5ec6]
+      OutOfLinePCRanges: [0xcd60c0..0xcd6126]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd5e60..0xcd5e89
+            - Range: 0xcd60c0..0xcd60e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd5e89..0xcd5e8e
+            - Range: 0xcd60e9..0xcd60ee
               Pieces:
                 - Size: 8
                   Op: null
@@ -2871,18 +3075,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd5e60..0xcd5ec6, Pieces: []}]
+          Locations: [{Range: 0xcd60c0..0xcd6126, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0xcd5ee0..0xcd5ee1]
+      OutOfLinePCRanges: [0xcd6140..0xcd6141]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd5ee0..0xcd5ee1
+            - Range: 0xcd6140..0xcd6141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,32 +3094,32 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcd5f00..0xcd5f54]
+      OutOfLinePCRanges: [0xcd6160..0xcd61b4]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *interface {}
           Locations:
-            - Range: 0xcd5f00..0xcd5f26
+            - Range: 0xcd6160..0xcd6186
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd5f00..0xcd5f54, Pieces: []}]
+          Locations: [{Range: 0xcd6160..0xcd61b4, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcd5f60..0xcd5f61]
+      OutOfLinePCRanges: [0xcd61c0..0xcd61c1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 158 StructureType main.structWithAny
           Locations:
-            - Range: 0xcd5f60..0xcd5f61
+            - Range: 0xcd61c0..0xcd61c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2923,309 +3127,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd65c0..0xcd65c1]
+      OutOfLinePCRanges: [0xcd6820..0xcd6821]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithMap
           Locations:
-            - Range: 0xcd65c0..0xcd65c1
+            - Range: 0xcd6820..0xcd6821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd65e0..0xcd65e1]
+      OutOfLinePCRanges: [0xcd6840..0xcd6841]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 165 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcd65e0..0xcd65e1
+            - Range: 0xcd6840..0xcd6841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd6600..0xcd6601]
+      OutOfLinePCRanges: [0xcd6860..0xcd6861]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[string]int
           Locations:
-            - Range: 0xcd6600..0xcd6601
+            - Range: 0xcd6860..0xcd6861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd6620..0xcd6621]
+      OutOfLinePCRanges: [0xcd6880..0xcd6881]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[string][]string
           Locations:
-            - Range: 0xcd6620..0xcd6621
+            - Range: 0xcd6880..0xcd6881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd6640..0xcd6641]
+      OutOfLinePCRanges: [0xcd68a0..0xcd68a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcd6640..0xcd6641
+            - Range: 0xcd68a0..0xcd68a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcd6660..0xcd6661]
+      OutOfLinePCRanges: [0xcd68c0..0xcd68c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[string]int
           Locations:
-            - Range: 0xcd6660..0xcd6661
+            - Range: 0xcd68c0..0xcd68c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcd6680..0xcd6681]
+      OutOfLinePCRanges: [0xcd68e0..0xcd68e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcd6680..0xcd6681
+            - Range: 0xcd68e0..0xcd68e1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcd66a0..0xcd66a1]
+      OutOfLinePCRanges: [0xcd6900..0xcd6901]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 PointerType *map[string]int
           Locations:
-            - Range: 0xcd66a0..0xcd66a1
+            - Range: 0xcd6900..0xcd6901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcd66c0..0xcd66c1]
+      OutOfLinePCRanges: [0xcd6920..0xcd6921]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 160 GoMapType map[int]int
           Locations:
-            - Range: 0xcd66c0..0xcd66c1
+            - Range: 0xcd6920..0xcd6921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcd66e0..0xcd66e1]
+      OutOfLinePCRanges: [0xcd6940..0xcd6941]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 187 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd66e0..0xcd66e1
+            - Range: 0xcd6940..0xcd6941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcd6700..0xcd6701]
+      OutOfLinePCRanges: [0xcd6960..0xcd6961]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcd6700..0xcd6701
+            - Range: 0xcd6960..0xcd6961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcd6720..0xcd6721]
+      OutOfLinePCRanges: [0xcd6980..0xcd6981]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcd6720..0xcd6721
+            - Range: 0xcd6980..0xcd6981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcd6740..0xcd6741]
+      OutOfLinePCRanges: [0xcd69a0..0xcd69a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd6740..0xcd6741
+            - Range: 0xcd69a0..0xcd69a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcd6760..0xcd6761]
+      OutOfLinePCRanges: [0xcd69c0..0xcd69c1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 197 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcd6760..0xcd6761
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcd6780..0xcd6781]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 202 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcd6780..0xcd6781
+            - Range: 0xcd69c0..0xcd69c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcd67a0..0xcd67a1]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcd69e0..0xcd69e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd67a0..0xcd67a1
+            - Range: 0xcd69e0..0xcd69e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcd67c0..0xcd67c1]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcd6a00..0xcd6a01]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcd67c0..0xcd67c1
+            - Range: 0xcd6a00..0xcd6a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcd6a20..0xcd6a21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 202 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcd6a20..0xcd6a21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcd67e0..0xcd67e1]
+      OutOfLinePCRanges: [0xcd6a40..0xcd6a41]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcd67e0..0xcd67e1
+            - Range: 0xcd6a40..0xcd6a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcd6800..0xcd6801]
+      OutOfLinePCRanges: [0xcd6a60..0xcd6a61]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcd6800..0xcd6801
+            - Range: 0xcd6a60..0xcd6a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcd6820..0xcd6821]
+      OutOfLinePCRanges: [0xcd6a80..0xcd6a81]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcd6820..0xcd6821
+            - Range: 0xcd6a80..0xcd6a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd7f60..0xcd7f61]
+      OutOfLinePCRanges: [0xcd81c0..0xcd81c1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7f60..0xcd7f61
+            - Range: 0xcd81c0..0xcd81c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd7f60..0xcd7f61
+            - Range: 0xcd81c0..0xcd81c1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xcd7f60..0xcd7f61
+            - Range: 0xcd81c0..0xcd81c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd8120..0xcd8121]
+      OutOfLinePCRanges: [0xcd8380..0xcd8381]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd8120..0xcd8121
+            - Range: 0xcd8380..0xcd8381
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd8120..0xcd8121
+            - Range: 0xcd8380..0xcd8381
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd8120..0xcd8121
+            - Range: 0xcd8380..0xcd8381
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8120..0xcd8121
+            - Range: 0xcd8380..0xcd8381
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8120..0xcd8121
+            - Range: 0xcd8380..0xcd8381
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3233,39 +3437,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd8340..0xcd8341]
+      OutOfLinePCRanges: [0xcd85a0..0xcd85a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 222 GoChannelType chan bool
           Locations:
-            - Range: 0xcd8340..0xcd8341
+            - Range: 0xcd85a0..0xcd85a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd8500..0xcd8501]
+      OutOfLinePCRanges: [0xcd8760..0xcd8761]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 223 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd8500..0xcd8501
+            - Range: 0xcd8760..0xcd8761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd8520..0xcd8521]
+      OutOfLinePCRanges: [0xcd8780..0xcd8781]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 225 StructureType main.node
           Locations:
-            - Range: 0xcd8520..0xcd8521
+            - Range: 0xcd8780..0xcd8781
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3273,195 +3477,195 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd8540..0xcd8541]
+      OutOfLinePCRanges: [0xcd87a0..0xcd87a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 226 PointerType *main.node
           Locations:
-            - Range: 0xcd8540..0xcd8541
+            - Range: 0xcd87a0..0xcd87a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd8560..0xcd8561]
+      OutOfLinePCRanges: [0xcd87c0..0xcd87c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd8560..0xcd8561
+            - Range: 0xcd87c0..0xcd87c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd85a0..0xcd85a1]
+      OutOfLinePCRanges: [0xcd8800..0xcd8801]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0xcd85a0..0xcd85a1
+            - Range: 0xcd8800..0xcd8801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd8680..0xcd8681]
+      OutOfLinePCRanges: [0xcd88e0..0xcd88e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0xcd8680..0xcd8681
+            - Range: 0xcd88e0..0xcd88e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd86c0..0xcd86c1]
+      OutOfLinePCRanges: [0xcd8920..0xcd8921]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd86c0..0xcd86c1
+            - Range: 0xcd8920..0xcd8921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd86c0..0xcd86c1
+            - Range: 0xcd8920..0xcd8921
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd8700..0xcd8701]
+      OutOfLinePCRanges: [0xcd8960..0xcd8961]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 227 PointerType *main.t
           Locations:
-            - Range: 0xcd8700..0xcd8701
+            - Range: 0xcd8960..0xcd8961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcd8b60..0xcd8bcc]
+      OutOfLinePCRanges: [0xcd8dc0..0xcd8e2c]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8b60..0xcd8b7e
+            - Range: 0xcd8dc0..0xcd8dde
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd8b7e..0xcd8bcc
+            - Range: 0xcd8dde..0xcd8e2c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd8b60..0xcd8bcc, Pieces: []}]
+          Locations: [{Range: 0xcd8dc0..0xcd8e2c, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcd8be0..0xcd8c6f]
+      OutOfLinePCRanges: [0xcd8e40..0xcd8ecf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8be0..0xcd8bfa
+            - Range: 0xcd8e40..0xcd8e5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 98 PointerType *int
-          Locations: [{Range: 0xcd8be0..0xcd8c6f, Pieces: []}]
+          Locations: [{Range: 0xcd8e40..0xcd8ecf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd8bff..0xcd8c15
+            - Range: 0xcd8e5f..0xcd8e75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd8c15..0xcd8c6f
+            - Range: 0xcd8e75..0xcd8ecf
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcd8c80..0xcd8d4f]
+      OutOfLinePCRanges: [0xcd8ee0..0xcd8faf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd8c80..0xcd8cd4
+            - Range: 0xcd8ee0..0xcd8f34
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd8cd4..0xcd8d4f
+            - Range: 0xcd8f34..0xcd8faf
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd8c80..0xcd8d4f, Pieces: []}]
+          Locations: [{Range: 0xcd8ee0..0xcd8faf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd8c80..0xcd8d4f, Pieces: []}]
+          Locations: [{Range: 0xcd8ee0..0xcd8faf, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd8c9f..0xcd8cd4
+            - Range: 0xcd8eff..0xcd8f34
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcd8cd4..0xcd8d4f
+            - Range: 0xcd8f34..0xcd8faf
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcd8d60..0xcd8dbb]
+      OutOfLinePCRanges: [0xcd8fc0..0xcd901b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd8d60..0xcd8d79
+            - Range: 0xcd8fc0..0xcd8fd9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcd8d60..0xcd8dbb, Pieces: []}]
+          Locations: [{Range: 0xcd8fc0..0xcd901b, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcd8dc0..0xcd8e3c]
+      OutOfLinePCRanges: [0xcd9020..0xcd909c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd8dc0..0xcd8de3
+            - Range: 0xcd9020..0xcd9043
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8de3..0xcd8de8
+            - Range: 0xcd9043..0xcd9048
               Pieces:
                 - Size: 8
                   Op: null
@@ -3472,41 +3676,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd8dc0..0xcd8de8
+            - Range: 0xcd9020..0xcd9048
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 151 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcd8dc0..0xcd8e3c, Pieces: []}]
+          Locations: [{Range: 0xcd9020..0xcd909c, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcd8dc0..0xcd8e3c, Pieces: []}]
+          Locations: [{Range: 0xcd9020..0xcd909c, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcd8e40..0xcd8ec8]
+      OutOfLinePCRanges: [0xcd90a0..0xcd9128]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd8e40..0xcd8e81
+            - Range: 0xcd90a0..0xcd90e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8e81..0xcd8e88
+            - Range: 0xcd90e1..0xcd90e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8e88..0xcd8ec8
+            - Range: 0xcd90e8..0xcd9128
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -3516,186 +3720,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 151 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcd8e40..0xcd8ec8, Pieces: []}]
+          Locations: [{Range: 0xcd90a0..0xcd9128, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcd8ee0..0xcd8ff4]
+      OutOfLinePCRanges: [0xcd9140..0xcd9254]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd8ee0..0xcd8f15
+            - Range: 0xcd9140..0xcd9175
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8f15..0xcd8f5f
+            - Range: 0xcd9175..0xcd91bf
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd8f5f..0xcd8f92
+            - Range: 0xcd91bf..0xcd91f2
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd8f92..0xcd8fb2
+            - Range: 0xcd91f2..0xcd9212
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8fb2..0xcd8fb9
+            - Range: 0xcd9212..0xcd9219
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8fb9..0xcd8ff4
+            - Range: 0xcd9219..0xcd9254
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 156 GoInterfaceType main.behavior
-          Locations: [{Range: 0xcd8ee0..0xcd8ff4, Pieces: []}]
+          Locations: [{Range: 0xcd9140..0xcd9254, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 156 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd8ee0..0xcd8f15
+            - Range: 0xcd9140..0xcd9175
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd8f15..0xcd8f5f
+            - Range: 0xcd9175..0xcd91bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8f5f..0xcd8f66
+            - Range: 0xcd91bf..0xcd91c6
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8f66..0xcd8f88
+            - Range: 0xcd91c6..0xcd91e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8f88..0xcd8f8a
+            - Range: 0xcd91e8..0xcd91ea
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd8f8a..0xcd8f8c
+            - Range: 0xcd91ea..0xcd91ec
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd8f8c..0xcd8ff4
+            - Range: 0xcd91ec..0xcd9254
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcd9000..0xcd908f]
+      OutOfLinePCRanges: [0xcd9260..0xcd92ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9000..0xcd903c
+            - Range: 0xcd9260..0xcd929c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd903c..0xcd908f
+            - Range: 0xcd929c..0xcd92ef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9000..0xcd908f, Pieces: []}]
+          Locations: [{Range: 0xcd9260..0xcd92ef, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcd90a0..0xcd9158]
+      OutOfLinePCRanges: [0xcd9300..0xcd93b8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd90a0..0xcd90e6
+            - Range: 0xcd9300..0xcd9346
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90e6..0xcd9158
+            - Range: 0xcd9346..0xcd93b8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd90a0..0xcd9158, Pieces: []}]
+          Locations: [{Range: 0xcd9300..0xcd93b8, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd90a0..0xcd9158, Pieces: []}]
+          Locations: [{Range: 0xcd9300..0xcd93b8, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcd9160..0xcd9215]
+      OutOfLinePCRanges: [0xcd93c0..0xcd9475]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9160..0xcd91a5
+            - Range: 0xcd93c0..0xcd9405
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd91a5..0xcd9215
+            - Range: 0xcd9405..0xcd9475
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9160..0xcd9215, Pieces: []}]
+          Locations: [{Range: 0xcd93c0..0xcd9475, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9160..0xcd9215, Pieces: []}]
+          Locations: [{Range: 0xcd93c0..0xcd9475, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9160..0xcd9215, Pieces: []}]
+          Locations: [{Range: 0xcd93c0..0xcd9475, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd9500..0xcd9501]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd9500..0xcd9501
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd9520..0xcd9521]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd9760..0xcd9761]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd9520..0xcd9521
+            - Range: 0xcd9760..0xcd9761
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3706,14 +3892,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd9540..0xcd9541]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd9780..0xcd9781]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 230 GoSliceHeaderType [][]uint
+          Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd9540..0xcd9541
+            - Range: 0xcd9780..0xcd9781
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3724,14 +3910,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd9560..0xcd9561]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcd97a0..0xcd97a1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 230 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcd9560..0xcd9561
+            - Range: 0xcd97a0..0xcd97a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3739,24 +3925,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd9560..0xcd9561
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd9580..0xcd9581]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcd97c0..0xcd97c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd9580..0xcd9581
+            - Range: 0xcd97c0..0xcd97c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3769,19 +3948,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9580..0xcd9581
+            - Range: 0xcd97c0..0xcd97c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd95a0..0xcd95a1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcd97e0..0xcd97e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd95a0..0xcd95a1
+            - Range: 0xcd97e0..0xcd97e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3794,19 +3973,44 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd95a0..0xcd95a1
+            - Range: 0xcd97e0..0xcd97e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd9800..0xcd9801]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd9800..0xcd9801
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9800..0xcd9801
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcd95c0..0xcd95c1]
+      OutOfLinePCRanges: [0xcd9820..0xcd9821]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 235 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcd95c0..0xcd95c1
+            - Range: 0xcd9820..0xcd9821
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3816,22 +4020,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd95e0..0xcd95e1]
+      OutOfLinePCRanges: [0xcd9840..0xcd9841]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd95e0..0xcd95e1
+            - Range: 0xcd9840..0xcd9841
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 236 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd95e0..0xcd95e1
+            - Range: 0xcd9840..0xcd9841
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3844,37 +4048,19 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd95e0..0xcd95e1
+            - Range: 0xcd9840..0xcd9841
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd9600..0xcd9601]
+      OutOfLinePCRanges: [0xcd9860..0xcd9861]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 237 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd9600..0xcd9601
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd9620..0xcd9621]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd9620..0xcd9621
+            - Range: 0xcd9860..0xcd9861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3885,24 +4071,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcd9880..0xcd9881]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 229 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd9880..0xcd9881
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd9960..0xcd99b2]
+      OutOfLinePCRanges: [0xcd9bc0..0xcd9c12]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd9960..0xcd99b2, Pieces: []}]
+          Locations: [{Range: 0xcd9bc0..0xcd9c12, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd99c0..0xcd99c1]
+      OutOfLinePCRanges: [0xcd9c20..0xcd9c21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd99c0..0xcd99c1
+            - Range: 0xcd9c20..0xcd9c21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3910,15 +4114,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd99e0..0xcd99e1]
+      OutOfLinePCRanges: [0xcd9c40..0xcd9c41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd99e0..0xcd99e1
+            - Range: 0xcd9c40..0xcd9c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3929,7 +4133,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd99e0..0xcd99e1
+            - Range: 0xcd9c40..0xcd9c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3940,7 +4144,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd99e0..0xcd99e1
+            - Range: 0xcd9c40..0xcd9c41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3948,15 +4152,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd9a00..0xcd9a1f]
+      OutOfLinePCRanges: [0xcd9c60..0xcd9c7f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd9a00..0xcd9a1f
+            - Range: 0xcd9c60..0xcd9c7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3972,55 +4176,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd9a20..0xcd9a21]
+      OutOfLinePCRanges: [0xcd9c80..0xcd9c81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd9a20..0xcd9a21
+            - Range: 0xcd9c80..0xcd9c81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd9a40..0xcd9a41]
+      OutOfLinePCRanges: [0xcd9ca0..0xcd9ca1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd9a40..0xcd9a41
+            - Range: 0xcd9ca0..0xcd9ca1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd9a60..0xcd9a61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd9a60..0xcd9a61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd9a80..0xcd9a81]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcd9cc0..0xcd9cc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9a80..0xcd9a81
+            - Range: 0xcd9cc0..0xcd9cc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4029,14 +4217,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd9aa0..0xcd9aa1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcd9ce0..0xcd9ce1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9aa0..0xcd9aa1
+            - Range: 0xcd9ce0..0xcd9ce1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4045,26 +4233,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcd9d00..0xcd9d01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd9d00..0xcd9d01
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcd9c00..0xcd9c01]
+      OutOfLinePCRanges: [0xcd9e60..0xcd9e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcd9c00..0xcd9c01
+            - Range: 0xcd9e60..0xcd9e61
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcd9c20..0xcd9c3f]
+      OutOfLinePCRanges: [0xcd9e80..0xcd9e9f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcd9c20..0xcd9c3f
+            - Range: 0xcd9e80..0xcd9e9f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4080,15 +4284,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd9d60..0xcd9d83]
+      OutOfLinePCRanges: [0xcd9fc0..0xcd9fe3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 286 StructureType main.aStruct
           Locations:
-            - Range: 0xcd9d60..0xcd9d83
+            - Range: 0xcd9fc0..0xcd9fe3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4106,108 +4310,108 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd9ee0..0xcd9ee1]
+      OutOfLinePCRanges: [0xcda140..0xcda141]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 288 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd9ee0..0xcd9ee1, Pieces: []}]
+          Locations: [{Range: 0xcda140..0xcda141, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcd9f00..0xcd9f01]
+      OutOfLinePCRanges: [0xcda160..0xcda161]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 289 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcd9f00..0xcd9f01
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd5680..0xcd56e2]
-      InlinePCRanges:
-        - Ranges: [0xcd5711..0xcd574d]
-          RootRanges: [0xcd5700..0xcd5771]
-        - Ranges: [0xcd5852..0xcd588e]
-          RootRanges: [0xcd5820..0xcd58a8]
-        - Ranges: [0xcd58dc..0xcd5918]
-          RootRanges: [0xcd58c0..0xcd5985]
-        - Ranges: [0xcd59af..0xcd59eb]
-          RootRanges: [0xcd59a0..0xcd5a02]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd5680..0xcd5699
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5711..0xcd571c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd5852..0xcd585d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd58d6..0xcd58e7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd58e7..0xcd5985
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd59a0..0xcd59ba
+            - Range: 0xcda160..0xcda161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xcd58e0..0xcd5942]
       InlinePCRanges:
-        - Ranges: [0xcd5926..0xcd595e]
-          RootRanges: [0xcd58c0..0xcd5985]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5a33..0xcd5a71]
-          RootRanges: [0xcd5a20..0xcd5b2e]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5ae6..0xcd5b1e]
-          RootRanges: [0xcd5a20..0xcd5b2e]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcd5b41..0xcd5b45]
-          RootRanges: [0xcd5b40..0xcd5b46]
+        - Ranges: [0xcd5971..0xcd59ad]
+          RootRanges: [0xcd5960..0xcd59d1]
+        - Ranges: [0xcd5ab2..0xcd5aee]
+          RootRanges: [0xcd5a80..0xcd5b08]
+        - Ranges: [0xcd5b3c..0xcd5b78]
+          RootRanges: [0xcd5b20..0xcd5be5]
+        - Ranges: [0xcd5c0f..0xcd5c4b]
+          RootRanges: [0xcd5c00..0xcd5c62]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd5b40..0xcd5b45
+            - Range: 0xcd58e0..0xcd58f9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5971..0xcd597c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5ab2..0xcd5abd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5b36..0xcd5b47
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5b47..0xcd5be5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcd5c00..0xcd5c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5b86..0xcd5bbe]
+          RootRanges: [0xcd5b20..0xcd5be5]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5c93..0xcd5cd1]
+          RootRanges: [0xcd5c80..0xcd5d8e]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5d46..0xcd5d7e]
+          RootRanges: [0xcd5c80..0xcd5d8e]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd5da1..0xcd5da5]
+          RootRanges: [0xcd5da0..0xcd5da6]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5da0..0xcd5da5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5b85..0xcd5b9d]
-          RootRanges: [0xcd5b60..0xcd5ba3]
-        - Ranges: [0xcd5c25..0xcd5c43]
-          RootRanges: [0xcd5bc0..0xcd5d45]
+        - Ranges: [0xcd5de5..0xcd5dfd]
+          RootRanges: [0xcd5dc0..0xcd5e03]
+        - Ranges: [0xcd5e85..0xcd5ea3]
+          RootRanges: [0xcd5e20..0xcd5fa5]
       Variables:
         - Name: a
           Type: 155 ArrayType [5]int
           Locations:
-            - Range: 0xcd5b6d..0xcd5ba3
+            - Range: 0xcd5dcd..0xcd5e03
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd5c0c..0xcd5d45
+            - Range: 0xcd5e6c..0xcd5fa5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
@@ -5047,14 +5251,14 @@ Types:
       ID: 759
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.020352e+06
+      GoRuntimeType: 1.018688e+06
       GoKind: 22
       Pointee: 760 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 761
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.02048e+06
+      GoRuntimeType: 1.018816e+06
       GoKind: 22
       Pointee: 762 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -5939,21 +6143,21 @@ Types:
       ID: 993
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.186016e+06
+      GoRuntimeType: 1.186272e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 991
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.185632e+06
+      GoRuntimeType: 1.185888e+06
       GoKind: 22
       Pointee: 992 StructureType io.discard
     - __kind: PointerType
       ID: 965
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.018816e+06
+      GoRuntimeType: 1.019584e+06
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7381,10 +7585,10 @@ Types:
       GoKind: 22
       Pointee: 756 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1377
+      ID: 1381
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1382
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7396,11 +7600,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1311
+      ID: 1315
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7412,11 +7616,11 @@ Types:
             Type: 157 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1312
+      ID: 1316
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7428,11 +7632,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1308
+      ID: 1312
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7444,11 +7648,11 @@ Types:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1313
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7460,7 +7664,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7496,7 +7700,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1320
+      ID: 1324
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7508,7 +7712,7 @@ Types:
             Type: 185 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7579,7 +7783,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1337
+      ID: 1341
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7591,11 +7795,11 @@ Types:
             Type: 222 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1335
+      ID: 1339
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7607,7 +7811,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7617,7 +7821,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7627,11 +7831,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1345
+      ID: 1349
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7643,7 +7847,7 @@ Types:
             Type: 227 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7743,7 +7947,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1370
+      ID: 1374
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7755,7 +7959,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7765,11 +7969,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1371
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7781,11 +7985,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1388
+      ID: 1392
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7797,11 +8001,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1395
+      ID: 1399
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7813,11 +8017,11 @@ Types:
             Type: 289 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1398
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7829,11 +8033,11 @@ Types:
             Type: 288 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1310
+      ID: 1314
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7845,11 +8049,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1296
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7861,14 +8065,14 @@ Types:
             Type: 153 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1294
+      ID: 1297
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1291
+      ID: 1294
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7880,14 +8084,14 @@ Types:
             Type: 149 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1292
+      ID: 1295
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1305
+      ID: 1308
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7899,12 +8103,70 @@ Types:
             Type: 155 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1306
+      ID: 1310
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1309
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1306
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1307
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7919,82 +8181,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1304
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1295
+      ID: 1298
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1296
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1299
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1300
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1297
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -8007,6 +8196,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1302
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1303
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1300
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -8014,26 +8244,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1298
+      ID: 1301
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1399
+      ID: 1404
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1400
+      ID: 1405
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1406
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1301
+      ID: 1407
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1304
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1302
+      ID: 1305
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1396
+      ID: 1400
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8045,14 +8281,30 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1402
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1401
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1408
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8064,11 +8316,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1410
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8080,7 +8348,7 @@ Types:
             Type: 155 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -8164,7 +8432,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1311
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8176,11 +8444,11 @@ Types:
             Type: 156 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1343
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8192,11 +8460,66 @@ Types:
             Type: 225 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1318
+      ID: 1291
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1292
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1293
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1322
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8208,11 +8531,11 @@ Types:
             Type: 180 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1329
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8224,11 +8547,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1326
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8240,11 +8563,11 @@ Types:
             Type: 160 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1334
+      ID: 1338
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8256,11 +8579,11 @@ Types:
             Type: 217 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1337
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8272,11 +8595,11 @@ Types:
             Type: 212 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1327
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8288,11 +8611,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1328
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8304,11 +8627,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1336
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8320,12 +8643,92 @@ Types:
             Type: 207 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1335
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 202 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1320
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 170 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1321
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 175 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1319
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 165 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1330
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 192 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1334
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8340,72 +8743,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 170 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1317
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 175 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1315
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 165 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1326
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 192 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1330
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1333
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8420,23 +8759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 202 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1328
+      ID: 1332
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8448,11 +8771,11 @@ Types:
             Type: 197 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1331
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8464,11 +8787,11 @@ Types:
             Type: 197 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1389
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8480,11 +8803,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1386
+      ID: 1390
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8496,12 +8819,110 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1366
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1367
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1340
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1364
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8516,9 +8937,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1365
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8531,106 +8952,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 10 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 16 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1360
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1361
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1344
+      ID: 1348
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8642,7 +8965,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8652,11 +8975,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1371
+      ID: 1375
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8668,7 +8991,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8678,11 +9001,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1377
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8694,7 +9017,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8704,7 +9027,7 @@ Types:
             Type: 236 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8714,11 +9037,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1374
+      ID: 1378
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8730,11 +9053,11 @@ Types:
             Type: 237 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1384
+      ID: 1388
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8746,11 +9069,11 @@ Types:
             Type: 240 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1344
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8762,11 +9085,11 @@ Types:
             Type: 226 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1325
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8778,11 +9101,11 @@ Types:
             Type: 186 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1338
+      ID: 1342
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8794,65 +9117,13 @@ Types:
             Type: 223 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 151 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1355
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 151 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1356
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8865,10 +9136,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1357
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1359
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8878,150 +9159,22 @@ Types:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1352
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1353
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1351
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1348
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1349
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 98 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1346
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1347
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1358
-      Name: Probe[main.testReturnsInterface]
+      ID: 1360
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -9036,7 +9189,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 151 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1356
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1357
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1354
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1355
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1352
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1353
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 98 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1350
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1351
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1362
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 151 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1363
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9048,7 +9371,7 @@ Types:
             Type: 156 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9228,7 +9551,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1379
+      ID: 1383
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9240,7 +9563,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9324,7 +9647,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1372
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9336,11 +9659,11 @@ Types:
             Type: 230 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1323
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9352,11 +9675,11 @@ Types:
             Type: 170 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1368
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9368,11 +9691,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1369
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9384,7 +9707,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9394,7 +9717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9404,7 +9727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9424,7 +9747,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1343
+      ID: 1347
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9436,11 +9759,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1376
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9452,7 +9775,7 @@ Types:
             Type: 235 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9488,7 +9811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1373
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9500,7 +9823,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9510,11 +9833,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1317
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9526,11 +9849,11 @@ Types:
             Type: 158 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1394
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9542,14 +9865,14 @@ Types:
             Type: 255 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1391
+      ID: 1395
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1389
+      ID: 1393
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9561,11 +9884,11 @@ Types:
             Type: 242 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1314
+      ID: 1318
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9577,11 +9900,11 @@ Types:
             Type: 159 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1396
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9593,14 +9916,14 @@ Types:
             Type: 286 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1393
+      ID: 1397
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1383
+      ID: 1387
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9612,11 +9935,11 @@ Types:
             Type: 239 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1385
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9628,14 +9951,14 @@ Types:
             Type: 238 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1382
+      ID: 1386
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1384
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9647,7 +9970,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9657,7 +9980,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9667,7 +9990,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9767,7 +10090,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1342
+      ID: 1346
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9779,11 +10102,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1370
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9795,11 +10118,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1387
+      ID: 1391
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9811,11 +10134,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1341
+      ID: 1345
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9827,7 +10150,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9847,7 +10170,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1375
+      ID: 1379
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9859,11 +10182,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1376
+      ID: 1380
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9875,7 +10198,7 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13024,7 +13347,7 @@ Types:
       ID: 1034
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.18576e+06
+      GoRuntimeType: 1.186016e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13037,7 +13360,7 @@ Types:
       ID: 1071
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.018944e+06
+      GoRuntimeType: 1.019712e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13063,7 +13386,7 @@ Types:
       ID: 125
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.018688e+06
+      GoRuntimeType: 1.019456e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13075,7 +13398,7 @@ Types:
     - __kind: StructureType
       ID: 992
       Name: io.discard
-      GoRuntimeType: 1.45808e+06
+      GoRuntimeType: 1.45856e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -17828,7 +18151,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989440
       GoKind: 5
-MaxTypeID: 1402
+MaxTypeID: 1410
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x17fd3a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd58d6..0xcd58e7
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd58e7..0xcd5985
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd59a0..0xcd5a02]
@@ -2765,7 +2774,29 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd5a20..0xcd5b2e]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5a7b..0xcd5a85
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xcd5a85..0xcd5aa0
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xcd5aa0..0xcd5ab4
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd5a76..0xcd5a80
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xcd5a80..0xcd5aa0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xcd5aa0..0xcd5aaf
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd5b40..0xcd5b46]
@@ -3357,6 +3388,15 @@ Subprograms:
           Locations: [{Range: 0xcd8be0..0xcd8c6f, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 98 PointerType *int
+          Locations:
+            - Range: 0xcd8bff..0xcd8c15
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd8c15..0xcd8c6f
+              Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcd8c80..0xcd8d4f]
@@ -3381,6 +3421,15 @@ Subprograms:
           Locations: [{Range: 0xcd8c80..0xcd8d4f, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0xcd8c9f..0xcd8cd4
+              Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
+            - Range: 0xcd8cd4..0xcd8d4f
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcd8d60..0xcd8dbb]
@@ -3509,6 +3558,45 @@ Subprograms:
           Locations: [{Range: 0xcd8ee0..0xcd8ff4, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 156 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xcd8ee0..0xcd8f15
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd8f15..0xcd8f5f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcd8f5f..0xcd8f66
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcd8f66..0xcd8f88
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcd8f88..0xcd8f8a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcd8f8a..0xcd8f8c
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcd8f8c..0xcd8ff4
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcd9000..0xcd908f]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1381 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd9bca", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1382 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcd9c05", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1312 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd60ca", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6105", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd616a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd619d", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1261 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1263 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1262 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a20", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a3e", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1250 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1247 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4100", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd85a0", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd81c0", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8960", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e00", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e20", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4ae0", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b00", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4c80", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ca0", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd97e0", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd9d00", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcda140", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcda160", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6140", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd564a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd568c", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd552e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55bb", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5da0", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5da5", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5dc4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5dfd", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1310 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1310 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5dc8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd5a8a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5aee", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bbe", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd5c0a", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c4b", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5b86", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5c8e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5d7e", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1405 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1405 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1407 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1407 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd58ea"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd592a", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1402 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1402 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd58ee"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1409 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1409 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5de5"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1254 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1252 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1311 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60a0", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4e9a", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f4d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5014", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6840", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd9cc0", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd930e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd939e", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd8380", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd92d2", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8920", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd9860", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd9800", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd9840", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd9ca0", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd87a0", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd8760", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcd9104", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcd9068"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd8fca", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd8ffa"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd8dca", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd8e14", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd8eee", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd8f91", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd8e4a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd8eb0", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcd91e2"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1265 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd46e0", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4700", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd9c20", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd93ce", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd945b", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd88e0", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd9820", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd9fc0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcd9fe2", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd97c0", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd61c0", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcd9e80", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcd9e9e", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcd9e60", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6820", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd9c40", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd9c60", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcd9c7e", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd9c80", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1258 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1259 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1260 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1257 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1256 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd9ce0", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd87c0", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1264 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd9880", Frameless: true}]
           Condition: null
@@ -8108,7 +8272,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1310
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -8255,13 +8419,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1405
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1407
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testInlinedBC]
@@ -8286,7 +8450,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1402
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8321,7 +8485,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1409
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8465,10 +8629,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1291
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1292
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8494,7 +8658,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1293
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1400 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcde40a", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1401 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcde445", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda9aa", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcda9e5", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcdaa4a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaa7d", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd933e", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdce20", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcddfc0", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcde020", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1411 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcde540", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1417 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcde980", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcde9a0", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9f2a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9f6c", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9e0e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9e9b", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda680", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda685", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda6a4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda6dd", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1329 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1329 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6a8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda36a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda3ce", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda49e", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda4ea", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda52b", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1422 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda466", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda56e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda653", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1423 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda573", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1424 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1424 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda573", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1425 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1426 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1426 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda1ca"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda20a", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1421 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1421 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda1ce"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1427 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda681", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1428 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1428 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda681", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda6c5"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda980", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdcfe0", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd979a", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd984d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9914", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb0c0", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1409 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcddb4e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcddbde", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdcc00", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddb12", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcde0a0", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcde040", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcde080", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcde4e0", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd000", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdcfc0", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcdd944", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcdd8a8"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcdd80a", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcdd83a"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd60a", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd654", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdd7d1", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd68a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd6f0", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1381 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcdda22"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1291 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1402 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcde460", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1292 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1293 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcddfe0", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcddc0e", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcddc9b", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd140", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcde060", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1415 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcde800", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1416 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcde822", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcde000", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcde6c0", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcde6de", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcde6a0", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0a0", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcde480", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcde4a0", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcde4be", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcde4c0", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd060", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcddfa0", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcde520", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd020", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null
@@ -8173,7 +8337,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1329
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -8320,13 +8484,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1426
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testInlinedBC]
@@ -8351,7 +8515,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1421
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8386,7 +8550,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1428
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8530,10 +8694,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1310
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1311
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8559,7 +8723,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1312
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcde1aa", Frameless: false}]
+          Type: 1400 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcde40a", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1397 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcde1e5", Frameless: false}]
+          Type: 1401 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcde445", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
+          Type: 1331 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcda9aa", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0xcda785", Frameless: false}]
+          Type: 1332 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0xcda9e5", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
+          Type: 1334 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0xcdaa4a", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1331 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0xcda81d", Frameless: false}]
+          Type: 1335 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0xcdaa7d", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcdaf00", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdcbc0", Frameless: true}]
+          Type: 1360 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdce20", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcdc7e0", Frameless: true}]
+          Type: 1358 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdcf60", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcddd60", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcddfc0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdddc0", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcde020", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1407 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcde2e0", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcde540", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1413 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcde720", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcde980", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcde740", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcde9a0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcda7c0", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0xcd9f2a", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1313 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0xcd9d0c", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0xcd9f6c", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0xcd9e0e", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1311 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0xcd9c3b", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0xcd9e9b", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcda420", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0xcda680", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1323 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0xcda425", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0xcda685", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcda444", Frameless: false}]
+          Type: 1327 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0xcda6a4", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1325 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0xcda47d", Frameless: false}]
+          Type: 1328 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0xcda6dd", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1329 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0xcda6a8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
+          Type: 1317 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0xcda36a", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1315 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0xcda16e", Frameless: false}]
+          Type: 1318 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0xcda3ce", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
+          Type: 1319 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0xcda23e", Frameless: false}]
+          Type: 1320 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0xcda49e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
+          Type: 1321 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0xcda4ea", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1319 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0xcda2cb", Frameless: false}]
+          Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0xcda52b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1417 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcda206", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcda466", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
+          Type: 1323 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0xcda56e", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1321 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0xcda3f3", Frameless: false}]
+          Type: 1324 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0xcda653", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcda313", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcda573", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1424 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0xcda573", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1419 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcda3bb", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1426 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1415 EventRootType Probe[main.testInlinedPrint]
+          Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd9f6a"
+            - PC: "0xcda1ca"
               Frameless: false
-            - PC: "0xcd9ff1"
+            - PC: "0xcda251"
               Frameless: false
-            - PC: "0xcda132"
+            - PC: "0xcda392"
               Frameless: false
-            - PC: "0xcda1bc"
+            - PC: "0xcda41c"
               Frameless: false
-            - PC: "0xcda28f"
+            - PC: "0xcda4ef"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1416 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0xcd9faa", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0xcda20a", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1421 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0xcda1ce"
+              Frameless: false
+            - PC: "0xcda251"
+              Frameless: false
+            - PC: "0xcda392"
+              Frameless: false
+            - PC: "0xcda41c"
+              Frameless: false
+            - PC: "0xcda4ef"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1420 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcda421", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcda681", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1428 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0xcda681", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcda465"
+            - PC: "0xcda6c5"
               Frameless: false
-            - PC: "0xcda505"
+            - PC: "0xcda765"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcda720", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0xcda980", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdcd80", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdcfe0", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd979a", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd984d", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0xcd9914", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcdaec0", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcdaf80", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcdaf40", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdb0a0", Frameless: true}]
+          Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcdb080", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcdaf60", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcdb060", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcdb040", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcdae80", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcdaea0", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcdae60", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcdb0c0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcdafa0", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcdb000", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcdb020", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcdafc0", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcdafe0", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcde2a0", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcde2a0", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
+          Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcddb4e", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcdd97e", Frameless: false}]
+          Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddbde", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcdc9a0", Frameless: true}]
+          Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcdcc00", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcdd84a", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1380 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcdd8b2", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddb12", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdcf20", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdde40", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcde0a0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcddde0", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcde040", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdde20", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcde080", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1403 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcde280", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcde4e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdcda0", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdd000", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcdaf20", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdcd60", Frameless: true}]
+          Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdcfc0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcdd68a", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1376 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xcdd6e4", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0xcdd944", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcdd60a", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1374 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcdd648"
+            - PC: "0xcdd8a8"
               Frameless: false
-            - PC: "0xcdd652"
+            - PC: "0xcdd8b2"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcdd5aa", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcdd80a", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1372 EventRootType Probe[main.testReturnsError]Return
+          Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcdd5da"
+            - PC: "0xcdd83a"
               Frameless: false
-            - PC: "0xcdd5e5"
+            - PC: "0xcdd845"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1365 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcdd3aa", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcdd60a", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1366 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcdd3f4", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcdd654", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcdd4ce", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1370 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcdd571", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcdd7d1", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcdd42a", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcdd68a", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1368 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcdd490", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcdd6f0", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1378 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcdd7c2"
+            - PC: "0xcdda22"
               Frameless: false
-            - PC: "0xcdd7cc"
+            - PC: "0xcdda2c"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcde200", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcde460", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcddd80", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcddfe0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcdaee0", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcdd9ae", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcddc0e", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1384 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcdda3b", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddc9b", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdcee0", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdd140", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdde00", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcde060", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1411 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcde5a0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcde800", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1412 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcde5c2", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcde822", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcddda0", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcde000", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0xcda840", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1409 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcde460", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcde6c0", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1410 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcde47e", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xcde6de", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcde440", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcde6a0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcdae40", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcdb0a0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcde220", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcde480", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcde240", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcde4a0", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1401 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcde25e", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcde4be", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcde260", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcde4c0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdce00", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdd060", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcddd40", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcddfa0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcde2c0", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcde520", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdcdc0", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdd020", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdde60", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0xcd9780..0xcd99ca]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9864..0xcd9885
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9938..0xcd994f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd984d..0xcd9850
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9850..0xcd9885
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9885..0xcd992b
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0xcd992b..0xcd9938
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xcd9938..0xcd99ca
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9847..0xcd9850
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9850..0xcd9850
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd9850..0xcd9885
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9885..0xcd992b
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0xcd992b..0xcd9930
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0xcd9930..0xcd9938
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xcd9938..0xcd994f
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+            - Range: 0xcd994f..0xcd99ca
+              Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd9ba0..0xcd9ca5]
+      OutOfLinePCRanges: [0xcd9e00..0xcd9f05]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 151 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd9ba0..0xcd9bf3
+            - Range: 0xcd9e00..0xcd9e53
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd9bf3..0xcd9bf8
+            - Range: 0xcd9e53..0xcd9e58
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd9bf8..0xcd9bfd
+            - Range: 0xcd9e58..0xcd9e5d
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,140 +2910,140 @@ Subprograms:
                   Op: {RegNo: 11, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd9cc0..0xcd9d23]
+      OutOfLinePCRanges: [0xcd9f20..0xcd9f83]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd9cc0..0xcd9ced
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcda100..0xcda188]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcda100..0xcda115
+            - Range: 0xcd9f20..0xcd9f4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcda1a0..0xcda265]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0xcda360..0xcda3e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda1a0..0xcda1b6
+            - Range: 0xcda360..0xcda375
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0xcda400..0xcda4c5]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda400..0xcda416
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda1a0..0xcda1c7
+            - Range: 0xcda400..0xcda427
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda1b6..0xcda1c7
+            - Range: 0xcda416..0xcda427
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1c7..0xcda265
+            - Range: 0xcda427..0xcda4c5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcda280..0xcda2e2]
+      OutOfLinePCRanges: [0xcda4e0..0xcda542]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda280..0xcda29a
+            - Range: 0xcda4e0..0xcda4fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcda300..0xcda405]
+      OutOfLinePCRanges: [0xcda560..0xcda665]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda35b..0xcda365
+            - Range: 0xcda5bb..0xcda5c5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda365..0xcda375
+            - Range: 0xcda5c5..0xcda5d5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcda375..0xcda389
+            - Range: 0xcda5d5..0xcda5e9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda356..0xcda360
+            - Range: 0xcda5b6..0xcda5c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda360..0xcda375
+            - Range: 0xcda5c0..0xcda5d5
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcda375..0xcda384
+            - Range: 0xcda5d5..0xcda5e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcda420..0xcda426]
+      OutOfLinePCRanges: [0xcda680..0xcda686]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda420..0xcda425
+            - Range: 0xcda680..0xcda685
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda420..0xcda426, Pieces: []}]
+          Locations: [{Range: 0xcda680..0xcda686, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcda440..0xcda483]
+      OutOfLinePCRanges: [0xcda6a0..0xcda6e3]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 ArrayType [5]int
           Locations:
-            - Range: 0xcda440..0xcda483
+            - Range: 0xcda6a0..0xcda6e3
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda440..0xcda483, Pieces: []}]
+          Locations: [{Range: 0xcda6a0..0xcda6e3, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcda720..0xcda721]
+      OutOfLinePCRanges: [0xcda980..0xcda981]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 158 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcda720..0xcda721
+            - Range: 0xcda980..0xcda981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2847,21 +3051,21 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0xcda740..0xcda7a6]
+      OutOfLinePCRanges: [0xcda9a0..0xcdaa06]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcda740..0xcda769
+            - Range: 0xcda9a0..0xcda9c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcda769..0xcda76e
+            - Range: 0xcda9c9..0xcda9ce
               Pieces:
                 - Size: 8
                   Op: null
@@ -2871,18 +3075,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcda740..0xcda7a6, Pieces: []}]
+          Locations: [{Range: 0xcda9a0..0xcdaa06, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0xcda7c0..0xcda7c1]
+      OutOfLinePCRanges: [0xcdaa20..0xcdaa21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcda7c0..0xcda7c1
+            - Range: 0xcdaa20..0xcdaa21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,32 +3094,32 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0xcda7e0..0xcda834]
+      OutOfLinePCRanges: [0xcdaa40..0xcdaa94]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType *interface {}
           Locations:
-            - Range: 0xcda7e0..0xcda806
+            - Range: 0xcdaa40..0xcdaa66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcda7e0..0xcda834, Pieces: []}]
+          Locations: [{Range: 0xcdaa40..0xcdaa94, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0xcda840..0xcda841]
+      OutOfLinePCRanges: [0xcdaaa0..0xcdaaa1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithAny
           Locations:
-            - Range: 0xcda840..0xcda841
+            - Range: 0xcdaaa0..0xcdaaa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2923,309 +3127,309 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcdae40..0xcdae41]
+      OutOfLinePCRanges: [0xcdb0a0..0xcdb0a1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 161 StructureType main.structWithMap
           Locations:
-            - Range: 0xcdae40..0xcdae41
+            - Range: 0xcdb0a0..0xcdb0a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcdae60..0xcdae61]
+      OutOfLinePCRanges: [0xcdb0c0..0xcdb0c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcdae60..0xcdae61
+            - Range: 0xcdb0c0..0xcdb0c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcdae80..0xcdae81]
+      OutOfLinePCRanges: [0xcdb0e0..0xcdb0e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string]int
           Locations:
-            - Range: 0xcdae80..0xcdae81
+            - Range: 0xcdb0e0..0xcdb0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcdaea0..0xcdaea1]
+      OutOfLinePCRanges: [0xcdb100..0xcdb101]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[string][]string
           Locations:
-            - Range: 0xcdaea0..0xcdaea1
+            - Range: 0xcdb100..0xcdb101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcdaec0..0xcdaec1]
+      OutOfLinePCRanges: [0xcdb120..0xcdb121]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0xcdaec0..0xcdaec1
+            - Range: 0xcdb120..0xcdb121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0xcdaee0..0xcdaee1]
+      OutOfLinePCRanges: [0xcdb140..0xcdb141]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string]int
           Locations:
-            - Range: 0xcdaee0..0xcdaee1
+            - Range: 0xcdb140..0xcdb141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0xcdaf00..0xcdaf01]
+      OutOfLinePCRanges: [0xcdb160..0xcdb161]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 ArrayType [2]map[string]int
           Locations:
-            - Range: 0xcdaf00..0xcdaf01
+            - Range: 0xcdb160..0xcdb161
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0xcdaf20..0xcdaf21]
+      OutOfLinePCRanges: [0xcdb180..0xcdb181]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 PointerType *map[string]int
           Locations:
-            - Range: 0xcdaf20..0xcdaf21
+            - Range: 0xcdb180..0xcdb181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0xcdaf40..0xcdaf41]
+      OutOfLinePCRanges: [0xcdb1a0..0xcdb1a1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 GoMapType map[int]int
           Locations:
-            - Range: 0xcdaf40..0xcdaf41
+            - Range: 0xcdb1a0..0xcdb1a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0xcdaf60..0xcdaf61]
+      OutOfLinePCRanges: [0xcdb1c0..0xcdb1c1]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 189 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdaf60..0xcdaf61
+            - Range: 0xcdb1c0..0xcdb1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0xcdaf80..0xcdaf81]
+      OutOfLinePCRanges: [0xcdb1e0..0xcdb1e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0xcdaf80..0xcdaf81
+            - Range: 0xcdb1e0..0xcdb1e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0xcdafa0..0xcdafa1]
+      OutOfLinePCRanges: [0xcdb200..0xcdb201]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 GoMapType map[bool]main.node
           Locations:
-            - Range: 0xcdafa0..0xcdafa1
+            - Range: 0xcdb200..0xcdb201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0xcdafc0..0xcdafc1]
+      OutOfLinePCRanges: [0xcdb220..0xcdb221]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdafc0..0xcdafc1
+            - Range: 0xcdb220..0xcdb221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0xcdafe0..0xcdafe1]
+      OutOfLinePCRanges: [0xcdb240..0xcdb241]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 199 GoMapType map[int]uint8
           Locations:
-            - Range: 0xcdafe0..0xcdafe1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0xcdb000..0xcdb001]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 204 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0xcdb000..0xcdb001
+            - Range: 0xcdb240..0xcdb241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0xcdb020..0xcdb021]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0xcdb260..0xcdb261]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdb020..0xcdb021
+            - Range: 0xcdb260..0xcdb261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0xcdb040..0xcdb041]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0xcdb280..0xcdb281]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0xcdb040..0xcdb041
+            - Range: 0xcdb280..0xcdb281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0xcdb2a0..0xcdb2a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 204 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0xcdb2a0..0xcdb2a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0xcdb060..0xcdb061]
+      OutOfLinePCRanges: [0xcdb2c0..0xcdb2c1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0xcdb060..0xcdb061
+            - Range: 0xcdb2c0..0xcdb2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0xcdb080..0xcdb081]
+      OutOfLinePCRanges: [0xcdb2e0..0xcdb2e1]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0xcdb080..0xcdb081
+            - Range: 0xcdb2e0..0xcdb2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0xcdb0a0..0xcdb0a1]
+      OutOfLinePCRanges: [0xcdb300..0xcdb301]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0xcdb0a0..0xcdb0a1
+            - Range: 0xcdb300..0xcdb301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcdc7e0..0xcdc7e1]
+      OutOfLinePCRanges: [0xcdca40..0xcdca41]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc7e0..0xcdc7e1
+            - Range: 0xcdca40..0xcdca41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc7e0..0xcdc7e1
+            - Range: 0xcdca40..0xcdca41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xcdc7e0..0xcdc7e1
+            - Range: 0xcdca40..0xcdca41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcdc9a0..0xcdc9a1]
+      OutOfLinePCRanges: [0xcdcc00..0xcdcc01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdc9a0..0xcdc9a1
+            - Range: 0xcdcc00..0xcdcc01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3233,39 +3437,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdcbc0..0xcdcbc1]
+      OutOfLinePCRanges: [0xcdce20..0xcdce21]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 224 GoChannelType chan bool
           Locations:
-            - Range: 0xcdcbc0..0xcdcbc1
+            - Range: 0xcdce20..0xcdce21
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdcd60..0xcdcd61]
+      OutOfLinePCRanges: [0xcdcfc0..0xcdcfc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 225 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdcd60..0xcdcd61
+            - Range: 0xcdcfc0..0xcdcfc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdcd80..0xcdcd81]
+      OutOfLinePCRanges: [0xcdcfe0..0xcdcfe1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 227 StructureType main.node
           Locations:
-            - Range: 0xcdcd80..0xcdcd81
+            - Range: 0xcdcfe0..0xcdcfe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3273,195 +3477,195 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdcda0..0xcdcda1]
+      OutOfLinePCRanges: [0xcdd000..0xcdd001]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 228 PointerType *main.node
           Locations:
-            - Range: 0xcdcda0..0xcdcda1
+            - Range: 0xcdd000..0xcdd001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdcdc0..0xcdcdc1]
+      OutOfLinePCRanges: [0xcdd020..0xcdd021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdcdc0..0xcdcdc1
+            - Range: 0xcdd020..0xcdd021
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdce00..0xcdce01]
+      OutOfLinePCRanges: [0xcdd060..0xcdd061]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0xcdce00..0xcdce01
+            - Range: 0xcdd060..0xcdd061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdcee0..0xcdcee1]
+      OutOfLinePCRanges: [0xcdd140..0xcdd141]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0xcdcee0..0xcdcee1
+            - Range: 0xcdd140..0xcdd141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdcf20..0xcdcf21]
+      OutOfLinePCRanges: [0xcdd180..0xcdd181]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdcf20..0xcdcf21
+            - Range: 0xcdd180..0xcdd181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdcf20..0xcdcf21
+            - Range: 0xcdd180..0xcdd181
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdcf60..0xcdcf61]
+      OutOfLinePCRanges: [0xcdd1c0..0xcdd1c1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 229 PointerType *main.t
           Locations:
-            - Range: 0xcdcf60..0xcdcf61
+            - Range: 0xcdd1c0..0xcdd1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdd3a0..0xcdd40c]
+      OutOfLinePCRanges: [0xcdd600..0xcdd66c]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd3a0..0xcdd3be
+            - Range: 0xcdd600..0xcdd61e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd3be..0xcdd40c
+            - Range: 0xcdd61e..0xcdd66c
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd3a0..0xcdd40c, Pieces: []}]
+          Locations: [{Range: 0xcdd600..0xcdd66c, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdd420..0xcdd4af]
+      OutOfLinePCRanges: [0xcdd680..0xcdd70f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd420..0xcdd43a
+            - Range: 0xcdd680..0xcdd69a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
-          Locations: [{Range: 0xcdd420..0xcdd4af, Pieces: []}]
+          Locations: [{Range: 0xcdd680..0xcdd70f, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd43f..0xcdd455
+            - Range: 0xcdd69f..0xcdd6b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd455..0xcdd4af
+            - Range: 0xcdd6b5..0xcdd70f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdd4c0..0xcdd58f]
+      OutOfLinePCRanges: [0xcdd720..0xcdd7ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd4c0..0xcdd514
+            - Range: 0xcdd720..0xcdd774
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd514..0xcdd58f
+            - Range: 0xcdd774..0xcdd7ef
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd4c0..0xcdd58f, Pieces: []}]
+          Locations: [{Range: 0xcdd720..0xcdd7ef, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcdd4c0..0xcdd58f, Pieces: []}]
+          Locations: [{Range: 0xcdd720..0xcdd7ef, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcdd4df..0xcdd514
+            - Range: 0xcdd73f..0xcdd774
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdd514..0xcdd58f
+            - Range: 0xcdd774..0xcdd7ef
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdd5a0..0xcdd5fb]
+      OutOfLinePCRanges: [0xcdd800..0xcdd85b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdd5a0..0xcdd5b9
+            - Range: 0xcdd800..0xcdd819
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcdd5a0..0xcdd5fb, Pieces: []}]
+          Locations: [{Range: 0xcdd800..0xcdd85b, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcdd600..0xcdd67c]
+      OutOfLinePCRanges: [0xcdd860..0xcdd8dc]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd600..0xcdd623
+            - Range: 0xcdd860..0xcdd883
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd623..0xcdd628
+            - Range: 0xcdd883..0xcdd888
               Pieces:
                 - Size: 8
                   Op: null
@@ -3472,41 +3676,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdd600..0xcdd628
+            - Range: 0xcdd860..0xcdd888
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 153 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcdd600..0xcdd67c, Pieces: []}]
+          Locations: [{Range: 0xcdd860..0xcdd8dc, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcdd600..0xcdd67c, Pieces: []}]
+          Locations: [{Range: 0xcdd860..0xcdd8dc, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcdd680..0xcdd708]
+      OutOfLinePCRanges: [0xcdd8e0..0xcdd968]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd680..0xcdd6c1
+            - Range: 0xcdd8e0..0xcdd921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd6c1..0xcdd6c8
+            - Range: 0xcdd921..0xcdd928
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd6c8..0xcdd708
+            - Range: 0xcdd928..0xcdd968
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -3516,186 +3720,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 153 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcdd680..0xcdd708, Pieces: []}]
+          Locations: [{Range: 0xcdd8e0..0xcdd968, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdd720..0xcdd834]
+      OutOfLinePCRanges: [0xcdd980..0xcdda94]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdd720..0xcdd755
+            - Range: 0xcdd980..0xcdd9b5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd755..0xcdd79f
+            - Range: 0xcdd9b5..0xcdd9ff
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd79f..0xcdd7d2
+            - Range: 0xcdd9ff..0xcdda32
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd7d2..0xcdd7f2
+            - Range: 0xcdda32..0xcdda52
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd7f2..0xcdd7f9
+            - Range: 0xcdda52..0xcdda59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd7f9..0xcdd834
+            - Range: 0xcdda59..0xcdda94
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 158 GoInterfaceType main.behavior
-          Locations: [{Range: 0xcdd720..0xcdd834, Pieces: []}]
+          Locations: [{Range: 0xcdd980..0xcdda94, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 158 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdd720..0xcdd755
+            - Range: 0xcdd980..0xcdd9b5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdd755..0xcdd79f
+            - Range: 0xcdd9b5..0xcdd9ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd79f..0xcdd7a6
+            - Range: 0xcdd9ff..0xcdda06
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd7a6..0xcdd7c8
+            - Range: 0xcdda06..0xcdda28
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd7c8..0xcdd7ca
+            - Range: 0xcdda28..0xcdda2a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcdd7ca..0xcdd7cc
+            - Range: 0xcdda2a..0xcdda2c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcdd7cc..0xcdd834
+            - Range: 0xcdda2c..0xcdda94
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcdd840..0xcdd8cf]
+      OutOfLinePCRanges: [0xcddaa0..0xcddb2f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd840..0xcdd87c
+            - Range: 0xcddaa0..0xcddadc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd87c..0xcdd8cf
+            - Range: 0xcddadc..0xcddb2f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd840..0xcdd8cf, Pieces: []}]
+          Locations: [{Range: 0xcddaa0..0xcddb2f, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcdd8e0..0xcdd998]
+      OutOfLinePCRanges: [0xcddb40..0xcddbf8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd926
+            - Range: 0xcddb40..0xcddb86
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd926..0xcdd998
+            - Range: 0xcddb86..0xcddbf8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd8e0..0xcdd998, Pieces: []}]
+          Locations: [{Range: 0xcddb40..0xcddbf8, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd8e0..0xcdd998, Pieces: []}]
+          Locations: [{Range: 0xcddb40..0xcddbf8, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcdd9a0..0xcdda55]
+      OutOfLinePCRanges: [0xcddc00..0xcddcb5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd9a0..0xcdd9e5
+            - Range: 0xcddc00..0xcddc45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd9e5..0xcdda55
+            - Range: 0xcddc45..0xcddcb5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd9a0..0xcdda55, Pieces: []}]
+          Locations: [{Range: 0xcddc00..0xcddcb5, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd9a0..0xcdda55, Pieces: []}]
+          Locations: [{Range: 0xcddc00..0xcddcb5, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd9a0..0xcdda55, Pieces: []}]
+          Locations: [{Range: 0xcddc00..0xcddcb5, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcddd40..0xcddd41]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 231 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcddd40..0xcddd41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcddd60..0xcddd61]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcddfa0..0xcddfa1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcddd60..0xcddd61
+            - Range: 0xcddfa0..0xcddfa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3706,14 +3892,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcddd80..0xcddd81]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcddfc0..0xcddfc1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 232 GoSliceHeaderType [][]uint
+          Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcddd80..0xcddd81
+            - Range: 0xcddfc0..0xcddfc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3724,14 +3910,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcddda0..0xcddda1]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcddfe0..0xcddfe1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 232 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0xcddda0..0xcddda1
+            - Range: 0xcddfe0..0xcddfe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3739,24 +3925,17 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcddda0..0xcddda1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcdddc0..0xcdddc1]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0xcde000..0xcde001]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcdddc0..0xcdddc1
+            - Range: 0xcde000..0xcde001
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3769,19 +3948,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdddc0..0xcdddc1
+            - Range: 0xcde000..0xcde001
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcddde0..0xcddde1]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0xcde020..0xcde021]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcddde0..0xcddde1
+            - Range: 0xcde020..0xcde021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3794,19 +3973,44 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddde0..0xcddde1
+            - Range: 0xcde020..0xcde021
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcde040..0xcde041]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcde040..0xcde041
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde040..0xcde041
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcdde00..0xcdde01]
+      OutOfLinePCRanges: [0xcde060..0xcde061]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 237 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcdde00..0xcdde01
+            - Range: 0xcde060..0xcde061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3816,22 +4020,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcdde20..0xcdde21]
+      OutOfLinePCRanges: [0xcde080..0xcde081]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdde20..0xcdde21
+            - Range: 0xcde080..0xcde081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 238 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdde20..0xcdde21
+            - Range: 0xcde080..0xcde081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -3844,37 +4048,19 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdde20..0xcdde21
+            - Range: 0xcde080..0xcde081
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdde40..0xcdde41]
+      OutOfLinePCRanges: [0xcde0a0..0xcde0a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 239 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcdde40..0xcdde41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdde60..0xcdde61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdde60..0xcdde61
+            - Range: 0xcde0a0..0xcde0a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3885,24 +4071,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcde0c0..0xcde0c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcde0c0..0xcde0c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0xcde1a0..0xcde1f2]
+      OutOfLinePCRanges: [0xcde400..0xcde452]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcde1a0..0xcde1f2, Pieces: []}]
+          Locations: [{Range: 0xcde400..0xcde452, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcde200..0xcde201]
+      OutOfLinePCRanges: [0xcde460..0xcde461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde200..0xcde201
+            - Range: 0xcde460..0xcde461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3910,15 +4114,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcde220..0xcde221]
+      OutOfLinePCRanges: [0xcde480..0xcde481]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde220..0xcde221
+            - Range: 0xcde480..0xcde481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3929,7 +4133,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde220..0xcde221
+            - Range: 0xcde480..0xcde481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3940,7 +4144,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde220..0xcde221
+            - Range: 0xcde480..0xcde481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3948,15 +4152,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcde240..0xcde25f]
+      OutOfLinePCRanges: [0xcde4a0..0xcde4bf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcde240..0xcde25f
+            - Range: 0xcde4a0..0xcde4bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3972,55 +4176,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcde260..0xcde261]
+      OutOfLinePCRanges: [0xcde4c0..0xcde4c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcde260..0xcde261
+            - Range: 0xcde4c0..0xcde4c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcde280..0xcde281]
+      OutOfLinePCRanges: [0xcde4e0..0xcde4e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcde280..0xcde281
+            - Range: 0xcde4e0..0xcde4e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcde2a0..0xcde2a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcde2a0..0xcde2a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcde2c0..0xcde2c1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcde500..0xcde501]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde2c0..0xcde2c1
+            - Range: 0xcde500..0xcde501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4029,14 +4217,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcde2e0..0xcde2e1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcde520..0xcde521]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde2e0..0xcde2e1
+            - Range: 0xcde520..0xcde521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4045,26 +4233,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcde540..0xcde541]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcde540..0xcde541
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcde440..0xcde441]
+      OutOfLinePCRanges: [0xcde6a0..0xcde6a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcde440..0xcde441
+            - Range: 0xcde6a0..0xcde6a1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcde460..0xcde47f]
+      OutOfLinePCRanges: [0xcde6c0..0xcde6df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcde460..0xcde47f
+            - Range: 0xcde6c0..0xcde6df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4080,15 +4284,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcde5a0..0xcde5c3]
+      OutOfLinePCRanges: [0xcde800..0xcde823]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 288 StructureType main.aStruct
           Locations:
-            - Range: 0xcde5a0..0xcde5c3
+            - Range: 0xcde800..0xcde823
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4106,108 +4310,108 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcde720..0xcde721]
+      OutOfLinePCRanges: [0xcde980..0xcde981]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 290 StructureType main.emptyStruct
-          Locations: [{Range: 0xcde720..0xcde721, Pieces: []}]
+          Locations: [{Range: 0xcde980..0xcde981, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcde740..0xcde741]
+      OutOfLinePCRanges: [0xcde9a0..0xcde9a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 291 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcde740..0xcde741
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd9f60..0xcd9fc2]
-      InlinePCRanges:
-        - Ranges: [0xcd9ff1..0xcda02d]
-          RootRanges: [0xcd9fe0..0xcda051]
-        - Ranges: [0xcda132..0xcda16e]
-          RootRanges: [0xcda100..0xcda188]
-        - Ranges: [0xcda1bc..0xcda1f8]
-          RootRanges: [0xcda1a0..0xcda265]
-        - Ranges: [0xcda28f..0xcda2cb]
-          RootRanges: [0xcda280..0xcda2e2]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcd9f60..0xcd9f79
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9ff1..0xcd9ffc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda132..0xcda13d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1b6..0xcda1c7
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1c7..0xcda265
-              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcda280..0xcda29a
+            - Range: 0xcde9a0..0xcde9a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0xcda1c0..0xcda222]
       InlinePCRanges:
-        - Ranges: [0xcda206..0xcda23e]
-          RootRanges: [0xcda1a0..0xcda265]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda313..0xcda351]
-          RootRanges: [0xcda300..0xcda405]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda3bb..0xcda3f3]
-          RootRanges: [0xcda300..0xcda405]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0xcda421..0xcda425]
-          RootRanges: [0xcda420..0xcda426]
+        - Ranges: [0xcda251..0xcda28d]
+          RootRanges: [0xcda240..0xcda2b1]
+        - Ranges: [0xcda392..0xcda3ce]
+          RootRanges: [0xcda360..0xcda3e8]
+        - Ranges: [0xcda41c..0xcda458]
+          RootRanges: [0xcda400..0xcda4c5]
+        - Ranges: [0xcda4ef..0xcda52b]
+          RootRanges: [0xcda4e0..0xcda542]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda420..0xcda425
+            - Range: 0xcda1c0..0xcda1d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda251..0xcda25c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda392..0xcda39d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda416..0xcda427
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda427..0xcda4c5
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcda4e0..0xcda4fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda466..0xcda49e]
+          RootRanges: [0xcda400..0xcda4c5]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda573..0xcda5b1]
+          RootRanges: [0xcda560..0xcda665]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda61b..0xcda653]
+          RootRanges: [0xcda560..0xcda665]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcda681..0xcda685]
+          RootRanges: [0xcda680..0xcda686]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda685
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcda465..0xcda47d]
-          RootRanges: [0xcda440..0xcda483]
-        - Ranges: [0xcda505..0xcda523]
-          RootRanges: [0xcda4a0..0xcda625]
+        - Ranges: [0xcda6c5..0xcda6dd]
+          RootRanges: [0xcda6a0..0xcda6e3]
+        - Ranges: [0xcda765..0xcda783]
+          RootRanges: [0xcda700..0xcda885]
       Variables:
         - Name: a
           Type: 157 ArrayType [5]int
           Locations:
-            - Range: 0xcda44d..0xcda483
+            - Range: 0xcda6ad..0xcda6e3
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcda4ec..0xcda625
+            - Range: 0xcda74c..0xcda885
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
@@ -5072,14 +5276,14 @@ Types:
       ID: 772
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.02464e+06
+      GoRuntimeType: 1.022976e+06
       GoKind: 22
       Pointee: 773 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 774
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.024768e+06
+      GoRuntimeType: 1.023104e+06
       GoKind: 22
       Pointee: 775 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -5990,21 +6194,21 @@ Types:
       ID: 1012
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.190016e+06
+      GoRuntimeType: 1.190272e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1010
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.189632e+06
+      GoRuntimeType: 1.189888e+06
       GoKind: 22
       Pointee: 1011 StructureType io.discard
     - __kind: PointerType
       ID: 984
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.023104e+06
+      GoRuntimeType: 1.023872e+06
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7446,10 +7650,10 @@ Types:
       GoKind: 22
       Pointee: 769 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1396
+      ID: 1400
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1397
+      ID: 1401
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7461,11 +7665,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1334
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7477,11 +7681,11 @@ Types:
             Type: 159 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1335
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7493,11 +7697,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1327
+      ID: 1331
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7509,11 +7713,11 @@ Types:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1328
+      ID: 1332
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7525,7 +7729,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7561,7 +7765,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1339
+      ID: 1343
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7573,7 +7777,7 @@ Types:
             Type: 187 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7644,7 +7848,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1356
+      ID: 1360
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7656,11 +7860,11 @@ Types:
             Type: 224 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7672,7 +7876,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7682,7 +7886,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7692,11 +7896,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1364
+      ID: 1368
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7708,7 +7912,7 @@ Types:
             Type: 229 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7808,7 +8012,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1389
+      ID: 1393
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7820,7 +8024,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7830,11 +8034,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1390
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7846,11 +8050,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1407
+      ID: 1411
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7862,11 +8066,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1418
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7878,11 +8082,11 @@ Types:
             Type: 291 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1417
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7894,11 +8098,11 @@ Types:
             Type: 290 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1329
+      ID: 1333
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7910,11 +8114,11 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1312
+      ID: 1315
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7926,14 +8130,14 @@ Types:
             Type: 155 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1316
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1310
+      ID: 1313
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7945,14 +8149,14 @@ Types:
             Type: 151 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1311
+      ID: 1314
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1327
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7964,12 +8168,70 @@ Types:
             Type: 157 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1325
+      ID: 1329
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1328
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1325
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1326
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7984,82 +8246,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1323
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1314
+      ID: 1317
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1315
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1318
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1319
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1316
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -8072,6 +8261,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1318
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1322
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1319
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -8079,26 +8309,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1320
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1418
+      ID: 1423
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1419
+      ID: 1424
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1425
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1320
+      ID: 1426
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1323
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1321
+      ID: 1324
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1415
+      ID: 1419
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8110,14 +8346,30 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1421
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1420
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1427
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8129,11 +8381,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1428
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8145,7 +8413,7 @@ Types:
             Type: 157 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -8229,7 +8497,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1326
+      ID: 1330
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8241,11 +8509,11 @@ Types:
             Type: 158 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1362
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8257,11 +8525,66 @@ Types:
             Type: 227 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1310
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1311
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1312
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1341
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8273,11 +8596,11 @@ Types:
             Type: 182 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1348
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8289,11 +8612,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1345
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8305,11 +8628,11 @@ Types:
             Type: 162 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1357
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8321,11 +8644,11 @@ Types:
             Type: 219 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1356
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8337,11 +8660,11 @@ Types:
             Type: 214 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1346
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8353,11 +8676,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1347
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8369,11 +8692,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1355
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8385,12 +8708,92 @@ Types:
             Type: 209 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1354
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 204 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1339
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 172 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1340
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 177 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1338
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 167 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1349
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 194 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1353
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8405,72 +8808,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 172 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1336
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 177 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1334
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 167 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1345
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 194 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1349
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1352
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8485,23 +8824,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 204 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1347
+      ID: 1351
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8513,11 +8836,11 @@ Types:
             Type: 199 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1350
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8529,11 +8852,11 @@ Types:
             Type: 199 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1408
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8545,11 +8868,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1405
+      ID: 1409
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8561,12 +8884,110 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1385
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1386
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1359
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1383
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8581,9 +9002,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1384
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8596,106 +9017,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 10 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 17 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1379
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1380
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1363
+      ID: 1367
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8707,7 +9030,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8717,11 +9040,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1394
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8733,7 +9056,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8743,11 +9066,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1396
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8759,7 +9082,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8769,7 +9092,7 @@ Types:
             Type: 238 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8779,11 +9102,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1397
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8795,11 +9118,11 @@ Types:
             Type: 239 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1403
+      ID: 1407
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8811,11 +9134,11 @@ Types:
             Type: 242 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1363
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8827,11 +9150,11 @@ Types:
             Type: 228 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1344
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8843,11 +9166,11 @@ Types:
             Type: 188 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1361
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8859,65 +9182,13 @@ Types:
             Type: 225 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1377
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 153 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1374
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 153 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1375
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8930,10 +9201,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1376
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1378
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8943,150 +9224,22 @@ Types:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1371
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1372
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 15 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1367
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1368
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1365
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1366
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1377
-      Name: Probe[main.testReturnsInterface]
+      ID: 1379
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -9101,7 +9254,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1378
+      ID: 1380
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 153 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1375
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1376
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1373
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1374
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1371
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1372
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1369
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1370
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1381
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 153 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1382
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9113,7 +9436,7 @@ Types:
             Type: 158 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9293,7 +9616,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1398
+      ID: 1402
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9305,7 +9628,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9389,7 +9712,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1391
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9401,11 +9724,11 @@ Types:
             Type: 232 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1338
+      ID: 1342
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9417,11 +9740,11 @@ Types:
             Type: 172 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1387
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9433,11 +9756,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1388
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9449,7 +9772,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9459,7 +9782,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9469,7 +9792,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9489,7 +9812,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1362
+      ID: 1366
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9501,11 +9824,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1395
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9517,7 +9840,7 @@ Types:
             Type: 237 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9553,7 +9876,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1392
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9565,7 +9888,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9575,11 +9898,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1336
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9591,11 +9914,11 @@ Types:
             Type: 160 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1409
+      ID: 1413
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9607,14 +9930,14 @@ Types:
             Type: 257 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1410
+      ID: 1414
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1408
+      ID: 1412
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9626,11 +9949,11 @@ Types:
             Type: 244 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1333
+      ID: 1337
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9642,11 +9965,11 @@ Types:
             Type: 161 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1415
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9658,14 +9981,14 @@ Types:
             Type: 288 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1412
+      ID: 1416
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1402
+      ID: 1406
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9677,11 +10000,11 @@ Types:
             Type: 241 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1404
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9693,14 +10016,14 @@ Types:
             Type: 240 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1401
+      ID: 1405
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1399
+      ID: 1403
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9712,7 +10035,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9722,7 +10045,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9732,7 +10055,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9832,7 +10155,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1361
+      ID: 1365
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9844,11 +10167,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1389
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9860,11 +10183,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1406
+      ID: 1410
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9876,11 +10199,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1364
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9892,7 +10215,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9912,7 +10235,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1394
+      ID: 1398
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9924,11 +10247,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1395
+      ID: 1399
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9940,7 +10263,7 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13148,7 +13471,7 @@ Types:
       ID: 1053
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.18976e+06
+      GoRuntimeType: 1.190016e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13161,7 +13484,7 @@ Types:
       ID: 1088
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.023232e+06
+      GoRuntimeType: 1.024e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13187,7 +13510,7 @@ Types:
       ID: 127
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.022976e+06
+      GoRuntimeType: 1.023744e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13199,7 +13522,7 @@ Types:
     - __kind: StructureType
       ID: 1011
       Name: io.discard
-      GoRuntimeType: 1.462656e+06
+      GoRuntimeType: 1.463136e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -18044,7 +18367,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 993952
       GoKind: 5
-MaxTypeID: 1421
+MaxTypeID: 1429
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1801520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1396 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcde1aa", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1397 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcde1e5", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1327 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda74a", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1328 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcda785", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1330 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcda7ea", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1331 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcda81d", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd933e", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1312 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9cca", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1313 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9d0c", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1310 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1311 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9c3b", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1322 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda420", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1323 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda425", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1324 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda444", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1325 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda47d", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1314 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda10a", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1315 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda16e", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1316 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda1ae", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1317 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda23e", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1318 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda28a", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1319 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda2cb", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1320 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda30e", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1321 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda3f3", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1415 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0xcda28f"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1416 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd9faa", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1381 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcdd8ee", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1382 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcdd97e", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1379 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcdd84a", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1380 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcdd8b2", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1375 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcdd68a", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1376 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcdd6e4", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1373 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcdd60a", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1374 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1371 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcdd5aa", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1372 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1365 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd3aa", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1366 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd3f4", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1369 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd4ce", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1370 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdd571", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1367 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd42a", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1368 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd490", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1377 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1378 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1383 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcdd9ae", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1384 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcdda3b", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1411 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcde5a0", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1412 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcde5c2", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1409 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcde460", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1410 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcde47e", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1400 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcde240", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1401 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcde25e", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1400 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcde40a", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1401 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcde445", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda9aa", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcda9e5", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcdaa4a", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaa7d", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9320", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd933e", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdce20", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdca40", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd1c0", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9700", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9720", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd93e0", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9400", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd9580", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95a0", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcddfc0", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcde020", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1411 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcde540", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1417 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcde980", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcde9a0", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa20", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9f2a", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9f6c", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9e0e", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9e9b", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda680", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda685", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda6a4", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda6dd", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1329 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6a8", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda36a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda3ce", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda49e", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda4ea", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda52b", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1422 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda466", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda56e", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda653", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1423 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda573", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1424 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda573", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1425 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1426 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda61b", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda1ca"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda20a", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1421 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda1ce"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1427 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda681", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1428 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda681", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda6c5"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda980", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdcfe0", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd979a", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd984d", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9914", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb0c0", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1409 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcde500", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcddb4e", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcddbde", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdcc00", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcddb12", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd180", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcde0a0", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcde040", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcde080", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcde4e0", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd000", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdcfc0", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0xcdd944", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcdd8a8"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcdd80a", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcdd83a"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd60a", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd654", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd72e", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdd7d1", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd68a", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd6f0", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1381 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcdda22"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd8fe0", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1291 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9000", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1402 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcde460", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1292 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1293 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcddfe0", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcddc0e", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcddc9b", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd140", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcde060", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1415 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcde800", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1416 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcde822", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcde000", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaaa0", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcde6c0", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcde6de", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcde6a0", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0a0", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcde480", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcde4a0", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcde4be", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcde4c0", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd060", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcddfa0", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcde520", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd020", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcde0c0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda1b6..0xcda1c7
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda1c7..0xcda265
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcda280..0xcda2e2]
@@ -2765,7 +2774,29 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcda300..0xcda405]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda35b..0xcda365
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xcda365..0xcda375
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+            - Range: 0xcda375..0xcda389
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda356..0xcda360
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xcda360..0xcda375
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0xcda375..0xcda384
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcda420..0xcda426]
@@ -3357,6 +3388,15 @@ Subprograms:
           Locations: [{Range: 0xcdd420..0xcdd4af, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 99 PointerType *int
+          Locations:
+            - Range: 0xcdd43f..0xcdd455
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdd455..0xcdd4af
+              Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcdd4c0..0xcdd58f]
@@ -3381,6 +3421,15 @@ Subprograms:
           Locations: [{Range: 0xcdd4c0..0xcdd58f, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 15 BaseType float64
+          Locations:
+            - Range: 0xcdd4df..0xcdd514
+              Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
+            - Range: 0xcdd514..0xcdd58f
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcdd5a0..0xcdd5fb]
@@ -3509,6 +3558,45 @@ Subprograms:
           Locations: [{Range: 0xcdd720..0xcdd834, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 158 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xcdd720..0xcdd755
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdd755..0xcdd79f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcdd79f..0xcdd7a6
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcdd7a6..0xcdd7c8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcdd7c8..0xcdd7ca
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcdd7ca..0xcdd7cc
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcdd7cc..0xcdd834
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcdd840..0xcdd8cf]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1226 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x890da8", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1227 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x890ddc", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1157 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88dd38", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1158 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd64", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1160 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88ddb8", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1161 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88dde4", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1106 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1108 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1169 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1107 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8a8", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1095 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1092 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1186 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88f9d0", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1184 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f750", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1194 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fc70", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1132 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1133 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1128 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c960", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1129 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c970", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1130 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1131 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1216 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x890a40", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x890a70", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1237 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x890e80", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1243 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x8911d0", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x8911e0", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1159 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88dd90", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1141 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d338", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d374", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1139 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d24c", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1140 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2bc", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1151 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88da60", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1152 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da68", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1153 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1154 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dab8", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1155 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1143 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d778", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1144 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d7d0", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1145 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d808", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1146 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d890", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1147 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d8d8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d914", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d858", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1149 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d958", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1150 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da48", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1250 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da10", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1252 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da10", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5d8"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d610", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1247 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5d8"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da64", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1254 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da64", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88da94"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1098 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1099 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1100 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1097 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1096 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1156 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd10", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1188 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cccc", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd60", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce0c", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1167 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1171 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1172 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1173 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1165 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1166 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1164 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e3d0", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1234 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1235 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890608", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890684", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f830", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1209 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x890568", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1210 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8905c4", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1193 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fc50", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1223 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x890ab0", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x890a80", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x890aa0", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x890e50", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1189 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fb90", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1170 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1205 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x890398", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1206 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x8903ec", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x8902f8", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x890338"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1201 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x890278", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x8902a8"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1195 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x890098", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1196 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x8900d8", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x8901b8", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x890240", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x89011c", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x890178", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1207 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x890438", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x8904c8"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1093 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1112 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1110 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1123 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1124 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1113 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1115 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1116 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1117 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1114 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1111 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1228 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x890e00", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1118 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1120 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1121 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1122 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1119 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1217 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x890a50", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1168 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x8906c8", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890744", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1094 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1192 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fc30", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1221 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x890a90", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1134 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1135 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1241 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1242 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x8910ec", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1218 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x890a60", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1162 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de10", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x890ff8", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x890fd0", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1163 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3c0", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1229 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x890e10", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x890e20", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x890e38", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x890e40", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1125 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1103 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1104 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1105 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1102 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1101 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1191 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fbc0", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1215 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x890a30", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1236 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x890e70", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1190 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fba0", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1109 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88d60c..0x88d61c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d61c..0x88d6c0
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x88d6c0..0x88d740]
@@ -2765,7 +2774,29 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x88d740..0x88d860]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88d7a8..0x88d7b0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x88d7b0..0x88d7c8
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x88d7c8..0x88d7dc
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88d7a4..0x88d7ac
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x88d7ac..0x88d7c8
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x88d7c8..0x88d7d8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x88d860..0x88d870]
@@ -3357,6 +3388,15 @@ Subprograms:
           Locations: [{Range: 0x88ff00..0x88ffa0, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 94 PointerType *int
+          Locations:
+            - Range: 0x88ff28..0x88ff40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88ff40..0x88ffa0
+              Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x88ffa0..0x890060]
@@ -3381,6 +3421,15 @@ Subprograms:
           Locations: [{Range: 0x88ffa0..0x890060, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0x88ffc0..0x88ffec
+              Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x88ffec..0x890060
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x890060..0x8900e0]
@@ -3509,6 +3558,45 @@ Subprograms:
           Locations: [{Range: 0x890220..0x890350, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 153 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0x890220..0x89025c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89025c..0x8902ac
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8902ac..0x8902bc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8902bc..0x8902d4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8902d4..0x8902d8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x8902d8..0x8902dc
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0x8902dc..0x890350
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x890350..0x8903f0]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1222 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x890ba8", Frameless: false}]
+          Type: 1226 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x890da8", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1223 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x890bdc", Frameless: false}]
+          Type: 1227 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x890ddc", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1153 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x88db38", Frameless: false}]
+          Type: 1157 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x88dd38", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1154 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x88db64", Frameless: false}]
+          Type: 1158 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x88dd64", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1156 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x88dbb8", Frameless: false}]
+          Type: 1160 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x88ddb8", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1157 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x88dbe4", Frameless: false}]
+          Type: 1161 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x88dde4", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1165 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88e220", Frameless: true}]
+          Type: 1169 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1182 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88f7d0", Frameless: true}]
+          Type: 1186 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88f9d0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1180 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88f550", Frameless: true}]
+          Type: 1184 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88f750", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1190 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88fa70", Frameless: true}]
+          Type: 1194 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88fc70", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1212 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x890840", Frameless: true}]
+          Type: 1216 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x890a40", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1215 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x890870", Frameless: true}]
+          Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x890a70", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1233 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x890c80", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x890e80", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1239 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x890fd0", Frameless: true}]
+          Type: 1243 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x8911d0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1240 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
+          Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x8911e0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1155 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88db90", Frameless: true}]
+          Type: 1159 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x88dd90", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1138 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x88d138", Frameless: false}]
+          Type: 1141 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x88d338", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1139 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x88d174", Frameless: false}]
+          Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x88d374", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1136 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x88d04c", Frameless: false}]
+          Type: 1139 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x88d24c", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1137 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x88d0bc", Frameless: false}]
+          Type: 1140 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x88d2bc", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1148 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x88d860", Frameless: true}]
+          Type: 1151 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x88da60", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1149 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x88d868", Frameless: true}]
+          Type: 1152 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x88da68", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1150 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x88d87c", Frameless: false}]
+          Type: 1153 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1151 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x88d8b8", Frameless: false}]
+          Type: 1154 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x88dab8", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1155 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1140 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x88d578", Frameless: false}]
+          Type: 1143 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x88d778", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1141 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x88d5d0", Frameless: false}]
+          Type: 1144 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x88d7d0", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1142 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x88d608", Frameless: false}]
+          Type: 1145 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x88d808", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1143 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x88d690", Frameless: false}]
+          Type: 1146 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x88d890", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1144 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x88d6d8", Frameless: false}]
+          Type: 1147 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x88d8d8", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1145 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x88d714", Frameless: false}]
+          Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x88d914", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1243 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x88d658", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x88d858", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1146 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x88d758", Frameless: false}]
+          Type: 1149 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x88d958", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1147 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x88d848", Frameless: false}]
+          Type: 1150 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x88da48", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1244 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x88d75c", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1250 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1245 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x88d810", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x88da10", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1252 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0x88da10", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1241 EventRootType Probe[main.testInlinedPrint]
+          Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x88d3d8"
+            - PC: "0x88d5d8"
               Frameless: false
-            - PC: "0x88d44c"
+            - PC: "0x88d64c"
               Frameless: false
-            - PC: "0x88d598"
+            - PC: "0x88d798"
               Frameless: false
-            - PC: "0x88d614"
+            - PC: "0x88d814"
               Frameless: false
-            - PC: "0x88d6dc"
+            - PC: "0x88d8dc"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1242 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x88d410", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x88d610", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1247 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0x88d5d8"
+              Frameless: false
+            - PC: "0x88d64c"
+              Frameless: false
+            - PC: "0x88d798"
+              Frameless: false
+            - PC: "0x88d814"
+              Frameless: false
+            - PC: "0x88d8dc"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1246 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x88d864", Frameless: true}]
+          Type: 1253 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x88da64", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1254 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0x88da64", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1247 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x88d894"
+            - PC: "0x88da94"
               Frameless: false
-            - PC: "0x88d92c"
+            - PC: "0x88db2c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1152 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88db10", Frameless: true}]
+          Type: 1156 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x88dd10", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1184 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88f980", Frameless: true}]
+          Type: 1188 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x88cccc", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x88cd60", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x88ce0c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1163 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88e200", Frameless: true}]
+          Type: 1167 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1170 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88e260", Frameless: true}]
+          Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1167 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88e240", Frameless: true}]
+          Type: 1171 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1179 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e2f0", Frameless: true}]
+          Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1178 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88e2e0", Frameless: true}]
+          Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1168 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e250", Frameless: true}]
+          Type: 1172 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1169 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e250", Frameless: true}]
+          Type: 1173 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1177 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e2d0", Frameless: true}]
+          Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1176 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88e2c0", Frameless: true}]
+          Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1161 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88e1e0", Frameless: true}]
+          Type: 1165 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1162 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88e1f0", Frameless: true}]
+          Type: 1166 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1160 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88e1d0", Frameless: true}]
+          Type: 1164 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88e3d0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1171 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88e270", Frameless: true}]
+          Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1174 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88e2a0", Frameless: true}]
+          Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1175 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88e2b0", Frameless: true}]
+          Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1172 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88e280", Frameless: true}]
+          Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1173 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88e290", Frameless: true}]
+          Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1230 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890c60", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1231 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890c60", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1207 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890408", Frameless: false}]
+          Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890608", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1208 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890484", Frameless: false}]
+          Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890684", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1181 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88f630", Frameless: true}]
+          Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88f830", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1205 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x890368", Frameless: false}]
+          Type: 1209 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890568", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1206 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x8903c4", Frameless: false}]
+          Type: 1210 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x8905c4", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1189 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88fa50", Frameless: true}]
+          Type: 1193 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88fc50", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1219 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x8908b0", Frameless: true}]
+          Type: 1223 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x890ab0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1216 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x890880", Frameless: true}]
+          Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x890a80", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1218 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x8908a0", Frameless: true}]
+          Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x890aa0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1229 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x890c50", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x890e50", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1185 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88f990", Frameless: true}]
+          Type: 1189 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88fb90", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1166 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88e230", Frameless: true}]
+          Type: 1170 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1183 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88f970", Frameless: true}]
+          Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1201 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x890198", Frameless: false}]
+          Type: 1205 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x890398", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1202 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x8901ec", Frameless: false}]
+          Type: 1206 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0x8903ec", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1199 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x8900f8", Frameless: false}]
+          Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x8902f8", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1200 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x890138"
+            - PC: "0x890338"
               Frameless: false
-            - PC: "0x89014c"
+            - PC: "0x89034c"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1197 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x890078", Frameless: false}]
+          Type: 1201 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x890278", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1198 EventRootType Probe[main.testReturnsError]Return
+          Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x8900a8"
+            - PC: "0x8902a8"
               Frameless: false
-            - PC: "0x8900bc"
+            - PC: "0x8902bc"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1191 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x88fe98", Frameless: false}]
+          Type: 1195 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x890098", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1192 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x88fed8", Frameless: false}]
+          Type: 1196 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x8900d8", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1195 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x88ffb8", Frameless: false}]
+          Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x8901b8", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1196 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x890040", Frameless: false}]
+          Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x890240", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1193 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x88ff1c", Frameless: false}]
+          Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x89011c", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1194 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x88ff78", Frameless: false}]
+          Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x890178", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1203 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x890238", Frameless: false}]
+          Type: 1207 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x890438", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1204 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x8902c8"
+            - PC: "0x8904c8"
               Frameless: false
-            - PC: "0x8902dc"
+            - PC: "0x8904dc"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1224 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x890c00", Frameless: true}]
+          Type: 1228 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x890e00", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1213 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x890850", Frameless: true}]
+          Type: 1217 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x890a50", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1164 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88e210", Frameless: true}]
+          Type: 1168 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1209 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
+          Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x8906c8", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1210 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x890544", Frameless: false}]
+          Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x890744", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1188 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88fa30", Frameless: true}]
+          Type: 1192 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88fc30", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1217 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x890890", Frameless: true}]
+          Type: 1221 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x890a90", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1237 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x890ed0", Frameless: true}]
+          Type: 1241 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x8910d0", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1238 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x890eec", Frameless: true}]
+          Type: 1242 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x8910ec", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1214 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x890860", Frameless: true}]
+          Type: 1218 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x890a60", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1158 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x88dc10", Frameless: true}]
+          Type: 1162 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x88de10", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1235 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x890de0", Frameless: true}]
+          Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1236 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x890df8", Frameless: true}]
+          Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x890ff8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1234 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x890dd0", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x890fd0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1159 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88e1c0", Frameless: true}]
+          Type: 1163 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88e3c0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1225 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x890c10", Frameless: true}]
+          Type: 1229 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x890e10", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1226 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x890c20", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x890e20", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1227 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x890c38", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x890e38", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1228 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x890c40", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x890e40", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1187 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88f9c0", Frameless: true}]
+          Type: 1191 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88fbc0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1211 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x890830", Frameless: true}]
+          Type: 1215 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x890a30", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1232 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x890c70", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x890e70", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1186 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
+          Type: 1190 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88fba0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1220 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8908c0", Frameless: true}]
+          Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1221 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8908c0", Frameless: true}]
+          Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0x88ccb0..0x88ceb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88cd78..0x88cd88
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88ce28..0x88ce38
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88cd60..0x88cd64
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x88cd64..0x88cd88
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x88cd88..0x88ce1c
+              Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
+            - Range: 0x88ce1c..0x88ce24
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x88ce24..0x88ceb0
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88cd5c..0x88cd64
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x88cd64..0x88cd64
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x88cd64..0x88cd88
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x88cd88..0x88ce1c
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0x88ce1c..0x88ce20
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x88ce20..0x88ce24
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x88ce24..0x88ce38
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x88ce38..0x88ceb0
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88d030..0x88d120]
+      OutOfLinePCRanges: [0x88d230..0x88d320]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 146 StructureType main.esotericStack
           Locations:
-            - Range: 0x88d030..0x88d078
+            - Range: 0x88d230..0x88d278
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d078..0x88d07c
+            - Range: 0x88d278..0x88d27c
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d07c..0x88d080
+            - Range: 0x88d27c..0x88d280
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,140 +2910,140 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88d120..0x88d1a0]
+      OutOfLinePCRanges: [0x88d320..0x88d3a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88d120..0x88d158
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88d560..0x88d5f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d560..0x88d598
+            - Range: 0x88d320..0x88d358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88d5f0..0x88d6c0]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x88d760..0x88d7f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d5f0..0x88d60c
+            - Range: 0x88d760..0x88d798
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x88d7f0..0x88d8c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88d7f0..0x88d80c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d5f0..0x88d61c
+            - Range: 0x88d7f0..0x88d81c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d60c..0x88d61c
+            - Range: 0x88d80c..0x88d81c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d61c..0x88d6c0
+            - Range: 0x88d81c..0x88d8c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88d6c0..0x88d740]
+      OutOfLinePCRanges: [0x88d8c0..0x88d940]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d6c0..0x88d6e4
+            - Range: 0x88d8c0..0x88d8e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88d740..0x88d860]
+      OutOfLinePCRanges: [0x88d940..0x88da60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d7a8..0x88d7b0
+            - Range: 0x88d9a8..0x88d9b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7b0..0x88d7c8
+            - Range: 0x88d9b0..0x88d9c8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d7c8..0x88d7dc
+            - Range: 0x88d9c8..0x88d9dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d7a4..0x88d7ac
+            - Range: 0x88d9a4..0x88d9ac
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7ac..0x88d7c8
+            - Range: 0x88d9ac..0x88d9c8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d7c8..0x88d7d8
+            - Range: 0x88d9c8..0x88d9d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88d860..0x88d870]
+      OutOfLinePCRanges: [0x88da60..0x88da70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d860..0x88d868
+            - Range: 0x88da60..0x88da68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d860..0x88d870, Pieces: []}]
+          Locations: [{Range: 0x88da60..0x88da70, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88d870..0x88d8d0]
+      OutOfLinePCRanges: [0x88da70..0x88dad0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 ArrayType [5]int
           Locations:
-            - Range: 0x88d870..0x88d8d0
+            - Range: 0x88da70..0x88dad0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88d870..0x88d8d0, Pieces: []}]
+          Locations: [{Range: 0x88da70..0x88dad0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88db10..0x88db20]
+      OutOfLinePCRanges: [0x88dd10..0x88dd20]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 153 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88db10..0x88db20
+            - Range: 0x88dd10..0x88dd20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2847,21 +3051,21 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0x88db20..0x88db90]
+      OutOfLinePCRanges: [0x88dd20..0x88dd90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88db20..0x88db50
+            - Range: 0x88dd20..0x88dd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88db50..0x88db54
+            - Range: 0x88dd50..0x88dd54
               Pieces:
                 - Size: 8
                   Op: null
@@ -2871,18 +3075,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88db20..0x88db90, Pieces: []}]
+          Locations: [{Range: 0x88dd20..0x88dd90, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0x88db90..0x88dba0]
+      OutOfLinePCRanges: [0x88dd90..0x88dda0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88db90..0x88dba0
+            - Range: 0x88dd90..0x88dda0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,32 +3094,32 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x88dba0..0x88dc10]
+      OutOfLinePCRanges: [0x88dda0..0x88de10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 154 PointerType *interface {}
           Locations:
-            - Range: 0x88dba0..0x88dbd0
+            - Range: 0x88dda0..0x88ddd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88dba0..0x88dc10, Pieces: []}]
+          Locations: [{Range: 0x88dda0..0x88de10, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x88dc10..0x88dc20]
+      OutOfLinePCRanges: [0x88de10..0x88de20]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 155 StructureType main.structWithAny
           Locations:
-            - Range: 0x88dc10..0x88dc20
+            - Range: 0x88de10..0x88de20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2923,309 +3127,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88e1c0..0x88e1d0]
+      OutOfLinePCRanges: [0x88e3c0..0x88e3d0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 156 StructureType main.structWithMap
           Locations:
-            - Range: 0x88e1c0..0x88e1d0
+            - Range: 0x88e3c0..0x88e3d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88e1d0..0x88e1e0]
+      OutOfLinePCRanges: [0x88e3d0..0x88e3e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88e1d0..0x88e1e0
+            - Range: 0x88e3d0..0x88e3e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88e1e0..0x88e1f0]
+      OutOfLinePCRanges: [0x88e3e0..0x88e3f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]int
           Locations:
-            - Range: 0x88e1e0..0x88e1f0
+            - Range: 0x88e3e0..0x88e3f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88e1f0..0x88e200]
+      OutOfLinePCRanges: [0x88e3f0..0x88e400]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string][]string
           Locations:
-            - Range: 0x88e1f0..0x88e200
+            - Range: 0x88e3f0..0x88e400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88e200..0x88e210]
+      OutOfLinePCRanges: [0x88e400..0x88e410]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x88e200..0x88e210
+            - Range: 0x88e400..0x88e410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88e210..0x88e220]
+      OutOfLinePCRanges: [0x88e410..0x88e420]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]int
           Locations:
-            - Range: 0x88e210..0x88e220
+            - Range: 0x88e410..0x88e420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88e220..0x88e230]
+      OutOfLinePCRanges: [0x88e420..0x88e430]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88e220..0x88e230
+            - Range: 0x88e420..0x88e430
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88e230..0x88e240]
+      OutOfLinePCRanges: [0x88e430..0x88e440]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 183 PointerType *map[string]int
           Locations:
-            - Range: 0x88e230..0x88e240
+            - Range: 0x88e430..0x88e440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88e240..0x88e250]
+      OutOfLinePCRanges: [0x88e440..0x88e450]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 157 GoMapType map[int]int
           Locations:
-            - Range: 0x88e240..0x88e250
+            - Range: 0x88e440..0x88e450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88e250..0x88e260]
+      OutOfLinePCRanges: [0x88e450..0x88e460]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 184 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e250..0x88e260
+            - Range: 0x88e450..0x88e460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88e260..0x88e270]
+      OutOfLinePCRanges: [0x88e460..0x88e470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 184 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x88e260..0x88e270
+            - Range: 0x88e460..0x88e470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88e270..0x88e280]
+      OutOfLinePCRanges: [0x88e470..0x88e480]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x88e270..0x88e280
+            - Range: 0x88e470..0x88e480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88e280..0x88e290]
+      OutOfLinePCRanges: [0x88e480..0x88e490]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e280..0x88e290
+            - Range: 0x88e480..0x88e490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x88e290..0x88e2a0]
+      OutOfLinePCRanges: [0x88e490..0x88e4a0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 194 GoMapType map[int]uint8
           Locations:
-            - Range: 0x88e290..0x88e2a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x88e2a0..0x88e2b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 199 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x88e2a0..0x88e2b0
+            - Range: 0x88e490..0x88e4a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x88e2b0..0x88e2c0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88e4a0..0x88e4b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e2b0..0x88e2c0
+            - Range: 0x88e4a0..0x88e4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x88e2c0..0x88e2d0]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88e4b0..0x88e4c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x88e2c0..0x88e2d0
+            - Range: 0x88e4b0..0x88e4c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e4c0..0x88e4d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 199 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e4c0..0x88e4d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88e2d0..0x88e2e0]
+      OutOfLinePCRanges: [0x88e4d0..0x88e4e0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x88e2d0..0x88e2e0
+            - Range: 0x88e4d0..0x88e4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x88e2e0..0x88e2f0]
+      OutOfLinePCRanges: [0x88e4e0..0x88e4f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x88e2e0..0x88e2f0
+            - Range: 0x88e4e0..0x88e4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x88e2f0..0x88e300]
+      OutOfLinePCRanges: [0x88e4f0..0x88e500]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x88e2f0..0x88e300
+            - Range: 0x88e4f0..0x88e500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88f550..0x88f560]
+      OutOfLinePCRanges: [0x88f750..0x88f760]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f550..0x88f560
+            - Range: 0x88f750..0x88f760
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f550..0x88f560
+            - Range: 0x88f750..0x88f760
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f550..0x88f560
+            - Range: 0x88f750..0x88f760
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88f630..0x88f640]
+      OutOfLinePCRanges: [0x88f830..0x88f840]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88f630..0x88f640
+            - Range: 0x88f830..0x88f840
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f630..0x88f640
+            - Range: 0x88f830..0x88f840
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88f630..0x88f640
+            - Range: 0x88f830..0x88f840
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f630..0x88f640
+            - Range: 0x88f830..0x88f840
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f630..0x88f640
+            - Range: 0x88f830..0x88f840
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3233,39 +3437,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88f7d0..0x88f7e0]
+      OutOfLinePCRanges: [0x88f9d0..0x88f9e0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 219 GoChannelType chan bool
           Locations:
-            - Range: 0x88f7d0..0x88f7e0
+            - Range: 0x88f9d0..0x88f9e0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88f970..0x88f980]
+      OutOfLinePCRanges: [0x88fb70..0x88fb80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 220 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88f970..0x88f980
+            - Range: 0x88fb70..0x88fb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88f980..0x88f990]
+      OutOfLinePCRanges: [0x88fb80..0x88fb90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 222 StructureType main.node
           Locations:
-            - Range: 0x88f980..0x88f990
+            - Range: 0x88fb80..0x88fb90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3273,195 +3477,195 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88f990..0x88f9a0]
+      OutOfLinePCRanges: [0x88fb90..0x88fba0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 223 PointerType *main.node
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88fb90..0x88fba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88f9a0..0x88f9b0]
+      OutOfLinePCRanges: [0x88fba0..0x88fbb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88f9a0..0x88f9b0
+            - Range: 0x88fba0..0x88fbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88f9c0..0x88f9d0]
+      OutOfLinePCRanges: [0x88fbc0..0x88fbd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x88f9c0..0x88f9d0
+            - Range: 0x88fbc0..0x88fbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88fa30..0x88fa40]
+      OutOfLinePCRanges: [0x88fc30..0x88fc40]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x88fa30..0x88fa40
+            - Range: 0x88fc30..0x88fc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88fa50..0x88fa60]
+      OutOfLinePCRanges: [0x88fc50..0x88fc60]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88fa50..0x88fa60
+            - Range: 0x88fc50..0x88fc60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fa50..0x88fa60
+            - Range: 0x88fc50..0x88fc60
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88fa70..0x88fa80]
+      OutOfLinePCRanges: [0x88fc70..0x88fc80]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 224 PointerType *main.t
           Locations:
-            - Range: 0x88fa70..0x88fa80
+            - Range: 0x88fc70..0x88fc80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x88fe80..0x88ff00]
+      OutOfLinePCRanges: [0x890080..0x890100]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88fe80..0x88fea4
+            - Range: 0x890080..0x8900a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88fea4..0x88ff00
+            - Range: 0x8900a4..0x890100
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88fe80..0x88ff00, Pieces: []}]
+          Locations: [{Range: 0x890080..0x890100, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x88ff00..0x88ffa0]
+      OutOfLinePCRanges: [0x890100..0x8901a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88ff00..0x88ff24
+            - Range: 0x890100..0x890124
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 94 PointerType *int
-          Locations: [{Range: 0x88ff00..0x88ffa0, Pieces: []}]
+          Locations: [{Range: 0x890100..0x8901a0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x88ff28..0x88ff40
+            - Range: 0x890128..0x890140
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88ff40..0x88ffa0
+            - Range: 0x890140..0x8901a0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x88ffa0..0x890060]
+      OutOfLinePCRanges: [0x8901a0..0x890260]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88ffa0..0x88ffec
+            - Range: 0x8901a0..0x8901ec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88ffec..0x890060
+            - Range: 0x8901ec..0x890260
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88ffa0..0x890060, Pieces: []}]
+          Locations: [{Range: 0x8901a0..0x890260, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x88ffa0..0x890060, Pieces: []}]
+          Locations: [{Range: 0x8901a0..0x890260, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x88ffc0..0x88ffec
+            - Range: 0x8901c0..0x8901ec
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x88ffec..0x890060
+            - Range: 0x8901ec..0x890260
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x890060..0x8900e0]
+      OutOfLinePCRanges: [0x890260..0x8902e0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x890060..0x890084
+            - Range: 0x890260..0x890284
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0x890060..0x8900e0, Pieces: []}]
+          Locations: [{Range: 0x890260..0x8902e0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x8900e0..0x890180]
+      OutOfLinePCRanges: [0x8902e0..0x890380]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8900e0..0x89010c
+            - Range: 0x8902e0..0x89030c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89010c..0x890110
+            - Range: 0x89030c..0x890310
               Pieces:
                 - Size: 8
                   Op: null
@@ -3472,41 +3676,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8900e0..0x890110
+            - Range: 0x8902e0..0x890310
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 148 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x8900e0..0x890180, Pieces: []}]
+          Locations: [{Range: 0x8902e0..0x890380, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0x8900e0..0x890180, Pieces: []}]
+          Locations: [{Range: 0x8902e0..0x890380, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x890180..0x890220]
+      OutOfLinePCRanges: [0x890380..0x890420]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890180..0x8901dc
+            - Range: 0x890380..0x8903dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8901dc..0x8901e0
+            - Range: 0x8903dc..0x8903e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8901e0..0x890220
+            - Range: 0x8903e0..0x890420
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3516,186 +3720,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 148 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x890180..0x890220, Pieces: []}]
+          Locations: [{Range: 0x890380..0x890420, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x890220..0x890350]
+      OutOfLinePCRanges: [0x890420..0x890550]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 148 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890220..0x89025c
+            - Range: 0x890420..0x89045c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89025c..0x8902bc
+            - Range: 0x89045c..0x8904bc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8902bc..0x8902e8
+            - Range: 0x8904bc..0x8904e8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8902e8..0x890310
+            - Range: 0x8904e8..0x890510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890310..0x890314
+            - Range: 0x890510..0x890514
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890314..0x890350
+            - Range: 0x890514..0x890550
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 153 GoInterfaceType main.behavior
-          Locations: [{Range: 0x890220..0x890350, Pieces: []}]
+          Locations: [{Range: 0x890420..0x890550, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 153 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890220..0x89025c
+            - Range: 0x890420..0x89045c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89025c..0x8902ac
+            - Range: 0x89045c..0x8904ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8902ac..0x8902bc
+            - Range: 0x8904ac..0x8904bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8902bc..0x8902d4
+            - Range: 0x8904bc..0x8904d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8902d4..0x8902d8
+            - Range: 0x8904d4..0x8904d8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8902d8..0x8902dc
+            - Range: 0x8904d8..0x8904dc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8902dc..0x890350
+            - Range: 0x8904dc..0x890550
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x890350..0x8903f0]
+      OutOfLinePCRanges: [0x890550..0x8905f0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890350..0x890390
+            - Range: 0x890550..0x890590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890390..0x8903f0
+            - Range: 0x890590..0x8905f0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0x890350..0x8903f0, Pieces: []}]
+          Locations: [{Range: 0x890550..0x8905f0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8903f0..0x8904b0]
+      OutOfLinePCRanges: [0x8905f0..0x8906b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8903f0..0x890434
+            - Range: 0x8905f0..0x890634
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890434..0x8904b0
+            - Range: 0x890634..0x8906b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0x8903f0..0x8904b0, Pieces: []}]
+          Locations: [{Range: 0x8905f0..0x8906b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0x8903f0..0x8904b0, Pieces: []}]
+          Locations: [{Range: 0x8905f0..0x8906b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x8904b0..0x890570]
+      OutOfLinePCRanges: [0x8906b0..0x890770]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8904b0..0x8904f0
+            - Range: 0x8906b0..0x8906f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8904f0..0x890570
+            - Range: 0x8906f0..0x890770
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x8904b0..0x890570, Pieces: []}]
+          Locations: [{Range: 0x8906b0..0x890770, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0x8904b0..0x890570, Pieces: []}]
+          Locations: [{Range: 0x8906b0..0x890770, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
-          Locations: [{Range: 0x8904b0..0x890570, Pieces: []}]
+          Locations: [{Range: 0x8906b0..0x890770, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x890830..0x890840]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 226 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x890830..0x890840
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x890840..0x890850]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x890a30..0x890a40]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x890840..0x890850
+            - Range: 0x890a30..0x890a40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3706,14 +3892,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x890850..0x890860]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x890a40..0x890a50]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 227 GoSliceHeaderType [][]uint
+          Type: 226 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x890850..0x890860
+            - Range: 0x890a40..0x890a50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3724,14 +3910,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x890860..0x890870]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x890a50..0x890a60]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 229 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 227 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x890860..0x890870
+            - Range: 0x890a50..0x890a60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3739,24 +3925,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x890860..0x890870
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x890870..0x890880]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x890a60..0x890a70]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x890870..0x890880
+            - Range: 0x890a60..0x890a70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3769,19 +3948,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890870..0x890880
+            - Range: 0x890a60..0x890a70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x890880..0x890890]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x890a70..0x890a80]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 229 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x890880..0x890890
+            - Range: 0x890a70..0x890a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3794,19 +3973,44 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890880..0x890890
+            - Range: 0x890a70..0x890a80
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x890a80..0x890a90]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 229 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x890a80..0x890a90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x890a80..0x890a90
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x890890..0x8908a0]
+      OutOfLinePCRanges: [0x890a90..0x890aa0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 232 GoSliceHeaderType []string
           Locations:
-            - Range: 0x890890..0x8908a0
+            - Range: 0x890a90..0x890aa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3816,22 +4020,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x8908a0..0x8908b0]
+      OutOfLinePCRanges: [0x890aa0..0x890ab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x8908a0..0x8908b0
+            - Range: 0x890aa0..0x890ab0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 233 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x8908a0..0x8908b0
+            - Range: 0x890aa0..0x890ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3844,37 +4048,19 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x8908a0..0x8908b0
+            - Range: 0x890aa0..0x890ab0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x8908b0..0x8908c0]
+      OutOfLinePCRanges: [0x890ab0..0x890ac0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x8908b0..0x8908c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x8908c0..0x8908d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 226 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8908c0..0x8908d0
+            - Range: 0x890ab0..0x890ac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3885,24 +4071,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x890ac0..0x890ad0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 226 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x890ac0..0x890ad0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0x890b90..0x890c00]
+      OutOfLinePCRanges: [0x890d90..0x890e00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x890b90..0x890c00, Pieces: []}]
+          Locations: [{Range: 0x890d90..0x890e00, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x890c00..0x890c10]
+      OutOfLinePCRanges: [0x890e00..0x890e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c00..0x890c10
+            - Range: 0x890e00..0x890e10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3910,15 +4114,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x890c10..0x890c20]
+      OutOfLinePCRanges: [0x890e10..0x890e20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c10..0x890c20
+            - Range: 0x890e10..0x890e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3929,7 +4133,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c10..0x890c20
+            - Range: 0x890e10..0x890e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3940,7 +4144,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c10..0x890c20
+            - Range: 0x890e10..0x890e20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3948,15 +4152,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x890c20..0x890c40]
+      OutOfLinePCRanges: [0x890e20..0x890e40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 235 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x890c20..0x890c40
+            - Range: 0x890e20..0x890e40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3972,55 +4176,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x890c40..0x890c50]
+      OutOfLinePCRanges: [0x890e40..0x890e50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 236 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x890c40..0x890c50
+            - Range: 0x890e40..0x890e50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x890c50..0x890c60]
+      OutOfLinePCRanges: [0x890e50..0x890e60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x890c50..0x890c60
+            - Range: 0x890e50..0x890e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x890c60..0x890c70]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x890c60..0x890c70
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x890c70..0x890c80]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x890e60..0x890e70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c70..0x890c80
+            - Range: 0x890e60..0x890e70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4029,14 +4217,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x890c80..0x890c90]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x890e70..0x890e80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890c80..0x890c90
+            - Range: 0x890e70..0x890e80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4045,26 +4233,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x890e80..0x890e90]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x890e80..0x890e90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x890dd0..0x890de0]
+      OutOfLinePCRanges: [0x890fd0..0x890fe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x890dd0..0x890de0
+            - Range: 0x890fd0..0x890fe0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x890de0..0x890e00]
+      OutOfLinePCRanges: [0x890fe0..0x891000]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x890de0..0x890e00
+            - Range: 0x890fe0..0x891000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4080,15 +4284,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0x890ed0..0x890ef0]
+      OutOfLinePCRanges: [0x8910d0..0x8910f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 283 StructureType main.aStruct
           Locations:
-            - Range: 0x890ed0..0x890ef0
+            - Range: 0x8910d0..0x8910f0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4106,108 +4310,108 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x890fd0..0x890fe0]
+      OutOfLinePCRanges: [0x8911d0..0x8911e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 285 StructureType main.emptyStruct
-          Locations: [{Range: 0x890fd0..0x890fe0, Pieces: []}]
+          Locations: [{Range: 0x8911d0..0x8911e0, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x890fe0..0x890ff0]
+      OutOfLinePCRanges: [0x8911e0..0x8911f0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 286 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x890fe0..0x890ff0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88d3c0..0x88d430]
-      InlinePCRanges:
-        - Ranges: [0x88d44c..0x88d484]
-          RootRanges: [0x88d430..0x88d4b0]
-        - Ranges: [0x88d598..0x88d5d0]
-          RootRanges: [0x88d560..0x88d5f0]
-        - Ranges: [0x88d614..0x88d64c]
-          RootRanges: [0x88d5f0..0x88d6c0]
-        - Ranges: [0x88d6dc..0x88d714]
-          RootRanges: [0x88d6c0..0x88d740]
-      Variables:
-        - Name: x
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x88d3c0..0x88d3e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d44c..0x88d454
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d598..0x88d5a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d60c..0x88d61c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d61c..0x88d6c0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88d6c0..0x88d6e4
+            - Range: 0x8911e0..0x8911f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x88d5c0..0x88d630]
       InlinePCRanges:
-        - Ranges: [0x88d658..0x88d690]
-          RootRanges: [0x88d5f0..0x88d6c0]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88d75c..0x88d7a0]
-          RootRanges: [0x88d740..0x88d860]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88d810..0x88d848]
-          RootRanges: [0x88d740..0x88d860]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x88d864..0x88d868]
-          RootRanges: [0x88d860..0x88d870]
+        - Ranges: [0x88d64c..0x88d684]
+          RootRanges: [0x88d630..0x88d6b0]
+        - Ranges: [0x88d798..0x88d7d0]
+          RootRanges: [0x88d760..0x88d7f0]
+        - Ranges: [0x88d814..0x88d84c]
+          RootRanges: [0x88d7f0..0x88d8c0]
+        - Ranges: [0x88d8dc..0x88d914]
+          RootRanges: [0x88d8c0..0x88d940]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d860..0x88d868
+            - Range: 0x88d5c0..0x88d5e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d64c..0x88d654
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d798..0x88d7a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d80c..0x88d81c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88d81c..0x88d8c0
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x88d8c0..0x88d8e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88d858..0x88d890]
+          RootRanges: [0x88d7f0..0x88d8c0]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88d95c..0x88d9a0]
+          RootRanges: [0x88d940..0x88da60]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88da10..0x88da48]
+          RootRanges: [0x88d940..0x88da60]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88da64..0x88da68]
+          RootRanges: [0x88da60..0x88da70]
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x88da60..0x88da68
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88d894..0x88d8b8]
-          RootRanges: [0x88d870..0x88d8d0]
-        - Ranges: [0x88d92c..0x88d954]
-          RootRanges: [0x88d8d0..0x88da20]
+        - Ranges: [0x88da94..0x88dab8]
+          RootRanges: [0x88da70..0x88dad0]
+        - Ranges: [0x88db2c..0x88db54]
+          RootRanges: [0x88dad0..0x88dc20]
       Variables:
         - Name: a
           Type: 152 ArrayType [5]int
           Locations:
-            - Range: 0x88d880..0x88d8d0
+            - Range: 0x88da80..0x88dad0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88d918..0x88da20
+            - Range: 0x88db18..0x88dc20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
@@ -5019,14 +5223,14 @@ Types:
       ID: 642
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 981696
+      GoRuntimeType: 980032
       GoKind: 22
       Pointee: 643 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 644
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 981824
+      GoRuntimeType: 980160
       GoKind: 22
       Pointee: 645 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -6024,21 +6228,21 @@ Types:
       ID: 870
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.10384e+06
+      GoRuntimeType: 1.104096e+06
       GoKind: 22
       Pointee: 871 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 868
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.103456e+06
+      GoRuntimeType: 1.103712e+06
       GoKind: 22
       Pointee: 869 StructureType io.discard
     - __kind: PointerType
       ID: 842
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 980160
+      GoRuntimeType: 980928
       GoKind: 22
       Pointee: 843 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7106,10 +7310,10 @@ Types:
       GoKind: 22
       Pointee: 639 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1222
+      ID: 1226
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1223
+      ID: 1227
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7121,11 +7325,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1156
+      ID: 1160
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7137,11 +7341,11 @@ Types:
             Type: 154 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1161
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7153,11 +7357,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1153
+      ID: 1157
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7169,11 +7373,11 @@ Types:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1154
+      ID: 1158
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7185,7 +7389,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7221,7 +7425,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1165
+      ID: 1169
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7233,7 +7437,7 @@ Types:
             Type: 182 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7304,7 +7508,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1182
+      ID: 1186
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7316,11 +7520,11 @@ Types:
             Type: 219 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1180
+      ID: 1184
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7332,7 +7536,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7342,7 +7546,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7352,11 +7556,11 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1190
+      ID: 1194
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7368,7 +7572,7 @@ Types:
             Type: 224 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7468,7 +7672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1219
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7480,7 +7684,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7490,11 +7694,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1216
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7506,11 +7710,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1233
+      ID: 1237
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7522,11 +7726,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1240
+      ID: 1244
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7538,11 +7742,11 @@ Types:
             Type: 286 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1239
+      ID: 1243
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7554,11 +7758,11 @@ Types:
             Type: 285 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1155
+      ID: 1159
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7570,11 +7774,11 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1138
+      ID: 1141
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7586,14 +7790,14 @@ Types:
             Type: 150 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1142
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1136
+      ID: 1139
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7605,14 +7809,14 @@ Types:
             Type: 146 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1137
+      ID: 1140
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1150
+      ID: 1153
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7624,12 +7828,70 @@ Types:
             Type: 152 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1151
+      ID: 1155
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1154
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1151
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1152
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7644,82 +7906,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1148
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1149
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1140
+      ID: 1143
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1141
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1144
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1145
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1142
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -7732,6 +7921,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1144
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1147
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1148
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1145
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -7739,26 +7969,32 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1143
+      ID: 1146
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1244
+      ID: 1249
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1245
+      ID: 1250
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1251
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1146
+      ID: 1252
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1149
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1147
+      ID: 1150
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1241
+      ID: 1245
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7770,14 +8006,30 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1247
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1246
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1253
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7789,11 +8041,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1247
+      ID: 1254
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1255
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7805,7 +8073,7 @@ Types:
             Type: 152 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -7889,7 +8157,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1156
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7901,11 +8169,11 @@ Types:
             Type: 153 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1184
+      ID: 1188
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7917,11 +8185,66 @@ Types:
             Type: 222 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1163
+      ID: 1136
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1137
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1138
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1167
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7933,11 +8256,11 @@ Types:
             Type: 177 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1170
+      ID: 1174
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7949,11 +8272,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1167
+      ID: 1171
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7965,11 +8288,11 @@ Types:
             Type: 157 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1183
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7981,11 +8304,11 @@ Types:
             Type: 214 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1182
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7997,11 +8320,11 @@ Types:
             Type: 209 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1168
+      ID: 1172
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8013,11 +8336,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1173
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8029,11 +8352,11 @@ Types:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1177
+      ID: 1181
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8045,12 +8368,92 @@ Types:
             Type: 204 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1180
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 199 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1176
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1165
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 167 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1166
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 172 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1164
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 162 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1175
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 189 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1179
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8065,72 +8468,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1161
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 167 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1162
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 172 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1160
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 162 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1171
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 189 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1175
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1178
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8145,23 +8484,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1174
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 199 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1173
+      ID: 1177
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8173,11 +8496,11 @@ Types:
             Type: 194 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1172
+      ID: 1176
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8189,11 +8512,11 @@ Types:
             Type: 194 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1230
+      ID: 1234
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8205,11 +8528,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1231
+      ID: 1235
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8221,12 +8544,110 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1207
+      ID: 1211
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1212
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1185
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1209
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8241,9 +8662,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1208
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1210
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8256,106 +8677,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 13 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 12 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1205
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1206
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1189
+      ID: 1193
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8367,7 +8690,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8377,11 +8700,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1216
+      ID: 1220
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8393,7 +8716,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8403,11 +8726,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1218
+      ID: 1222
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8419,7 +8742,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8429,7 +8752,7 @@ Types:
             Type: 233 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8439,11 +8762,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1223
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8455,11 +8778,11 @@ Types:
             Type: 234 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1229
+      ID: 1233
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8471,11 +8794,11 @@ Types:
             Type: 237 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1185
+      ID: 1189
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8487,11 +8810,11 @@ Types:
             Type: 223 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1166
+      ID: 1170
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8503,11 +8826,11 @@ Types:
             Type: 183 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1183
+      ID: 1187
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8519,65 +8842,13 @@ Types:
             Type: 220 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1203
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 148 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1200
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 148 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1201
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8590,10 +8861,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1202
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1204
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8603,150 +8884,22 @@ Types:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1197
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1198
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1195
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1196
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1193
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1194
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 94 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1191
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1192
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1203
-      Name: Probe[main.testReturnsInterface]
+      ID: 1205
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8761,7 +8914,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1204
+      ID: 1206
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 148 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1201
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1202
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1199
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1200
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1197
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1198
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1195
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1196
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1207
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 148 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1208
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8773,7 +9096,7 @@ Types:
             Type: 153 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -8953,7 +9276,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1224
+      ID: 1228
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8965,7 +9288,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9049,7 +9372,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1217
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9061,11 +9384,11 @@ Types:
             Type: 227 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1164
+      ID: 1168
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9077,11 +9400,11 @@ Types:
             Type: 167 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1213
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9093,11 +9416,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1214
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9109,7 +9432,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9119,7 +9442,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9129,7 +9452,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9149,7 +9472,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1188
+      ID: 1192
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9161,11 +9484,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1221
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9177,7 +9500,7 @@ Types:
             Type: 232 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9213,7 +9536,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1214
+      ID: 1218
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9225,7 +9548,7 @@ Types:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9235,11 +9558,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1158
+      ID: 1162
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9251,11 +9574,11 @@ Types:
             Type: 155 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1239
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9267,14 +9590,14 @@ Types:
             Type: 252 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1236
+      ID: 1240
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1234
+      ID: 1238
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9286,11 +9609,11 @@ Types:
             Type: 239 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1159
+      ID: 1163
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9302,11 +9625,11 @@ Types:
             Type: 156 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1237
+      ID: 1241
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9318,14 +9641,14 @@ Types:
             Type: 283 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1238
+      ID: 1242
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1228
+      ID: 1232
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9337,11 +9660,11 @@ Types:
             Type: 236 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1226
+      ID: 1230
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9353,14 +9676,14 @@ Types:
             Type: 235 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1227
+      ID: 1231
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1225
+      ID: 1229
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9372,7 +9695,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9382,7 +9705,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9392,7 +9715,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9492,7 +9815,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1187
+      ID: 1191
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9504,11 +9827,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1215
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9520,11 +9843,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1232
+      ID: 1236
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9536,11 +9859,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1186
+      ID: 1190
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9552,7 +9875,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9572,7 +9895,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1220
+      ID: 1224
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9584,11 +9907,11 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1221
+      ID: 1225
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9600,7 +9923,7 @@ Types:
             Type: 226 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13687,7 +14010,7 @@ Types:
       ID: 912
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.103584e+06
+      GoRuntimeType: 1.10384e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13700,7 +14023,7 @@ Types:
       ID: 943
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 980288
+      GoRuntimeType: 981056
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13726,7 +14049,7 @@ Types:
       ID: 120
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 980032
+      GoRuntimeType: 980800
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13738,7 +14061,7 @@ Types:
     - __kind: StructureType
       ID: 869
       Name: io.discard
-      GoRuntimeType: 1.280608e+06
+      GoRuntimeType: 1.281088e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -16263,7 +16586,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 951968
       GoKind: 5
-MaxTypeID: 1247
+MaxTypeID: 1255
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1222 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x890ba8", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1223 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x890bdc", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1153 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88db38", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1154 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88db64", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1156 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88dbb8", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1157 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88dbe4", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8a8", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1138 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d138", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1139 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d174", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1136 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d04c", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1137 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d0bc", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1148 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88d860", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1149 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88d868", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1150 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88d87c", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1151 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88d8b8", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1140 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d578", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1141 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d5d0", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1142 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d608", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1143 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d690", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1144 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d6d8", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1145 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d714", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1146 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d758", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1147 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88d848", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1241 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0x88d6dc"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1242 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d410", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1207 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890408", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1208 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890484", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1205 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x890368", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1206 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8903c4", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1201 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x890198", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1202 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x8901ec", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1199 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x8900f8", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1200 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1197 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x890078", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1198 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1191 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x88fe98", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1192 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x88fed8", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1195 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x88ffb8", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1196 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x890040", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1193 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x88ff1c", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1194 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x88ff78", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1203 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x890238", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1204 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1209 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1210 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890544", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1237 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x890ed0", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1238 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x890eec", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1235 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x890de0", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1236 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x890df8", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1226 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x890c20", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1227 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x890c38", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1226 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x890da8", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1227 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x890ddc", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1157 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88dd38", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1158 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd64", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1160 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88ddb8", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1161 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88dde4", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1106 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1108 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1169 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1107 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1126 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c890", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1127 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8a8", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1095 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1092 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c230", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1186 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88f9d0", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1184 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f750", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1194 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fc70", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1132 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc70", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1133 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cc80", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1128 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c960", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1129 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c970", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1130 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb10", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1131 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb20", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1216 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x890a40", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1219 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x890a70", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1237 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x890e80", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1243 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x8911d0", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1244 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x8911e0", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1159 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88dd90", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1141 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d338", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1142 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d374", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1139 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d24c", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1140 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2bc", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1151 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88da60", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1152 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da68", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1153 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1154 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dab8", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1155 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1155 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88da7c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1143 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d778", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1144 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d7d0", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1145 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d808", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1146 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d890", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1147 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d8d8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1148 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d914", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d858", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1149 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d958", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1150 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da48", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1250 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1250 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d95c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da10", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1252 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1252 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da10", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1245 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5d8"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1246 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d610", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1247 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1247 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5d8"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da64", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1254 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1254 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da64", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88da94"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1098 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1099 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1100 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1097 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1096 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1156 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd10", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1188 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1136 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cccc", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1137 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd60", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1138 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce0c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1167 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1174 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1171 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1183 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1182 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1172 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1173 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1181 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1180 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1165 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1166 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1164 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e3d0", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1175 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1178 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1179 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1176 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1177 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1234 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1235 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x890e60", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1211 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890608", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1212 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890684", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1185 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f830", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1209 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x890568", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1210 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x8905c4", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1193 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fc50", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1223 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x890ab0", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1220 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x890a80", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1222 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x890aa0", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1233 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x890e50", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1189 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fb90", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1170 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1187 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1205 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x890398", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1206 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x8903ec", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1203 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x8902f8", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1204 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x890338"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1201 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x890278", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1202 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x8902a8"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1195 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x890098", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1196 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x8900d8", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1199 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x8901b8", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1200 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x890240", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1197 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x89011c", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1198 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x890178", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1207 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x890438", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1208 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x8904c8"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1093 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1112 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1110 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c690", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1123 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1124 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1113 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1115 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1116 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1117 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1114 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1111 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6a0", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1228 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x890e00", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1118 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1120 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1121 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1122 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1119 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1217 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x890a50", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1168 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1213 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x8906c8", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1214 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890744", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1094 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1192 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fc30", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1221 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x890a90", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1134 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1135 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1241 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x8910d0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1242 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x8910ec", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1218 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x890a60", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1162 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de10", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1239 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1240 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x890ff8", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1238 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x890fd0", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1163 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3c0", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1229 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x890e10", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1230 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x890e20", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1231 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x890e38", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1232 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x890e40", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1125 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1103 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1104 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1105 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1102 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1101 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1191 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fbc0", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1215 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x890a30", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1236 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x890e70", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1190 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fba0", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1109 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1224 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1225 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x890ac0", Frameless: true}]
           Condition: null
@@ -7833,7 +7997,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1155
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -7980,13 +8144,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1250
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1251
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1252
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1149
       Name: Probe[main.testInlinedBC]
@@ -8011,7 +8175,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1247
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8046,7 +8210,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1254
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8190,10 +8354,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1136
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1137
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8219,7 +8383,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1138
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84e238", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84e438", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1378 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x84e26c", Frameless: false}]
+          Type: 1382 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x84e46c", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x84b238", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x84b438", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1309 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x84b264", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x84b464", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x84b2b8", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x84b4b8", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1312 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x84b2e4", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x84b4e4", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84b920", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84cf70", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84d170", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84ccf0", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84cef0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84d210", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d410", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84ded0", Frameless: true}]
+          Type: 1371 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84e0d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84df00", Frameless: true}]
+          Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84e100", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84e310", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84e510", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84e660", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84e860", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84e670", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x84e870", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84b290", Frameless: true}]
+          Type: 1314 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x84b490", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1293 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x84a858", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x84aa58", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1294 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x84a894", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x84aa94", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1291 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x84a78c", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x84a98c", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1292 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x84a7fc", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x84a9fc", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x84af70", Frameless: true}]
+          Type: 1306 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x84b170", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1304 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x84af78", Frameless: true}]
+          Type: 1307 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x84b178", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x84af8c", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1306 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x84afc8", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x84b1c8", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1310 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1295 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x84ac98", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x84ae98", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1296 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x84acf0", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x84aef0", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1297 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x84ad28", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x84af28", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1298 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x84adb0", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x84afb0", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1299 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x84ade8", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x84afe8", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1300 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x84ae24", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x84b024", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x84ad78", Frameless: false}]
+          Type: 1403 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x84af78", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x84ae68", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x84b068", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1302 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x84af58", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x84b158", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x84ae6c", Frameless: false}]
+          Type: 1404 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1405 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x84af20", Frameless: false}]
+          Type: 1406 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x84b120", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1407 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0x84b120", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testInlinedPrint]
+          Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x84aaf8"
+            - PC: "0x84acf8"
               Frameless: false
-            - PC: "0x84ab6c"
+            - PC: "0x84ad6c"
               Frameless: false
-            - PC: "0x84acb8"
+            - PC: "0x84aeb8"
               Frameless: false
-            - PC: "0x84ad34"
+            - PC: "0x84af34"
               Frameless: false
-            - PC: "0x84adec"
+            - PC: "0x84afec"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1397 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x84ab30", Frameless: false}]
+          Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x84ad30", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1402 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0x84acf8"
+              Frameless: false
+            - PC: "0x84ad6c"
+              Frameless: false
+            - PC: "0x84aeb8"
+              Frameless: false
+            - PC: "0x84af34"
+              Frameless: false
+            - PC: "0x84afec"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1401 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84af74", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x84b174", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1409 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0x84b174", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x84afa4"
+            - PC: "0x84b1a4"
               Frameless: false
-            - PC: "0x84b03c"
+            - PC: "0x84b23c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84b210", Frameless: true}]
+          Type: 1311 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x84b410", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84d120", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84d320", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x84a40c", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x84a49c", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x84a544", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84b900", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84b960", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84b940", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b9f0", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84b9e0", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84b950", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84b950", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84b9d0", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84b9c0", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84b8e0", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84b8f0", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84b8d0", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84bad0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84b970", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84b9a0", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84b9b0", Frameless: true}]
+          Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84b980", Frameless: true}]
+          Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84b990", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84e2f0", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84e2f0", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
+          Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84dcb8", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84db34", Frameless: false}]
+          Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84dd34", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84cdd0", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84cfd0", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84da18", Frameless: false}]
+          Type: 1364 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84dc18", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1361 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84da74", Frameless: false}]
+          Type: 1365 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84dc74", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84d1f0", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d3f0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84df40", Frameless: true}]
+          Type: 1378 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84e140", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84df10", Frameless: true}]
+          Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84e110", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84df30", Frameless: true}]
+          Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84e130", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84e2e0", Frameless: true}]
+          Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84e4e0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84d130", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84d330", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84b930", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84d110", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84d310", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x84d868", Frameless: false}]
+          Type: 1360 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x84da68", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1357 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x84d8b8", Frameless: false}]
+          Type: 1361 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x84d7c8", Frameless: false}]
+          Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x84d9c8", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1355 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x84d808"
+            - PC: "0x84da08"
               Frameless: false
-            - PC: "0x84d81c"
+            - PC: "0x84da1c"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x84d748", Frameless: false}]
+          Type: 1356 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x84d948", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1353 EventRootType Probe[main.testReturnsError]Return
+          Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x84d778"
+            - PC: "0x84d978"
               Frameless: false
-            - PC: "0x84d78c"
+            - PC: "0x84d98c"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x84d568", Frameless: false}]
+          Type: 1350 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x84d768", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1347 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x84d5a8", Frameless: false}]
+          Type: 1351 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x84d7a8", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x84d688", Frameless: false}]
+          Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x84d888", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1351 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x84d710", Frameless: false}]
+          Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x84d910", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1348 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x84d5ec", Frameless: false}]
+          Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x84d7ec", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1349 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x84d644", Frameless: false}]
+          Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x84d844", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x84d8f8", Frameless: false}]
+          Type: 1362 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x84daf8", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1359 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x84d984"
+            - PC: "0x84db84"
               Frameless: false
-            - PC: "0x84d998"
+            - PC: "0x84db98"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84e290", Frameless: true}]
+          Type: 1383 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84e490", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84dee0", Frameless: true}]
+          Type: 1372 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84e0e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84b910", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x84db78", Frameless: false}]
+          Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x84dd78", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1365 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x84dbf0", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x84ddf0", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84d1d0", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d3d0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84df20", Frameless: true}]
+          Type: 1376 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84e120", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84e560", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84e760", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1393 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x84e57c", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x84e77c", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84def0", Frameless: true}]
+          Type: 1373 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84e0f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x84b310", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x84b510", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x84e470", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x84e670", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1391 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x84e488", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x84e688", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x84e460", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x84e660", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84b8c0", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84bac0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84e2a0", Frameless: true}]
+          Type: 1384 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84e4a0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84e2b0", Frameless: true}]
+          Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84e4b0", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84e2c8", Frameless: true}]
+          Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x84e4c8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84e2d0", Frameless: true}]
+          Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84e4d0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84d160", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84d360", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84dec0", Frameless: true}]
+          Type: 1370 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84e0c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84e300", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84e500", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84d140", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84d340", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84df50", Frameless: true}]
+          Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1376 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84df50", Frameless: true}]
+          Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0x84a3f0..0x84a5f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84a4b4..0x84a4c4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84a560..0x84a570
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84a49c..0x84a4a0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84a4a0..0x84a4c4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84a4c4..0x84a554
+              Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
+            - Range: 0x84a554..0x84a55c
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x84a55c..0x84a5f0
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84a498..0x84a4a0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84a4a0..0x84a4a0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84a4a0..0x84a4c4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84a4c4..0x84a554
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0x84a554..0x84a558
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x84a558..0x84a55c
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x84a55c..0x84a570
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x84a570..0x84a5f0
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x84a770..0x84a840]
+      OutOfLinePCRanges: [0x84a970..0x84aa40]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 149 StructureType main.esotericStack
           Locations:
-            - Range: 0x84a770..0x84a7b8
+            - Range: 0x84a970..0x84a9b8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84a7b8..0x84a7bc
+            - Range: 0x84a9b8..0x84a9bc
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x84a7bc..0x84a7c0
+            - Range: 0x84a9bc..0x84a9c0
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,140 +2910,140 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x84a840..0x84a8c0]
+      OutOfLinePCRanges: [0x84aa40..0x84aac0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 153 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x84a840..0x84a878
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84ac80..0x84ad10]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84ac80..0x84acb8
+            - Range: 0x84aa40..0x84aa78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84ad10..0x84add0]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x84ae80..0x84af10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ad10..0x84ad2c
+            - Range: 0x84ae80..0x84aeb8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x84af10..0x84afd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84af10..0x84af2c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ad10..0x84ad3c
+            - Range: 0x84af10..0x84af3c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ad2c..0x84ad3c
+            - Range: 0x84af2c..0x84af3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad3c..0x84add0
+            - Range: 0x84af3c..0x84afd0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84add0..0x84ae50]
+      OutOfLinePCRanges: [0x84afd0..0x84b050]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84add0..0x84adf4
+            - Range: 0x84afd0..0x84aff4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84ae50..0x84af70]
+      OutOfLinePCRanges: [0x84b050..0x84b170]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84aeb8..0x84aec0
+            - Range: 0x84b0b8..0x84b0c0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aec0..0x84aed8
+            - Range: 0x84b0c0..0x84b0d8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84aed8..0x84aeec
+            - Range: 0x84b0d8..0x84b0ec
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84aeb4..0x84aebc
+            - Range: 0x84b0b4..0x84b0bc
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aebc..0x84aed8
+            - Range: 0x84b0bc..0x84b0d8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84aed8..0x84aee8
+            - Range: 0x84b0d8..0x84b0e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84af70..0x84af80]
+      OutOfLinePCRanges: [0x84b170..0x84b180]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84af70..0x84af78
+            - Range: 0x84b170..0x84b178
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84af70..0x84af80, Pieces: []}]
+          Locations: [{Range: 0x84b170..0x84b180, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84af80..0x84afe0]
+      OutOfLinePCRanges: [0x84b180..0x84b1e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 155 ArrayType [5]int
           Locations:
-            - Range: 0x84af80..0x84afe0
+            - Range: 0x84b180..0x84b1e0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84af80..0x84afe0, Pieces: []}]
+          Locations: [{Range: 0x84b180..0x84b1e0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84b210..0x84b220]
+      OutOfLinePCRanges: [0x84b410..0x84b420]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 156 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84b210..0x84b220
+            - Range: 0x84b410..0x84b420
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2847,21 +3051,21 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0x84b220..0x84b290]
+      OutOfLinePCRanges: [0x84b420..0x84b490]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84b220..0x84b250
+            - Range: 0x84b420..0x84b450
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84b250..0x84b254
+            - Range: 0x84b450..0x84b454
               Pieces:
                 - Size: 8
                   Op: null
@@ -2871,18 +3075,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b220..0x84b290, Pieces: []}]
+          Locations: [{Range: 0x84b420..0x84b490, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0x84b290..0x84b2a0]
+      OutOfLinePCRanges: [0x84b490..0x84b4a0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84b290..0x84b2a0
+            - Range: 0x84b490..0x84b4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,32 +3094,32 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x84b2a0..0x84b310]
+      OutOfLinePCRanges: [0x84b4a0..0x84b510]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 PointerType *interface {}
           Locations:
-            - Range: 0x84b2a0..0x84b2d0
+            - Range: 0x84b4a0..0x84b4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b2a0..0x84b310, Pieces: []}]
+          Locations: [{Range: 0x84b4a0..0x84b510, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x84b310..0x84b320]
+      OutOfLinePCRanges: [0x84b510..0x84b520]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 158 StructureType main.structWithAny
           Locations:
-            - Range: 0x84b310..0x84b320
+            - Range: 0x84b510..0x84b520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2923,309 +3127,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84b8c0..0x84b8d0]
+      OutOfLinePCRanges: [0x84bac0..0x84bad0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithMap
           Locations:
-            - Range: 0x84b8c0..0x84b8d0
+            - Range: 0x84bac0..0x84bad0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84b8d0..0x84b8e0]
+      OutOfLinePCRanges: [0x84bad0..0x84bae0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 165 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84b8d0..0x84b8e0
+            - Range: 0x84bad0..0x84bae0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84b8e0..0x84b8f0]
+      OutOfLinePCRanges: [0x84bae0..0x84baf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[string]int
           Locations:
-            - Range: 0x84b8e0..0x84b8f0
+            - Range: 0x84bae0..0x84baf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84b8f0..0x84b900]
+      OutOfLinePCRanges: [0x84baf0..0x84bb00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 175 GoMapType map[string][]string
           Locations:
-            - Range: 0x84b8f0..0x84b900
+            - Range: 0x84baf0..0x84bb00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84b900..0x84b910]
+      OutOfLinePCRanges: [0x84bb00..0x84bb10]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 180 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x84b900..0x84b910
+            - Range: 0x84bb00..0x84bb10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84b910..0x84b920]
+      OutOfLinePCRanges: [0x84bb10..0x84bb20]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 170 GoMapType map[string]int
           Locations:
-            - Range: 0x84b910..0x84b920
+            - Range: 0x84bb10..0x84bb20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84b920..0x84b930]
+      OutOfLinePCRanges: [0x84bb20..0x84bb30]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 185 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x84b920..0x84b930
+            - Range: 0x84bb20..0x84bb30
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84b930..0x84b940]
+      OutOfLinePCRanges: [0x84bb30..0x84bb40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 PointerType *map[string]int
           Locations:
-            - Range: 0x84b930..0x84b940
+            - Range: 0x84bb30..0x84bb40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84b940..0x84b950]
+      OutOfLinePCRanges: [0x84bb40..0x84bb50]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 160 GoMapType map[int]int
           Locations:
-            - Range: 0x84b940..0x84b950
+            - Range: 0x84bb40..0x84bb50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84b950..0x84b960]
+      OutOfLinePCRanges: [0x84bb50..0x84bb60]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 187 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84b950..0x84b960
+            - Range: 0x84bb50..0x84bb60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84b960..0x84b970]
+      OutOfLinePCRanges: [0x84bb60..0x84bb70]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x84b960..0x84b970
+            - Range: 0x84bb60..0x84bb70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84b970..0x84b980]
+      OutOfLinePCRanges: [0x84bb70..0x84bb80]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 192 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x84b970..0x84b980
+            - Range: 0x84bb70..0x84bb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84b980..0x84b990]
+      OutOfLinePCRanges: [0x84bb80..0x84bb90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 197 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84b980..0x84b990
+            - Range: 0x84bb80..0x84bb90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84b990..0x84b9a0]
+      OutOfLinePCRanges: [0x84bb90..0x84bba0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 197 GoMapType map[int]uint8
           Locations:
-            - Range: 0x84b990..0x84b9a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84b9a0..0x84b9b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 202 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84b9a0..0x84b9b0
+            - Range: 0x84bb90..0x84bba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84b9b0..0x84b9c0]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84bba0..0x84bbb0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84b9b0..0x84b9c0
+            - Range: 0x84bba0..0x84bbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84b9c0..0x84b9d0]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84bbb0..0x84bbc0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 202 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x84b9c0..0x84b9d0
+            - Range: 0x84bbb0..0x84bbc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84bbc0..0x84bbd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 202 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84bbc0..0x84bbd0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84b9d0..0x84b9e0]
+      OutOfLinePCRanges: [0x84bbd0..0x84bbe0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 207 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x84b9d0..0x84b9e0
+            - Range: 0x84bbd0..0x84bbe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x84b9e0..0x84b9f0]
+      OutOfLinePCRanges: [0x84bbe0..0x84bbf0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 212 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x84b9e0..0x84b9f0
+            - Range: 0x84bbe0..0x84bbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x84b9f0..0x84ba00]
+      OutOfLinePCRanges: [0x84bbf0..0x84bc00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 217 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x84b9f0..0x84ba00
+            - Range: 0x84bbf0..0x84bc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84ccf0..0x84cd00]
+      OutOfLinePCRanges: [0x84cef0..0x84cf00]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84ccf0..0x84cd00
+            - Range: 0x84cef0..0x84cf00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84ccf0..0x84cd00
+            - Range: 0x84cef0..0x84cf00
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x84ccf0..0x84cd00
+            - Range: 0x84cef0..0x84cf00
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84cdd0..0x84cde0]
+      OutOfLinePCRanges: [0x84cfd0..0x84cfe0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84cfd0..0x84cfe0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84cfd0..0x84cfe0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84cfd0..0x84cfe0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84cfd0..0x84cfe0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84cdd0..0x84cde0
+            - Range: 0x84cfd0..0x84cfe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3233,39 +3437,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84cf70..0x84cf80]
+      OutOfLinePCRanges: [0x84d170..0x84d180]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 222 GoChannelType chan bool
           Locations:
-            - Range: 0x84cf70..0x84cf80
+            - Range: 0x84d170..0x84d180
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84d110..0x84d120]
+      OutOfLinePCRanges: [0x84d310..0x84d320]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 223 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84d110..0x84d120
+            - Range: 0x84d310..0x84d320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84d120..0x84d130]
+      OutOfLinePCRanges: [0x84d320..0x84d330]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 225 StructureType main.node
           Locations:
-            - Range: 0x84d120..0x84d130
+            - Range: 0x84d320..0x84d330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3273,195 +3477,195 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84d130..0x84d140]
+      OutOfLinePCRanges: [0x84d330..0x84d340]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 226 PointerType *main.node
           Locations:
-            - Range: 0x84d130..0x84d140
+            - Range: 0x84d330..0x84d340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84d140..0x84d150]
+      OutOfLinePCRanges: [0x84d340..0x84d350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84d140..0x84d150
+            - Range: 0x84d340..0x84d350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84d160..0x84d170]
+      OutOfLinePCRanges: [0x84d360..0x84d370]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0x84d160..0x84d170
+            - Range: 0x84d360..0x84d370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84d1d0..0x84d1e0]
+      OutOfLinePCRanges: [0x84d3d0..0x84d3e0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x84d1d0..0x84d1e0
+            - Range: 0x84d3d0..0x84d3e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84d1f0..0x84d200]
+      OutOfLinePCRanges: [0x84d3f0..0x84d400]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84d1f0..0x84d200
+            - Range: 0x84d3f0..0x84d400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d1f0..0x84d200
+            - Range: 0x84d3f0..0x84d400
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84d210..0x84d220]
+      OutOfLinePCRanges: [0x84d410..0x84d420]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 227 PointerType *main.t
           Locations:
-            - Range: 0x84d210..0x84d220
+            - Range: 0x84d410..0x84d420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x84d550..0x84d5d0]
+      OutOfLinePCRanges: [0x84d750..0x84d7d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d550..0x84d574
+            - Range: 0x84d750..0x84d774
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d574..0x84d5d0
+            - Range: 0x84d774..0x84d7d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84d550..0x84d5d0, Pieces: []}]
+          Locations: [{Range: 0x84d750..0x84d7d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x84d5d0..0x84d670]
+      OutOfLinePCRanges: [0x84d7d0..0x84d870]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d5d0..0x84d5f4
+            - Range: 0x84d7d0..0x84d7f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
-          Locations: [{Range: 0x84d5d0..0x84d670, Pieces: []}]
+          Locations: [{Range: 0x84d7d0..0x84d870, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d5f8..0x84d60c
+            - Range: 0x84d7f8..0x84d80c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d60c..0x84d670
+            - Range: 0x84d80c..0x84d870
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84d670..0x84d730]
+      OutOfLinePCRanges: [0x84d870..0x84d930]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d670..0x84d6bc
+            - Range: 0x84d870..0x84d8bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d6bc..0x84d730
+            - Range: 0x84d8bc..0x84d930
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84d670..0x84d730, Pieces: []}]
+          Locations: [{Range: 0x84d870..0x84d930, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84d670..0x84d730, Pieces: []}]
+          Locations: [{Range: 0x84d870..0x84d930, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84d690..0x84d6bc
+            - Range: 0x84d890..0x84d8bc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84d6bc..0x84d730
+            - Range: 0x84d8bc..0x84d930
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84d730..0x84d7b0]
+      OutOfLinePCRanges: [0x84d930..0x84d9b0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84d730..0x84d754
+            - Range: 0x84d930..0x84d954
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x84d730..0x84d7b0, Pieces: []}]
+          Locations: [{Range: 0x84d930..0x84d9b0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84d7b0..0x84d850]
+      OutOfLinePCRanges: [0x84d9b0..0x84da50]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84d7b0..0x84d7dc
+            - Range: 0x84d9b0..0x84d9dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84d7dc..0x84d7e0
+            - Range: 0x84d9dc..0x84d9e0
               Pieces:
                 - Size: 8
                   Op: null
@@ -3472,41 +3676,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84d7b0..0x84d7e0
+            - Range: 0x84d9b0..0x84d9e0
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 151 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x84d7b0..0x84d850, Pieces: []}]
+          Locations: [{Range: 0x84d9b0..0x84da50, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x84d7b0..0x84d850, Pieces: []}]
+          Locations: [{Range: 0x84d9b0..0x84da50, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84d850..0x84d8e0]
+      OutOfLinePCRanges: [0x84da50..0x84dae0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84d850..0x84d898
+            - Range: 0x84da50..0x84da98
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84d898..0x84d8a0
+            - Range: 0x84da98..0x84daa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d8a0..0x84d8e0
+            - Range: 0x84daa0..0x84dae0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3516,186 +3720,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 151 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x84d850..0x84d8e0, Pieces: []}]
+          Locations: [{Range: 0x84da50..0x84dae0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84d8e0..0x84da00]
+      OutOfLinePCRanges: [0x84dae0..0x84dc00]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 151 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84d8e0..0x84d91c
+            - Range: 0x84dae0..0x84db1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84d91c..0x84d964
+            - Range: 0x84db1c..0x84db64
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84d964..0x84d9a4
+            - Range: 0x84db64..0x84dba4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84d9a4..0x84d9cc
+            - Range: 0x84dba4..0x84dbcc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d9cc..0x84d9d0
+            - Range: 0x84dbcc..0x84dbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d9d0..0x84da00
+            - Range: 0x84dbd0..0x84dc00
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 156 GoInterfaceType main.behavior
-          Locations: [{Range: 0x84d8e0..0x84da00, Pieces: []}]
+          Locations: [{Range: 0x84dae0..0x84dc00, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 156 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84d8e0..0x84d91c
+            - Range: 0x84dae0..0x84db1c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84d91c..0x84d964
+            - Range: 0x84db1c..0x84db64
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d964..0x84d96c
+            - Range: 0x84db64..0x84db6c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d96c..0x84d990
+            - Range: 0x84db6c..0x84db90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d990..0x84d994
+            - Range: 0x84db90..0x84db94
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84d994..0x84d998
+            - Range: 0x84db94..0x84db98
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84d998..0x84da00
+            - Range: 0x84db98..0x84dc00
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84da00..0x84daa0]
+      OutOfLinePCRanges: [0x84dc00..0x84dca0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84da00..0x84da40
+            - Range: 0x84dc00..0x84dc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84da40..0x84daa0
+            - Range: 0x84dc40..0x84dca0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x84da00..0x84daa0, Pieces: []}]
+          Locations: [{Range: 0x84dc00..0x84dca0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84daa0..0x84db60]
+      OutOfLinePCRanges: [0x84dca0..0x84dd60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84daa0..0x84dae4
+            - Range: 0x84dca0..0x84dce4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dae4..0x84db60
+            - Range: 0x84dce4..0x84dd60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x84daa0..0x84db60, Pieces: []}]
+          Locations: [{Range: 0x84dca0..0x84dd60, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84daa0..0x84db60, Pieces: []}]
+          Locations: [{Range: 0x84dca0..0x84dd60, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84db60..0x84dc10]
+      OutOfLinePCRanges: [0x84dd60..0x84de10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84db60..0x84dba0
+            - Range: 0x84dd60..0x84dda0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dba0..0x84dc10
+            - Range: 0x84dda0..0x84de10
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84db60..0x84dc10, Pieces: []}]
+          Locations: [{Range: 0x84dd60..0x84de10, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84db60..0x84dc10, Pieces: []}]
+          Locations: [{Range: 0x84dd60..0x84de10, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84db60..0x84dc10, Pieces: []}]
+          Locations: [{Range: 0x84dd60..0x84de10, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84dec0..0x84ded0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84dec0..0x84ded0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84ded0..0x84dee0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84e0c0..0x84e0d0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84ded0..0x84dee0
+            - Range: 0x84e0c0..0x84e0d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3706,14 +3892,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84dee0..0x84def0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84e0d0..0x84e0e0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 230 GoSliceHeaderType [][]uint
+          Type: 229 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84dee0..0x84def0
+            - Range: 0x84e0d0..0x84e0e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3724,14 +3910,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84def0..0x84df00]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84e0e0..0x84e0f0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 230 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x84def0..0x84df00
+            - Range: 0x84e0e0..0x84e0f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3739,24 +3925,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84def0..0x84df00
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84df00..0x84df10]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84e0f0..0x84e100]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84df00..0x84df10
+            - Range: 0x84e0f0..0x84e100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3769,19 +3948,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84df00..0x84df10
+            - Range: 0x84e0f0..0x84e100
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84df10..0x84df20]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84e100..0x84e110]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 232 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84df10..0x84df20
+            - Range: 0x84e100..0x84e110
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3794,19 +3973,44 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84df10..0x84df20
+            - Range: 0x84e100..0x84e110
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84e110..0x84e120]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 232 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84e110..0x84e120
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e110..0x84e120
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84df20..0x84df30]
+      OutOfLinePCRanges: [0x84e120..0x84e130]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 235 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84df20..0x84df30
+            - Range: 0x84e120..0x84e130
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3816,22 +4020,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84df30..0x84df40]
+      OutOfLinePCRanges: [0x84e130..0x84e140]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84df30..0x84df40
+            - Range: 0x84e130..0x84e140
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 236 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84df30..0x84df40
+            - Range: 0x84e130..0x84e140
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3844,37 +4048,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84df30..0x84df40
+            - Range: 0x84e130..0x84e140
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84df40..0x84df50]
+      OutOfLinePCRanges: [0x84e140..0x84e150]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 237 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84df40..0x84df50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84df50..0x84df60]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 229 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84df50..0x84df60
+            - Range: 0x84e140..0x84e150
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3885,24 +4071,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84e150..0x84e160]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 229 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84e150..0x84e160
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0x84e220..0x84e290]
+      OutOfLinePCRanges: [0x84e420..0x84e490]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84e220..0x84e290, Pieces: []}]
+          Locations: [{Range: 0x84e420..0x84e490, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84e290..0x84e2a0]
+      OutOfLinePCRanges: [0x84e490..0x84e4a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e290..0x84e2a0
+            - Range: 0x84e490..0x84e4a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3910,15 +4114,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84e2a0..0x84e2b0]
+      OutOfLinePCRanges: [0x84e4a0..0x84e4b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84e4a0..0x84e4b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3929,7 +4133,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84e4a0..0x84e4b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3940,7 +4144,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84e4a0..0x84e4b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3948,15 +4152,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84e2b0..0x84e2d0]
+      OutOfLinePCRanges: [0x84e4b0..0x84e4d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84e2b0..0x84e2d0
+            - Range: 0x84e4b0..0x84e4d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3972,55 +4176,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84e2d0..0x84e2e0]
+      OutOfLinePCRanges: [0x84e4d0..0x84e4e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84e2d0..0x84e2e0
+            - Range: 0x84e4d0..0x84e4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84e2e0..0x84e2f0]
+      OutOfLinePCRanges: [0x84e4e0..0x84e4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84e2e0..0x84e2f0
+            - Range: 0x84e4e0..0x84e4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84e2f0..0x84e300]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84e2f0..0x84e300
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84e300..0x84e310]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x84e4f0..0x84e500]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e300..0x84e310
+            - Range: 0x84e4f0..0x84e500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4029,14 +4217,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84e310..0x84e320]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x84e500..0x84e510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e310..0x84e320
+            - Range: 0x84e500..0x84e510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4045,26 +4233,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x84e510..0x84e520]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84e510..0x84e520
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x84e460..0x84e470]
+      OutOfLinePCRanges: [0x84e660..0x84e670]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x84e460..0x84e470
+            - Range: 0x84e660..0x84e670
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x84e470..0x84e490]
+      OutOfLinePCRanges: [0x84e670..0x84e690]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 255 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x84e470..0x84e490
+            - Range: 0x84e670..0x84e690
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4080,15 +4284,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84e560..0x84e580]
+      OutOfLinePCRanges: [0x84e760..0x84e780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 286 StructureType main.aStruct
           Locations:
-            - Range: 0x84e560..0x84e580
+            - Range: 0x84e760..0x84e780
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4106,108 +4310,108 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84e660..0x84e670]
+      OutOfLinePCRanges: [0x84e860..0x84e870]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 288 StructureType main.emptyStruct
-          Locations: [{Range: 0x84e660..0x84e670, Pieces: []}]
+          Locations: [{Range: 0x84e860..0x84e870, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84e670..0x84e680]
+      OutOfLinePCRanges: [0x84e870..0x84e880]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 289 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x84e670..0x84e680
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84aae0..0x84ab50]
-      InlinePCRanges:
-        - Ranges: [0x84ab6c..0x84aba4]
-          RootRanges: [0x84ab50..0x84abd0]
-        - Ranges: [0x84acb8..0x84acf0]
-          RootRanges: [0x84ac80..0x84ad10]
-        - Ranges: [0x84ad34..0x84ad6c]
-          RootRanges: [0x84ad10..0x84add0]
-        - Ranges: [0x84adec..0x84ae24]
-          RootRanges: [0x84add0..0x84ae50]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84aae0..0x84ab00
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ab6c..0x84ab74
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84acb8..0x84acc0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad2c..0x84ad3c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ad3c..0x84add0
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84add0..0x84adf4
+            - Range: 0x84e870..0x84e880
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x84ace0..0x84ad50]
       InlinePCRanges:
-        - Ranges: [0x84ad78..0x84adb0]
-          RootRanges: [0x84ad10..0x84add0]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84ae6c..0x84aeb0]
-          RootRanges: [0x84ae50..0x84af70]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84af20..0x84af58]
-          RootRanges: [0x84ae50..0x84af70]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x84af74..0x84af78]
-          RootRanges: [0x84af70..0x84af80]
+        - Ranges: [0x84ad6c..0x84ada4]
+          RootRanges: [0x84ad50..0x84add0]
+        - Ranges: [0x84aeb8..0x84aef0]
+          RootRanges: [0x84ae80..0x84af10]
+        - Ranges: [0x84af34..0x84af6c]
+          RootRanges: [0x84af10..0x84afd0]
+        - Ranges: [0x84afec..0x84b024]
+          RootRanges: [0x84afd0..0x84b050]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84af70..0x84af78
+            - Range: 0x84ace0..0x84ad00
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84ad6c..0x84ad74
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84aeb8..0x84aec0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84af2c..0x84af3c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84af3c..0x84afd0
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x84afd0..0x84aff4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84af78..0x84afb0]
+          RootRanges: [0x84af10..0x84afd0]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b06c..0x84b0b0]
+          RootRanges: [0x84b050..0x84b170]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b120..0x84b158]
+          RootRanges: [0x84b050..0x84b170]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84b174..0x84b178]
+          RootRanges: [0x84b170..0x84b180]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84b170..0x84b178
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84afa4..0x84afc8]
-          RootRanges: [0x84af80..0x84afe0]
-        - Ranges: [0x84b03c..0x84b064]
-          RootRanges: [0x84afe0..0x84b130]
+        - Ranges: [0x84b1a4..0x84b1c8]
+          RootRanges: [0x84b180..0x84b1e0]
+        - Ranges: [0x84b23c..0x84b264]
+          RootRanges: [0x84b1e0..0x84b330]
       Variables:
         - Name: a
           Type: 155 ArrayType [5]int
           Locations:
-            - Range: 0x84af90..0x84afe0
+            - Range: 0x84b190..0x84b1e0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84b028..0x84b130
+            - Range: 0x84b228..0x84b330
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
@@ -5047,14 +5251,14 @@ Types:
       ID: 759
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.019648e+06
+      GoRuntimeType: 1.017984e+06
       GoKind: 22
       Pointee: 760 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 761
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.019776e+06
+      GoRuntimeType: 1.018112e+06
       GoKind: 22
       Pointee: 762 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -5939,21 +6143,21 @@ Types:
       ID: 993
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.185312e+06
+      GoRuntimeType: 1.185568e+06
       GoKind: 22
       Pointee: 994 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 991
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.184928e+06
+      GoRuntimeType: 1.185184e+06
       GoKind: 22
       Pointee: 992 StructureType io.discard
     - __kind: PointerType
       ID: 965
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.018112e+06
+      GoRuntimeType: 1.01888e+06
       GoKind: 22
       Pointee: 966 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7381,10 +7585,10 @@ Types:
       GoKind: 22
       Pointee: 756 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1377
+      ID: 1381
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1378
+      ID: 1382
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7396,11 +7600,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1311
+      ID: 1315
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7412,11 +7616,11 @@ Types:
             Type: 157 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1312
+      ID: 1316
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7428,11 +7632,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1308
+      ID: 1312
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7444,11 +7648,11 @@ Types:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1309
+      ID: 1313
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7460,7 +7664,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7496,7 +7700,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1320
+      ID: 1324
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7508,7 +7712,7 @@ Types:
             Type: 185 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7579,7 +7783,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1337
+      ID: 1341
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7591,11 +7795,11 @@ Types:
             Type: 222 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1335
+      ID: 1339
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7607,7 +7811,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7617,7 +7821,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7627,11 +7831,11 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1345
+      ID: 1349
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7643,7 +7847,7 @@ Types:
             Type: 227 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7743,7 +7947,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1370
+      ID: 1374
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7755,7 +7959,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7765,11 +7969,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1371
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7781,11 +7985,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1388
+      ID: 1392
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7797,11 +8001,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1395
+      ID: 1399
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7813,11 +8017,11 @@ Types:
             Type: 289 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1398
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7829,11 +8033,11 @@ Types:
             Type: 288 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1310
+      ID: 1314
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7845,11 +8049,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1296
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7861,14 +8065,14 @@ Types:
             Type: 153 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1294
+      ID: 1297
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1291
+      ID: 1294
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7880,14 +8084,14 @@ Types:
             Type: 149 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1292
+      ID: 1295
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1305
+      ID: 1308
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7899,12 +8103,70 @@ Types:
             Type: 155 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1306
+      ID: 1310
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1309
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1306
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1307
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7919,82 +8181,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1304
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1295
+      ID: 1298
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1296
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1299
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1300
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1398
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1297
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -8007,6 +8196,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1302
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1303
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1300
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -8014,26 +8244,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1298
+      ID: 1301
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1399
+      ID: 1404
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1400
+      ID: 1405
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1406
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1301
+      ID: 1407
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1304
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1302
+      ID: 1305
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1396
+      ID: 1400
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8045,14 +8281,30 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1402
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1401
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1408
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8064,11 +8316,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1410
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8080,7 +8348,7 @@ Types:
             Type: 155 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -8164,7 +8432,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1311
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8176,11 +8444,11 @@ Types:
             Type: 156 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1339
+      ID: 1343
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8192,11 +8460,66 @@ Types:
             Type: 225 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1318
+      ID: 1291
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1292
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1293
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1322
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8208,11 +8531,11 @@ Types:
             Type: 180 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1329
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8224,11 +8547,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1326
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8240,11 +8563,11 @@ Types:
             Type: 160 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1334
+      ID: 1338
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8256,11 +8579,11 @@ Types:
             Type: 217 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1337
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8272,11 +8595,11 @@ Types:
             Type: 212 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1327
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8288,11 +8611,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1328
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8304,11 +8627,11 @@ Types:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1336
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8320,12 +8643,92 @@ Types:
             Type: 207 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1335
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 202 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1320
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 170 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1321
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 175 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1319
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 165 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1330
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 192 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1334
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8340,72 +8743,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 170 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1317
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 175 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1315
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 165 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1326
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 192 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1330
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1333
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8420,23 +8759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1329
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 202 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1328
+      ID: 1332
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8448,11 +8771,11 @@ Types:
             Type: 197 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1327
+      ID: 1331
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8464,11 +8787,11 @@ Types:
             Type: 197 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1389
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8480,11 +8803,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1386
+      ID: 1390
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8496,12 +8819,110 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1366
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1367
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1340
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1364
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8516,9 +8937,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1365
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8531,106 +8952,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 10 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1360
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1361
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1344
+      ID: 1348
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8642,7 +8965,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8652,11 +8975,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1371
+      ID: 1375
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8668,7 +8991,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8678,11 +9001,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1377
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8694,7 +9017,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8704,7 +9027,7 @@ Types:
             Type: 236 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8714,11 +9037,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1374
+      ID: 1378
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8730,11 +9053,11 @@ Types:
             Type: 237 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1384
+      ID: 1388
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8746,11 +9069,11 @@ Types:
             Type: 240 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1344
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8762,11 +9085,11 @@ Types:
             Type: 226 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1325
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8778,11 +9101,11 @@ Types:
             Type: 186 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1338
+      ID: 1342
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8794,65 +9117,13 @@ Types:
             Type: 223 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 151 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1355
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 151 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1356
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8865,10 +9136,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1357
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1359
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8878,150 +9159,22 @@ Types:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1352
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1353
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1351
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1348
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1349
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1346
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1347
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1358
-      Name: Probe[main.testReturnsInterface]
+      ID: 1360
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -9036,7 +9189,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 151 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1356
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1357
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1354
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1355
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1352
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1353
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1350
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1351
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1362
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 151 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1363
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9048,7 +9371,7 @@ Types:
             Type: 156 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9228,7 +9551,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1379
+      ID: 1383
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9240,7 +9563,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9324,7 +9647,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1372
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9336,11 +9659,11 @@ Types:
             Type: 230 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1323
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9352,11 +9675,11 @@ Types:
             Type: 170 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1368
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9368,11 +9691,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1369
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9384,7 +9707,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9394,7 +9717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9404,7 +9727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9424,7 +9747,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1343
+      ID: 1347
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9436,11 +9759,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1376
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9452,7 +9775,7 @@ Types:
             Type: 235 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9488,7 +9811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1373
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9500,7 +9823,7 @@ Types:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9510,11 +9833,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1317
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9526,11 +9849,11 @@ Types:
             Type: 158 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1390
+      ID: 1394
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9542,14 +9865,14 @@ Types:
             Type: 255 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1391
+      ID: 1395
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1389
+      ID: 1393
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9561,11 +9884,11 @@ Types:
             Type: 242 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1314
+      ID: 1318
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9577,11 +9900,11 @@ Types:
             Type: 159 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1396
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9593,14 +9916,14 @@ Types:
             Type: 286 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1393
+      ID: 1397
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1383
+      ID: 1387
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9612,11 +9935,11 @@ Types:
             Type: 239 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1385
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9628,14 +9951,14 @@ Types:
             Type: 238 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1382
+      ID: 1386
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1380
+      ID: 1384
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9647,7 +9970,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9657,7 +9980,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9667,7 +9990,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9767,7 +10090,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1342
+      ID: 1346
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9779,11 +10102,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1370
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9795,11 +10118,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1387
+      ID: 1391
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9811,11 +10134,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1341
+      ID: 1345
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9827,7 +10150,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9847,7 +10170,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1375
+      ID: 1379
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9859,11 +10182,11 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1376
+      ID: 1380
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9875,7 +10198,7 @@ Types:
             Type: 229 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13024,7 +13347,7 @@ Types:
       ID: 1034
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.185056e+06
+      GoRuntimeType: 1.185312e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13037,7 +13360,7 @@ Types:
       ID: 1071
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.01824e+06
+      GoRuntimeType: 1.019008e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13063,7 +13386,7 @@ Types:
       ID: 125
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.017984e+06
+      GoRuntimeType: 1.018752e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13075,7 +13398,7 @@ Types:
     - __kind: StructureType
       ID: 992
       Name: io.discard
-      GoRuntimeType: 1.457376e+06
+      GoRuntimeType: 1.457856e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -17828,7 +18151,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 988736
       GoKind: 5
-MaxTypeID: 1402
+MaxTypeID: 1410
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x131d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ad2c..0x84ad3c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84ad3c..0x84add0
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x84add0..0x84ae50]
@@ -2765,7 +2774,29 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x84ae50..0x84af70]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84aeb8..0x84aec0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x84aec0..0x84aed8
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+            - Range: 0x84aed8..0x84aeec
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84aeb4..0x84aebc
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x84aebc..0x84aed8
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+            - Range: 0x84aed8..0x84aee8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x84af70..0x84af80]
@@ -3357,6 +3388,15 @@ Subprograms:
           Locations: [{Range: 0x84d5d0..0x84d670, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 99 PointerType *int
+          Locations:
+            - Range: 0x84d5f8..0x84d60c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d60c..0x84d670
+              Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x84d670..0x84d730]
@@ -3381,6 +3421,15 @@ Subprograms:
           Locations: [{Range: 0x84d670..0x84d730, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0x84d690..0x84d6bc
+              Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x84d6bc..0x84d730
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x84d730..0x84d7b0]
@@ -3509,6 +3558,45 @@ Subprograms:
           Locations: [{Range: 0x84d8e0..0x84da00, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 156 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0x84d8e0..0x84d91c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84d91c..0x84d964
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x84d964..0x84d96c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x84d96c..0x84d990
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x84d990..0x84d994
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x84d994..0x84d998
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0x84d998..0x84da00
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x84da00..0x84daa0]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1381 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84e438", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1382 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84e46c", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1312 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b438", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b464", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b4b8", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b4e4", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1261 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1263 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1262 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x849fe8", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1250 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1247 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d170", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84cef0", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d410", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a250", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84e0d0", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84e100", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84e510", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x84e860", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x84e870", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b490", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84aa58", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aa94", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a98c", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84a9fc", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84b170", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1c8", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1310 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ae98", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84aef0", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84af28", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afb0", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84afe8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b024", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af78", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84b068", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b158", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1405 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b120", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1407 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b120", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84acf8"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad30", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1402 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84acf8"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b174", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1409 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b174", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1a4"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1254 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1252 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1311 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b410", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d320", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a40c", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a49c", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a544", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84bad0", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84dcb8", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84dd34", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84cfd0", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84dc18", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84dc74", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d3f0", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84e140", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84e110", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84e130", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84e4e0", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d330", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d310", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84da68", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84d9c8", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x84da08"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84d948", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x84d978"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d768", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d7a8", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84d888", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84d910", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d7ec", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84d844", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84daf8", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x84db84"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1265 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84e490", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84e0e0", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84dd78", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84ddf0", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d3d0", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84e120", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84e760", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x84e77c", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84e0f0", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b510", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x84e670", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x84e688", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x84e660", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bac0", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84e4a0", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84e4b0", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84e4c8", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84e4d0", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1258 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1259 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1260 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1257 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1256 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d360", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84e0c0", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84e500", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d340", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1264 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1377 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84e238", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1378 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84e26c", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1308 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b238", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1309 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b264", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1311 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b2b8", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1312 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b2e4", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x849fe8", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1293 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84a858", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1294 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84a894", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1291 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a78c", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1292 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84a7fc", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1303 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84af70", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1304 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84af78", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1305 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84af8c", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1306 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84afc8", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1295 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ac98", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1296 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84acf0", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1297 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84ad28", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1298 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84adb0", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1299 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84ade8", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1300 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84ae24", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1301 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84ae68", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1302 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84af58", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1396 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0x84adec"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1397 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ab30", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1362 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1363 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84db34", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1360 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84da18", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1361 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84da74", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1356 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84d868", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1357 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x84d8b8", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1354 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84d7c8", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1355 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1352 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84d748", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1353 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1346 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d568", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1347 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d5a8", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1350 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84d688", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1351 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84d710", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1348 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d5ec", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1349 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84d644", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1358 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84d8f8", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1359 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1364 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84db78", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1365 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84dbf0", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1392 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84e560", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1393 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x84e57c", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1390 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x84e470", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1391 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x84e488", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1381 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84e2b0", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1382 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84e2c8", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1381 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84e438", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1382 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84e46c", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1312 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b438", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b464", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b4b8", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b4e4", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1261 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1263 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1262 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849fd0", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x849fe8", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1250 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1247 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849970", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d170", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84cef0", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d410", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3b0", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3c0", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0a0", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0b0", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a250", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a260", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84e0d0", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84e100", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84e510", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x84e860", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x84e870", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b490", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84aa58", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aa94", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a98c", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84a9fc", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84b170", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1c8", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1310 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1310 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b18c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84ae98", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84aef0", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84af28", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afb0", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84afe8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b024", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af78", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84b068", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b158", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1405 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1405 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b06c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b120", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1407 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1407 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b120", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1400 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84acf8"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1401 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad30", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1402 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1402 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84acf8"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b174", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1409 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1409 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b174", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1a4"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1253 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1254 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1255 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1252 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1251 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1311 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b410", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d320", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1291 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a40c", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1292 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a49c", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1293 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a544", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1329 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84bad0", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84e4f0", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84dcb8", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84dd34", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84cfd0", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84dc18", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84dc74", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d3f0", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84e140", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84e110", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84e130", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84e4e0", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d330", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d310", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84da68", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84d9c8", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x84da08"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84d948", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x84d978"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d768", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d7a8", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84d888", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84d910", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d7ec", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84d844", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84daf8", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x84db84"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1248 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1265 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849dd0", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849de0", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84e490", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84e0e0", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84dd78", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84ddf0", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1249 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d3d0", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84e120", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84e760", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x84e77c", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84e0f0", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b510", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x84e670", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x84e688", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x84e660", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bac0", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84e4a0", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84e4b0", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84e4c8", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84e4d0", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1258 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1259 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1260 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1257 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1256 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d360", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84e0c0", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84e500", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d340", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1264 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84e150", Frameless: true}]
           Condition: null
@@ -8108,7 +8272,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1310
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -8255,13 +8419,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1405
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1407
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1304
       Name: Probe[main.testInlinedBC]
@@ -8286,7 +8450,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1402
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8321,7 +8485,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1409
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8465,10 +8629,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1291
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1292
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8494,7 +8658,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1293
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -2749,6 +2749,15 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+        - Name: z
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80755c..0x80756c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80756c..0x807600
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 48
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x807600..0x807670]
@@ -2765,7 +2774,25 @@ Subprograms:
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x807670..0x807780]
       InlinePCRanges: []
-      Variables: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80768c..0x8076f8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8076f8..0x807700
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80768c..0x8076f8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8076f8..0x8076fc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 50
       Name: main.testFrameless
       OutOfLinePCRanges: [0x807780..0x807790]
@@ -3357,6 +3384,15 @@ Subprograms:
           Locations: [{Range: 0x809c80..0x809d10, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: '&i'
+          Type: 100 PointerType *int
+          Locations:
+            - Range: 0x809ca8..0x809cbc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x809cbc..0x809d10
+              Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 90
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x809d10..0x809dd0]
@@ -3381,6 +3417,15 @@ Subprograms:
           Locations: [{Range: 0x809d10..0x809dd0, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: f
+          Type: 16 BaseType float64
+          Locations:
+            - Range: 0x809d30..0x809d58
+              Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
+            - Range: 0x809d58..0x809dd0
+              Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 91
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x809dd0..0x809e50]
@@ -3509,6 +3554,45 @@ Subprograms:
           Locations: [{Range: 0x809f60..0x80a070, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: b
+          Type: 158 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0x809f60..0x809f9c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x809f9c..0x809fdc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x809fdc..0x809fe4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x809fe4..0x80a008
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -48}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x80a008..0x80a00c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x80a00c..0x80a010
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0x80a010..0x80a070
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x80a070..0x80a100]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
-        - ID: 132
+        - ID: 136
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x80a838", Frameless: false}]
+          Type: 1400 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x80aa18", Frameless: false}]
           Condition: null
-        - ID: 131
+        - ID: 135
           Kind: Return
-          Type: 1397 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x80a868", Frameless: false}]
+          Type: 1401 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x80aa48", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -28,17 +28,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 63
+        - ID: 67
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x807a18", Frameless: false}]
+          Type: 1331 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x807bf8", Frameless: false}]
           Condition: null
-        - ID: 62
+        - ID: 66
           Kind: Return
-          Type: 1328 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x807a40", Frameless: false}]
+          Type: 1332 EventRootType Probe[main.testAny]Return
+          InjectionPoints: [{PC: "0x807c20", Frameless: false}]
           Condition: null
     - id: testAnyPtr
       version: 0
@@ -48,17 +48,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 66
+        - ID: 70
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x807a88", Frameless: false}]
+          Type: 1334 EventRootType Probe[main.testAnyPtr]
+          InjectionPoints: [{PC: "0x807c68", Frameless: false}]
           Condition: null
-        - ID: 65
+        - ID: 69
           Kind: Return
-          Type: 1331 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
+          Type: 1335 EventRootType Probe[main.testAnyPtr]Return
+          InjectionPoints: [{PC: "0x807c90", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -98,12 +98,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 74
+        - ID: 78
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x808080", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -178,12 +178,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 91
+        - ID: 95
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x809670", Frameless: true}]
+          Type: 1360 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x809850", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -193,12 +193,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 89
+        - ID: 93
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x8093f0", Frameless: true}]
+          Type: 1358 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x8095d0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -208,12 +208,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 99
+        - ID: 103
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x8098f0", Frameless: true}]
+          Type: 1368 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
       version: 0
@@ -313,12 +313,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 121
+        - ID: 125
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x80a500", Frameless: true}]
+          Type: 1390 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x80a6e0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -328,12 +328,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 124
+        - ID: 128
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x80a530", Frameless: true}]
+          Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x80a710", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -344,12 +344,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
-        - ID: 142
+        - ID: 146
           Kind: Entry
-          Type: 1407 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80a8f0", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80aad0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -359,12 +359,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
-        - ID: 148
+        - ID: 152
           Kind: Entry
-          Type: 1413 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80abc0", Frameless: true}]
+          Type: 1417 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80ada0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -373,12 +373,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
-        - ID: 149
+        - ID: 153
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80abd0", Frameless: true}]
+          Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80adb0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -388,12 +388,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 64
+        - ID: 68
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x807a60", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x807c40", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -403,17 +403,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 45}
+      subprogram: {subprogram: 46}
       events:
-        - ID: 48
+        - ID: 51
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x8070b8", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testEsotericHeap]
+          InjectionPoints: [{PC: "0x807298", Frameless: false}]
           Condition: null
-        - ID: 47
+        - ID: 50
           Kind: Return
-          Type: 1313 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x8070f0", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
+          InjectionPoints: [{PC: "0x8072d0", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -423,17 +423,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 44}
+      subprogram: {subprogram: 45}
       events:
-        - ID: 46
+        - ID: 49
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x806ffc", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testEsotericStack]
+          InjectionPoints: [{PC: "0x8071dc", Frameless: false}]
           Condition: null
-        - ID: 45
+        - ID: 48
           Kind: Return
-          Type: 1311 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x807058", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testEsotericStack]Return
+          InjectionPoints: [{PC: "0x807238", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -443,17 +443,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 50}
+      subprogram: {subprogram: 51}
       events:
-        - ID: 58
+        - ID: 61
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x807780", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testFrameless]
+          InjectionPoints: [{PC: "0x807960", Frameless: true}]
           Condition: null
-        - ID: 57
+        - ID: 60
           Kind: Return
-          Type: 1323 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x807788", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testFrameless]Return
+          InjectionPoints: [{PC: "0x807968", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -463,17 +463,35 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 60
+        - ID: 63
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x80779c", Frameless: false}]
+          Type: 1327 EventRootType Probe[main.testFramelessArray]
+          InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
-        - ID: 59
+        - ID: 62
           Kind: Return
-          Type: 1325 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x8077d0", Frameless: false}]
+          Type: 1328 EventRootType Probe[main.testFramelessArray]Return
+          InjectionPoints: [{PC: "0x8079b0", Frameless: false}]
+          Condition: null
+    - id: testFramelessArrayLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testFramelessArray
+        sourceFile: inlined.go
+        lines: ["93"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 52}
+      events:
+        - ID: 64
+          Kind: EventKind(3)
+          Type: 1329 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -483,17 +501,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 46}
+      subprogram: {subprogram: 47}
       events:
-        - ID: 50
+        - ID: 53
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x8074c8", Frameless: false}]
+          Type: 1317 EventRootType Probe[main.testInlinedBA]
+          InjectionPoints: [{PC: "0x8076a8", Frameless: false}]
           Condition: null
-        - ID: 49
+        - ID: 52
           Kind: Return
-          Type: 1315 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x80751c", Frameless: false}]
+          Type: 1318 EventRootType Probe[main.testInlinedBA]Return
+          InjectionPoints: [{PC: "0x8076fc", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -503,17 +521,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 47}
+      subprogram: {subprogram: 48}
       events:
-        - ID: 52
+        - ID: 55
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x807558", Frameless: false}]
+          Type: 1319 EventRootType Probe[main.testInlinedBB]
+          InjectionPoints: [{PC: "0x807738", Frameless: false}]
           Condition: null
-        - ID: 51
+        - ID: 54
           Kind: Return
-          Type: 1317 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
+          Type: 1320 EventRootType Probe[main.testInlinedBB]Return
+          InjectionPoints: [{PC: "0x8077b8", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -523,17 +541,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 48}
+      subprogram: {subprogram: 49}
       events:
-        - ID: 54
+        - ID: 57
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x807618", Frameless: false}]
+          Type: 1321 EventRootType Probe[main.testInlinedBBA]
+          InjectionPoints: [{PC: "0x8077f8", Frameless: false}]
           Condition: null
-        - ID: 53
+        - ID: 56
           Kind: Return
-          Type: 1319 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x807650", Frameless: false}]
+          Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
+          InjectionPoints: [{PC: "0x807830", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -543,12 +561,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
-        - ID: 152
+        - ID: 157
           Kind: Entry
-          Type: 1417 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x8075a4", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x807784", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -558,17 +576,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 49}
+      subprogram: {subprogram: 50}
       events:
-        - ID: 56
+        - ID: 59
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x807688", Frameless: false}]
+          Type: 1323 EventRootType Probe[main.testInlinedBC]
+          InjectionPoints: [{PC: "0x807868", Frameless: false}]
           Condition: null
-        - ID: 55
+        - ID: 58
           Kind: Return
-          Type: 1321 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x807764", Frameless: false}]
+          Type: 1324 EventRootType Probe[main.testInlinedBC]Return
+          InjectionPoints: [{PC: "0x807944", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -578,12 +596,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
-        - ID: 153
+        - ID: 158
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x80768c", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x80786c", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCALine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCA
+        sourceFile: inlined.go
+        lines: ["63"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 159
+          Kind: EventKind(3)
+          Type: 1424 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          InjectionPoints: [{PC: "0x80786c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -593,12 +629,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
-        - ID: 154
+        - ID: 160
           Kind: Entry
-          Type: 1419 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x807730", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x807910", Frameless: false}]
+          Condition: null
+    - id: testInlinedBCBLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedBCB
+        sourceFile: inlined.go
+        lines: ["67"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 161
+          Kind: EventKind(3)
+          Type: 1426 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          InjectionPoints: [{PC: "0x807910", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -609,27 +663,55 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
-        - ID: 151
+        - ID: 155
           Kind: Entry
-          Type: 1415 EventRootType Probe[main.testInlinedPrint]
+          Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x807338"
+            - PC: "0x807518"
               Frameless: false
-            - PC: "0x8073ac"
+            - PC: "0x80758c"
               Frameless: false
-            - PC: "0x8074e8"
+            - PC: "0x8076c8"
               Frameless: false
-            - PC: "0x807564"
+            - PC: "0x807744"
               Frameless: false
-            - PC: "0x80761c"
+            - PC: "0x8077fc"
               Frameless: false
           Condition: null
-        - ID: 150
+        - ID: 154
           Kind: Return
-          Type: 1416 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x80736c", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
+          InjectionPoints: [{PC: "0x80754c", Frameless: false}]
+          Condition: null
+    - id: testInlinedPrintLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 156
+          Kind: EventKind(3)
+          Type: 1421 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          InjectionPoints:
+            - PC: "0x807518"
+              Frameless: false
+            - PC: "0x80758c"
+              Frameless: false
+            - PC: "0x8076c8"
+              Frameless: false
+            - PC: "0x807744"
+              Frameless: false
+            - PC: "0x8077fc"
+              Frameless: false
           Condition: null
     - id: testInlinedSq
       version: 0
@@ -639,12 +721,30 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
-        - ID: 155
+        - ID: 162
           Kind: Entry
-          Type: 1420 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x807784", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x807964", Frameless: true}]
+          Condition: null
+    - id: testInlinedSqLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedSq
+        sourceFile: inlined.go
+        lines: ["75"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 163
+          Kind: EventKind(3)
+          Type: 1428 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          InjectionPoints: [{PC: "0x807964", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -655,15 +755,15 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 156
+        - ID: 164
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x8077b4"
+            - PC: "0x807994"
               Frameless: false
-            - PC: "0x80783c"
+            - PC: "0x807a1c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -749,12 +849,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 61
+        - ID: 65
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x8079f0", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testInterface]
+          InjectionPoints: [{PC: "0x807bd0", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -764,12 +864,66 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 93
+        - ID: 97
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x809800", Frameless: true}]
+          Type: 1362 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x8099e0", Frameless: true}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineA
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["208"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 45
+          Kind: EventKind(3)
+          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x806ccc", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineB
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["215"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 46
+          Kind: EventKind(3)
+          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x806d50", Frameless: false}]
+          Condition: null
+    - id: testLongFunctionWithChangingStateLineC
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testLongFunctionWithChangingState
+        sourceFile: complex.go
+        lines: ["220"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 44}
+      events:
+        - ID: 47
+          Kind: EventKind(3)
+          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          InjectionPoints: [{PC: "0x806dec", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -779,12 +933,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 72
+        - ID: 76
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x808060", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -794,12 +948,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 79
+        - ID: 83
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x8080c0", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -809,12 +963,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 76
+        - ID: 80
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x8080a0", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -824,12 +978,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 88
+        - ID: 92
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x808150", Frameless: true}]
+          Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -839,12 +993,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 87
+        - ID: 91
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x808140", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -854,12 +1008,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 77
+        - ID: 81
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
       version: 0
@@ -869,12 +1023,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 78
+        - ID: 82
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x8080b0", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -884,12 +1038,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 86
+        - ID: 90
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x808130", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -899,12 +1053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 85
+        - ID: 89
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x808120", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -914,12 +1068,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 70
+        - ID: 74
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x808040", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -929,12 +1083,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 71
+        - ID: 75
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x808050", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -944,12 +1098,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 69
+        - ID: 73
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x808030", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x808210", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -959,12 +1113,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 80
+        - ID: 84
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x8080d0", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -974,12 +1128,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 83
+        - ID: 87
           Kind: Entry
-          Type: 1348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x808100", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -989,12 +1143,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 84
+        - ID: 88
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x808110", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -1004,12 +1158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 81
+        - ID: 85
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x8080e0", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -1019,12 +1173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 82
+        - ID: 86
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x8080f0", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -1034,12 +1188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 139
+        - ID: 143
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80a8d0", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1050,12 +1204,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
-        - ID: 140
+        - ID: 144
           Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80a8d0", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1064,17 +1218,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 117
+        - ID: 121
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a118", Frameless: false}]
+          Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
           Condition: null
-        - ID: 116
+        - ID: 120
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a188", Frameless: false}]
+          Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a368", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1084,12 +1238,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 90
+        - ID: 94
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x8094d0", Frameless: true}]
+          Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x8096b0", Frameless: true}]
           Condition: null
     - id: testNamedReturn
       version: 0
@@ -1098,17 +1252,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 115
+        - ID: 119
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a088", Frameless: false}]
+          Type: 1383 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a268", Frameless: false}]
           Condition: null
-        - ID: 114
+        - ID: 118
           Kind: Return
-          Type: 1380 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a0dc", Frameless: false}]
+          Type: 1384 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a2bc", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1118,12 +1272,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 98
+        - ID: 102
           Kind: Entry
-          Type: 1363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x8098d0", Frameless: true}]
+          Type: 1367 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x809ab0", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -1133,12 +1287,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
-        - ID: 128
+        - ID: 132
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x80a570", Frameless: true}]
+          Type: 1397 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x80a750", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1148,12 +1302,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 125
+        - ID: 129
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x80a540", Frameless: true}]
+          Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x80a720", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1163,12 +1317,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
-        - ID: 127
+        - ID: 131
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x80a560", Frameless: true}]
+          Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x80a740", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1178,12 +1332,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
-        - ID: 138
+        - ID: 142
           Kind: Entry
-          Type: 1403 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80a8c0", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1193,12 +1347,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 94
+        - ID: 98
           Kind: Entry
-          Type: 1359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x809810", Frameless: true}]
+          Type: 1363 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x8099f0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -1208,12 +1362,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 75
+        - ID: 79
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x808090", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -1223,12 +1377,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 92
+        - ID: 96
           Kind: Entry
-          Type: 1357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x8097f0", Frameless: true}]
+          Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
       version: 0
@@ -1238,17 +1392,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 111
+        - ID: 115
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x809ef8", Frameless: false}]
+          Type: 1379 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x80a0d8", Frameless: false}]
           Condition: null
-        - ID: 110
+        - ID: 114
           Kind: Return
-          Type: 1376 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x809f40", Frameless: false}]
+          Type: 1380 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints: [{PC: "0x80a120", Frameless: false}]
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1258,20 +1412,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 109
+        - ID: 113
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x809e68", Frameless: false}]
+          Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
-        - ID: 108
+        - ID: 112
           Kind: Return
-          Type: 1374 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x809ea4"
+            - PC: "0x80a084"
               Frameless: false
-            - PC: "0x809eb8"
+            - PC: "0x80a098"
               Frameless: false
           Condition: null
     - id: testReturnsError
@@ -1282,20 +1436,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 107
+        - ID: 111
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x809de8", Frameless: false}]
+          Type: 1375 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
-        - ID: 106
+        - ID: 110
           Kind: Return
-          Type: 1372 EventRootType Probe[main.testReturnsError]Return
+          Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x809e14"
+            - PC: "0x809ff4"
               Frameless: false
-            - PC: "0x809e28"
+            - PC: "0x80a008"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1305,17 +1459,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 101
+        - ID: 105
           Kind: Entry
-          Type: 1365 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x809c18", Frameless: false}]
+          Type: 1369 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x809df8", Frameless: false}]
           Condition: null
-        - ID: 100
+        - ID: 104
           Kind: Return
-          Type: 1366 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x809c54", Frameless: false}]
+          Type: 1370 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x809e34", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1324,17 +1478,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 105
+        - ID: 109
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x809d28", Frameless: false}]
+          Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x809f08", Frameless: false}]
           Condition: null
-        - ID: 104
+        - ID: 108
           Kind: Return
-          Type: 1370 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x809da4", Frameless: false}]
+          Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x809f84", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1343,17 +1497,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 103
+        - ID: 107
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x809c9c", Frameless: false}]
+          Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x809e7c", Frameless: false}]
           Condition: null
-        - ID: 102
+        - ID: 106
           Kind: Return
-          Type: 1368 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x809cf0", Frameless: false}]
+          Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x809ed0", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1363,20 +1517,20 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 113
+        - ID: 117
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x809f78", Frameless: false}]
+          Type: 1381 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x80a158", Frameless: false}]
           Condition: null
-        - ID: 112
+        - ID: 116
           Kind: Return
-          Type: 1378 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x809ffc"
+            - PC: "0x80a1dc"
               Frameless: false
-            - PC: "0x80a010"
+            - PC: "0x80a1f0"
               Frameless: false
           Condition: null
     - id: testRuneArray
@@ -1552,12 +1706,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
-        - ID: 133
+        - ID: 137
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x80a880", Frameless: true}]
+          Type: 1402 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x80aa60", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1642,12 +1796,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 122
+        - ID: 126
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x80a510", Frameless: true}]
+          Type: 1391 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x80a6f0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1657,12 +1811,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 73
+        - ID: 77
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x808070", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
       version: 0
@@ -1671,17 +1825,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 119
+        - ID: 123
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x80a1c8", Frameless: false}]
+          Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
-        - ID: 118
+        - ID: 122
           Kind: Return
-          Type: 1384 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a238", Frameless: false}]
+          Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a418", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1706,12 +1860,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 97
+        - ID: 101
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x8098b0", Frameless: true}]
+          Type: 1366 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x809a90", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1721,12 +1875,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
-        - ID: 126
+        - ID: 130
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x80a550", Frameless: true}]
+          Type: 1395 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x80a730", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1766,17 +1920,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
-        - ID: 147
+        - ID: 151
           Kind: Entry
-          Type: 1411 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80aaf0", Frameless: true}]
+          Type: 1415 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80acd0", Frameless: true}]
           Condition: null
-        - ID: 146
+        - ID: 150
           Kind: Return
-          Type: 1412 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x80ab00", Frameless: true}]
+          Type: 1416 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80ace0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1786,12 +1940,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 123
+        - ID: 127
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x80a520", Frameless: true}]
+          Type: 1392 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x80a700", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -1801,12 +1955,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 67
+        - ID: 71
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x807ad0", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testStructWithAny]
+          InjectionPoints: [{PC: "0x807cb0", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -1815,17 +1969,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
-        - ID: 145
+        - ID: 149
           Kind: Entry
-          Type: 1409 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x80ac20", Frameless: true}]
           Condition: null
-        - ID: 144
+        - ID: 148
           Kind: Return
-          Type: 1410 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x80aa4c", Frameless: true}]
+          Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x80ac2c", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -1834,12 +1988,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
-        - ID: 143
+        - ID: 147
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x80aa30", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x80ac10", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1849,12 +2003,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 68
+        - ID: 72
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x808020", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x808200", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1864,12 +2018,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
-        - ID: 134
+        - ID: 138
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x80a890", Frameless: true}]
+          Type: 1403 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x80aa70", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1879,17 +2033,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
-        - ID: 136
+        - ID: 140
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80a8a0", Frameless: true}]
+          Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80aa80", Frameless: true}]
           Condition: null
-        - ID: 135
+        - ID: 139
           Kind: Return
-          Type: 1401 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80a8ac", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80aa8c", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1899,12 +2053,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
-        - ID: 137
+        - ID: 141
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80a8b0", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2004,12 +2158,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 96
+        - ID: 100
           Kind: Entry
-          Type: 1361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x809840", Frameless: true}]
+          Type: 1365 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x809a20", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -2019,12 +2173,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 120
+        - ID: 124
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x80a4f0", Frameless: true}]
+          Type: 1389 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x80a6d0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2034,12 +2188,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
-        - ID: 141
+        - ID: 145
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80a8e0", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80aac0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2049,12 +2203,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 95
+        - ID: 99
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x809820", Frameless: true}]
+          Type: 1364 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x809a00", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -2079,12 +2233,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 129
+        - ID: 133
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80a580", Frameless: true}]
+          Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2094,12 +2248,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
-        - ID: 130
+        - ID: 134
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80a580", Frameless: true}]
+          Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -2637,14 +2791,64 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 44
+      Name: main.testLongFunctionWithChangingState
+      OutOfLinePCRanges: [0x806cb0..0x806e90]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x806d68..0x806d78
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x806e08..0x806e18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x806d50..0x806d54
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x806d54..0x806d78
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x806d78..0x806dfc
+              Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
+            - Range: 0x806dfc..0x806e04
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x806e04..0x806e90
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x806d48..0x806d54
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x806d54..0x806d54
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x806d54..0x806d78
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x806d78..0x806dfc
+              Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
+            - Range: 0x806dfc..0x806e00
+              Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
+            - Range: 0x806e00..0x806e04
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x806e04..0x806e18
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+            - Range: 0x806e18..0x806e90
+              Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 45
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x806fe0..0x8070a0]
+      OutOfLinePCRanges: [0x8071c0..0x807280]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 151 StructureType main.esotericStack
           Locations:
-            - Range: 0x806fe0..0x807018
+            - Range: 0x8071c0..0x8071f8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -2664,7 +2868,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x807018..0x80701c
+            - Range: 0x8071f8..0x8071fc
               Pieces:
                 - Size: 4
                   Op: null
@@ -2684,7 +2888,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x80701c..0x807020
+            - Range: 0x8071fc..0x807200
               Pieces:
                 - Size: 4
                   Op: null
@@ -2706,136 +2910,136 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 45
+    - ID: 46
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x8070a0..0x807110]
+      OutOfLinePCRanges: [0x807280..0x8072f0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 155 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x8070a0..0x8070d4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 46
-      Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x8074b0..0x807540]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x8074b0..0x8074e8
+            - Range: 0x807280..0x8072b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
-      Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x807540..0x807600]
+      Name: main.testInlinedBA
+      OutOfLinePCRanges: [0x807690..0x807720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807540..0x80755c
+            - Range: 0x807690..0x8076c8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 48
+      Name: main.testInlinedBB
+      OutOfLinePCRanges: [0x807720..0x8077e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x807720..0x80773c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807540..0x80756c
+            - Range: 0x807720..0x80774c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80755c..0x80756c
+            - Range: 0x80773c..0x80774c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80756c..0x807600
+            - Range: 0x80774c..0x8077e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
-    - ID: 48
+    - ID: 49
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x807600..0x807670]
+      OutOfLinePCRanges: [0x8077e0..0x807850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807600..0x807624
+            - Range: 0x8077e0..0x807804
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 49
+    - ID: 50
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x807670..0x807780]
+      OutOfLinePCRanges: [0x807850..0x807960]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80768c..0x8076f8
+            - Range: 0x80786c..0x8078d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x807700
+            - Range: 0x8078d8..0x8078e0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80768c..0x8076f8
+            - Range: 0x80786c..0x8078d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8076f8..0x8076fc
+            - Range: 0x8078d8..0x8078dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
-    - ID: 50
+    - ID: 51
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x807780..0x807790]
+      OutOfLinePCRanges: [0x807960..0x807970]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807780..0x807788
+            - Range: 0x807960..0x807968
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807780..0x807790, Pieces: []}]
+          Locations: [{Range: 0x807960..0x807970, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 51
+    - ID: 52
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x807790..0x8077e0]
+      OutOfLinePCRanges: [0x807970..0x8079c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 157 ArrayType [5]int
           Locations:
-            - Range: 0x807790..0x8077e0
+            - Range: 0x807970..0x8079c0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807790..0x8077e0, Pieces: []}]
+          Locations: [{Range: 0x807970..0x8079c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 52
+    - ID: 53
       Name: main.testInterface
-      OutOfLinePCRanges: [0x8079f0..0x807a00]
+      OutOfLinePCRanges: [0x807bd0..0x807be0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 158 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8079f0..0x807a00
+            - Range: 0x807bd0..0x807be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2843,21 +3047,21 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testAny
-      OutOfLinePCRanges: [0x807a00..0x807a60]
+      OutOfLinePCRanges: [0x807be0..0x807c40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x807a00..0x807a2c
+            - Range: 0x807be0..0x807c0c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x807a2c..0x807a30
+            - Range: 0x807c0c..0x807c10
               Pieces:
                 - Size: 8
                   Op: null
@@ -2867,18 +3071,18 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807a00..0x807a60, Pieces: []}]
+          Locations: [{Range: 0x807be0..0x807c40, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 54
+    - ID: 55
       Name: main.testError
-      OutOfLinePCRanges: [0x807a60..0x807a70]
+      OutOfLinePCRanges: [0x807c40..0x807c50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x807a60..0x807a70
+            - Range: 0x807c40..0x807c50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2886,32 +3090,32 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 55
+    - ID: 56
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x807a70..0x807ad0]
+      OutOfLinePCRanges: [0x807c50..0x807cb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 159 PointerType *interface {}
           Locations:
-            - Range: 0x807a70..0x807a9c
+            - Range: 0x807c50..0x807c7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807a70..0x807ad0, Pieces: []}]
+          Locations: [{Range: 0x807c50..0x807cb0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 56
+    - ID: 57
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x807ad0..0x807ae0]
+      OutOfLinePCRanges: [0x807cb0..0x807cc0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithAny
           Locations:
-            - Range: 0x807ad0..0x807ae0
+            - Range: 0x807cb0..0x807cc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2919,309 +3123,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 57
+    - ID: 58
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x808020..0x808030]
+      OutOfLinePCRanges: [0x808200..0x808210]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 161 StructureType main.structWithMap
           Locations:
-            - Range: 0x808020..0x808030
+            - Range: 0x808200..0x808210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
+    - ID: 59
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x808030..0x808040]
+      OutOfLinePCRanges: [0x808210..0x808220]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 167 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x808030..0x808040
+            - Range: 0x808210..0x808220
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
+    - ID: 60
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x808040..0x808050]
+      OutOfLinePCRanges: [0x808220..0x808230]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string]int
           Locations:
-            - Range: 0x808040..0x808050
+            - Range: 0x808220..0x808230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
+    - ID: 61
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x808050..0x808060]
+      OutOfLinePCRanges: [0x808230..0x808240]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 177 GoMapType map[string][]string
           Locations:
-            - Range: 0x808050..0x808060
+            - Range: 0x808230..0x808240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
+    - ID: 62
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x808060..0x808070]
+      OutOfLinePCRanges: [0x808240..0x808250]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 182 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x808060..0x808070
+            - Range: 0x808240..0x808250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
+    - ID: 63
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x808070..0x808080]
+      OutOfLinePCRanges: [0x808250..0x808260]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 172 GoMapType map[string]int
           Locations:
-            - Range: 0x808070..0x808080
+            - Range: 0x808250..0x808260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
+    - ID: 64
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x808080..0x808090]
+      OutOfLinePCRanges: [0x808260..0x808270]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x808080..0x808090
+            - Range: 0x808260..0x808270
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
+    - ID: 65
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x808090..0x8080a0]
+      OutOfLinePCRanges: [0x808270..0x808280]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 188 PointerType *map[string]int
           Locations:
-            - Range: 0x808090..0x8080a0
+            - Range: 0x808270..0x808280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
+    - ID: 66
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x8080a0..0x8080b0]
+      OutOfLinePCRanges: [0x808280..0x808290]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 162 GoMapType map[int]int
           Locations:
-            - Range: 0x8080a0..0x8080b0
+            - Range: 0x808280..0x808290
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
+    - ID: 67
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x8080b0..0x8080c0]
+      OutOfLinePCRanges: [0x808290..0x8082a0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 189 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8080b0..0x8080c0
+            - Range: 0x808290..0x8082a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
+    - ID: 68
       Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x8080c0..0x8080d0]
+      OutOfLinePCRanges: [0x8082a0..0x8082b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 189 GoMapType map[string][]main.structWithMap
           Locations:
-            - Range: 0x8080c0..0x8080d0
+            - Range: 0x8082a0..0x8082b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
+    - ID: 69
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x8080d0..0x8080e0]
+      OutOfLinePCRanges: [0x8082b0..0x8082c0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 194 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x8080d0..0x8080e0
+            - Range: 0x8082b0..0x8082c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
+    - ID: 70
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x8080e0..0x8080f0]
+      OutOfLinePCRanges: [0x8082c0..0x8082d0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 199 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8080e0..0x8080f0
+            - Range: 0x8082c0..0x8082d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
+    - ID: 71
       Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x8080f0..0x808100]
+      OutOfLinePCRanges: [0x8082d0..0x8082e0]
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
           Type: 199 GoMapType map[int]uint8
           Locations:
-            - Range: 0x8080f0..0x808100
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 71
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x808100..0x808110]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 204 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x808100..0x808110
+            - Range: 0x8082d0..0x8082e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 72
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x808110..0x808120]
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x8082e0..0x8082f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808110..0x808120
+            - Range: 0x8082e0..0x8082f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 73
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x808120..0x808130]
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x8082f0..0x808300]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 204 GoMapType map[uint8]uint8
           Locations:
-            - Range: 0x808120..0x808130
+            - Range: 0x8082f0..0x808300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 74
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x808300..0x808310]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 204 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x808300..0x808310
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 75
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x808130..0x808140]
+      OutOfLinePCRanges: [0x808310..0x808320]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 209 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x808130..0x808140
+            - Range: 0x808310..0x808320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x808140..0x808150]
+      OutOfLinePCRanges: [0x808320..0x808330]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 214 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x808140..0x808150
+            - Range: 0x808320..0x808330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x808150..0x808160]
+      OutOfLinePCRanges: [0x808330..0x808340]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 219 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x808150..0x808160
+            - Range: 0x808330..0x808340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x8093f0..0x809400]
+      OutOfLinePCRanges: [0x8095d0..0x8095e0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8093f0..0x809400
+            - Range: 0x8095d0..0x8095e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8093f0..0x809400
+            - Range: 0x8095d0..0x8095e0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x8093f0..0x809400
+            - Range: 0x8095d0..0x8095e0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x8094d0..0x8094e0]
+      OutOfLinePCRanges: [0x8096b0..0x8096c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x8096b0..0x8096c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x8096b0..0x8096c0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x8096b0..0x8096c0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x8096b0..0x8096c0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x8094d0..0x8094e0
+            - Range: 0x8096b0..0x8096c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3229,39 +3433,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testChannel
-      OutOfLinePCRanges: [0x809670..0x809680]
+      OutOfLinePCRanges: [0x809850..0x809860]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 224 GoChannelType chan bool
           Locations:
-            - Range: 0x809670..0x809680
+            - Range: 0x809850..0x809860
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x8097f0..0x809800]
+      OutOfLinePCRanges: [0x8099d0..0x8099e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 225 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x8097f0..0x809800
+            - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809800..0x809810]
+      OutOfLinePCRanges: [0x8099e0..0x8099f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 227 StructureType main.node
           Locations:
-            - Range: 0x809800..0x809810
+            - Range: 0x8099e0..0x8099f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3269,195 +3473,195 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809810..0x809820]
+      OutOfLinePCRanges: [0x8099f0..0x809a00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 228 PointerType *main.node
           Locations:
-            - Range: 0x809810..0x809820
+            - Range: 0x8099f0..0x809a00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
+    - ID: 84
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809820..0x809830]
+      OutOfLinePCRanges: [0x809a00..0x809a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x809820..0x809830
+            - Range: 0x809a00..0x809a10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 84
+    - ID: 85
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x809840..0x809850]
+      OutOfLinePCRanges: [0x809a20..0x809a30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0x809840..0x809850
+            - Range: 0x809a20..0x809a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 85
+    - ID: 86
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x8098b0..0x8098c0]
+      OutOfLinePCRanges: [0x809a90..0x809aa0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0x8098b0..0x8098c0
+            - Range: 0x809a90..0x809aa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 86
+    - ID: 87
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x8098d0..0x8098e0]
+      OutOfLinePCRanges: [0x809ab0..0x809ac0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x8098d0..0x8098e0
+            - Range: 0x809ab0..0x809ac0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x8098d0..0x8098e0
+            - Range: 0x809ab0..0x809ac0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 87
+    - ID: 88
       Name: main.testCycle
-      OutOfLinePCRanges: [0x8098f0..0x809900]
+      OutOfLinePCRanges: [0x809ad0..0x809ae0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 229 PointerType *main.t
           Locations:
-            - Range: 0x8098f0..0x809900
+            - Range: 0x809ad0..0x809ae0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 88
+    - ID: 89
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x809c00..0x809c80]
+      OutOfLinePCRanges: [0x809de0..0x809e60]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809c00..0x809c24
+            - Range: 0x809de0..0x809e04
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809c24..0x809c80
+            - Range: 0x809e04..0x809e60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x809c00..0x809c80, Pieces: []}]
+          Locations: [{Range: 0x809de0..0x809e60, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 89
+    - ID: 90
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x809c80..0x809d10]
+      OutOfLinePCRanges: [0x809e60..0x809ef0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809c80..0x809ca4
+            - Range: 0x809e60..0x809e84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 100 PointerType *int
-          Locations: [{Range: 0x809c80..0x809d10, Pieces: []}]
+          Locations: [{Range: 0x809e60..0x809ef0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: '&i'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x809ca8..0x809cbc
+            - Range: 0x809e88..0x809e9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809cbc..0x809d10
+            - Range: 0x809e9c..0x809ef0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x809d10..0x809dd0]
+      OutOfLinePCRanges: [0x809ef0..0x809fb0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809d10..0x809d58
+            - Range: 0x809ef0..0x809f38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809d58..0x809dd0
+            - Range: 0x809f38..0x809fb0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x809d10..0x809dd0, Pieces: []}]
+          Locations: [{Range: 0x809ef0..0x809fb0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x809d10..0x809dd0, Pieces: []}]
+          Locations: [{Range: 0x809ef0..0x809fb0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: f
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x809d30..0x809d58
+            - Range: 0x809f10..0x809f38
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x809d58..0x809dd0
+            - Range: 0x809f38..0x809fb0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x809dd0..0x809e50]
+      OutOfLinePCRanges: [0x809fb0..0x80a030]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809dd0..0x809df4
+            - Range: 0x809fb0..0x809fd4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x809dd0..0x809e50, Pieces: []}]
+          Locations: [{Range: 0x809fb0..0x80a030, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 92
+    - ID: 93
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x809e50..0x809ee0]
+      OutOfLinePCRanges: [0x80a030..0x80a0c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x809e50..0x809e7c
+            - Range: 0x80a030..0x80a05c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809e7c..0x809e80
+            - Range: 0x80a05c..0x80a060
               Pieces:
                 - Size: 8
                   Op: null
@@ -3468,41 +3672,41 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x809e50..0x809e80
+            - Range: 0x80a030..0x80a060
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 153 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x809e50..0x809ee0, Pieces: []}]
+          Locations: [{Range: 0x80a030..0x80a0c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x809e50..0x809ee0, Pieces: []}]
+          Locations: [{Range: 0x80a030..0x80a0c0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 93
+    - ID: 94
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x809ee0..0x809f60]
+      OutOfLinePCRanges: [0x80a0c0..0x80a140]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x809ee0..0x809f20
+            - Range: 0x80a0c0..0x80a100
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809f20..0x809f28
+            - Range: 0x80a100..0x80a108
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x809f28..0x809f60
+            - Range: 0x80a108..0x80a140
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3512,186 +3716,168 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 153 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x809ee0..0x809f60, Pieces: []}]
+          Locations: [{Range: 0x80a0c0..0x80a140, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x809f60..0x80a070]
+      OutOfLinePCRanges: [0x80a140..0x80a250]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 153 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x809f60..0x809f9c
+            - Range: 0x80a140..0x80a17c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809f9c..0x809fdc
+            - Range: 0x80a17c..0x80a1bc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x809fdc..0x80a01c
+            - Range: 0x80a1bc..0x80a1fc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a01c..0x80a044
+            - Range: 0x80a1fc..0x80a224
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a044..0x80a048
+            - Range: 0x80a224..0x80a228
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a048..0x80a070
+            - Range: 0x80a228..0x80a250
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 158 GoInterfaceType main.behavior
-          Locations: [{Range: 0x809f60..0x80a070, Pieces: []}]
+          Locations: [{Range: 0x80a140..0x80a250, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 158 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x809f60..0x809f9c
+            - Range: 0x80a140..0x80a17c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x809f9c..0x809fdc
+            - Range: 0x80a17c..0x80a1bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x809fdc..0x809fe4
+            - Range: 0x80a1bc..0x80a1c4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x809fe4..0x80a008
+            - Range: 0x80a1c4..0x80a1e8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a008..0x80a00c
+            - Range: 0x80a1e8..0x80a1ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a00c..0x80a010
+            - Range: 0x80a1ec..0x80a1f0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a010..0x80a070
+            - Range: 0x80a1f0..0x80a250
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a070..0x80a100]
+      OutOfLinePCRanges: [0x80a250..0x80a2e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a070..0x80a0ac
+            - Range: 0x80a250..0x80a28c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a0ac..0x80a100
+            - Range: 0x80a28c..0x80a2e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a070..0x80a100, Pieces: []}]
+          Locations: [{Range: 0x80a250..0x80a2e0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 96
+    - ID: 97
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a100..0x80a1b0]
+      OutOfLinePCRanges: [0x80a2e0..0x80a390]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a100..0x80a140
+            - Range: 0x80a2e0..0x80a320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a140..0x80a1b0
+            - Range: 0x80a320..0x80a390
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a100..0x80a1b0, Pieces: []}]
+          Locations: [{Range: 0x80a2e0..0x80a390, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a100..0x80a1b0, Pieces: []}]
+          Locations: [{Range: 0x80a2e0..0x80a390, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 97
+    - ID: 98
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a1b0..0x80a260]
+      OutOfLinePCRanges: [0x80a390..0x80a440]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a1b0..0x80a1ec
+            - Range: 0x80a390..0x80a3cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a1ec..0x80a260
+            - Range: 0x80a3cc..0x80a440
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a1b0..0x80a260, Pieces: []}]
+          Locations: [{Range: 0x80a390..0x80a440, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a1b0..0x80a260, Pieces: []}]
+          Locations: [{Range: 0x80a390..0x80a440, Pieces: []}]
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a1b0..0x80a260, Pieces: []}]
+          Locations: [{Range: 0x80a390..0x80a440, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 98
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80a4f0..0x80a500]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 231 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a4f0..0x80a500
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 99
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80a500..0x80a510]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80a6d0..0x80a6e0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a500..0x80a510
+            - Range: 0x80a6d0..0x80a6e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3702,14 +3888,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 100
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80a510..0x80a520]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x80a6e0..0x80a6f0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 232 GoSliceHeaderType [][]uint
+          Type: 231 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a510..0x80a520
+            - Range: 0x80a6e0..0x80a6f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3720,14 +3906,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80a520..0x80a530]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x80a6f0..0x80a700]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 232 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x80a520..0x80a530
+            - Range: 0x80a6f0..0x80a700
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3735,24 +3921,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80a520..0x80a530
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 102
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80a530..0x80a540]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x80a700..0x80a710]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a530..0x80a540
+            - Range: 0x80a700..0x80a710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3765,19 +3944,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a530..0x80a540
+            - Range: 0x80a700..0x80a710
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 103
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80a540..0x80a550]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x80a710..0x80a720]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 234 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a540..0x80a550
+            - Range: 0x80a710..0x80a720
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3790,19 +3969,44 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a540..0x80a550
+            - Range: 0x80a710..0x80a720
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 104
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80a720..0x80a730]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 234 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80a720..0x80a730
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a720..0x80a730
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 105
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80a550..0x80a560]
+      OutOfLinePCRanges: [0x80a730..0x80a740]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 237 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80a550..0x80a560
+            - Range: 0x80a730..0x80a740
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3812,22 +4016,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 105
+    - ID: 106
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80a560..0x80a570]
+      OutOfLinePCRanges: [0x80a740..0x80a750]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a740..0x80a750
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 238 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a740..0x80a750
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -3840,37 +4044,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80a560..0x80a570
+            - Range: 0x80a740..0x80a750
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 106
+    - ID: 107
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80a570..0x80a580]
+      OutOfLinePCRanges: [0x80a750..0x80a760]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 239 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80a570..0x80a580
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 107
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80a580..0x80a590]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a580..0x80a590
+            - Range: 0x80a750..0x80a760
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3881,24 +4067,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 108
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80a760..0x80a770]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x80a760..0x80a770
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 109
       Name: main.stackC
-      OutOfLinePCRanges: [0x80a820..0x80a880]
+      OutOfLinePCRanges: [0x80aa00..0x80aa60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x80a820..0x80a880, Pieces: []}]
+          Locations: [{Range: 0x80aa00..0x80aa60, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 109
+    - ID: 110
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80a880..0x80a890]
+      OutOfLinePCRanges: [0x80aa60..0x80aa70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a880..0x80a890
+            - Range: 0x80aa60..0x80aa70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3906,15 +4110,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 111
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80a890..0x80a8a0]
+      OutOfLinePCRanges: [0x80aa70..0x80aa80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a890..0x80a8a0
+            - Range: 0x80aa70..0x80aa80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3925,7 +4129,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a890..0x80a8a0
+            - Range: 0x80aa70..0x80aa80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -3936,7 +4140,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a890..0x80a8a0
+            - Range: 0x80aa70..0x80aa80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -3944,15 +4148,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 112
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80a8a0..0x80a8b0]
+      OutOfLinePCRanges: [0x80aa80..0x80aa90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 240 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80a8a0..0x80a8b0
+            - Range: 0x80aa80..0x80aa90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3968,55 +4172,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 113
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80a8b0..0x80a8c0]
+      OutOfLinePCRanges: [0x80aa90..0x80aaa0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80a8b0..0x80a8c0
+            - Range: 0x80aa90..0x80aaa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 114
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80a8c0..0x80a8d0]
+      OutOfLinePCRanges: [0x80aaa0..0x80aab0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80a8c0..0x80a8d0
+            - Range: 0x80aaa0..0x80aab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 114
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80a8d0..0x80a8e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80a8d0..0x80a8e0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 115
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80a8e0..0x80a8f0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80aab0..0x80aac0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a8e0..0x80a8f0
+            - Range: 0x80aab0..0x80aac0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4025,14 +4213,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 116
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80a8f0..0x80a900]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80aac0..0x80aad0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80a8f0..0x80a900
+            - Range: 0x80aac0..0x80aad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4041,26 +4229,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 117
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80aad0..0x80aae0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80aad0..0x80aae0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 118
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80aa30..0x80aa40]
+      OutOfLinePCRanges: [0x80ac10..0x80ac20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80aa30..0x80aa40
+            - Range: 0x80ac10..0x80ac20
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 119
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80aa40..0x80aa50]
+      OutOfLinePCRanges: [0x80ac20..0x80ac30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 257 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80aa40..0x80aa50
+            - Range: 0x80ac20..0x80ac30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4076,15 +4280,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 120
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80aaf0..0x80ab10]
+      OutOfLinePCRanges: [0x80acd0..0x80acf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 288 StructureType main.aStruct
           Locations:
-            - Range: 0x80aaf0..0x80ab10
+            - Range: 0x80acd0..0x80acf0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4102,108 +4306,108 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 121
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80abc0..0x80abd0]
+      OutOfLinePCRanges: [0x80ada0..0x80adb0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 290 StructureType main.emptyStruct
-          Locations: [{Range: 0x80abc0..0x80abd0, Pieces: []}]
+          Locations: [{Range: 0x80ada0..0x80adb0, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 122
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80abd0..0x80abe0]
+      OutOfLinePCRanges: [0x80adb0..0x80adc0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 291 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80abd0..0x80abe0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 122
-      Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x807320..0x807390]
-      InlinePCRanges:
-        - Ranges: [0x8073ac..0x8073e0]
-          RootRanges: [0x807390..0x807400]
-        - Ranges: [0x8074e8..0x80751c]
-          RootRanges: [0x8074b0..0x807540]
-        - Ranges: [0x807564..0x807598]
-          RootRanges: [0x807540..0x807600]
-        - Ranges: [0x80761c..0x807650]
-          RootRanges: [0x807600..0x807670]
-      Variables:
-        - Name: x
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x807320..0x807340
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8073ac..0x8073b4
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8074e8..0x8074f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80755c..0x80756c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80756c..0x807600
-              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x807600..0x807624
+            - Range: 0x80adb0..0x80adc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 123
-      Name: main.testInlinedBBB
-      OutOfLinePCRanges: []
+      Name: main.testInlinedPrint
+      OutOfLinePCRanges: [0x807500..0x807570]
       InlinePCRanges:
-        - Ranges: [0x8075a4..0x8075d8]
-          RootRanges: [0x807540..0x807600]
-      Variables: []
-    - ID: 124
-      Name: main.testInlinedBCA
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x80768c..0x8076c0, 0x8076c8..0x8076cc]
-          RootRanges: [0x807670..0x807780]
-      Variables: []
-    - ID: 125
-      Name: main.testInlinedBCB
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x807730..0x807764]
-          RootRanges: [0x807670..0x807780]
-      Variables: []
-    - ID: 126
-      Name: main.testInlinedSq
-      OutOfLinePCRanges: []
-      InlinePCRanges:
-        - Ranges: [0x807784..0x807788]
-          RootRanges: [0x807780..0x807790]
+        - Ranges: [0x80758c..0x8075c0]
+          RootRanges: [0x807570..0x8075e0]
+        - Ranges: [0x8076c8..0x8076fc]
+          RootRanges: [0x807690..0x807720]
+        - Ranges: [0x807744..0x807778]
+          RootRanges: [0x807720..0x8077e0]
+        - Ranges: [0x8077fc..0x807830]
+          RootRanges: [0x8077e0..0x807850]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807780..0x807788
+            - Range: 0x807500..0x807520
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80758c..0x807594
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8076c8..0x8076d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80773c..0x80774c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80774c..0x8077e0
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x8077e0..0x807804
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 124
+      Name: main.testInlinedBBB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x807784..0x8077b8]
+          RootRanges: [0x807720..0x8077e0]
+      Variables: []
+    - ID: 125
+      Name: main.testInlinedBCA
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x80786c..0x8078a0, 0x8078a8..0x8078ac]
+          RootRanges: [0x807850..0x807960]
+      Variables: []
+    - ID: 126
+      Name: main.testInlinedBCB
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x807910..0x807944]
+          RootRanges: [0x807850..0x807960]
+      Variables: []
     - ID: 127
+      Name: main.testInlinedSq
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x807964..0x807968]
+          RootRanges: [0x807960..0x807970]
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x807960..0x807968
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 128
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x8077b4..0x8077d0]
-          RootRanges: [0x807790..0x8077e0]
-        - Ranges: [0x80783c..0x80785c]
-          RootRanges: [0x8077e0..0x807920]
+        - Ranges: [0x807994..0x8079b0]
+          RootRanges: [0x807970..0x8079c0]
+        - Ranges: [0x807a1c..0x807a3c]
+          RootRanges: [0x8079c0..0x807b00]
       Variables:
         - Name: a
           Type: 157 ArrayType [5]int
           Locations:
-            - Range: 0x8077a0..0x8077e0
+            - Range: 0x807980..0x8079c0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x807828..0x807920
+            - Range: 0x807a08..0x807b00
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
@@ -5068,14 +5272,14 @@ Types:
       ID: 772
       Name: '*fmt.wrapError'
       ByteSize: 8
-      GoRuntimeType: 1.023936e+06
+      GoRuntimeType: 1.022272e+06
       GoKind: 22
       Pointee: 773 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
       ID: 774
       Name: '*fmt.wrapErrors'
       ByteSize: 8
-      GoRuntimeType: 1.024064e+06
+      GoRuntimeType: 1.0224e+06
       GoKind: 22
       Pointee: 775 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
@@ -5986,21 +6190,21 @@ Types:
       ID: 1012
       Name: '*io.PipeWriter'
       ByteSize: 8
-      GoRuntimeType: 1.189312e+06
+      GoRuntimeType: 1.189568e+06
       GoKind: 22
       Pointee: 1013 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
       ID: 1010
       Name: '*io.discard'
       ByteSize: 8
-      GoRuntimeType: 1.188928e+06
+      GoRuntimeType: 1.189184e+06
       GoKind: 22
       Pointee: 1011 StructureType io.discard
     - __kind: PointerType
       ID: 984
       Name: '*io.multiWriter'
       ByteSize: 8
-      GoRuntimeType: 1.0224e+06
+      GoRuntimeType: 1.023168e+06
       GoKind: 22
       Pointee: 985 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
@@ -7442,10 +7646,10 @@ Types:
       GoKind: 22
       Pointee: 769 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1396
+      ID: 1400
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1397
+      ID: 1401
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7457,11 +7661,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1334
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7473,11 +7677,11 @@ Types:
             Type: 159 PointerType *interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: a}
+                  Variable: {subprogram: 56, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1335
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7489,11 +7693,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 1, name: ~r0}
+                  Variable: {subprogram: 56, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1327
+      ID: 1331
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7505,11 +7709,11 @@ Types:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: a}
+                  Variable: {subprogram: 54, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1328
+      ID: 1332
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7521,7 +7725,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 1, name: ~r0}
+                  Variable: {subprogram: 54, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7557,7 +7761,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1339
+      ID: 1343
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7569,7 +7773,7 @@ Types:
             Type: 187 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -7640,7 +7844,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1356
+      ID: 1360
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7652,11 +7856,11 @@ Types:
             Type: 224 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: c}
+                  Variable: {subprogram: 80, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7668,7 +7872,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: w}
+                  Variable: {subprogram: 78, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7678,7 +7882,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 1, name: x}
+                  Variable: {subprogram: 78, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7688,11 +7892,11 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 2, name: y}
+                  Variable: {subprogram: 78, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1364
+      ID: 1368
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7704,7 +7908,7 @@ Types:
             Type: 229 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: t}
+                  Variable: {subprogram: 88, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -7804,7 +8008,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1389
+      ID: 1393
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7816,7 +8020,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: xs}
+                  Variable: {subprogram: 103, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -7826,11 +8030,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: a}
+                  Variable: {subprogram: 103, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1390
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7842,11 +8046,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: u}
+                  Variable: {subprogram: 100, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1407
+      ID: 1411
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7858,11 +8062,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 117, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1418
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7874,11 +8078,11 @@ Types:
             Type: 291 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: e}
+                  Variable: {subprogram: 122, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1417
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7890,11 +8094,11 @@ Types:
             Type: 290 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: e}
+                  Variable: {subprogram: 121, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1329
+      ID: 1333
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7906,11 +8110,11 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: e}
+                  Variable: {subprogram: 55, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1312
+      ID: 1315
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7922,14 +8126,14 @@ Types:
             Type: 155 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 45, index: 0, name: e}
+                  Variable: {subprogram: 46, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1316
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1310
+      ID: 1313
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7941,14 +8145,14 @@ Types:
             Type: 151 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 44, index: 0, name: e}
+                  Variable: {subprogram: 45, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1311
+      ID: 1314
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1324
+      ID: 1327
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7960,12 +8164,70 @@ Types:
             Type: 157 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: a}
+                  Variable: {subprogram: 52, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1325
+      ID: 1329
+      Name: Probe[main.testFramelessArray]EventKind(3)
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 40
+        - Name: ~r0
+          Offset: 41
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1328
       Name: Probe[main.testFramelessArray]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 52, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1325
+      Name: Probe[main.testFrameless]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1326
+      Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -7980,82 +8242,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
-      Name: Probe[main.testFrameless]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1323
-      Name: Probe[main.testFrameless]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 50, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1314
+      ID: 1317
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1315
-      Name: Probe[main.testInlinedBA]Return
-    - __kind: EventRootType
-      ID: 1318
-      Name: Probe[main.testInlinedBBA]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 48, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1319
-      Name: Probe[main.testInlinedBBA]Return
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testInlinedBBB]
-    - __kind: EventRootType
-      ID: 1316
-      Name: Probe[main.testInlinedBB]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -8068,6 +8257,47 @@ Types:
                   Variable: {subprogram: 47, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
+    - __kind: EventRootType
+      ID: 1318
+      Name: Probe[main.testInlinedBA]Return
+    - __kind: EventRootType
+      ID: 1321
+      Name: Probe[main.testInlinedBBA]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 49, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1322
+      Name: Probe[main.testInlinedBBA]Return
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testInlinedBBB]
+    - __kind: EventRootType
+      ID: 1319
+      Name: Probe[main.testInlinedBB]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 48, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 9
           Kind: argument
@@ -8075,26 +8305,32 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 47, index: 1, name: y}
+                  Variable: {subprogram: 48, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1320
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1418
+      ID: 1423
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1419
+      ID: 1424
+      Name: Probe[main.testInlinedBCA]EventKind(3)
+    - __kind: EventRootType
+      ID: 1425
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1320
+      ID: 1426
+      Name: Probe[main.testInlinedBCB]EventKind(3)
+    - __kind: EventRootType
+      ID: 1323
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1321
+      ID: 1324
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1415
+      ID: 1419
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8106,14 +8342,30 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 123, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testInlinedPrint]Return
+      ID: 1421
+      Name: Probe[main.testInlinedPrint]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
     - __kind: EventRootType
       ID: 1420
+      Name: Probe[main.testInlinedPrint]Return
+    - __kind: EventRootType
+      ID: 1427
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8125,11 +8377,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 127, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1428
+      Name: Probe[main.testInlinedSq]EventKind(3)
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8141,7 +8409,7 @@ Types:
             Type: 157 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -8225,7 +8493,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1326
+      ID: 1330
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8237,11 +8505,11 @@ Types:
             Type: 158 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: b}
+                  Variable: {subprogram: 53, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1362
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8253,11 +8521,66 @@ Types:
             Type: 227 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: a}
+                  Variable: {subprogram: 82, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1337
+      ID: 1310
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+    - __kind: EventRootType
+      ID: 1311
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1312
+      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 44, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1341
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8269,11 +8592,11 @@ Types:
             Type: 182 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: m}
+                  Variable: {subprogram: 62, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1348
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8285,11 +8608,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 67, index: 0, name: m}
+                  Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1345
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8301,11 +8624,11 @@ Types:
             Type: 162 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1357
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8317,11 +8640,11 @@ Types:
             Type: 219 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: m}
+                  Variable: {subprogram: 77, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1356
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8333,11 +8656,11 @@ Types:
             Type: 214 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: m}
+                  Variable: {subprogram: 76, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1342
+      ID: 1346
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8349,11 +8672,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1343
+      ID: 1347
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8365,11 +8688,11 @@ Types:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 67, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1355
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8381,12 +8704,92 @@ Types:
             Type: 209 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
+                  Variable: {subprogram: 75, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1354
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 204 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
                   Variable: {subprogram: 74, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
-      Name: Probe[main.testMapSmallKeySmallValue]
+      ID: 1339
+      Name: Probe[main.testMapStringToInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 172 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 60, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1340
+      Name: Probe[main.testMapStringToSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 177 GoMapType map[string][]string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 61, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1338
+      Name: Probe[main.testMapStringToStruct]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 167 GoMapType map[string]main.nestedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 59, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1349
+      Name: Probe[main.testMapWithLinkedList]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 194 GoMapType map[bool]main.node
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1353
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8401,72 +8804,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
-      Name: Probe[main.testMapStringToInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 172 GoMapType map[string]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1336
-      Name: Probe[main.testMapStringToSlice]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 177 GoMapType map[string][]string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1334
-      Name: Probe[main.testMapStringToStruct]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 167 GoMapType map[string]main.nestedStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1345
-      Name: Probe[main.testMapWithLinkedList]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 194 GoMapType map[bool]main.node
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 68, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1349
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      ID: 1352
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8481,23 +8820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 204 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1347
+      ID: 1351
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8509,11 +8832,11 @@ Types:
             Type: 199 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 71, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1350
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8525,11 +8848,11 @@ Types:
             Type: 199 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1408
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8541,11 +8864,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1405
+      ID: 1409
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8557,12 +8880,110 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: x}
+                  Variable: {subprogram: 115, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1385
       Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1386
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1359
+      Name: Probe[main.testMultipleSimpleParams]
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 7
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 15
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 79, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1383
+      Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8577,9 +8998,9 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
+      ID: 1384
+      Name: Probe[main.testNamedReturn]Return
+      ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
         - Name: result
@@ -8592,106 +9013,8 @@ Types:
                   Variable: {subprogram: 96, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
-      Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 31
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 2
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 3
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: d
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 10 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1379
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1380
-      Name: Probe[main.testNamedReturn]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1363
+      ID: 1367
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8703,7 +9026,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: z}
+                  Variable: {subprogram: 87, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -8713,11 +9036,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
+                  Variable: {subprogram: 87, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1394
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8729,7 +9052,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: xs}
+                  Variable: {subprogram: 104, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8739,11 +9062,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: a}
+                  Variable: {subprogram: 104, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1396
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -8755,7 +9078,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: a}
+                  Variable: {subprogram: 106, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -8765,7 +9088,7 @@ Types:
             Type: 238 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: s}
+                  Variable: {subprogram: 106, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -8775,11 +9098,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: x}
+                  Variable: {subprogram: 106, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1397
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8791,11 +9114,11 @@ Types:
             Type: 239 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: xs}
+                  Variable: {subprogram: 107, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1403
+      ID: 1407
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8807,11 +9130,11 @@ Types:
             Type: 242 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: a}
+                  Variable: {subprogram: 114, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1363
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8823,11 +9146,11 @@ Types:
             Type: 228 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: a}
+                  Variable: {subprogram: 83, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1344
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8839,11 +9162,11 @@ Types:
             Type: 188 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1361
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8855,65 +9178,13 @@ Types:
             Type: 225 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: a}
+                  Variable: {subprogram: 81, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1377
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 153 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: failed
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1374
-      Name: Probe[main.testReturnsAnyAndError]Return
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 153 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 2, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: ~r1
-          Offset: 17
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 3, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1375
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
         - Name: v
@@ -8926,10 +9197,20 @@ Types:
                   Variable: {subprogram: 93, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
+        - Name: failed
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 93, index: 1, name: failed}
+                  Offset: 0
+                  ByteSize: 1
     - __kind: EventRootType
-      ID: 1376
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
+      ID: 1378
+      Name: Probe[main.testReturnsAnyAndError]Return
+      ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
         - Name: ~r0
@@ -8939,150 +9220,22 @@ Types:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1371
-      Name: Probe[main.testReturnsError]
-      ByteSize: 2
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1372
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
+        - Name: ~r1
+          Offset: 17
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Variable: {subprogram: 93, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1370
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 16 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1367
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1368
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 100 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1365
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1366
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1377
-      Name: Probe[main.testReturnsInterface]
+      ID: 1379
+      Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -9097,7 +9250,177 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1378
+      ID: 1380
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 153 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1375
+      Name: Probe[main.testReturnsError]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1376
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 92, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1373
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1374
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 91, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1371
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1372
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 100 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 90, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1369
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1370
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1381
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 153 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1382
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9109,7 +9432,7 @@ Types:
             Type: 158 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9289,7 +9612,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1398
+      ID: 1402
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9301,7 +9624,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: x}
+                  Variable: {subprogram: 110, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9385,7 +9708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1391
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9397,11 +9720,11 @@ Types:
             Type: 232 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: u}
+                  Variable: {subprogram: 101, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1338
+      ID: 1342
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9413,11 +9736,11 @@ Types:
             Type: 172 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1387
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9429,11 +9752,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
+                  Variable: {subprogram: 98, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1388
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9445,7 +9768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -9455,7 +9778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: result2}
+                  Variable: {subprogram: 98, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -9465,7 +9788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 3, name: ~r2}
+                  Variable: {subprogram: 98, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9485,7 +9808,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1362
+      ID: 1366
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9497,11 +9820,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: z}
+                  Variable: {subprogram: 86, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1395
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9513,7 +9836,7 @@ Types:
             Type: 237 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: s}
+                  Variable: {subprogram: 105, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -9549,7 +9872,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1392
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9561,7 +9884,7 @@ Types:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: xs}
+                  Variable: {subprogram: 102, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9571,11 +9894,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: a}
+                  Variable: {subprogram: 102, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1336
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9587,11 +9910,11 @@ Types:
             Type: 160 StructureType main.structWithAny
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: s}
+                  Variable: {subprogram: 57, index: 0, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1409
+      ID: 1413
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9603,14 +9926,14 @@ Types:
             Type: 257 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 119, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1410
+      ID: 1414
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1408
+      ID: 1412
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -9622,11 +9945,11 @@ Types:
             Type: 244 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: a}
+                  Variable: {subprogram: 118, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1333
+      ID: 1337
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9638,11 +9961,11 @@ Types:
             Type: 161 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: s}
+                  Variable: {subprogram: 58, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1415
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -9654,14 +9977,14 @@ Types:
             Type: 288 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: x}
+                  Variable: {subprogram: 120, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1412
+      ID: 1416
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1402
+      ID: 1406
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9673,11 +9996,11 @@ Types:
             Type: 241 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: a}
+                  Variable: {subprogram: 113, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1404
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9689,14 +10012,14 @@ Types:
             Type: 240 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 112, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1401
+      ID: 1405
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1399
+      ID: 1403
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -9708,7 +10031,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: x}
+                  Variable: {subprogram: 111, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -9718,7 +10041,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 1, name: y}
+                  Variable: {subprogram: 111, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -9728,7 +10051,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 2, name: z}
+                  Variable: {subprogram: 111, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -9828,7 +10151,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1361
+      ID: 1365
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9840,11 +10163,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: x}
+                  Variable: {subprogram: 85, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1389
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9856,11 +10179,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: u}
+                  Variable: {subprogram: 99, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1406
+      ID: 1410
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9872,11 +10195,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: x}
+                  Variable: {subprogram: 116, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1364
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9888,7 +10211,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: x}
+                  Variable: {subprogram: 84, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -9908,7 +10231,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1394
+      ID: 1398
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9920,11 +10243,11 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1395
+      ID: 1399
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9936,7 +10259,7 @@ Types:
             Type: 231 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 108, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: ArrayType
@@ -13144,7 +13467,7 @@ Types:
       ID: 1053
       Name: io.ReadWriteCloser
       ByteSize: 16
-      GoRuntimeType: 1.189056e+06
+      GoRuntimeType: 1.189312e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13157,7 +13480,7 @@ Types:
       ID: 1088
       Name: io.Reader
       ByteSize: 16
-      GoRuntimeType: 1.022528e+06
+      GoRuntimeType: 1.023296e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13183,7 +13506,7 @@ Types:
       ID: 127
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.022272e+06
+      GoRuntimeType: 1.02304e+06
       GoKind: 20
       RawFields:
         - Name: tab
@@ -13195,7 +13518,7 @@ Types:
     - __kind: StructureType
       ID: 1011
       Name: io.discard
-      GoRuntimeType: 1.461952e+06
+      GoRuntimeType: 1.462432e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
@@ -18040,7 +18363,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 993248
       GoKind: 5
-MaxTypeID: 1421
+MaxTypeID: 1429
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -10,12 +10,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 108}
       events:
-        - ID: 131
+        - ID: 132
           Kind: Entry
           Type: 1396 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80a838", Frameless: false}]
           Condition: null
-        - ID: 132
+        - ID: 131
           Kind: Return
           Type: 1397 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80a868", Frameless: false}]
@@ -30,12 +30,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 53}
       events:
-        - ID: 62
+        - ID: 63
           Kind: Entry
           Type: 1327 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807a18", Frameless: false}]
           Condition: null
-        - ID: 63
+        - ID: 62
           Kind: Return
           Type: 1328 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807a40", Frameless: false}]
@@ -50,12 +50,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 55}
       events:
-        - ID: 65
+        - ID: 66
           Kind: Entry
           Type: 1330 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807a88", Frameless: false}]
           Condition: null
-        - ID: 66
+        - ID: 65
           Kind: Return
           Type: 1331 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
@@ -130,12 +130,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 35}
       events:
-        - ID: 35
+        - ID: 36
           Kind: Entry
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
-        - ID: 36
+        - ID: 35
           Kind: Return
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068dc", Frameless: true}]
@@ -405,12 +405,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 45}
       events:
-        - ID: 47
+        - ID: 48
           Kind: Entry
           Type: 1312 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8070b8", Frameless: false}]
           Condition: null
-        - ID: 48
+        - ID: 47
           Kind: Return
           Type: 1313 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8070f0", Frameless: false}]
@@ -425,12 +425,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 44}
       events:
-        - ID: 45
+        - ID: 46
           Kind: Entry
           Type: 1310 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x806ffc", Frameless: false}]
           Condition: null
-        - ID: 46
+        - ID: 45
           Kind: Return
           Type: 1311 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807058", Frameless: false}]
@@ -445,12 +445,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 50}
       events:
-        - ID: 57
+        - ID: 58
           Kind: Entry
           Type: 1322 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807780", Frameless: true}]
           Condition: null
-        - ID: 58
+        - ID: 57
           Kind: Return
           Type: 1323 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807788", Frameless: true}]
@@ -465,12 +465,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 51}
       events:
-        - ID: 59
+        - ID: 60
           Kind: Entry
           Type: 1324 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80779c", Frameless: false}]
           Condition: null
-        - ID: 60
+        - ID: 59
           Kind: Return
           Type: 1325 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8077d0", Frameless: false}]
@@ -485,12 +485,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 46}
       events:
-        - ID: 49
+        - ID: 50
           Kind: Entry
           Type: 1314 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8074c8", Frameless: false}]
           Condition: null
-        - ID: 50
+        - ID: 49
           Kind: Return
           Type: 1315 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x80751c", Frameless: false}]
@@ -505,12 +505,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 47}
       events:
-        - ID: 51
+        - ID: 52
           Kind: Entry
           Type: 1316 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807558", Frameless: false}]
           Condition: null
-        - ID: 52
+        - ID: 51
           Kind: Return
           Type: 1317 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
@@ -525,12 +525,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 48}
       events:
-        - ID: 53
+        - ID: 54
           Kind: Entry
           Type: 1318 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x807618", Frameless: false}]
           Condition: null
-        - ID: 54
+        - ID: 53
           Kind: Return
           Type: 1319 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807650", Frameless: false}]
@@ -560,12 +560,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 49}
       events:
-        - ID: 55
+        - ID: 56
           Kind: Entry
           Type: 1320 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807688", Frameless: false}]
           Condition: null
-        - ID: 56
+        - ID: 55
           Kind: Return
           Type: 1321 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807764", Frameless: false}]
@@ -611,7 +611,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 122}
       events:
-        - ID: 150
+        - ID: 151
           Kind: Entry
           Type: 1415 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
@@ -626,7 +626,7 @@ Probes:
             - PC: "0x80761c"
               Frameless: false
           Condition: null
-        - ID: 151
+        - ID: 150
           Kind: Return
           Type: 1416 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80736c", Frameless: false}]
@@ -1066,12 +1066,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 96}
       events:
-        - ID: 116
+        - ID: 117
           Kind: Entry
           Type: 1381 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a118", Frameless: false}]
           Condition: null
-        - ID: 117
+        - ID: 116
           Kind: Return
           Type: 1382 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a188", Frameless: false}]
@@ -1100,12 +1100,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 95}
       events:
-        - ID: 114
+        - ID: 115
           Kind: Entry
           Type: 1379 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a088", Frameless: false}]
           Condition: null
-        - ID: 115
+        - ID: 114
           Kind: Return
           Type: 1380 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a0dc", Frameless: false}]
@@ -1240,12 +1240,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 93}
       events:
-        - ID: 110
+        - ID: 111
           Kind: Entry
           Type: 1375 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x809ef8", Frameless: false}]
           Condition: null
-        - ID: 111
+        - ID: 110
           Kind: Return
           Type: 1376 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x809f40", Frameless: false}]
@@ -1260,12 +1260,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 92}
       events:
-        - ID: 108
+        - ID: 109
           Kind: Entry
           Type: 1373 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x809e68", Frameless: false}]
           Condition: null
-        - ID: 109
+        - ID: 108
           Kind: Return
           Type: 1374 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
@@ -1284,12 +1284,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 91}
       events:
-        - ID: 106
+        - ID: 107
           Kind: Entry
           Type: 1371 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x809de8", Frameless: false}]
           Condition: null
-        - ID: 107
+        - ID: 106
           Kind: Return
           Type: 1372 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
@@ -1307,12 +1307,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 88}
       events:
-        - ID: 100
+        - ID: 101
           Kind: Entry
           Type: 1365 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809c18", Frameless: false}]
           Condition: null
-        - ID: 101
+        - ID: 100
           Kind: Return
           Type: 1366 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x809c54", Frameless: false}]
@@ -1326,12 +1326,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 90}
       events:
-        - ID: 104
+        - ID: 105
           Kind: Entry
           Type: 1369 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x809d28", Frameless: false}]
           Condition: null
-        - ID: 105
+        - ID: 104
           Kind: Return
           Type: 1370 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x809da4", Frameless: false}]
@@ -1345,12 +1345,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 89}
       events:
-        - ID: 102
+        - ID: 103
           Kind: Entry
           Type: 1367 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x809c9c", Frameless: false}]
           Condition: null
-        - ID: 103
+        - ID: 102
           Kind: Return
           Type: 1368 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x809cf0", Frameless: false}]
@@ -1365,12 +1365,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 94}
       events:
-        - ID: 112
+        - ID: 113
           Kind: Entry
           Type: 1377 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x809f78", Frameless: false}]
           Condition: null
-        - ID: 113
+        - ID: 112
           Kind: Return
           Type: 1378 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
@@ -1673,12 +1673,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 97}
       events:
-        - ID: 118
+        - ID: 119
           Kind: Entry
           Type: 1383 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a1c8", Frameless: false}]
           Condition: null
-        - ID: 119
+        - ID: 118
           Kind: Return
           Type: 1384 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a238", Frameless: false}]
@@ -1768,12 +1768,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 119}
       events:
-        - ID: 146
+        - ID: 147
           Kind: Entry
           Type: 1411 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80aaf0", Frameless: true}]
           Condition: null
-        - ID: 147
+        - ID: 146
           Kind: Return
           Type: 1412 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80ab00", Frameless: true}]
@@ -1817,12 +1817,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 118}
       events:
-        - ID: 144
+        - ID: 145
           Kind: Entry
           Type: 1409 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80aa40", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 144
           Kind: Return
           Type: 1410 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80aa4c", Frameless: true}]
@@ -1881,12 +1881,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 111}
       events:
-        - ID: 135
+        - ID: 136
           Kind: Entry
           Type: 1400 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80a8a0", Frameless: true}]
           Condition: null
-        - ID: 136
+        - ID: 135
           Kind: Return
           Type: 1401 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80a8ac", Frameless: true}]

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,11 +12,13 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
+          SourceLine: ""
           Type: 1400 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80aa18", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
+          SourceLine: ""
           Type: 1401 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80aa48", Frameless: false}]
           Condition: null
@@ -32,11 +34,13 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
+          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807bf8", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
+          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c20", Frameless: false}]
           Condition: null
@@ -52,11 +56,13 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
+          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807c68", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
+          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807c90", Frameless: false}]
           Condition: null
@@ -72,6 +78,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
@@ -87,6 +94,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
@@ -102,6 +110,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
+          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
@@ -117,6 +126,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
+          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
@@ -132,11 +142,13 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
+          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
+          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068dc", Frameless: true}]
           Condition: null
@@ -152,6 +164,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
@@ -167,6 +180,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
+          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
@@ -182,6 +196,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
+          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809850", Frameless: true}]
           Condition: null
@@ -197,6 +212,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
+          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x8095d0", Frameless: true}]
           Condition: null
@@ -212,6 +228,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
+          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
           Condition: null
@@ -227,6 +244,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
+          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c70", Frameless: true}]
           Condition: null
@@ -242,6 +260,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
+          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806c80", Frameless: true}]
           Condition: null
@@ -257,6 +276,7 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
+          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x806990", Frameless: true}]
           Condition: null
@@ -272,6 +292,7 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
+          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
           Condition: null
@@ -287,6 +308,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
+          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b10", Frameless: true}]
           Condition: null
@@ -302,6 +324,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
+          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
@@ -317,6 +340,7 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
+          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80a6e0", Frameless: true}]
           Condition: null
@@ -332,6 +356,7 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
+          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80a710", Frameless: true}]
           Condition: null
@@ -348,6 +373,7 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
+          SourceLine: ""
           Type: 1411 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80aad0", Frameless: true}]
           Condition: null
@@ -363,6 +389,7 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
+          SourceLine: ""
           Type: 1417 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80ada0", Frameless: true}]
           Condition: null
@@ -377,6 +404,7 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
+          SourceLine: ""
           Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80adb0", Frameless: true}]
           Condition: null
@@ -392,6 +420,7 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
+          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c40", Frameless: true}]
           Condition: null
@@ -407,11 +436,13 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
+          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x807298", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
+          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072d0", Frameless: false}]
           Condition: null
@@ -427,11 +458,13 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
+          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x8071dc", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
+          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807238", Frameless: false}]
           Condition: null
@@ -447,11 +480,13 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
+          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807960", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
+          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807968", Frameless: true}]
           Condition: null
@@ -467,11 +502,13 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
+          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
+          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079b0", Frameless: false}]
           Condition: null
@@ -489,8 +526,9 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 64
-          Kind: EventKind(3)
-          Type: 1329 EventRootType Probe[main.testFramelessArray]EventKind(3)
+          Kind: Line
+          SourceLine: "93"
+          Type: 1329 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -505,11 +543,13 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
+          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8076a8", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
+          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x8076fc", Frameless: false}]
           Condition: null
@@ -525,11 +565,13 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
+          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807738", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
+          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077b8", Frameless: false}]
           Condition: null
@@ -545,11 +587,13 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
+          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x8077f8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
+          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807830", Frameless: false}]
           Condition: null
@@ -565,6 +609,7 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
+          SourceLine: ""
           Type: 1422 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x807784", Frameless: false}]
           Condition: null
@@ -580,11 +625,13 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
+          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807868", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
+          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807944", Frameless: false}]
           Condition: null
@@ -600,6 +647,7 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
+          SourceLine: ""
           Type: 1423 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80786c", Frameless: false}]
           Condition: null
@@ -617,8 +665,9 @@ Probes:
       subprogram: {subprogram: 125}
       events:
         - ID: 159
-          Kind: EventKind(3)
-          Type: 1424 EventRootType Probe[main.testInlinedBCA]EventKind(3)
+          Kind: Line
+          SourceLine: "63"
+          Type: 1424 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80786c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -633,6 +682,7 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
+          SourceLine: ""
           Type: 1425 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807910", Frameless: false}]
           Condition: null
@@ -650,8 +700,9 @@ Probes:
       subprogram: {subprogram: 126}
       events:
         - ID: 161
-          Kind: EventKind(3)
-          Type: 1426 EventRootType Probe[main.testInlinedBCB]EventKind(3)
+          Kind: Line
+          SourceLine: "67"
+          Type: 1426 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807910", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -667,6 +718,7 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
+          SourceLine: ""
           Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807518"
@@ -682,6 +734,7 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
+          SourceLine: ""
           Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80754c", Frameless: false}]
           Condition: null
@@ -699,8 +752,9 @@ Probes:
       subprogram: {subprogram: 123}
       events:
         - ID: 156
-          Kind: EventKind(3)
-          Type: 1421 EventRootType Probe[main.testInlinedPrint]EventKind(3)
+          Kind: Line
+          SourceLine: "14"
+          Type: 1421 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807518"
               Frameless: false
@@ -725,6 +779,7 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
+          SourceLine: ""
           Type: 1427 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807964", Frameless: true}]
           Condition: null
@@ -742,8 +797,9 @@ Probes:
       subprogram: {subprogram: 127}
       events:
         - ID: 163
-          Kind: EventKind(3)
-          Type: 1428 EventRootType Probe[main.testInlinedSq]EventKind(3)
+          Kind: Line
+          SourceLine: "75"
+          Type: 1428 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807964", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -759,6 +815,7 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
+          SourceLine: ""
           Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x807994"
@@ -778,6 +835,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
+          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
@@ -793,6 +851,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
@@ -808,6 +867,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
+          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
@@ -823,6 +883,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
@@ -838,6 +899,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
+          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
@@ -853,6 +915,7 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
+          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bd0", Frameless: true}]
           Condition: null
@@ -868,6 +931,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
+          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8099e0", Frameless: true}]
           Condition: null
@@ -885,8 +949,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 45
-          Kind: EventKind(3)
-          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "208"
+          Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806ccc", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -903,8 +968,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 46
-          Kind: EventKind(3)
-          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "215"
+          Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d50", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -921,8 +987,9 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 47
-          Kind: EventKind(3)
-          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]EventKind(3)
+          Kind: Line
+          SourceLine: "220"
+          Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806dec", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
@@ -937,6 +1004,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
+          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
@@ -952,6 +1020,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
+          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
@@ -967,6 +1036,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
+          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
@@ -982,6 +1052,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
+          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
@@ -997,6 +1068,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
+          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
@@ -1012,6 +1084,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
+          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
@@ -1027,6 +1100,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
+          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
@@ -1042,6 +1116,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
+          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
@@ -1057,6 +1132,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
+          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
@@ -1072,6 +1148,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
+          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
@@ -1087,6 +1164,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
+          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
@@ -1102,6 +1180,7 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
+          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808210", Frameless: true}]
           Condition: null
@@ -1117,6 +1196,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
+          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
@@ -1132,6 +1212,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
+          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
@@ -1147,6 +1228,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
+          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
@@ -1162,6 +1244,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
+          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
@@ -1177,6 +1260,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
+          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
@@ -1192,6 +1276,7 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
+          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
@@ -1208,6 +1293,7 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
+          SourceLine: ""
           Type: 1409 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
@@ -1222,11 +1308,13 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
+          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
+          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a368", Frameless: false}]
           Condition: null
@@ -1242,6 +1330,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
+          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x8096b0", Frameless: true}]
           Condition: null
@@ -1256,11 +1345,13 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
+          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a268", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
+          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a2bc", Frameless: false}]
           Condition: null
@@ -1276,6 +1367,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
+          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809ab0", Frameless: true}]
           Condition: null
@@ -1291,6 +1383,7 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
+          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80a750", Frameless: true}]
           Condition: null
@@ -1306,6 +1399,7 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
+          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80a720", Frameless: true}]
           Condition: null
@@ -1321,6 +1415,7 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
+          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80a740", Frameless: true}]
           Condition: null
@@ -1336,6 +1431,7 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
+          SourceLine: ""
           Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
           Condition: null
@@ -1351,6 +1447,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
+          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8099f0", Frameless: true}]
           Condition: null
@@ -1366,6 +1463,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
+          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
@@ -1381,6 +1479,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
+          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
@@ -1396,11 +1495,13 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
+          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x80a0d8", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
+          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x80a120", Frameless: false}]
           Condition: null
@@ -1416,11 +1517,13 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
+          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
+          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80a084"
@@ -1440,11 +1543,13 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
+          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
+          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x809ff4"
@@ -1463,11 +1568,13 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
+          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809df8", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
+          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x809e34", Frameless: false}]
           Condition: null
@@ -1482,11 +1589,13 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
+          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x809f08", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
+          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x809f84", Frameless: false}]
           Condition: null
@@ -1501,11 +1610,13 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
+          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x809e7c", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
+          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x809ed0", Frameless: false}]
           Condition: null
@@ -1521,11 +1632,13 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
+          SourceLine: ""
           Type: 1381 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x80a158", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
+          SourceLine: ""
           Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x80a1dc"
@@ -1545,6 +1658,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
@@ -1560,6 +1674,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
@@ -1575,6 +1690,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
@@ -1590,6 +1706,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
+          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
@@ -1605,6 +1722,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
+          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
@@ -1620,6 +1738,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
+          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
@@ -1635,6 +1754,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
@@ -1650,6 +1770,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
@@ -1665,6 +1786,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
+          SourceLine: ""
           Type: 1291 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
@@ -1680,6 +1802,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
@@ -1695,6 +1818,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
+          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
@@ -1710,6 +1834,7 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
+          SourceLine: ""
           Type: 1402 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80aa60", Frameless: true}]
           Condition: null
@@ -1725,6 +1850,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
+          SourceLine: ""
           Type: 1292 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
@@ -1740,6 +1866,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
+          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
@@ -1755,6 +1882,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
+          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
@@ -1770,6 +1898,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
+          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
@@ -1785,6 +1914,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
+          SourceLine: ""
           Type: 1293 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
@@ -1800,6 +1930,7 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
+          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80a6f0", Frameless: true}]
           Condition: null
@@ -1815,6 +1946,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
+          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
@@ -1829,11 +1961,13 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
+          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
+          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a418", Frameless: false}]
           Condition: null
@@ -1849,6 +1983,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
+          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
@@ -1864,6 +1999,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
+          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809a90", Frameless: true}]
           Condition: null
@@ -1879,6 +2015,7 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
+          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80a730", Frameless: true}]
           Condition: null
@@ -1894,6 +2031,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
+          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
@@ -1909,6 +2047,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
+          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
@@ -1924,11 +2063,13 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
+          SourceLine: ""
           Type: 1415 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80acd0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
+          SourceLine: ""
           Type: 1416 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80ace0", Frameless: true}]
           Condition: null
@@ -1944,6 +2085,7 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
+          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80a700", Frameless: true}]
           Condition: null
@@ -1959,6 +2101,7 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
+          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cb0", Frameless: true}]
           Condition: null
@@ -1973,11 +2116,13 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
+          SourceLine: ""
           Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80ac20", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
+          SourceLine: ""
           Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80ac2c", Frameless: true}]
           Condition: null
@@ -1992,6 +2137,7 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
+          SourceLine: ""
           Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80ac10", Frameless: true}]
           Condition: null
@@ -2007,6 +2153,7 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
+          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808200", Frameless: true}]
           Condition: null
@@ -2022,6 +2169,7 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
+          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80aa70", Frameless: true}]
           Condition: null
@@ -2037,11 +2185,13 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
+          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80aa80", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
+          SourceLine: ""
           Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80aa8c", Frameless: true}]
           Condition: null
@@ -2057,6 +2207,7 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
+          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
           Condition: null
@@ -2072,6 +2223,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
+          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
@@ -2087,6 +2239,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
@@ -2102,6 +2255,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
@@ -2117,6 +2271,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
+          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
@@ -2132,6 +2287,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
+          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
@@ -2147,6 +2303,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
@@ -2162,6 +2319,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
+          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809a20", Frameless: true}]
           Condition: null
@@ -2177,6 +2335,7 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
+          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80a6d0", Frameless: true}]
           Condition: null
@@ -2192,6 +2351,7 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
+          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80aac0", Frameless: true}]
           Condition: null
@@ -2207,6 +2367,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
+          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809a00", Frameless: true}]
           Condition: null
@@ -2222,6 +2383,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
+          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
@@ -2237,6 +2399,7 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
+          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null
@@ -2252,6 +2415,7 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
+          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null
@@ -8169,7 +8333,7 @@ Types:
                   ByteSize: 40
     - __kind: EventRootType
       ID: 1329
-      Name: Probe[main.testFramelessArray]EventKind(3)
+      Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
@@ -8316,13 +8480,13 @@ Types:
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testInlinedBCA]EventKind(3)
+      Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
       ID: 1426
-      Name: Probe[main.testInlinedBCB]EventKind(3)
+      Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1323
       Name: Probe[main.testInlinedBC]
@@ -8347,7 +8511,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1421
-      Name: Probe[main.testInlinedPrint]EventKind(3)
+      Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8382,7 +8546,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1428
-      Name: Probe[main.testInlinedSq]EventKind(3)
+      Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -8526,10 +8690,10 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1310
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
       ID: 1311
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -8555,7 +8719,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 1312
-      Name: Probe[main.testLongFunctionWithChangingState]EventKind(3)
+      Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,13 +12,11 @@ Probes:
       events:
         - ID: 136
           Kind: Entry
-          SourceLine: ""
           Type: 1400 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80aa18", Frameless: false}]
           Condition: null
         - ID: 135
           Kind: Return
-          SourceLine: ""
           Type: 1401 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80aa48", Frameless: false}]
           Condition: null
@@ -34,13 +32,11 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          SourceLine: ""
           Type: 1331 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807bf8", Frameless: false}]
           Condition: null
         - ID: 66
           Kind: Return
-          SourceLine: ""
           Type: 1332 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c20", Frameless: false}]
           Condition: null
@@ -56,13 +52,11 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          SourceLine: ""
           Type: 1334 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807c68", Frameless: false}]
           Condition: null
         - ID: 69
           Kind: Return
-          SourceLine: ""
           Type: 1335 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807c90", Frameless: false}]
           Condition: null
@@ -78,7 +72,6 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 1280 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
@@ -94,7 +87,6 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 1282 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
@@ -110,7 +102,6 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          SourceLine: ""
           Type: 1343 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
@@ -126,7 +117,6 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          SourceLine: ""
           Type: 1281 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
@@ -142,13 +132,11 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          SourceLine: ""
           Type: 1300 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068d0", Frameless: true}]
           Condition: null
         - ID: 35
           Kind: Return
-          SourceLine: ""
           Type: 1301 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068dc", Frameless: true}]
           Condition: null
@@ -164,7 +152,6 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 1269 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
@@ -180,7 +167,6 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          SourceLine: ""
           Type: 1266 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806280", Frameless: true}]
           Condition: null
@@ -196,7 +182,6 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          SourceLine: ""
           Type: 1360 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809850", Frameless: true}]
           Condition: null
@@ -212,7 +197,6 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          SourceLine: ""
           Type: 1358 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x8095d0", Frameless: true}]
           Condition: null
@@ -228,7 +212,6 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          SourceLine: ""
           Type: 1368 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809ad0", Frameless: true}]
           Condition: null
@@ -244,7 +227,6 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          SourceLine: ""
           Type: 1306 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c70", Frameless: true}]
           Condition: null
@@ -260,7 +242,6 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          SourceLine: ""
           Type: 1307 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806c80", Frameless: true}]
           Condition: null
@@ -276,7 +257,6 @@ Probes:
       events:
         - ID: 37
           Kind: Entry
-          SourceLine: ""
           Type: 1302 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x806990", Frameless: true}]
           Condition: null
@@ -292,7 +272,6 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          SourceLine: ""
           Type: 1303 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069a0", Frameless: true}]
           Condition: null
@@ -308,7 +287,6 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          SourceLine: ""
           Type: 1304 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b10", Frameless: true}]
           Condition: null
@@ -324,7 +302,6 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          SourceLine: ""
           Type: 1305 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b20", Frameless: true}]
           Condition: null
@@ -340,7 +317,6 @@ Probes:
       events:
         - ID: 125
           Kind: Entry
-          SourceLine: ""
           Type: 1390 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80a6e0", Frameless: true}]
           Condition: null
@@ -356,7 +332,6 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          SourceLine: ""
           Type: 1393 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80a710", Frameless: true}]
           Condition: null
@@ -373,7 +348,6 @@ Probes:
       events:
         - ID: 146
           Kind: Entry
-          SourceLine: ""
           Type: 1411 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80aad0", Frameless: true}]
           Condition: null
@@ -389,7 +363,6 @@ Probes:
       events:
         - ID: 152
           Kind: Entry
-          SourceLine: ""
           Type: 1417 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80ada0", Frameless: true}]
           Condition: null
@@ -404,7 +377,6 @@ Probes:
       events:
         - ID: 153
           Kind: Entry
-          SourceLine: ""
           Type: 1418 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80adb0", Frameless: true}]
           Condition: null
@@ -420,7 +392,6 @@ Probes:
       events:
         - ID: 68
           Kind: Entry
-          SourceLine: ""
           Type: 1333 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c40", Frameless: true}]
           Condition: null
@@ -436,13 +407,11 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          SourceLine: ""
           Type: 1315 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x807298", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          SourceLine: ""
           Type: 1316 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072d0", Frameless: false}]
           Condition: null
@@ -458,13 +427,11 @@ Probes:
       events:
         - ID: 49
           Kind: Entry
-          SourceLine: ""
           Type: 1313 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x8071dc", Frameless: false}]
           Condition: null
         - ID: 48
           Kind: Return
-          SourceLine: ""
           Type: 1314 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807238", Frameless: false}]
           Condition: null
@@ -480,13 +447,11 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          SourceLine: ""
           Type: 1325 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807960", Frameless: true}]
           Condition: null
         - ID: 60
           Kind: Return
-          SourceLine: ""
           Type: 1326 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807968", Frameless: true}]
           Condition: null
@@ -502,13 +467,11 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          SourceLine: ""
           Type: 1327 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
         - ID: 62
           Kind: Return
-          SourceLine: ""
           Type: 1328 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079b0", Frameless: false}]
           Condition: null
@@ -527,7 +490,6 @@ Probes:
       events:
         - ID: 64
           Kind: Line
-          SourceLine: "93"
           Type: 1329 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80797c", Frameless: false}]
           Condition: null
@@ -543,13 +505,11 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          SourceLine: ""
           Type: 1317 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8076a8", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          SourceLine: ""
           Type: 1318 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x8076fc", Frameless: false}]
           Condition: null
@@ -565,13 +525,11 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          SourceLine: ""
           Type: 1319 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807738", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          SourceLine: ""
           Type: 1320 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077b8", Frameless: false}]
           Condition: null
@@ -587,13 +545,11 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          SourceLine: ""
           Type: 1321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x8077f8", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          SourceLine: ""
           Type: 1322 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807830", Frameless: false}]
           Condition: null
@@ -609,7 +565,6 @@ Probes:
       events:
         - ID: 157
           Kind: Entry
-          SourceLine: ""
           Type: 1422 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x807784", Frameless: false}]
           Condition: null
@@ -625,13 +580,11 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          SourceLine: ""
           Type: 1323 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807868", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          SourceLine: ""
           Type: 1324 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807944", Frameless: false}]
           Condition: null
@@ -647,7 +600,6 @@ Probes:
       events:
         - ID: 158
           Kind: Entry
-          SourceLine: ""
           Type: 1423 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80786c", Frameless: false}]
           Condition: null
@@ -666,7 +618,6 @@ Probes:
       events:
         - ID: 159
           Kind: Line
-          SourceLine: "63"
           Type: 1424 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80786c", Frameless: false}]
           Condition: null
@@ -682,7 +633,6 @@ Probes:
       events:
         - ID: 160
           Kind: Entry
-          SourceLine: ""
           Type: 1425 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807910", Frameless: false}]
           Condition: null
@@ -701,7 +651,6 @@ Probes:
       events:
         - ID: 161
           Kind: Line
-          SourceLine: "67"
           Type: 1426 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807910", Frameless: false}]
           Condition: null
@@ -718,7 +667,6 @@ Probes:
       events:
         - ID: 155
           Kind: Entry
-          SourceLine: ""
           Type: 1419 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807518"
@@ -734,7 +682,6 @@ Probes:
           Condition: null
         - ID: 154
           Kind: Return
-          SourceLine: ""
           Type: 1420 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80754c", Frameless: false}]
           Condition: null
@@ -753,7 +700,6 @@ Probes:
       events:
         - ID: 156
           Kind: Line
-          SourceLine: "14"
           Type: 1421 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807518"
@@ -779,7 +725,6 @@ Probes:
       events:
         - ID: 162
           Kind: Entry
-          SourceLine: ""
           Type: 1427 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807964", Frameless: true}]
           Condition: null
@@ -798,7 +743,6 @@ Probes:
       events:
         - ID: 163
           Kind: Line
-          SourceLine: "75"
           Type: 1428 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807964", Frameless: true}]
           Condition: null
@@ -815,7 +759,6 @@ Probes:
       events:
         - ID: 164
           Kind: Entry
-          SourceLine: ""
           Type: 1429 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x807994"
@@ -835,7 +778,6 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          SourceLine: ""
           Type: 1272 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
@@ -851,7 +793,6 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 1273 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
@@ -867,7 +808,6 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          SourceLine: ""
           Type: 1274 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
@@ -883,7 +823,6 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 1271 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
@@ -899,7 +838,6 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          SourceLine: ""
           Type: 1270 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
@@ -915,7 +853,6 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          SourceLine: ""
           Type: 1330 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bd0", Frameless: true}]
           Condition: null
@@ -931,7 +868,6 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          SourceLine: ""
           Type: 1362 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8099e0", Frameless: true}]
           Condition: null
@@ -950,7 +886,6 @@ Probes:
       events:
         - ID: 45
           Kind: Line
-          SourceLine: "208"
           Type: 1310 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806ccc", Frameless: false}]
           Condition: null
@@ -969,7 +904,6 @@ Probes:
       events:
         - ID: 46
           Kind: Line
-          SourceLine: "215"
           Type: 1311 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d50", Frameless: false}]
           Condition: null
@@ -988,7 +922,6 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          SourceLine: "220"
           Type: 1312 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806dec", Frameless: false}]
           Condition: null
@@ -1004,7 +937,6 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          SourceLine: ""
           Type: 1341 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
@@ -1020,7 +952,6 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          SourceLine: ""
           Type: 1348 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
@@ -1036,7 +967,6 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          SourceLine: ""
           Type: 1345 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
@@ -1052,7 +982,6 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          SourceLine: ""
           Type: 1357 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
@@ -1068,7 +997,6 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          SourceLine: ""
           Type: 1356 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
@@ -1084,7 +1012,6 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          SourceLine: ""
           Type: 1346 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
@@ -1100,7 +1027,6 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          SourceLine: ""
           Type: 1347 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
@@ -1116,7 +1042,6 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          SourceLine: ""
           Type: 1355 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
@@ -1132,7 +1057,6 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          SourceLine: ""
           Type: 1354 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
@@ -1148,7 +1072,6 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          SourceLine: ""
           Type: 1339 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
@@ -1164,7 +1087,6 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          SourceLine: ""
           Type: 1340 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
@@ -1180,7 +1102,6 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          SourceLine: ""
           Type: 1338 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808210", Frameless: true}]
           Condition: null
@@ -1196,7 +1117,6 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          SourceLine: ""
           Type: 1349 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
@@ -1212,7 +1132,6 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          SourceLine: ""
           Type: 1352 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
@@ -1228,7 +1147,6 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          SourceLine: ""
           Type: 1353 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
@@ -1244,7 +1162,6 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          SourceLine: ""
           Type: 1350 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
@@ -1260,7 +1177,6 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          SourceLine: ""
           Type: 1351 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
@@ -1276,7 +1192,6 @@ Probes:
       events:
         - ID: 143
           Kind: Entry
-          SourceLine: ""
           Type: 1408 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
@@ -1293,7 +1208,6 @@ Probes:
       events:
         - ID: 144
           Kind: Entry
-          SourceLine: ""
           Type: 1409 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80aab0", Frameless: true}]
           Condition: null
@@ -1308,13 +1222,11 @@ Probes:
       events:
         - ID: 121
           Kind: Entry
-          SourceLine: ""
           Type: 1385 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a2f8", Frameless: false}]
           Condition: null
         - ID: 120
           Kind: Return
-          SourceLine: ""
           Type: 1386 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a368", Frameless: false}]
           Condition: null
@@ -1330,7 +1242,6 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          SourceLine: ""
           Type: 1359 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x8096b0", Frameless: true}]
           Condition: null
@@ -1345,13 +1256,11 @@ Probes:
       events:
         - ID: 119
           Kind: Entry
-          SourceLine: ""
           Type: 1383 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a268", Frameless: false}]
           Condition: null
         - ID: 118
           Kind: Return
-          SourceLine: ""
           Type: 1384 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a2bc", Frameless: false}]
           Condition: null
@@ -1367,7 +1276,6 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          SourceLine: ""
           Type: 1367 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809ab0", Frameless: true}]
           Condition: null
@@ -1383,7 +1291,6 @@ Probes:
       events:
         - ID: 132
           Kind: Entry
-          SourceLine: ""
           Type: 1397 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80a750", Frameless: true}]
           Condition: null
@@ -1399,7 +1306,6 @@ Probes:
       events:
         - ID: 129
           Kind: Entry
-          SourceLine: ""
           Type: 1394 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80a720", Frameless: true}]
           Condition: null
@@ -1415,7 +1321,6 @@ Probes:
       events:
         - ID: 131
           Kind: Entry
-          SourceLine: ""
           Type: 1396 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80a740", Frameless: true}]
           Condition: null
@@ -1431,7 +1336,6 @@ Probes:
       events:
         - ID: 142
           Kind: Entry
-          SourceLine: ""
           Type: 1407 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80aaa0", Frameless: true}]
           Condition: null
@@ -1447,7 +1351,6 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          SourceLine: ""
           Type: 1363 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8099f0", Frameless: true}]
           Condition: null
@@ -1463,7 +1366,6 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          SourceLine: ""
           Type: 1344 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
@@ -1479,7 +1381,6 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          SourceLine: ""
           Type: 1361 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
@@ -1495,13 +1396,11 @@ Probes:
       events:
         - ID: 115
           Kind: Entry
-          SourceLine: ""
           Type: 1379 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x80a0d8", Frameless: false}]
           Condition: null
         - ID: 114
           Kind: Return
-          SourceLine: ""
           Type: 1380 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints: [{PC: "0x80a120", Frameless: false}]
           Condition: null
@@ -1517,13 +1416,11 @@ Probes:
       events:
         - ID: 113
           Kind: Entry
-          SourceLine: ""
           Type: 1377 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
         - ID: 112
           Kind: Return
-          SourceLine: ""
           Type: 1378 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80a084"
@@ -1543,13 +1440,11 @@ Probes:
       events:
         - ID: 111
           Kind: Entry
-          SourceLine: ""
           Type: 1375 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
         - ID: 110
           Kind: Return
-          SourceLine: ""
           Type: 1376 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x809ff4"
@@ -1568,13 +1463,11 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          SourceLine: ""
           Type: 1369 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809df8", Frameless: false}]
           Condition: null
         - ID: 104
           Kind: Return
-          SourceLine: ""
           Type: 1370 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x809e34", Frameless: false}]
           Condition: null
@@ -1589,13 +1482,11 @@ Probes:
       events:
         - ID: 109
           Kind: Entry
-          SourceLine: ""
           Type: 1373 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x809f08", Frameless: false}]
           Condition: null
         - ID: 108
           Kind: Return
-          SourceLine: ""
           Type: 1374 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x809f84", Frameless: false}]
           Condition: null
@@ -1610,13 +1501,11 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          SourceLine: ""
           Type: 1371 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x809e7c", Frameless: false}]
           Condition: null
         - ID: 106
           Kind: Return
-          SourceLine: ""
           Type: 1372 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x809ed0", Frameless: false}]
           Condition: null
@@ -1632,13 +1521,11 @@ Probes:
       events:
         - ID: 117
           Kind: Entry
-          SourceLine: ""
           Type: 1381 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x80a158", Frameless: false}]
           Condition: null
         - ID: 116
           Kind: Return
-          SourceLine: ""
           Type: 1382 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x80a1dc"
@@ -1658,7 +1545,6 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 1267 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
@@ -1674,7 +1560,6 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 1286 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
@@ -1690,7 +1575,6 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 1284 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8066e0", Frameless: true}]
           Condition: null
@@ -1706,7 +1590,6 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          SourceLine: ""
           Type: 1297 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
@@ -1722,7 +1605,6 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          SourceLine: ""
           Type: 1298 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
@@ -1738,7 +1620,6 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          SourceLine: ""
           Type: 1287 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
@@ -1754,7 +1635,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 1289 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
@@ -1770,7 +1650,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 1290 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
@@ -1786,7 +1665,6 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          SourceLine: ""
           Type: 1291 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
@@ -1802,7 +1680,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 1288 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
@@ -1818,7 +1695,6 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          SourceLine: ""
           Type: 1285 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8066f0", Frameless: true}]
           Condition: null
@@ -1834,7 +1710,6 @@ Probes:
       events:
         - ID: 137
           Kind: Entry
-          SourceLine: ""
           Type: 1402 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80aa60", Frameless: true}]
           Condition: null
@@ -1850,7 +1725,6 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          SourceLine: ""
           Type: 1292 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
@@ -1866,7 +1740,6 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          SourceLine: ""
           Type: 1294 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
@@ -1882,7 +1755,6 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          SourceLine: ""
           Type: 1295 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
@@ -1898,7 +1770,6 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          SourceLine: ""
           Type: 1296 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
@@ -1914,7 +1785,6 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          SourceLine: ""
           Type: 1293 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
@@ -1930,7 +1800,6 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          SourceLine: ""
           Type: 1391 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80a6f0", Frameless: true}]
           Condition: null
@@ -1946,7 +1815,6 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          SourceLine: ""
           Type: 1342 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
@@ -1961,13 +1829,11 @@ Probes:
       events:
         - ID: 123
           Kind: Entry
-          SourceLine: ""
           Type: 1387 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
         - ID: 122
           Kind: Return
-          SourceLine: ""
           Type: 1388 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a418", Frameless: false}]
           Condition: null
@@ -1983,7 +1849,6 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          SourceLine: ""
           Type: 1268 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
@@ -1999,7 +1864,6 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          SourceLine: ""
           Type: 1366 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809a90", Frameless: true}]
           Condition: null
@@ -2015,7 +1879,6 @@ Probes:
       events:
         - ID: 130
           Kind: Entry
-          SourceLine: ""
           Type: 1395 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80a730", Frameless: true}]
           Condition: null
@@ -2031,7 +1894,6 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          SourceLine: ""
           Type: 1308 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
@@ -2047,7 +1909,6 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          SourceLine: ""
           Type: 1309 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
@@ -2063,13 +1924,11 @@ Probes:
       events:
         - ID: 151
           Kind: Entry
-          SourceLine: ""
           Type: 1415 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80acd0", Frameless: true}]
           Condition: null
         - ID: 150
           Kind: Return
-          SourceLine: ""
           Type: 1416 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80ace0", Frameless: true}]
           Condition: null
@@ -2085,7 +1944,6 @@ Probes:
       events:
         - ID: 127
           Kind: Entry
-          SourceLine: ""
           Type: 1392 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80a700", Frameless: true}]
           Condition: null
@@ -2101,7 +1959,6 @@ Probes:
       events:
         - ID: 71
           Kind: Entry
-          SourceLine: ""
           Type: 1336 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cb0", Frameless: true}]
           Condition: null
@@ -2116,13 +1973,11 @@ Probes:
       events:
         - ID: 149
           Kind: Entry
-          SourceLine: ""
           Type: 1413 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80ac20", Frameless: true}]
           Condition: null
         - ID: 148
           Kind: Return
-          SourceLine: ""
           Type: 1414 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80ac2c", Frameless: true}]
           Condition: null
@@ -2137,7 +1992,6 @@ Probes:
       events:
         - ID: 147
           Kind: Entry
-          SourceLine: ""
           Type: 1412 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80ac10", Frameless: true}]
           Condition: null
@@ -2153,7 +2007,6 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          SourceLine: ""
           Type: 1337 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808200", Frameless: true}]
           Condition: null
@@ -2169,7 +2022,6 @@ Probes:
       events:
         - ID: 138
           Kind: Entry
-          SourceLine: ""
           Type: 1403 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80aa70", Frameless: true}]
           Condition: null
@@ -2185,13 +2037,11 @@ Probes:
       events:
         - ID: 140
           Kind: Entry
-          SourceLine: ""
           Type: 1404 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80aa80", Frameless: true}]
           Condition: null
         - ID: 139
           Kind: Return
-          SourceLine: ""
           Type: 1405 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80aa8c", Frameless: true}]
           Condition: null
@@ -2207,7 +2057,6 @@ Probes:
       events:
         - ID: 141
           Kind: Entry
-          SourceLine: ""
           Type: 1406 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80aa90", Frameless: true}]
           Condition: null
@@ -2223,7 +2072,6 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          SourceLine: ""
           Type: 1299 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
@@ -2239,7 +2087,6 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 1277 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
@@ -2255,7 +2102,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 1278 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
@@ -2271,7 +2117,6 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          SourceLine: ""
           Type: 1279 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
@@ -2287,7 +2132,6 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          SourceLine: ""
           Type: 1276 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
@@ -2303,7 +2147,6 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 1275 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
@@ -2319,7 +2162,6 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          SourceLine: ""
           Type: 1365 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809a20", Frameless: true}]
           Condition: null
@@ -2335,7 +2177,6 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          SourceLine: ""
           Type: 1389 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80a6d0", Frameless: true}]
           Condition: null
@@ -2351,7 +2192,6 @@ Probes:
       events:
         - ID: 145
           Kind: Entry
-          SourceLine: ""
           Type: 1410 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80aac0", Frameless: true}]
           Condition: null
@@ -2367,7 +2207,6 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          SourceLine: ""
           Type: 1364 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809a00", Frameless: true}]
           Condition: null
@@ -2383,7 +2222,6 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          SourceLine: ""
           Type: 1283 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
@@ -2399,7 +2237,6 @@ Probes:
       events:
         - ID: 133
           Kind: Entry
-          SourceLine: ""
           Type: 1398 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null
@@ -2415,7 +2252,6 @@ Probes:
       events:
         - ID: 134
           Kind: Entry
-          SourceLine: ""
           Type: 1399 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80a760", Frameless: true}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 176 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 177 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 182 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 183 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 161 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 162 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 167 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 168 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 165 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 166 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 174 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 175 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 178 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 179 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 163 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 164 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 171 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 172 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 169 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 170 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 178 EventRootType Probe[main.PointerChainArg]
+          Type: 184 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -27,7 +27,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 179 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 185 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -41,12 +41,12 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 170 EventRootType Probe[main.bigMapArg]
+          Type: 176 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          Type: 171 EventRootType Probe[main.bigMapArg]Return
+          Type: 177 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
     - id: inlined
@@ -61,7 +61,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 176 EventRootType Probe[main.inlined]
+          Type: 182 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
               Frameless: false
@@ -70,7 +70,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          Type: 177 EventRootType Probe[main.inlined]Return
+          Type: 183 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
     - id: intArg
@@ -84,12 +84,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 155 EventRootType Probe[main.intArg]
+          Type: 161 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 156 EventRootType Probe[main.intArg]Return
+          Type: 162 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -103,12 +103,12 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 161 EventRootType Probe[main.intArrayArg]
+          Type: 167 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          Type: 162 EventRootType Probe[main.intArrayArg]Return
+          Type: 168 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -122,7 +122,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 167 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -136,12 +136,12 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 159 EventRootType Probe[main.intSliceArg]
+          Type: 165 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          Type: 160 EventRootType Probe[main.intSliceArg]Return
+          Type: 166 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -155,12 +155,12 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 168 EventRootType Probe[main.mapArg]
+          Type: 174 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          Type: 169 EventRootType Probe[main.mapArg]Return
+          Type: 175 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -174,12 +174,12 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 172 EventRootType Probe[main.noArgs]
+          Type: 178 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          Type: 173 EventRootType Probe[main.noArgs]Return
+          Type: 179 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -193,12 +193,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 157 EventRootType Probe[main.stringArg]
+          Type: 163 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 158 EventRootType Probe[main.stringArg]Return
+          Type: 164 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
     - id: stringArrayArg
@@ -212,12 +212,12 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 165 EventRootType Probe[main.stringArrayArg]
+          Type: 171 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          Type: 166 EventRootType Probe[main.stringArrayArg]Return
+          Type: 172 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -231,12 +231,12 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 163 EventRootType Probe[main.stringSliceArg]
+          Type: 169 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 164 EventRootType Probe[main.stringSliceArg]Return
+          Type: 170 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -251,12 +251,12 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 174 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          Type: 175 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -401,6 +401,11 @@ Subprograms:
           Locations: [{Range: 0x4a6660..0x4a6845, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: m
+          Type: 120 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0x4a6660..0x4a6845, Pieces: []}]
+          IsParameter: false
+          IsReturn: false
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4a6420..0x4a6482]
@@ -425,7 +430,7 @@ Subprograms:
           RootRanges: [0x4a5c80..0x4a60ea]
       Variables:
         - Name: ptr
-          Type: 120 PointerType *****int
+          Type: 125 PointerType *****int
           Locations:
             - Range: 0x4a601f..0x4a606b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -439,7 +444,7 @@ Subprograms:
           RootRanges: [0x4a5c80..0x4a60ea]
       Variables:
         - Name: ptr
-          Type: 122 PointerType **int
+          Type: 127 PointerType **int
           Locations:
             - Range: 0x4a6090..0x4a60ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
@@ -447,38 +452,38 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 120
+      ID: 125
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32992
       GoKind: 22
-      Pointee: 121 PointerType ****int
+      Pointee: 126 PointerType ****int
     - __kind: PointerType
-      ID: 121
+      ID: 126
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32928
       GoKind: 22
-      Pointee: 154 PointerType ***int
+      Pointee: 160 PointerType ***int
     - __kind: PointerType
-      ID: 154
+      ID: 160
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32864
       GoKind: 22
-      Pointee: 122 PointerType **int
+      Pointee: 127 PointerType **int
     - __kind: PointerType
-      ID: 122
+      ID: 127
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32800
       GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
-      ID: 130
+      ID: 135
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 129 GoSliceDataType []int.array
+      Pointee: 134 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -487,20 +492,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 132
+      ID: 137
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 131 GoSliceDataType []string.array
+      Pointee: 136 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 126
+      ID: 131
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 125 GoSliceDataType []uint8.array
+      Pointee: 130 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 128
+      ID: 133
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 127 GoSliceDataType []uintptr.array
+      Pointee: 132 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -509,10 +514,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 146
+      ID: 151
       Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 152 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 106
       Name: '*bucket<string,int>'
@@ -523,6 +528,11 @@ Types:
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 114 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 123
+      Name: '*bucket<string,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 124 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 118
       Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
@@ -550,10 +560,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 144
+      ID: 149
       Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 145 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 150 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 104
       Name: '*hash<string,int>'
@@ -564,6 +574,11 @@ Types:
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 112 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 121
+      Name: '*hash<string,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 122 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 116
       Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
@@ -591,12 +606,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 138
+      ID: 143
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24736
       GoKind: 22
-      Pointee: 139 StructureType main.bigStruct
+      Pointee: 144 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -675,10 +690,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 124
+      ID: 129
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 123 GoStringDataType string.str
+      Pointee: 128 GoStringDataType string.str
     - __kind: PointerType
       ID: 97
       Name: '*uint'
@@ -722,7 +737,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 178
+      ID: 184
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -731,14 +746,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 120 PointerType *****int
+            Type: 125 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 179
+      ID: 185
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -747,14 +762,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 122 PointerType **int
+            Type: 127 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 170
+      ID: 176
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -770,10 +785,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 171
+      ID: 177
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 176
+      ID: 182
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -789,10 +804,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 177
+      ID: 183
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 155
+      ID: 161
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -808,10 +823,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 156
+      ID: 162
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 161
+      ID: 167
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -827,10 +842,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 162
+      ID: 168
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 159
+      ID: 165
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -846,10 +861,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 160
+      ID: 166
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 168
+      ID: 174
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -865,16 +880,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 169
+      ID: 175
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 172
+      ID: 178
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 173
+      ID: 179
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 157
+      ID: 163
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -890,10 +905,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 158
+      ID: 164
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 167
+      ID: 173
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -909,7 +924,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 165
+      ID: 171
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -925,10 +940,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 166
+      ID: 172
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 163
+      ID: 169
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -944,13 +959,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 164
+      ID: 170
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 174
+      ID: 180
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 175
+      ID: 181
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -975,7 +990,7 @@ Types:
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 153
+      ID: 159
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 42720
@@ -1083,7 +1098,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 133
+      ID: 138
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 42336
@@ -1092,25 +1107,31 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 158
       Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Element: 152 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 141
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 107 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 145
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 114 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 154
+      Name: '[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 124 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 153
       Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
@@ -1131,29 +1152,29 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 129 GoSliceDataType []int.array
+      Data: 134 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 129
+      ID: 134
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 149
+      ID: 155
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 134
+      ID: 139
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 141
+      ID: 146
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -1179,9 +1200,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 131 GoSliceDataType []string.array
+      Data: 136 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 131
+      ID: 136
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1202,9 +1223,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 125 GoSliceDataType []uint8.array
+      Data: 130 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 125
+      ID: 130
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1225,41 +1246,41 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 127 GoSliceDataType []uintptr.array
+      Data: 132 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 127
+      ID: 132
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 135
+      ID: 140
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 150
+      ID: 156
       Name: '[]val<main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 151 StructureType main.aStructNotUsedAsAnArgument
+      Element: 157 StructureType main.aStructNotUsedAsAnArgument
     - __kind: ArrayType
-      ID: 137
+      ID: 142
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 138 PointerType *main.bigStruct
+      Element: 143 PointerType *main.bigStruct
     - __kind: ArrayType
-      ID: 142
+      ID: 147
       Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 143 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      Element: 148 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1267,24 +1288,24 @@ Types:
       GoRuntimeType: 39200
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 147
+      ID: 152
       Name: bucket<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 133 ArrayType [8]uint8
+          Type: 138 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 149 ArrayType []key<int>
+          Type: 155 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 150 ArrayType []val<main.aStructNotUsedAsAnArgument>
+          Type: 156 ArrayType []val<main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 136
-          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 151 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
       KeyType: 9 BaseType int
-      ValueType: 151 StructureType main.aStructNotUsedAsAnArgument
+      ValueType: 157 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 107
       Name: bucket<string,int>
@@ -1292,13 +1313,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 133 ArrayType [8]uint8
+          Type: 138 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 134 ArrayType []key<string>
+          Type: 139 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 135 ArrayType []val<int>
+          Type: 140 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 106 PointerType *bucket<string,int>
@@ -1311,18 +1332,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 133 ArrayType [8]uint8
+          Type: 138 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 134 ArrayType []key<string>
+          Type: 139 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 137 ArrayType []val<main.bigStruct>
+          Type: 142 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 113 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 138 PointerType *main.bigStruct
+      ValueType: 143 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 124
+      Name: bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 138 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 139 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 147 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 200
+          Type: 123 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 148 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 119
       Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
@@ -1330,18 +1370,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 133 ArrayType [8]uint8
+          Type: 138 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 141 ArrayType []key<uint8>
+          Type: 146 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 142 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 147 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 80
           Type: 118 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 3 BaseType uint8
-      ValueType: 143 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 148 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -1392,7 +1432,7 @@ Types:
       GoRuntimeType: 52512
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 145
+      ID: 150
       Name: hash<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -1413,18 +1453,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 151 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 146 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 151 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
-      BucketType: 147 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
-      BucketsType: 152 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
+      BucketType: 152 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 158 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 105
       Name: hash<string,int>
@@ -1458,7 +1498,7 @@ Types:
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
       BucketType: 107 GoHMapBucketType bucket<string,int>
-      BucketsType: 136 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 141 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 112
       Name: hash<string,main.bigStruct>
@@ -1492,7 +1532,41 @@ Types:
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
       BucketType: 114 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 140 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 145 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 122
+      Name: hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 123 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 123 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 108 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 154 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 117
       Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
@@ -1526,7 +1600,7 @@ Types:
           Offset: 40
           Type: 108 PointerType *runtime.mapextra
       BucketType: 119 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 148 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketsType: 153 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1651,14 +1725,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 151
+      ID: 157
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 64640
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 139
+      ID: 144
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 112544
@@ -1687,14 +1761,14 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 153 ArrayType [128]uint8
+          Type: 159 ArrayType [128]uint8
     - __kind: GoMapType
-      ID: 143
+      ID: 148
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 55680
       GoKind: 21
-      HeaderType: 145 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 150 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 103
       Name: map[string]int
@@ -1709,6 +1783,13 @@ Types:
       GoRuntimeType: 55872
       GoKind: 21
       HeaderType: 112 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 120
+      Name: map[string]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55968
+      GoKind: 21
+      HeaderType: 122 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 115
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
@@ -2445,13 +2526,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 124 PointerType *string.str
+          Type: 129 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 123 GoStringDataType string.str
+      Data: 128 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 123
+      ID: 128
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -2497,7 +2578,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39264
       GoKind: 26
-MaxTypeID: 179
+MaxTypeID: 185
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x573240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6046", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6090", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 176 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 177 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 182 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5e0e"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 183 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 161 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 162 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 167 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 168 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 173 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a6400", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 165 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 166 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 174 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 175 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 178 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 179 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 163 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 164 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 171 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 172 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 169 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 170 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 180 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 176 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a642a"
-              Frameless: false
             - PC: "0x4a5e0e"
+              Frameless: false
+            - PC: "0x4a642a"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 170 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a6553", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 171 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a65de", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 176 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0x4a5e0e"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 177 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a646a", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 155 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a610a", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 156 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a614a", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 161 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a628a", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 162 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a62d6", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 159 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a620a", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 160 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a624f", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 168 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a64ea", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 169 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a651f", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 172 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a660a", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 173 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a6646", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 157 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a618a", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 158 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a61cf", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 165 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a638a", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 166 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a63d6", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 163 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a630a", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 164 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a634f", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 174 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a6676", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 175 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a682e", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 202 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 193 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 194 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7e0e"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 178 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 179 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a814a", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 182 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 183 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 191 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 192 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 195 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 196 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 180 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 181 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 188 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 189 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 199 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4a842a"
-              Frameless: false
             - PC: "0x4a7e0e"
+              Frameless: false
+            - PC: "0x4a842a"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 193 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 194 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 199 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0x4a7e0e"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 200 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 178 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 179 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a814a", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 184 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 185 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 182 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 183 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 191 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 192 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 195 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 196 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 180 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 181 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 188 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 189 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 186 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 187 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8046", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 202 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8090", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 193 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a8553", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 194 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a85de", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7e0e"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a846a", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 178 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a810a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 179 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a814a", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a828a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a82d6", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 190 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a8400", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 182 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a820a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 183 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a824f", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 191 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a84ea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 192 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a851f", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 195 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a860a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 196 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a8646", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 180 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a818a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 181 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a81cf", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 188 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a838a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 189 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a83d6", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a830a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a834f", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 197 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a883c", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 204 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0x4aea2a"
-              Frameless: false
             - PC: "0x4ae40e"
+              Frameless: false
+            - PC: "0x4aea2a"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 206 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 207 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 204 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae40e"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 205 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 183 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4ae74a", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 189 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 190 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 195 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 187 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 188 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 196 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 197 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 193 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 194 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 191 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 192 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 198 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 199 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 204 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0x4ae40e"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 205 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 183 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 184 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4ae74a", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 189 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 190 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 187 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 188 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 196 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 197 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 200 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 201 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 185 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 186 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 193 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 194 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 191 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 192 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 206 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae646", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 207 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae690", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4aeb53", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4aebde", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 204 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae40e"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 205 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4aea6a", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 183 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4ae70a", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4ae74a", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 189 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4ae88a", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 190 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4ae8d6", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 195 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4aea00", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 187 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4ae80a", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 188 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4ae84f", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 196 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4aeaea", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 197 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4aeb1f", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4aec0a", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4aec46", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4ae78a", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4ae7cf", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 193 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4ae98a", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 194 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4ae9d6", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 191 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4ae90a", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 192 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4ae94f", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 202 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aec76", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4aee44", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 186 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 177 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 178 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 183 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 162 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 163 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5460", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 168 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 169 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 166 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 167 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 175 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 176 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 179 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 180 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 164 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 165 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 172 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 173 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 170 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5628", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 171 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5664", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 186 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 177 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 178 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 183 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 162 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 163 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5460", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 168 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 169 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 166 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 167 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 175 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 176 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 179 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 180 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 164 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 165 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 172 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 173 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 170 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5628", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 171 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5664", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 179 EventRootType Probe[main.PointerChainArg]
+          Type: 185 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5388", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -27,7 +27,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 180 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 186 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb53c0", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -41,12 +41,12 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 171 EventRootType Probe[main.bigMapArg]
+          Type: 177 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          Type: 172 EventRootType Probe[main.bigMapArg]Return
+          Type: 178 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
           Condition: null
     - id: inlined
@@ -61,7 +61,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 177 EventRootType Probe[main.inlined]
+          Type: 183 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb519c"
               Frameless: false
@@ -70,7 +70,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          Type: 178 EventRootType Probe[main.inlined]Return
+          Type: 184 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
           Condition: null
     - id: intArg
@@ -84,12 +84,12 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 156 EventRootType Probe[main.intArg]
+          Type: 162 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          Type: 157 EventRootType Probe[main.intArg]Return
+          Type: 163 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5460", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -103,12 +103,12 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 162 EventRootType Probe[main.intArrayArg]
+          Type: 168 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          Type: 163 EventRootType Probe[main.intArrayArg]Return
+          Type: 169 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -122,7 +122,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 168 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 174 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5720", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -136,12 +136,12 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 160 EventRootType Probe[main.intSliceArg]
+          Type: 166 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          Type: 161 EventRootType Probe[main.intSliceArg]Return
+          Type: 167 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -155,12 +155,12 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 169 EventRootType Probe[main.mapArg]
+          Type: 175 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          Type: 170 EventRootType Probe[main.mapArg]Return
+          Type: 176 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
           Condition: null
     - id: noArgs
@@ -174,12 +174,12 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 173 EventRootType Probe[main.noArgs]
+          Type: 179 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          Type: 174 EventRootType Probe[main.noArgs]Return
+          Type: 180 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -193,12 +193,12 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 158 EventRootType Probe[main.stringArg]
+          Type: 164 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          Type: 159 EventRootType Probe[main.stringArg]Return
+          Type: 165 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
           Condition: null
     - id: stringArrayArg
@@ -212,12 +212,12 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 166 EventRootType Probe[main.stringArrayArg]
+          Type: 172 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          Type: 167 EventRootType Probe[main.stringArrayArg]Return
+          Type: 173 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -231,12 +231,12 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 164 EventRootType Probe[main.stringSliceArg]
+          Type: 170 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5628", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          Type: 165 EventRootType Probe[main.stringSliceArg]Return
+          Type: 171 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5664", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -251,12 +251,12 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 175 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 181 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          Type: 176 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 182 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]
           Condition: null
 Subprograms:
@@ -401,6 +401,11 @@ Subprograms:
           Locations: [{Range: 0xb5990..0xb5b40, Pieces: []}]
           IsParameter: true
           IsReturn: true
+        - Name: m
+          Type: 121 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
+          Locations: [{Range: 0xb5990..0xb5b40, Pieces: []}]
+          IsParameter: false
+          IsReturn: false
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb5730..0xb57a0]
@@ -425,7 +430,7 @@ Subprograms:
           RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: ptr
-          Type: 121 PointerType *****int
+          Type: 126 PointerType *****int
           Locations:
             - Range: 0xb5360..0xb53a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -439,7 +444,7 @@ Subprograms:
           RootRanges: [0xb5000..0xb5410]
       Variables:
         - Name: ptr
-          Type: 123 PointerType **int
+          Type: 128 PointerType **int
           Locations:
             - Range: 0xb53c0..0xb53f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
@@ -447,38 +452,38 @@ Subprograms:
           IsReturn: false
 Types:
     - __kind: PointerType
-      ID: 121
+      ID: 126
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 32960
       GoKind: 22
-      Pointee: 122 PointerType ****int
+      Pointee: 127 PointerType ****int
     - __kind: PointerType
-      ID: 122
+      ID: 127
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 32896
       GoKind: 22
-      Pointee: 155 PointerType ***int
+      Pointee: 161 PointerType ***int
     - __kind: PointerType
-      ID: 155
+      ID: 161
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 32832
       GoKind: 22
-      Pointee: 123 PointerType **int
+      Pointee: 128 PointerType **int
     - __kind: PointerType
-      ID: 123
+      ID: 128
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 32768
       GoKind: 22
       Pointee: 94 PointerType *int
     - __kind: PointerType
-      ID: 131
+      ID: 136
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 130 GoSliceDataType []int.array
+      Pointee: 135 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -487,20 +492,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 133
+      ID: 138
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []string.array
+      Pointee: 137 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 127
+      ID: 132
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 126 GoSliceDataType []uint8.array
+      Pointee: 131 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 129
+      ID: 134
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 128 GoSliceDataType []uintptr.array
+      Pointee: 133 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -509,10 +514,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 147
+      ID: 152
       Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 153 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,int>'
@@ -523,6 +528,11 @@ Types:
       Name: '*bucket<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 115 GoHMapBucketType bucket<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 124
+      Name: '*bucket<string,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 125 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 119
       Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
@@ -550,10 +560,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 145
+      ID: 150
       Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 146 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 151 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*hash<string,int>'
@@ -564,6 +574,11 @@ Types:
       Name: '*hash<string,main.bigStruct>'
       ByteSize: 8
       Pointee: 113 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: PointerType
+      ID: 122
+      Name: '*hash<string,map[int]main.aStructNotUsedAsAnArgument>'
+      ByteSize: 8
+      Pointee: 123 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 117
       Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
@@ -591,12 +606,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 139
+      ID: 144
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24704
       GoKind: 22
-      Pointee: 140 StructureType main.bigStruct
+      Pointee: 145 StructureType main.bigStruct
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -675,10 +690,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 125
+      ID: 130
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 124 GoStringDataType string.str
+      Pointee: 129 GoStringDataType string.str
     - __kind: PointerType
       ID: 98
       Name: '*uint'
@@ -722,7 +737,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 179
+      ID: 185
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -731,14 +746,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 121 PointerType *****int
+            Type: 126 PointerType *****int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 180
+      ID: 186
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -747,14 +762,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 123 PointerType **int
+            Type: 128 PointerType **int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 171
+      ID: 177
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -770,10 +785,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 172
+      ID: 178
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 177
+      ID: 183
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -789,10 +804,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 178
+      ID: 184
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 156
+      ID: 162
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -808,10 +823,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 157
+      ID: 163
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 162
+      ID: 168
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -827,10 +842,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 163
+      ID: 169
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 160
+      ID: 166
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -846,10 +861,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 161
+      ID: 167
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 169
+      ID: 175
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -865,16 +880,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 170
+      ID: 176
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 173
+      ID: 179
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 174
+      ID: 180
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 158
+      ID: 164
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -890,10 +905,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 159
+      ID: 165
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 168
+      ID: 174
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -909,7 +924,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 166
+      ID: 172
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -925,10 +940,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 167
+      ID: 173
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 164
+      ID: 170
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -944,13 +959,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 165
+      ID: 171
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 175
+      ID: 181
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 176
+      ID: 182
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -975,7 +990,7 @@ Types:
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 154
+      ID: 160
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 42688
@@ -1083,7 +1098,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 134
+      ID: 139
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 42304
@@ -1092,25 +1107,31 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 159
       Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Element: 153 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 142
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 108 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 146
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 155
+      Name: '[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array'
+      DynamicSizeClass: hashmap
+      ByteSize: 208
+      Element: 125 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+    - __kind: GoSliceDataType
+      ID: 154
       Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
@@ -1131,29 +1152,29 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 130 GoSliceDataType []int.array
+      Data: 135 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 130
+      ID: 135
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 150
+      ID: 156
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 135
+      ID: 140
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 142
+      ID: 147
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -1179,9 +1200,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 132 GoSliceDataType []string.array
+      Data: 137 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 137
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -1202,9 +1223,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 126 GoSliceDataType []uint8.array
+      Data: 131 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 126
+      ID: 131
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -1225,41 +1246,41 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 128 GoSliceDataType []uintptr.array
+      Data: 133 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 128
+      ID: 133
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 136
+      ID: 141
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 151
+      ID: 157
       Name: '[]val<main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 152 StructureType main.aStructNotUsedAsAnArgument
+      Element: 158 StructureType main.aStructNotUsedAsAnArgument
     - __kind: ArrayType
-      ID: 138
+      ID: 143
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 139 PointerType *main.bigStruct
+      Element: 144 PointerType *main.bigStruct
     - __kind: ArrayType
-      ID: 143
+      ID: 148
       Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 144 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      Element: 149 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -1267,24 +1288,24 @@ Types:
       GoRuntimeType: 39168
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 148
+      ID: 153
       Name: bucket<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 134 ArrayType [8]uint8
+          Type: 139 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<int>
+          Type: 156 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 151 ArrayType []val<main.aStructNotUsedAsAnArgument>
+          Type: 157 ArrayType []val<main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 136
-          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 152 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
       KeyType: 9 BaseType int
-      ValueType: 152 StructureType main.aStructNotUsedAsAnArgument
+      ValueType: 158 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 108
       Name: bucket<string,int>
@@ -1292,13 +1313,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 134 ArrayType [8]uint8
+          Type: 139 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 135 ArrayType []key<string>
+          Type: 140 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 136 ArrayType []val<int>
+          Type: 141 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 107 PointerType *bucket<string,int>
@@ -1311,18 +1332,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 134 ArrayType [8]uint8
+          Type: 139 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 135 ArrayType []key<string>
+          Type: 140 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 138 ArrayType []val<main.bigStruct>
+          Type: 143 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 114 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 139 PointerType *main.bigStruct
+      ValueType: 144 PointerType *main.bigStruct
+    - __kind: GoHMapBucketType
+      ID: 125
+      Name: bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 208
+      RawFields:
+        - Name: tophash
+          Offset: 0
+          Type: 139 ArrayType [8]uint8
+        - Name: keys
+          Offset: 8
+          Type: 140 ArrayType []key<string>
+        - Name: values
+          Offset: 136
+          Type: 148 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+        - Name: overflow
+          Offset: 200
+          Type: 124 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      KeyType: 10 GoStringHeaderType string
+      ValueType: 149 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 120
       Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
@@ -1330,18 +1370,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 134 ArrayType [8]uint8
+          Type: 139 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 142 ArrayType []key<uint8>
+          Type: 147 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 143 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 148 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 80
           Type: 119 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 3 BaseType uint8
-      ValueType: 144 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 149 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -1392,7 +1432,7 @@ Types:
       GoRuntimeType: 52384
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 146
+      ID: 151
       Name: hash<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -1413,18 +1453,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 152 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 147 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 152 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 148 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
-      BucketsType: 153 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
+      BucketType: 153 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 159 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 106
       Name: hash<string,int>
@@ -1458,7 +1498,7 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,int>
-      BucketsType: 137 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 142 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 113
       Name: hash<string,main.bigStruct>
@@ -1492,7 +1532,41 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 115 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 141 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 146 GoSliceDataType []bucket<string,main.bigStruct>.array
+    - __kind: GoHMapHeaderType
+      ID: 123
+      Name: hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      ByteSize: 48
+      RawFields:
+        - Name: count
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: flags
+          Offset: 8
+          Type: 3 BaseType uint8
+        - Name: B
+          Offset: 9
+          Type: 3 BaseType uint8
+        - Name: noverflow
+          Offset: 10
+          Type: 7 BaseType uint16
+        - Name: hash0
+          Offset: 12
+          Type: 2 BaseType uint32
+        - Name: buckets
+          Offset: 16
+          Type: 124 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: oldbuckets
+          Offset: 24
+          Type: 124 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+        - Name: nevacuate
+          Offset: 32
+          Type: 1 BaseType uintptr
+        - Name: extra
+          Offset: 40
+          Type: 109 PointerType *runtime.mapextra
+      BucketType: 125 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 155 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 118
       Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
@@ -1526,7 +1600,7 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 120 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 149 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketsType: 154 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -1657,14 +1731,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 152
+      ID: 158
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 64512
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 140
+      ID: 145
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 112416
@@ -1693,14 +1767,14 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 154 ArrayType [128]uint8
+          Type: 160 ArrayType [128]uint8
     - __kind: GoMapType
-      ID: 144
+      ID: 149
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 55552
       GoKind: 21
-      HeaderType: 146 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 151 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
@@ -1715,6 +1789,13 @@ Types:
       GoRuntimeType: 55744
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
+    - __kind: GoMapType
+      ID: 121
+      Name: map[string]map[int]main.aStructNotUsedAsAnArgument
+      ByteSize: 8
+      GoRuntimeType: 55840
+      GoKind: 21
+      HeaderType: 123 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 116
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
@@ -2451,13 +2532,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 125 PointerType *string.str
+          Type: 130 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 124 GoStringDataType string.str
+      Data: 129 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 124
+      ID: 129
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -2503,7 +2584,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39232
       GoKind: 26
-MaxTypeID: 180
+MaxTypeID: 186
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 177 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb5748"
-              Frameless: false
             - PC: "0xb519c"
+              Frameless: false
+            - PC: "0xb5748"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 171 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb5880", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 172 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb58f4", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 177 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0xb519c"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 178 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb5780", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 156 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 157 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5460", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 162 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb55a8", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 163 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb55ec", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 160 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5518", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 161 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5554", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 169 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5808", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 170 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb5838", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 173 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb5938", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 174 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb5970", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 158 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5498", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 159 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb54d4", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 166 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb56b8", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 167 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb56fc", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 164 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5628", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 165 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5664", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 175 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb59b0", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 176 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb5b24", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 202 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 203 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 194 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 195 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb502c"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 179 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb52b8", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 180 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb52f0", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 186 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 191 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 183 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 192 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 193 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 196 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 197 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 181 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 182 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5364", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 189 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 190 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 188 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 202 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb520c", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 203 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb5244", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 194 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 195 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb502c"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 179 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb52b8", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 180 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb52f0", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 186 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 191 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb5590", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 183 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 192 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 193 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 196 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 197 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 181 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 182 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5364", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 189 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 190 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 188 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 200 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb55b8"
-              Frameless: false
             - PC: "0xb502c"
+              Frameless: false
+            - PC: "0xb55b8"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 194 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb56f0", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 195 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb5764", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 200 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0xb502c"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 201 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb55f0", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 179 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb52b8", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 180 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb52f0", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 185 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5428", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 186 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb546c", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 183 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb53a8", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 184 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb53e4", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 192 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb5678", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 193 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb56a8", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 196 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb57a8", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 197 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb57e0", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 181 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5328", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 182 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5364", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 189 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5528", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 190 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb556c", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 187 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb54a8", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 188 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb54e4", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 198 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb5820", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 199 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb59a0", Frameless: false}]

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,6 +12,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
+          SourceLine: ""
           Type: 207 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
@@ -27,6 +28,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
+          SourceLine: ""
           Type: 208 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
@@ -41,11 +43,13 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
+          SourceLine: ""
           Type: 199 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
+          SourceLine: ""
           Type: 200 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
           Condition: null
@@ -61,6 +65,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
+          SourceLine: ""
           Type: 205 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7bc8"
@@ -70,6 +75,7 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
+          SourceLine: ""
           Type: 206 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
           Condition: null
@@ -84,11 +90,13 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
+          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb7e38", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
+          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb7e6c", Frameless: false}]
           Condition: null
@@ -103,11 +111,13 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
+          SourceLine: ""
           Type: 190 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
+          SourceLine: ""
           Type: 191 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
           Condition: null
@@ -122,6 +132,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
+          SourceLine: ""
           Type: 196 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
@@ -136,11 +147,13 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
+          SourceLine: ""
           Type: 188 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
+          SourceLine: ""
           Type: 189 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
           Condition: null
@@ -155,11 +168,13 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
+          SourceLine: ""
           Type: 197 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
+          SourceLine: ""
           Type: 198 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
           Condition: null
@@ -174,11 +189,13 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
+          SourceLine: ""
           Type: 201 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
+          SourceLine: ""
           Type: 202 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
           Condition: null
@@ -193,11 +210,13 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
+          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
+          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
           Condition: null
@@ -212,11 +231,13 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
+          SourceLine: ""
           Type: 194 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
+          SourceLine: ""
           Type: 195 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
           Condition: null
@@ -231,11 +252,13 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
+          SourceLine: ""
           Type: 192 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb8008", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
+          SourceLine: ""
           Type: 193 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb8040", Frameless: false}]
           Condition: null
@@ -251,11 +274,13 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
+          SourceLine: ""
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
+          SourceLine: ""
           Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -63,9 +63,9 @@ Probes:
           Kind: Entry
           Type: 205 EventRootType Probe[main.inlined]
           InjectionPoints:
-            - PC: "0xb8108"
-              Frameless: false
             - PC: "0xb7bc8"
+              Frameless: false
+            - PC: "0xb8108"
               Frameless: false
           Condition: null
         - ID: 22

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,7 +12,6 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          SourceLine: ""
           Type: 207 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7da0", Frameless: false}]
           Condition: null
@@ -28,7 +27,6 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          SourceLine: ""
           Type: 208 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7dd4", Frameless: false}]
           Condition: null
@@ -43,13 +41,11 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          SourceLine: ""
           Type: 199 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
         - ID: 16
           Kind: Return
-          SourceLine: ""
           Type: 200 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
           Condition: null
@@ -65,7 +61,6 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          SourceLine: ""
           Type: 205 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7bc8"
@@ -75,7 +70,6 @@ Probes:
           Condition: null
         - ID: 22
           Kind: Return
-          SourceLine: ""
           Type: 206 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
           Condition: null
@@ -90,13 +84,11 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          SourceLine: ""
           Type: 184 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb7e38", Frameless: false}]
           Condition: null
         - ID: 1
           Kind: Return
-          SourceLine: ""
           Type: 185 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb7e6c", Frameless: false}]
           Condition: null
@@ -111,13 +103,11 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          SourceLine: ""
           Type: 190 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
         - ID: 7
           Kind: Return
-          SourceLine: ""
           Type: 191 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
           Condition: null
@@ -132,7 +122,6 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          SourceLine: ""
           Type: 196 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb80e0", Frameless: true}]
           Condition: null
@@ -147,13 +136,11 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          SourceLine: ""
           Type: 188 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
         - ID: 5
           Kind: Return
-          SourceLine: ""
           Type: 189 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
           Condition: null
@@ -168,13 +155,11 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          SourceLine: ""
           Type: 197 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
         - ID: 14
           Kind: Return
-          SourceLine: ""
           Type: 198 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
           Condition: null
@@ -189,13 +174,11 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          SourceLine: ""
           Type: 201 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
         - ID: 18
           Kind: Return
-          SourceLine: ""
           Type: 202 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
           Condition: null
@@ -210,13 +193,11 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          SourceLine: ""
           Type: 186 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
         - ID: 3
           Kind: Return
-          SourceLine: ""
           Type: 187 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
           Condition: null
@@ -231,13 +212,11 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          SourceLine: ""
           Type: 194 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
         - ID: 11
           Kind: Return
-          SourceLine: ""
           Type: 195 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
           Condition: null
@@ -252,13 +231,11 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          SourceLine: ""
           Type: 192 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb8008", Frameless: false}]
           Condition: null
         - ID: 9
           Kind: Return
-          SourceLine: ""
           Type: 193 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb8040", Frameless: false}]
           Condition: null
@@ -274,13 +251,11 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          SourceLine: ""
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
         - ID: 20
           Kind: Return
-          SourceLine: ""
           Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]
           Condition: null

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -39,12 +39,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 9}
       events:
-        - ID: 16
+        - ID: 17
           Kind: Entry
           Type: 199 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8240", Frameless: false}]
           Condition: null
-        - ID: 17
+        - ID: 16
           Kind: Return
           Type: 200 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb82b0", Frameless: false}]
@@ -59,7 +59,7 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 12}
       events:
-        - ID: 22
+        - ID: 23
           Kind: Entry
           Type: 205 EventRootType Probe[main.inlined]
           InjectionPoints:
@@ -68,7 +68,7 @@ Probes:
             - PC: "0xb7bc8"
               Frameless: false
           Condition: null
-        - ID: 23
+        - ID: 22
           Kind: Return
           Type: 206 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb813c", Frameless: false}]
@@ -82,12 +82,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 1
+        - ID: 2
           Kind: Entry
           Type: 184 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb7e38", Frameless: false}]
           Condition: null
-        - ID: 2
+        - ID: 1
           Kind: Return
           Type: 185 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb7e6c", Frameless: false}]
@@ -101,12 +101,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 7
+        - ID: 8
           Kind: Entry
           Type: 190 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb7f98", Frameless: false}]
           Condition: null
-        - ID: 8
+        - ID: 7
           Kind: Return
           Type: 191 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb7fd8", Frameless: false}]
@@ -134,12 +134,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 5
+        - ID: 6
           Kind: Entry
           Type: 188 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb7f18", Frameless: false}]
           Condition: null
-        - ID: 6
+        - ID: 5
           Kind: Return
           Type: 189 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb7f50", Frameless: false}]
@@ -153,12 +153,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 8}
       events:
-        - ID: 14
+        - ID: 15
           Kind: Entry
           Type: 197 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb81c8", Frameless: false}]
           Condition: null
-        - ID: 15
+        - ID: 14
           Kind: Return
           Type: 198 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb81f4", Frameless: false}]
@@ -172,12 +172,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 10}
       events:
-        - ID: 18
+        - ID: 19
           Kind: Entry
           Type: 201 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb82e8", Frameless: false}]
           Condition: null
-        - ID: 19
+        - ID: 18
           Kind: Return
           Type: 202 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb831c", Frameless: false}]
@@ -191,12 +191,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 3
+        - ID: 4
           Kind: Entry
           Type: 186 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
           Condition: null
-        - ID: 4
+        - ID: 3
           Kind: Return
           Type: 187 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb7ee0", Frameless: false}]
@@ -210,12 +210,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 11
+        - ID: 12
           Kind: Entry
           Type: 194 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8088", Frameless: false}]
           Condition: null
-        - ID: 12
+        - ID: 11
           Kind: Return
           Type: 195 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb80c8", Frameless: false}]
@@ -229,12 +229,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 9
+        - ID: 10
           Kind: Entry
           Type: 192 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb8008", Frameless: false}]
           Condition: null
-        - ID: 10
+        - ID: 9
           Kind: Return
           Type: 193 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb8040", Frameless: false}]
@@ -249,12 +249,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 11}
       events:
-        - ID: 20
+        - ID: 21
           Kind: Entry
           Type: 203 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb8360", Frameless: false}]
           Condition: null
-        - ID: 21
+        - ID: 20
           Kind: Return
           Type: 204 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb84d8", Frameless: false}]

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -107,7 +107,7 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 		return fmt.Errorf("unknown event pairing expectation: %d", evHeader.Event_pairing_expectation)
 	}
 	decodedBytes, probe, err = s.decoder.Decode(decode.Event{
-		Entry:       entryEvent,
+		EntryOrLine: entryEvent,
 		Return:      returnEvent,
 		ServiceName: s.service,
 	}, s.symbolicator, decodedBytes)

--- a/pkg/dyninst/rcjson/rcjson_test.go
+++ b/pkg/dyninst/rcjson/rcjson_test.go
@@ -38,6 +38,63 @@ var testCases = []testCase{
 				"type": "LOG_PROBE",
 				"version": 1,
 				"where": {
+					"methodName": "MyMethod",
+					"sourceFile": "myfile.go",
+					"lines": ["10"]
+				},
+				"tags": ["tag1", "tag2"],
+				"language": "go",
+				"template": "Hello {name}",
+				"segments": [{"str": "Hello "}, {"dsl": "name", "json": {"ref": "name"}}],
+				"capture": {
+					"maxReferenceDepth": 3,
+					"maxLength": 123,
+					"maxCollectionSize": 100
+				},
+				"sampling": {
+					"snapshotsPerSecond": 1.0
+				},
+				"evaluateAt": "entry"
+			}`,
+		want: &LogProbe{
+			LogProbeCommon: LogProbeCommon{
+				ProbeCommon: ProbeCommon{
+					ID:      "log-probe-1",
+					Version: 1,
+					Type:    TypeLogProbe.String(),
+					Where: &Where{
+						MethodName: "MyMethod",
+						SourceFile: "myfile.go",
+						Lines:      []string{"10"},
+					},
+					Tags:       []string{"tag1", "tag2"},
+					Language:   "go",
+					EvaluateAt: "entry",
+				},
+				Capture: &Capture{
+					MaxReferenceDepth: intPtr(3),
+					MaxLength:         intPtr(123),
+					MaxCollectionSize: intPtr(100),
+				},
+				Sampling: &Sampling{
+					SnapshotsPerSecond: 1.0,
+				},
+				Template: "Hello {name}",
+				Segments: []json.RawMessage{
+					json.RawMessage(`{"str": "Hello "}`),
+					json.RawMessage(`{"dsl": "name", "json": {"ref": "name"}}`),
+				},
+			},
+		},
+	},
+	{
+		name: "log probe with file and multiple lines",
+		input: `{
+				"id": "log-probe-1",
+				"type": "LOG_PROBE",
+				"version": 1,
+				"where": {
+					"methodName": "MyMethod",
 					"sourceFile": "myfile.go",
 					"lines": ["10", "20"]
 				},
@@ -55,7 +112,6 @@ var testCases = []testCase{
 				},
 				"evaluateAt": "entry"
 			}`,
-		validationErr: `sourceFile and lines are not supported`,
 		want: &LogProbe{
 			LogProbeCommon: LogProbeCommon{
 				ProbeCommon: ProbeCommon{
@@ -63,6 +119,7 @@ var testCases = []testCase{
 					Version: 1,
 					Type:    TypeLogProbe.String(),
 					Where: &Where{
+						MethodName: "MyMethod",
 						SourceFile: "myfile.go",
 						Lines:      []string{"10", "20"},
 					},
@@ -85,6 +142,7 @@ var testCases = []testCase{
 				},
 			},
 		},
+		validationErr: `lines must be a single line number`,
 	},
 	{
 		name: "log probe with method and signature",

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -5,14 +5,14 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: o: main.outer (declared at line 204, available: )
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: o: main.outer (declared at line 225, available: )
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -172,9 +172,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:52]
@@ -213,16 +213,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -283,18 +283,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -359,14 +359,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -403,8 +407,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -417,8 +421,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -582,10 +586,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -5,13 +5,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -160,9 +160,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -202,16 +202,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -272,18 +272,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -348,14 +348,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -392,8 +396,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -406,8 +410,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -571,10 +575,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -5,13 +5,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -159,9 +159,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -201,16 +201,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -271,18 +271,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -347,14 +347,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -391,8 +395,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -405,8 +409,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -570,10 +574,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -5,14 +5,14 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: o: main.outer (declared at line 204, available: )
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: o: main.outer (declared at line 225, available: )
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -172,9 +172,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [16:18]
 		Arg: value: int (declared at line 16, available: [16-17])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:52]
@@ -213,16 +213,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -283,18 +283,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -359,14 +359,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -403,8 +407,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -417,8 +421,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -582,10 +586,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -5,13 +5,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -160,9 +160,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -202,16 +202,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -272,18 +272,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -348,14 +348,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -392,8 +396,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -406,8 +410,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -571,10 +575,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -5,13 +5,13 @@ Package: main
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [98:123]
 	Function: executeBasicFuncs (main.executeBasicFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [76:95]
-	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [203:267]
-		Var: s: []*string (declared at line 215, available: )
-		Var: str: string (declared at line 214, available: [203-267])
-		Var: circ: main.circularReferenceType (declared at line 236, available: [203-267])
-		Var: s1: main.stringType1 (declared at line 262, available: [257-267])
-		Var: s2: main.stringType2 (declared at line 263, available: [257-267])
-		Var: s2p: *main.stringType2 (declared at line 264, available: [257-267])
+	Function: executeComplexFuncs (main.executeComplexFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [224:290]
+		Var: s: []*string (declared at line 236, available: )
+		Var: str: string (declared at line 235, available: [224-290])
+		Var: circ: main.circularReferenceType (declared at line 257, available: [224-290])
+		Var: s1: main.stringType1 (declared at line 283, available: [278-290])
+		Var: s2: main.stringType2 (declared at line 284, available: [278-290])
+		Var: s2p: *main.stringType2 (declared at line 285, available: [278-290])
 	Function: executeEsoteric (main.executeEsoteric) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/esoteric.go [51:69]
 		Var: &capture: *int (declared at line 52, available: [51-69])
 		Var: esotericHeap: *main.esotericHeap (declared at line 61, available: [61-62], [68-69])
@@ -159,9 +159,9 @@ Package: main
 		Var: result: map[string][]main.structWithMap (declared at line 98, available: [97-107])
 		Scope: 97-107
 			Var: i: int (declared at line 99, available: [97-107])
-	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [113:113]
-	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [139:139]
-	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [177:177]
+	Function: init.0 (main.init.0) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [114:114]
+	Function: init.1 (main.init.1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [140:140]
+	Function: init.2 (main.init.2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [178:178]
 	Function: iterExample.rangeOverIterator-range1 (main.iterExample.rangeOverIterator-range1) in  [16:0]
 		Arg: #r: bool (declared at line 0, available: )
 		Var: #tmpState: int (declared at line 0, available: )
@@ -201,16 +201,16 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
-	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [81:81]
-		Arg: b: main.bigStruct (declared at line 81, available: [81-81])
+	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82]
+		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
 	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18]
 		Arg: c: chan bool (declared at line 18, available: [18-18])
-	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [89:89]
-		Arg: x: main.circularReferenceType (declared at line 89, available: [89-89])
+	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90]
+		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34]
 		Arg: w: uint8 (declared at line 34, available: [34-34])
 		Arg: x: bool (declared at line 34, available: [34-34])
@@ -271,18 +271,18 @@ Package: main
 		Arg: z: *main.reallyComplexType (declared at line 75, available: [75-75])
 	Function: testCycle (main.testCycle) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [109:109]
 		Arg: t: *main.t (declared at line 109, available: [109-109])
-	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [180:180]
-		Arg: a: main.deepMap1 (declared at line 180, available: [180-180])
-	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [183:183]
-		Arg: a: *main.deepMap7 (declared at line 183, available: [183-183])
-	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [116:116]
-		Arg: a: main.deepPtr1 (declared at line 116, available: [116-116])
-	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [119:119]
-		Arg: a: *main.deepPtr7 (declared at line 119, available: [119-119])
-	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [142:142]
-		Arg: a: main.deepSlice1 (declared at line 142, available: [142-142])
-	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [145:145]
-		Arg: a: *main.deepSlice7 (declared at line 145, available: [145-145])
+	Function: testDeepMap1 (main.testDeepMap1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [181:181]
+		Arg: a: main.deepMap1 (declared at line 181, available: [181-181])
+	Function: testDeepMap7 (main.testDeepMap7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [184:184]
+		Arg: a: *main.deepMap7 (declared at line 184, available: [184-184])
+	Function: testDeepPtr1 (main.testDeepPtr1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [117:117]
+		Arg: a: main.deepPtr1 (declared at line 117, available: [117-117])
+	Function: testDeepPtr7 (main.testDeepPtr7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [120:120]
+		Arg: a: *main.deepPtr7 (declared at line 120, available: [120-120])
+	Function: testDeepSlice1 (main.testDeepSlice1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [143:143]
+		Arg: a: main.deepSlice1 (declared at line 143, available: [143-143])
+	Function: testDeepSlice7 (main.testDeepSlice7) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [146:146]
+		Arg: a: *main.deepSlice7 (declared at line 146, available: [146-146])
 	Function: testDeepStruct (main.testDeepStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [120:120]
 		Arg: t: main.deepStruct1 (declared at line 120, available: [120-120])
 	Function: testEmptySlice (main.testEmptySlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [33:33]
@@ -347,14 +347,18 @@ Package: main
 		Arg: x: [2]int (declared at line 30, available: [30-30])
 	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:50]
 		Arg: b: main.behavior (declared at line 50, available: [50-50])
-	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [93:93]
-		Arg: a: int (declared at line 93, available: [93-93])
-		Arg: b: error (declared at line 93, available: [93-93])
-		Arg: c: uint (declared at line 93, available: [93-93])
-	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [63:63]
-		Arg: a: main.interfaceComplexityA (declared at line 63, available: [63-63])
+	Function: testInterfaceAndInt (main.testInterfaceAndInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [94:94]
+		Arg: a: int (declared at line 94, available: [94-94])
+		Arg: b: error (declared at line 94, available: [94-94])
+		Arg: c: uint (declared at line 94, available: [94-94])
+	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64]
+		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
+	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221]
+		Var: s: int (declared at line 205, available: [215-215], [220-220])
+		Var: a: int (declared at line 206, available: [204-221])
+		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34]
@@ -391,8 +395,8 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42]
 		Arg: x: string (declared at line 42, available: [42-42])
-	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [71:71]
-		Arg: o: main.outer (declared at line 71, available: [71-71])
+	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72]
+		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
 	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76]
@@ -405,8 +409,8 @@ Package: main
 		Arg: c: int32 (declared at line 78, available: [78-78])
 		Arg: d: uint (declared at line 78, available: [78-78])
 		Arg: e: string (declared at line 78, available: [78-78])
-	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [67:67]
-		Arg: a: main.tierA (declared at line 67, available: [67-67])
+	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68]
+		Arg: a: main.tierA (declared at line 68, available: [68-68])
 	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68]
 		Arg: i: int (declared at line 65, available: [65-68])
 		Arg: result: int (declared at line 65, available: )
@@ -570,10 +574,10 @@ Package: main
 		Arg: a: *[]string (declared at line 95, available: [95-95])
 	Function: testStringStruct (main.testStringStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [116:116]
 		Arg: t: main.threestrings (declared at line 116, available: [116-116])
-	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [194:194]
-		Arg: a: *main.stringType1 (declared at line 194, available: [194-194])
-	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [200:200]
-		Arg: a: **main.stringType2 (declared at line 200, available: [200-200])
+	Function: testStringType1 (main.testStringType1) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [195:195]
+		Arg: a: *main.stringType1 (declared at line 195, available: [195-195])
+	Function: testStringType2 (main.testStringType2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [201:201]
+		Arg: a: **main.stringType2 (declared at line 201, available: [201-201])
 	Function: testStruct (main.testStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [84:84]
 		Arg: x: main.aStruct (declared at line 84, available: [84-84])
 	Function: testStructAndByte (main.testStructAndByte) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [104:104]

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testBigStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 81
+            "lineNumber": 82
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 217
+            "lineNumber": 238
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 180
+            "lineNumber": 181
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 259
+            "lineNumber": 280
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepMap7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepMap7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 183
+            "lineNumber": 184
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 260
+            "lineNumber": 281
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 116
+            "lineNumber": 117
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 253
+            "lineNumber": 274
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepPtr7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepPtr7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 119
+            "lineNumber": 120
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 254
+            "lineNumber": 275
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 142
+            "lineNumber": 143
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 256
+            "lineNumber": 277
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
+++ b/pkg/dyninst/testdata/decoded/sample/testDeepSlice7.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testDeepSlice7",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 145
+            "lineNumber": 146
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 257
+            "lineNumber": 278
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -50,37 +50,39 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "[5]int",
-                "size": "5",
-                "elements": [
-                  {
-                    "type": "int",
-                    "value": "1"
-                  },
-                  {
-                    "type": "int",
-                    "value": "2"
-                  },
-                  {
-                    "type": "int",
-                    "value": "3"
-                  },
-                  {
-                    "type": "int",
-                    "value": "4"
-                  },
-                  {
-                    "type": "int",
-                    "value": "5"
-                  }
-                ]
-              },
-              "~r0": {
-                "type": "int",
-                "notCapturedReason": "unavailable"
+          "lines": {
+            "93": {
+              "locals": {
+                "a": {
+                  "type": "[5]int",
+                  "size": "5",
+                  "elements": [
+                    {
+                      "type": "int",
+                      "value": "1"
+                    },
+                    {
+                      "type": "int",
+                      "value": "2"
+                    },
+                    {
+                      "type": "int",
+                      "value": "3"
+                    },
+                    {
+                      "type": "int",
+                      "value": "4"
+                    },
+                    {
+                      "type": "int",
+                      "value": "5"
+                    }
+                  ]
+                },
+                "~r0": {
+                  "type": "int",
+                  "notCapturedReason": "unavailable"
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArrayLine.json
@@ -1,0 +1,92 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testFramelessArray",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testFramelessArray",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 93
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 105
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testFramelessArrayLine",
+          "location": {
+            "method": "main.testFramelessArray",
+            "file": "inlined.go",
+            "line": 93
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "[5]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  {
+                    "type": "int",
+                    "value": "5"
+                  }
+                ]
+              },
+              "~r0": {
+                "type": "int",
+                "notCapturedReason": "unavailable"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -1,0 +1,67 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBCA",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBCA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 63
+          },
+          {
+            "function": "main.testInlinedBC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 53
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBCALine",
+          "location": {
+            "method": "main.testInlinedBCA",
+            "file": "inlined.go",
+            "line": 63
+          }
+        },
+        "captures": {}
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCALine.json
@@ -59,7 +59,11 @@
             "line": 63
           }
         },
-        "captures": {}
+        "captures": {
+          "lines": {
+            "63": {}
+          }
+        }
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -1,0 +1,67 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedBCB",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedBCB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 67
+          },
+          {
+            "function": "main.testInlinedBC",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 59
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 24
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedBCBLine",
+          "location": {
+            "method": "main.testInlinedBCB",
+            "file": "inlined.go",
+            "line": 67
+          }
+        },
+        "captures": {}
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCBLine.json
@@ -59,7 +59,11 @@
             "line": 67
           }
         },
-        "captures": {}
+        "captures": {
+          "lines": {
+            "67": {}
+          }
+        }
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -55,11 +55,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "25"
+          "lines": {
+            "14": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "25"
+                }
               }
             }
           }
@@ -129,11 +131,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "3"
+          "lines": {
+            "14": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "3"
+                }
               }
             }
           }
@@ -203,11 +207,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "150"
+          "lines": {
+            "14": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "150"
+                }
               }
             }
           }
@@ -282,11 +288,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "150"
+          "lines": {
+            "14": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "150"
+                }
               }
             }
           }
@@ -351,11 +359,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "1"
+          "lines": {
+            "14": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "1"
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedPrintLine.json
@@ -1,0 +1,367 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 101
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrintLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "25"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrintLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 39
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrintLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "150"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 45
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrintLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "150"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.forceOutOfLine",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 103
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedPrintLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testStringType2",
+      "method": "main.testInlinedSq",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,19 +16,24 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testStringType2",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 201
+            "function": "main.testInlinedSq",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 75
           },
           {
-            "function": "main.executeComplexFuncs",
-            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 287
+            "function": "main.testFrameless",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 80
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 104
           },
           {
             "function": "main.main",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
-            "lineNumber": 36
+            "lineNumber": 34
           },
           {
             "function": "runtime.main",
@@ -42,17 +47,19 @@
           }
         ],
         "probe": {
-          "id": "testStringType2",
+          "id": "testInlinedSqLine",
           "location": {
-            "method": "main.testStringType2"
+            "method": "main.testInlinedSq",
+            "file": "inlined.go",
+            "line": 75
           }
         },
         "captures": {
           "entry": {
-            "arguments": {
-              "a": {
-                "type": "**main.stringType2",
-                "notCapturedReason": "depth"
+            "locals": {
+              "x": {
+                "type": "int",
+                "value": "10"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedSqLine.json
@@ -55,11 +55,13 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "x": {
-                "type": "int",
-                "value": "10"
+          "lines": {
+            "75": {
+              "locals": {
+                "x": {
+                  "type": "int",
+                  "value": "10"
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testStringType2",
+      "method": "main.testLongFunctionWithChangingState",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testStringType2",
+            "function": "main.testLongFunctionWithChangingState",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 201
+            "lineNumber": 208
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 287
+            "lineNumber": 289
           },
           {
             "function": "main.main",
@@ -42,21 +42,14 @@
           }
         ],
         "probe": {
-          "id": "testStringType2",
+          "id": "testLongFunctionWithChangingStateLineA",
           "location": {
-            "method": "main.testStringType2"
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 208
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {
-              "a": {
-                "type": "**main.stringType2",
-                "notCapturedReason": "depth"
-              }
-            }
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineA.json
@@ -49,7 +49,11 @@
             "line": 208
           }
         },
-        "captures": {}
+        "captures": {
+          "lines": {
+            "208": {}
+          }
+        }
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -1,0 +1,682 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "1"
+              },
+              "b": {
+                "type": "int",
+                "value": "1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "1"
+              },
+              "b": {
+                "type": "int",
+                "value": "1"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "2"
+              },
+              "b": {
+                "type": "int",
+                "value": "2"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "3"
+              },
+              "b": {
+                "type": "int",
+                "value": "3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "5"
+              },
+              "b": {
+                "type": "int",
+                "value": "5"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "8"
+              },
+              "b": {
+                "type": "int",
+                "value": "8"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "13"
+              },
+              "b": {
+                "type": "int",
+                "value": "13"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "21"
+              },
+              "b": {
+                "type": "int",
+                "value": "21"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "34"
+              },
+              "b": {
+                "type": "int",
+                "value": "34"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 215
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineB",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 215
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "55"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineB.json
@@ -50,15 +50,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "1"
-              },
-              "b": {
-                "type": "int",
-                "value": "1"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "1"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "1"
+                }
               }
             }
           }
@@ -118,15 +120,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "1"
-              },
-              "b": {
-                "type": "int",
-                "value": "1"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "1"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "1"
+                }
               }
             }
           }
@@ -186,15 +190,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "2"
-              },
-              "b": {
-                "type": "int",
-                "value": "2"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "2"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "2"
+                }
               }
             }
           }
@@ -254,15 +260,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "3"
-              },
-              "b": {
-                "type": "int",
-                "value": "3"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "3"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "3"
+                }
               }
             }
           }
@@ -322,15 +330,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "5"
-              },
-              "b": {
-                "type": "int",
-                "value": "5"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "5"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "5"
+                }
               }
             }
           }
@@ -390,15 +400,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "8"
-              },
-              "b": {
-                "type": "int",
-                "value": "8"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "8"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "8"
+                }
               }
             }
           }
@@ -458,15 +470,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "13"
-              },
-              "b": {
-                "type": "int",
-                "value": "13"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "13"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "13"
+                }
               }
             }
           }
@@ -526,15 +540,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "21"
-              },
-              "b": {
-                "type": "int",
-                "value": "21"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "21"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "21"
+                }
               }
             }
           }
@@ -594,15 +610,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "34"
-              },
-              "b": {
-                "type": "int",
-                "value": "34"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "34"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "34"
+                }
               }
             }
           }
@@ -662,15 +680,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "55"
+          "lines": {
+            "215": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "55"
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -50,15 +50,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -118,15 +120,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -186,15 +190,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -254,15 +260,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -322,15 +330,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -390,15 +400,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -458,15 +470,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -526,15 +540,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -594,15 +610,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }
@@ -662,15 +680,17 @@
           }
         },
         "captures": {
-          "entry": {
-            "locals": {
-              "a": {
-                "type": "int",
-                "value": "55"
-              },
-              "b": {
-                "type": "int",
-                "value": "89"
+          "lines": {
+            "220": {
+              "locals": {
+                "a": {
+                  "type": "int",
+                  "value": "55"
+                },
+                "b": {
+                  "type": "int",
+                  "value": "89"
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLongFunctionWithChangingStateLineC.json
@@ -1,0 +1,682 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLongFunctionWithChangingState",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLongFunctionWithChangingState",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 220
+          },
+          {
+            "function": "main.executeComplexFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
+            "lineNumber": 289
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 36
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLongFunctionWithChangingStateLineC",
+          "location": {
+            "method": "main.testLongFunctionWithChangingState",
+            "file": "complex.go",
+            "line": 220
+          }
+        },
+        "captures": {
+          "entry": {
+            "locals": {
+              "a": {
+                "type": "int",
+                "value": "55"
+              },
+              "b": {
+                "type": "int",
+                "value": "89"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testStringType1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStringType1.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testStringType1",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 194
+            "lineNumber": 195
           },
           {
             "function": "main.executeComplexFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go",
-            "lineNumber": 265
+            "lineNumber": 286
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/sample/complex.go
+++ b/pkg/dyninst/testprogs/progs/sample/complex.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -199,6 +200,26 @@ func testStringType1(a *stringType1) {}
 //go:noinline
 func testStringType2(a **stringType2) {}
 
+//go:noinline
+func testLongFunctionWithChangingState() {
+	s := 3
+	a := 0
+	b := 1
+	fmt.Println(s, a, b)
+	// This loop and the following print statement reproduce
+	// https://github.com/golang/go/issues/75615
+	for _ = range 10 {
+		a, b = b, a+b
+	}
+	s += a
+	fmt.Println(s, a, b)
+	for _ = range 10 {
+		a, b = b-a, a
+	}
+	s += b
+	fmt.Println(s, a, b)
+}
+
 //nolint:all
 func executeComplexFuncs() {
 	o := outer{
@@ -264,4 +285,6 @@ func executeComplexFuncs() {
 	s2p := &s2
 	testStringType1(&s1)
 	testStringType2(&s2p)
+
+	testLongFunctionWithChangingState()
 }

--- a/pkg/dyninst/testprogs/progs/sample/inlined.go
+++ b/pkg/dyninst/testprogs/progs/sample/inlined.go
@@ -52,7 +52,7 @@ func testInlinedBBB() {
 func testInlinedBC() {
 	testInlinedBCA()
 	s := 0
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		s += rand.Intn(100)
 	}
 	fmt.Println(s)

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -1,911 +1,991 @@
 binary: sample
 probes:
-- id: testSingleByte
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleByte
-  captureSnapshot: true
-- id: testSingleRune
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleRune
-  captureSnapshot: true
-- id: testSingleBool
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleBool
-  captureSnapshot: true
-- id: testSingleInt
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleInt
-  captureSnapshot: true
-- id: testSingleInt8
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleInt8
-  captureSnapshot: true
-- id: testSingleInt16
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleInt16
-  captureSnapshot: true
-- id: testSingleInt32
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleInt32
-  captureSnapshot: true
-- id: testSingleInt64
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleInt64
-  captureSnapshot: true
-- id: testSingleUint
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleUint
-  captureSnapshot: true
-- id: testSingleUint8
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleUint8
-  captureSnapshot: true
-- id: testSingleUint16
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleUint16
-  captureSnapshot: true
-- id: testSingleUint32
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleUint32
-  captureSnapshot: true
-- id: testSingleUint64
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleUint64
-  captureSnapshot: true
-- id: testSingleFloat32
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleFloat32
-  captureSnapshot: true
-- id: testSingleFloat64
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleFloat64
-  captureSnapshot: true
-- id: testTypeAlias
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testTypeAlias
-  captureSnapshot: true
-- id: testSingleString
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSingleString
-  captureSnapshot: true
-- id: testUnitializedString
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUnitializedString
-  captureSnapshot: true
-- id: testMassiveString
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMassiveString
-  captureSnapshot: true
-- id: testMassiveStringWithSizeLimit
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMassiveString
-  captureSnapshot: true
-  capture:
-    maxLength: 11
-- id: testEmptyString
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEmptyString
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testThreeStrings
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testThreeStrings
-  captureSnapshot: true
-- id: testThreeStringsInStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testThreeStringsInStruct
-  captureSnapshot: true
-- id: testUnsafePointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUnsafePointer
-  captureSnapshot: true
-- id: testThreeStringsInStructPointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testThreeStringsInStructPointer
-  captureSnapshot: true
-- id: testOneStringInStructPointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testOneStringInStructPointer
-  captureSnapshot: true
-- id: testByteArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testByteArray
-  captureSnapshot: true
-- id: testRuneArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testRuneArray
-  captureSnapshot: true
-- id: testStringArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStringArray
-  captureSnapshot: true
-- id: testBoolArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testBoolArray
-  captureSnapshot: true
-- id: testIntArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testIntArray
-  captureSnapshot: true
-- id: testInt8Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInt8Array
-  captureSnapshot: true
-- id: testInt16Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInt16Array
-  captureSnapshot: true
-- id: testInt32Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInt32Array
-  captureSnapshot: true
-- id: testInt64Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInt64Array
-  captureSnapshot: true
-- id: testUintArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUintArray
-  captureSnapshot: true
-- id: testUint8Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUint8Array
-  captureSnapshot: true
-- id: testUint16Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUint16Array
-  captureSnapshot: true
-- id: testUint32Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUint32Array
-  captureSnapshot: true
-- id: testUint64Array
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUint64Array
-  captureSnapshot: true
-- id: testArrayOfArrays
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testArrayOfArrays
-  captureSnapshot: true
-- id: testArrayOfStrings
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testArrayOfStrings
-  captureSnapshot: true
-- id: testArrayOfArraysOfArrays
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testArrayOfArraysOfArrays
-  captureSnapshot: true
-# - id: testArrayOfStructs
-#   type: LOG_PROBE
-#   where:
-#     methodName: main.testArrayOfStructs
-#   captureSnapshot: true
-- id: testUintSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUintSlice
-  captureSnapshot: true
-- id: testVeryLargeSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testVeryLargeSlice
-  captureSnapshot: true
-- id: testVeryLargeSliceWithSizeLimit
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testVeryLargeSlice
-  captureSnapshot: true
-  capture:
-    collectionSizeLimit: 12
-- id: testVeryLargeArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testVeryLargeArray
-  captureSnapshot: true
-- id: testEmptySlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEmptySlice
-  captureSnapshot: true
-- id: testSliceOfSlices
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSliceOfSlices
-  captureSnapshot: true
-- id: testStructSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStructSlice
-  captureSnapshot: true
-- id: testEmptySliceOfStructs
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEmptySliceOfStructs
-  captureSnapshot: true
-- id: testNilSliceOfStructs
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testNilSliceOfStructs
-  captureSnapshot: true
-- id: testStringSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStringSlice
-  captureSnapshot: true
-- id: testNilSliceWithOtherParams
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testNilSliceWithOtherParams
-  captureSnapshot: true
-- id: testNilSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testNilSlice
-  captureSnapshot: true
-- id: testStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStruct
-  captureSnapshot: true
-- id: testEmptyStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEmptyStruct
-  captureSnapshot: true
-- id: testUintPointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testUintPointer
-  captureSnapshot: true
-- id: testStringPointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStringPointer
-  captureSnapshot: true
-- id: testNilPointer
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testNilPointer
-  captureSnapshot: true
-- id: testCombinedByte
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testCombinedByte
-  captureSnapshot: true
-- id: testMultipleSimpleParams
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMultipleSimpleParams
-  captureSnapshot: true
-- id: testInterface
-  type: LOG_PROBE
-  where:
-    methodName: main.testInterface
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testAny
-  type: LOG_PROBE
-  where:
-    methodName: main.testAny
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testError
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testError
-  captureSnapshot: true
-- id: testBigStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testBigStruct
-  captureSnapshot: true
-- id: stackC
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.stackC
-  captureSnapshot: true
-- id: testChannel
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testChannel
-  captureSnapshot: true
-- id: testLinkedList
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testLinkedList
-  captureSnapshot: true
-- id: testPointerLoop
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testPointerLoop
-  captureSnapshot: true
-- id: testCycle
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testCycle
-  captureSnapshot: true
-- id: testPointerToSimpleStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testPointerToSimpleStruct
-  captureSnapshot: true
-- id: testEsotericStack
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEsotericStack
-  captureSnapshot: true
-- id: testEsotericHeap
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testEsotericHeap
-  captureSnapshot: true
-- id: testSmallMap
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testSmallMap
-  captureSnapshot: true
-- id: testMapIntToInt
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapIntToInt
-  captureSnapshot: true
-- id: testMapStringToInt
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapStringToInt
-  captureSnapshot: true
-- id: testMapStringToSlice
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapStringToSlice
-  captureSnapshot: true
-- id: testMapArrayToArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapArrayToArray
-  captureSnapshot: true
-- id: testMapStringToStruct
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapStringToStruct
-  captureSnapshot: true
-- id: testMapMassive
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapMassive
-  captureSnapshot: true
-- id: testMapMassiveWithSizeLimit
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapMassive
-  captureSnapshot: true
-  capture:
-    collectionSizeLimit: 3
-- id: testMapEmbeddedMaps
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapEmbeddedMaps
-  captureSnapshot: true
-- id: testMapWithLinkedList
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapWithLinkedList
-  captureSnapshot: true
-- id: testMapWithSmallValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapWithSmallValue
-  captureSnapshot: true
-- id: testMapWithSmallValueMassive
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapWithSmallValueMassive
-  captureSnapshot: true
-- id: testMapWithSmallKeyAndValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapWithSmallKeyAndValue
-  captureSnapshot: true
-- id: testMapWithSmallKeyAndValueMassive
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapWithSmallKeyAndValueMassive
-  captureSnapshot: true
-- id: testMapSmallKeySmallValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapSmallKeySmallValue
-  captureSnapshot: true
-- id: testMapSmallKeyLargeValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapSmallKeyLargeValue
-  captureSnapshot: true
-- id: testMapLargeKeySmallValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapLargeKeySmallValue
-  captureSnapshot: true
-- id: testMapLargeKeyLargeValue
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testMapLargeKeyLargeValue
-  captureSnapshot: true
-- id: testStructWithMap
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testStructWithMap
-  captureSnapshot: true
-- id: testArrayOfMaps
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testArrayOfMaps
-  captureSnapshot: true
-- id: testPointerToMap
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testPointerToMap
-  captureSnapshot: true
-- id: testInlinedPrint
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedPrint
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testInlinedSumArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedSumArray
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testInlinedSq
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedSq
-  captureSnapshot: true
-- id: testInlinedBA
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBA
-  captureSnapshot: true
-- id: testInlinedBB
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBB
-  captureSnapshot: true
-- id: testInlinedBBA
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBBA
-  captureSnapshot: true
-- id: testInlinedBBB
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBBB
-  captureSnapshot: true
-- id: testInlinedBC
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBC
-  captureSnapshot: true
-- id: testInlinedBCA
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBCA
-  captureSnapshot: true
-- id: testInlinedBCB
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testInlinedBCB
-  captureSnapshot: true
-- id: testFrameless
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testFrameless
-  captureSnapshot: true
-- id: testFramelessArray
-  type: LOG_PROBE
-  tags:
-    - "foo:bar"
-  where:
-    methodName: main.testFramelessArray
-  captureSnapshot: true
-- id: testDeepPtr1
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepPtr1
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testDeepPtr7
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepPtr7
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 5
-- id: testDeepSlice1
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepSlice1
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testDeepSlice7
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepSlice7
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 5
-- id: testDeepMap1
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepMap1
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testDeepMap7
-  type: LOG_PROBE
-  where:
-    methodName: main.testDeepMap7
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 5
-- id: testStringType1
-  type: LOG_PROBE
-  where:
-    methodName: main.testStringType1
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testStringType2
-  type: LOG_PROBE
-  where:
-    methodName: main.testStringType2
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testEmptyStructPointer
-  type: LOG_PROBE
-  where:
-    methodName: main.testEmptyStructPointer
-  captureSnapshot: true
-- id: testAnyPtr
-  type: LOG_PROBE
-  where:
-    methodName: main.testAnyPtr
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testStructWithAny
-  type: LOG_PROBE
-  where:
-    methodName: main.testStructWithAny
-  captureSnapshot: true
-  capture:
-    maxReferenceDepth: 1
-- id: testStructWithCyclicSlices
-  type: LOG_PROBE
-  where:
-    methodName: main.testStructWithCyclicSlices
-  captureSnapshot: true
-- id: testStructWithCyclicMaps
-  type: LOG_PROBE
-  where:
-    methodName: main.testStructWithCyclicMaps
-  captureSnapshot: true
-- id: testReturnsInt
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsInt
-  captureSnapshot: true
-- id: testReturnsIntPointer
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsIntPointer
-  captureSnapshot: true
-- id: testReturnsIntAndFloat
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsIntAndFloat
-  captureSnapshot: true
-- id: testReturnsError
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsError
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testReturnsAnyAndError
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsAnyAndError
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testReturnsAny
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsAny
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testReturnsInterface
-  type: LOG_PROBE
-  where:
-    methodName: main.testReturnsInterface
-  captureSnapshot: true
-  sampling:
-    snapshotsPerSecond: 10
-- id: testNamedReturn
-  type: LOG_PROBE
-  where:
-    methodName: main.testNamedReturn
-  captureSnapshot: true
-- id: testMultipleNamedReturn
-  type: LOG_PROBE
-  where:
-    methodName: main.testMultipleNamedReturn
-  captureSnapshot: true
-- id: testSomeNamedReturn
-  type: LOG_PROBE
-  where:
-    methodName: main.testSomeNamedReturn
-  captureSnapshot: true
+  - id: testSingleByte
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleByte
+    captureSnapshot: true
+  - id: testSingleRune
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleRune
+    captureSnapshot: true
+  - id: testSingleBool
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleBool
+    captureSnapshot: true
+  - id: testSingleInt
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleInt
+    captureSnapshot: true
+  - id: testSingleInt8
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleInt8
+    captureSnapshot: true
+  - id: testSingleInt16
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleInt16
+    captureSnapshot: true
+  - id: testSingleInt32
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleInt32
+    captureSnapshot: true
+  - id: testSingleInt64
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleInt64
+    captureSnapshot: true
+  - id: testSingleUint
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleUint
+    captureSnapshot: true
+  - id: testSingleUint8
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleUint8
+    captureSnapshot: true
+  - id: testSingleUint16
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleUint16
+    captureSnapshot: true
+  - id: testSingleUint32
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleUint32
+    captureSnapshot: true
+  - id: testSingleUint64
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleUint64
+    captureSnapshot: true
+  - id: testSingleFloat32
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleFloat32
+    captureSnapshot: true
+  - id: testSingleFloat64
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleFloat64
+    captureSnapshot: true
+  - id: testTypeAlias
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testTypeAlias
+    captureSnapshot: true
+  - id: testSingleString
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSingleString
+    captureSnapshot: true
+  - id: testUnitializedString
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUnitializedString
+    captureSnapshot: true
+  - id: testMassiveString
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMassiveString
+    captureSnapshot: true
+  - id: testMassiveStringWithSizeLimit
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMassiveString
+    captureSnapshot: true
+    capture:
+      maxLength: 11
+  - id: testEmptyString
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEmptyString
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testThreeStrings
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testThreeStrings
+    captureSnapshot: true
+  - id: testThreeStringsInStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testThreeStringsInStruct
+    captureSnapshot: true
+  - id: testUnsafePointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUnsafePointer
+    captureSnapshot: true
+  - id: testThreeStringsInStructPointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testThreeStringsInStructPointer
+    captureSnapshot: true
+  - id: testOneStringInStructPointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testOneStringInStructPointer
+    captureSnapshot: true
+  - id: testByteArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testByteArray
+    captureSnapshot: true
+  - id: testRuneArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testRuneArray
+    captureSnapshot: true
+  - id: testStringArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStringArray
+    captureSnapshot: true
+  - id: testBoolArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testBoolArray
+    captureSnapshot: true
+  - id: testIntArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testIntArray
+    captureSnapshot: true
+  - id: testInt8Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInt8Array
+    captureSnapshot: true
+  - id: testInt16Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInt16Array
+    captureSnapshot: true
+  - id: testInt32Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInt32Array
+    captureSnapshot: true
+  - id: testInt64Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInt64Array
+    captureSnapshot: true
+  - id: testUintArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUintArray
+    captureSnapshot: true
+  - id: testUint8Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUint8Array
+    captureSnapshot: true
+  - id: testUint16Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUint16Array
+    captureSnapshot: true
+  - id: testUint32Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUint32Array
+    captureSnapshot: true
+  - id: testUint64Array
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUint64Array
+    captureSnapshot: true
+  - id: testArrayOfArrays
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testArrayOfArrays
+    captureSnapshot: true
+  - id: testArrayOfStrings
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testArrayOfStrings
+    captureSnapshot: true
+  - id: testArrayOfArraysOfArrays
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testArrayOfArraysOfArrays
+    captureSnapshot: true
+  # - id: testArrayOfStructs
+  #   type: LOG_PROBE
+  #   where:
+  #     methodName: main.testArrayOfStructs
+  #   captureSnapshot: true
+  - id: testUintSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUintSlice
+    captureSnapshot: true
+  - id: testVeryLargeSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testVeryLargeSlice
+    captureSnapshot: true
+  - id: testVeryLargeSliceWithSizeLimit
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testVeryLargeSlice
+    captureSnapshot: true
+    capture:
+      collectionSizeLimit: 12
+  - id: testVeryLargeArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testVeryLargeArray
+    captureSnapshot: true
+  - id: testEmptySlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEmptySlice
+    captureSnapshot: true
+  - id: testSliceOfSlices
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSliceOfSlices
+    captureSnapshot: true
+  - id: testStructSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStructSlice
+    captureSnapshot: true
+  - id: testEmptySliceOfStructs
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEmptySliceOfStructs
+    captureSnapshot: true
+  - id: testNilSliceOfStructs
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testNilSliceOfStructs
+    captureSnapshot: true
+  - id: testStringSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStringSlice
+    captureSnapshot: true
+  - id: testNilSliceWithOtherParams
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testNilSliceWithOtherParams
+    captureSnapshot: true
+  - id: testNilSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testNilSlice
+    captureSnapshot: true
+  - id: testStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStruct
+    captureSnapshot: true
+  - id: testEmptyStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEmptyStruct
+    captureSnapshot: true
+  - id: testUintPointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testUintPointer
+    captureSnapshot: true
+  - id: testStringPointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStringPointer
+    captureSnapshot: true
+  - id: testNilPointer
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testNilPointer
+    captureSnapshot: true
+  - id: testCombinedByte
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testCombinedByte
+    captureSnapshot: true
+  - id: testMultipleSimpleParams
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMultipleSimpleParams
+    captureSnapshot: true
+  - id: testInterface
+    type: LOG_PROBE
+    where:
+      methodName: main.testInterface
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testAny
+    type: LOG_PROBE
+    where:
+      methodName: main.testAny
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testError
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testError
+    captureSnapshot: true
+  - id: testBigStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testBigStruct
+    captureSnapshot: true
+  - id: stackC
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.stackC
+    captureSnapshot: true
+  - id: testChannel
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testChannel
+    captureSnapshot: true
+  - id: testLinkedList
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testLinkedList
+    captureSnapshot: true
+  - id: testPointerLoop
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testPointerLoop
+    captureSnapshot: true
+  - id: testCycle
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testCycle
+    captureSnapshot: true
+  - id: testPointerToSimpleStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testPointerToSimpleStruct
+    captureSnapshot: true
+  - id: testEsotericStack
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEsotericStack
+    captureSnapshot: true
+  - id: testEsotericHeap
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testEsotericHeap
+    captureSnapshot: true
+  - id: testSmallMap
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testSmallMap
+    captureSnapshot: true
+  - id: testMapIntToInt
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapIntToInt
+    captureSnapshot: true
+  - id: testMapStringToInt
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapStringToInt
+    captureSnapshot: true
+  - id: testMapStringToSlice
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapStringToSlice
+    captureSnapshot: true
+  - id: testMapArrayToArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapArrayToArray
+    captureSnapshot: true
+  - id: testMapStringToStruct
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapStringToStruct
+    captureSnapshot: true
+  - id: testMapMassive
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapMassive
+    captureSnapshot: true
+  - id: testMapMassiveWithSizeLimit
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapMassive
+    captureSnapshot: true
+    capture:
+      collectionSizeLimit: 3
+  - id: testMapEmbeddedMaps
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapEmbeddedMaps
+    captureSnapshot: true
+  - id: testMapWithLinkedList
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapWithLinkedList
+    captureSnapshot: true
+  - id: testMapWithSmallValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapWithSmallValue
+    captureSnapshot: true
+  - id: testMapWithSmallValueMassive
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapWithSmallValueMassive
+    captureSnapshot: true
+  - id: testMapWithSmallKeyAndValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapWithSmallKeyAndValue
+    captureSnapshot: true
+  - id: testMapWithSmallKeyAndValueMassive
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapWithSmallKeyAndValueMassive
+    captureSnapshot: true
+  - id: testMapSmallKeySmallValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapSmallKeySmallValue
+    captureSnapshot: true
+  - id: testMapSmallKeyLargeValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapSmallKeyLargeValue
+    captureSnapshot: true
+  - id: testMapLargeKeySmallValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapLargeKeySmallValue
+    captureSnapshot: true
+  - id: testMapLargeKeyLargeValue
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testMapLargeKeyLargeValue
+    captureSnapshot: true
+  - id: testStructWithMap
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testStructWithMap
+    captureSnapshot: true
+  - id: testArrayOfMaps
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testArrayOfMaps
+    captureSnapshot: true
+  - id: testPointerToMap
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testPointerToMap
+    captureSnapshot: true
+  - id: testInlinedPrint
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedPrint
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testInlinedSumArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedSumArray
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testInlinedSq
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedSq
+    captureSnapshot: true
+  - id: testInlinedBA
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBA
+    captureSnapshot: true
+  - id: testInlinedBB
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBB
+    captureSnapshot: true
+  - id: testInlinedBBA
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBBA
+    captureSnapshot: true
+  - id: testInlinedBBB
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBBB
+    captureSnapshot: true
+  - id: testInlinedBC
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBC
+    captureSnapshot: true
+  - id: testInlinedBCA
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBCA
+    captureSnapshot: true
+  - id: testInlinedBCB
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testInlinedBCB
+    captureSnapshot: true
+  - id: testFrameless
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testFrameless
+    captureSnapshot: true
+  - id: testFramelessArray
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testFramelessArray
+    captureSnapshot: true
+  - id: testDeepPtr1
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepPtr1
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testDeepPtr7
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepPtr7
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 5
+  - id: testDeepSlice1
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepSlice1
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testDeepSlice7
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepSlice7
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 5
+  - id: testDeepMap1
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepMap1
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testDeepMap7
+    type: LOG_PROBE
+    where:
+      methodName: main.testDeepMap7
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 5
+  - id: testStringType1
+    type: LOG_PROBE
+    where:
+      methodName: main.testStringType1
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testStringType2
+    type: LOG_PROBE
+    where:
+      methodName: main.testStringType2
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testEmptyStructPointer
+    type: LOG_PROBE
+    where:
+      methodName: main.testEmptyStructPointer
+    captureSnapshot: true
+  - id: testAnyPtr
+    type: LOG_PROBE
+    where:
+      methodName: main.testAnyPtr
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testStructWithAny
+    type: LOG_PROBE
+    where:
+      methodName: main.testStructWithAny
+    captureSnapshot: true
+    capture:
+      maxReferenceDepth: 1
+  - id: testStructWithCyclicSlices
+    type: LOG_PROBE
+    where:
+      methodName: main.testStructWithCyclicSlices
+    captureSnapshot: true
+  - id: testStructWithCyclicMaps
+    type: LOG_PROBE
+    where:
+      methodName: main.testStructWithCyclicMaps
+    captureSnapshot: true
+  - id: testReturnsInt
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsInt
+    captureSnapshot: true
+  - id: testReturnsIntPointer
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsIntPointer
+    captureSnapshot: true
+  - id: testReturnsIntAndFloat
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsIntAndFloat
+    captureSnapshot: true
+  - id: testReturnsError
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsError
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testReturnsAnyAndError
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsAnyAndError
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testReturnsAny
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsAny
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testReturnsInterface
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsInterface
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 10
+  - id: testNamedReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testNamedReturn
+    captureSnapshot: true
+  - id: testMultipleNamedReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleNamedReturn
+    captureSnapshot: true
+  - id: testSomeNamedReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testSomeNamedReturn
+    captureSnapshot: true
+  - id: testInlinedPrintLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedPrint
+      sourceFile: inlined.go
+      lines:
+        - "14"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testInlinedBCALine
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedBCA
+      sourceFile: inlined.go
+      lines:
+        - "63"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testInlinedBCBLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedBCB
+      sourceFile: inlined.go
+      lines:
+        - "67"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testInlinedSqLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedSq
+      sourceFile: inlined.go
+      lines:
+        - "75"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testFramelessArrayLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testFramelessArray
+      sourceFile: inlined.go
+      lines:
+        - "93"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testLongFunctionWithChangingStateLineA
+    type: LOG_PROBE
+    where:
+      methodName: main.testLongFunctionWithChangingState
+      sourceFile: complex.go
+      lines:
+        - "208"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testLongFunctionWithChangingStateLineB
+    type: LOG_PROBE
+    where:
+      methodName: main.testLongFunctionWithChangingState
+      sourceFile: complex.go
+      lines:
+        - "215"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testLongFunctionWithChangingStateLineC
+    type: LOG_PROBE
+    where:
+      methodName: main.testLongFunctionWithChangingState
+      sourceFile: complex.go
+      lines:
+        - "220"
+    captureSnapshot: true
+    sampling:
+      snapshotsPerSecond: 100


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/DEBUG-4042

Note argument variables are decoded as locals (given that values can change between function call and line probe being hit).

This also reproduces go bug which mismaps a source line outside of the loop with a machine instruction inside a loop, causing surprising over-probing (issue filed against golang/go).