### PR TITLE
dyninst/decode,ir: extend decoder to be able to represent return and locals

### DIFF
--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -77,13 +77,8 @@ type Decoder struct {
 	approximateBootTime  time.Time
 
 	// These fields are initialized and reset for each message.
-	snapshotMessage   snapshotMessage
-	dataItems         map[typeAndAddr]output.DataItem
-	currentlyEncoding map[typeAndAddr]struct{}
-	// skippedArgumentExpressions is a bitset of the indices of the arguments
-	// that should be skipped during encoding because they encountered an
-	// evaluation during a previous attempt.
-	skippedArgumentExpressions bitset
+	snapshotMessage snapshotMessage
+	entry           captureEvent
 }
 
 // NewDecoder creates a new Decoder for the given program.
@@ -101,10 +96,7 @@ func NewDecoder(
 		typeNameResolver:     typeNameResolver,
 		approximateBootTime:  approximateBootTime,
 
-		snapshotMessage:            snapshotMessage{},
-		dataItems:                  make(map[typeAndAddr]output.DataItem),
-		currentlyEncoding:          make(map[typeAndAddr]struct{}),
-		skippedArgumentExpressions: nil,
+		snapshotMessage: snapshotMessage{},
 	}
 	for _, probe := range program.Probes {
 		for _, event := range probe.Events {
@@ -124,6 +116,13 @@ func NewDecoder(
 		if goRuntimeType, ok := t.GetGoRuntimeType(); ok {
 			decoder.typesByGoRuntimeType[goRuntimeType] = id
 		}
+	}
+	decoder.entry.encodingContext = encodingContext{
+		typesByID:            decoder.decoderTypes,
+		typesByGoRuntimeType: decoder.typesByGoRuntimeType,
+		typeResolver:         typeNameResolver,
+		dataItems:            make(map[typeAndAddr]output.DataItem),
+		currentlyEncoding:    make(map[typeAndAddr]struct{}),
 	}
 	return decoder, nil
 }
@@ -160,7 +159,7 @@ func (d *Decoder) Decode(
 	}
 	b := bytes.NewBuffer(buf)
 	enc := jsontext.NewEncoder(b)
-	numExpressions := len(d.snapshotMessage.Debugger.Snapshot.Captures.Entry.Arguments.rootType.Expressions)
+	numExpressions := len(d.snapshotMessage.Debugger.Snapshot.Captures.Entry.rootType.Expressions)
 	// We loop here because when evaluation errors occur, we reduce the amount of data we attempt
 	// to encode and then try again after resetting the buffer.
 	for range numExpressions + 1 { // +1 for the initial attempt
@@ -178,7 +177,8 @@ func (d *Decoder) Decode(
 }
 
 func (d *Decoder) resetForNextMessage() {
-	clear(d.dataItems)
+	clear(d.entry.dataItems)
+	d.entry.clear()
 	d.snapshotMessage = snapshotMessage{}
 }
 
@@ -213,7 +213,6 @@ func (s *snapshotMessage) init(
 	var rootType *ir.EventRootType
 	var probe ir.ProbeDefinition
 	var rootData []byte
-
 	for item, err := range event.Event.DataItems() {
 		if err != nil {
 			return probe, fmt.Errorf("error getting data items: %w", err)
@@ -244,7 +243,7 @@ func (s *snapshotMessage) init(
 		// The value is a data item with a counter of how many times it has been referenced.
 		// If the counter is greater than 1, we know that the data item is a pointer to another data item.
 		// We can then encode the pointer as a string and not as an object.
-		decoder.dataItems[typeAndAddr{
+		decoder.entry.dataItems[typeAndAddr{
 			irType: uint32(item.Type()),
 			addr:   item.Header().Address,
 		}] = item
@@ -252,6 +251,10 @@ func (s *snapshotMessage) init(
 	if rootType == nil {
 		return probe, errors.New("no root type found")
 	}
+	decoder.entry.rootType = rootType
+	decoder.entry.rootData = rootData
+	decoder.entry.skippedIndices.reset(len(rootType.Expressions))
+	decoder.entry.evaluationErrors = &s.Debugger.EvaluationErrors
 	header, err := event.Event.Header()
 	if err != nil {
 		return probe, fmt.Errorf("error getting header %w", err)
@@ -290,15 +293,7 @@ func (s *snapshotMessage) init(
 	s.Logger.ThreadID = int(header.Goid)
 	s.Debugger.Snapshot.Probe.ID = probe.GetID()
 	s.Debugger.Snapshot.Stack.frames = stackFrames
-
-	decoder.skippedArgumentExpressions.reset(len(rootType.Expressions))
-	s.Debugger.Snapshot.Captures.Entry.Arguments = argumentsData{
-		rootType:         rootType,
-		rootData:         rootData,
-		decoder:          decoder,
-		evaluationErrors: &s.Debugger.EvaluationErrors,
-		skippedIndices:   &decoder.skippedArgumentExpressions,
-	}
+	s.Debugger.Snapshot.Captures.Entry = &decoder.entry
 	return probe, nil
 }
 

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -195,8 +195,6 @@ type snapshotMessage struct {
 	Logger    logger           `json:"logger"`
 	Debugger  debuggerData     `json:"debugger"`
 	Timestamp int              `json:"timestamp"`
-
-	rootData []byte
 }
 
 func (s *snapshotMessage) init(
@@ -214,6 +212,7 @@ func (s *snapshotMessage) init(
 	}
 	var rootType *ir.EventRootType
 	var probe ir.ProbeDefinition
+	var rootData []byte
 
 	for item, err := range event.Event.DataItems() {
 		if err != nil {
@@ -221,7 +220,7 @@ func (s *snapshotMessage) init(
 		}
 		if rootType == nil {
 			var ok bool
-			s.rootData, ok = item.Data()
+			rootData, ok = item.Data()
 			if !ok {
 				// This should never happen.
 				return probe, errors.New("root data item marked as a failed read")
@@ -294,9 +293,8 @@ func (s *snapshotMessage) init(
 
 	decoder.skippedArgumentExpressions.reset(len(rootType.Expressions))
 	s.Debugger.Snapshot.Captures.Entry.Arguments = argumentsData{
-		event:            event,
 		rootType:         rootType,
-		rootData:         s.rootData,
+		rootData:         rootData,
 		decoder:          decoder,
 		evaluationErrors: &s.Debugger.EvaluationErrors,
 		skippedIndices:   &decoder.skippedArgumentExpressions,

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -44,8 +44,8 @@ func FuzzDecoder(f *testing.F) {
 			Event:       output.Event(item),
 			ServiceName: "foo",
 		}, &noopSymbolicator{}, []byte{})
-		require.Empty(t, decoder.dataItems)
-		require.Empty(t, decoder.currentlyEncoding)
+		require.Empty(t, decoder.entry.dataItems)
+		require.Empty(t, decoder.entry.currentlyEncoding)
 	})
 }
 
@@ -72,8 +72,11 @@ func TestDecoderManually(t *testing.T) {
 			var e eventCaptures
 			require.NoError(t, json.Unmarshal(buf, &e))
 			require.Equal(t, c.expected, e.Debugger.Snapshot.Captures.Entry.Arguments)
-			require.Empty(t, decoder.dataItems)
-			require.Empty(t, decoder.currentlyEncoding)
+			require.Empty(t, decoder.entry.dataItems)
+			require.Empty(t, decoder.entry.currentlyEncoding)
+			require.Nil(t, decoder.entry.rootType)
+			require.Nil(t, decoder.entry.rootData)
+			require.Zero(t, decoder.entry.evaluationErrors)
 			require.Zero(t, decoder.snapshotMessage)
 		})
 	}
@@ -742,7 +745,9 @@ type panicDecoderType struct {
 
 var _ decoderType = (*panicDecoderType)(nil)
 
-func (t *panicDecoderType) encodeValueFields(*Decoder, *jsontext.Encoder, []byte) error {
+func (t *panicDecoderType) encodeValueFields(
+	*encodingContext, *jsontext.Encoder, []byte,
+) error {
 	panic("boom")
 }
 

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -57,19 +57,26 @@ type locationData struct {
 }
 
 type captureData struct {
-	Entry capturePointData `json:"entry"`
+	Entry *captureEvent `json:"entry,omitempty"`
 }
 
-type capturePointData struct {
-	Arguments argumentsData `json:"arguments"`
-}
+type captureEvent struct {
+	encodingContext
 
-type argumentsData struct {
 	rootData         []byte
 	rootType         *ir.EventRootType
-	decoder          *Decoder
 	evaluationErrors *[]string
-	skippedIndices   *bitset
+	skippedIndices   bitset
+}
+
+func (ce *captureEvent) clear() {
+	ce.rootData = nil
+	ce.rootType = nil
+	ce.evaluationErrors = nil
+
+	clear(ce.dataItems)
+	clear(ce.currentlyEncoding)
+	ce.skippedIndices.reset(0)
 }
 
 var ddDebuggerString = jsontext.String("dd_debugger")
@@ -83,7 +90,7 @@ func (ddDebuggerSource) MarshalJSONTo(enc *jsontext.Encoder) error {
 var errEvaluation = errors.New("evaluation error")
 
 // processExpression processes a single expression from the root type expressions
-func (ad *argumentsData) processExpression(
+func (ce *captureEvent) processExpression(
 	enc *jsontext.Encoder,
 	expr *ir.RootExpression,
 	presenceBitSet bitset,
@@ -92,16 +99,19 @@ func (ad *argumentsData) processExpression(
 	parameterType := expr.Expression.Type
 	parameterSize := parameterType.GetByteSize()
 	ub := expr.Offset + parameterSize
-	if int(ub) > len(ad.rootData) {
-		*ad.evaluationErrors = append(*ad.evaluationErrors, "could not read parameter data from root data, length mismatch")
+	if int(ub) > len(ce.rootData) {
+		*ce.evaluationErrors = append(
+			*ce.evaluationErrors,
+			"could not read parameter data from root data, length mismatch",
+		)
 		return errEvaluation
 	}
-	parameterData := ad.rootData[expr.Offset:ub]
+	data := ce.rootData[expr.Offset:ub]
 	if err := writeTokens(enc, jsontext.String(expr.Name)); err != nil {
 		return err
 	}
 	if !presenceBitSet.get(expressionIndex) && parameterSize != 0 {
-		// Set not capture reason
+		// Set not capture reason.
 		if err := writeTokens(enc,
 			jsontext.BeginObject,
 			jsontext.String("type"),
@@ -114,40 +124,62 @@ func (ad *argumentsData) processExpression(
 		}
 		return nil
 	}
-	err := ad.decoder.encodeValue(enc,
-		parameterType.GetID(),
-		parameterData,
-		parameterType.GetName(),
+	err := encodeValue(
+		&ce.encodingContext, enc, parameterType.GetID(), data, parameterType.GetName(),
 	)
 	if err != nil {
-		*ad.evaluationErrors = append(*ad.evaluationErrors, ad.rootType.Name+err.Error())
+		*ce.evaluationErrors = append(*ce.evaluationErrors, ce.rootType.Name+err.Error())
 		return errEvaluation
 	}
 	return nil
 }
 
-func (ad *argumentsData) MarshalJSONTo(enc *jsontext.Encoder) error {
+func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
+	if ce.rootType.PresenceBitsetSize > uint32(len(ce.rootData)) {
+		return errors.New("presence bitset is out of bounds")
+	}
+	presenceBitSet := ce.rootData[:ce.rootType.PresenceBitsetSize]
+
 	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
 		return err
 	}
-
-	if ad.rootType.PresenceBitsetSize > uint32(len(ad.rootData)) {
-		return errors.New("presence bitset is out of bounds")
-	}
-	presenceBitSet := ad.rootData[:ad.rootType.PresenceBitsetSize]
-	// We iterate over the 'Expressions' of the EventRoot which contains
-	// metadata and raw bytes of the parameters of this function.
-	for i, expr := range ad.rootType.Expressions {
-		if ad.skippedIndices.get(i) {
-			continue
+	for _, kind := range []struct {
+		kind  ir.RootExpressionKind
+		token jsontext.Token
+	}{
+		{kind: ir.RootExpressionKindArgument, token: jsontext.String("arguments")},
+		{kind: ir.RootExpressionKindLocal, token: jsontext.String("locals")},
+	} {
+		// We iterate over the 'Expressions' of the EventRoot which contains
+		// metadata and raw bytes of the parameters of this function.
+		var haveKind bool
+		for i, expr := range ce.rootType.Expressions {
+			if expr.Kind != kind.kind {
+				continue
+			}
+			if ce.skippedIndices.get(i) {
+				continue
+			}
+			if !haveKind {
+				haveKind = true
+				if err := writeTokens(enc, kind.token, jsontext.BeginObject); err != nil {
+					return err
+				}
+			}
+			err := ce.processExpression(enc, expr, presenceBitSet, i)
+			if errors.Is(err, errEvaluation) {
+				// This expression resulted in an evaluation error, we mark it to be
+				// skipped and will try again
+				ce.skippedIndices.set(i)
+			}
+			if err != nil {
+				return err
+			}
 		}
-		if err := ad.processExpression(enc, expr, presenceBitSet, i); errors.Is(err, errEvaluation) {
-			// This expression resulted in an evaluation error, we mark it to be skipped
-			// and will try again
-			ad.skippedIndices.set(i)
-			return err
-		} else if err != nil {
-			return err
+		if haveKind {
+			if err := writeTokens(enc, jsontext.EndObject); err != nil {
+				return err
+			}
 		}
 	}
 	if err := writeTokens(enc, jsontext.EndObject); err != nil {
@@ -199,13 +231,14 @@ func (sl *stackLine) MarshalJSONTo(enc *jsontext.Encoder) error {
 	return nil
 }
 
-func (d *Decoder) encodeValue(
+func encodeValue(
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	typeID ir.TypeID,
 	data []byte,
 	valueType string,
 ) error {
-	decoderType, ok := d.decoderTypes[typeID]
+	decoderType, ok := c.getType(typeID)
 	if !ok {
 		return errors.New("no decoder type found")
 	}
@@ -215,7 +248,7 @@ func (d *Decoder) encodeValue(
 	if err := writeTokens(enc, jsontext.String("type"), jsontext.String(valueType)); err != nil {
 		return err
 	}
-	if err := decoderType.encodeValueFields(d, enc, data); err != nil {
+	if err := decoderType.encodeValueFields(c, enc, data); err != nil {
 		return err
 	}
 	if err := writeTokens(enc, jsontext.EndObject); err != nil {

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -67,7 +67,6 @@ type capturePointData struct {
 type argumentsData struct {
 	rootData         []byte
 	rootType         *ir.EventRootType
-	event            Event
 	decoder          *Decoder
 	evaluationErrors *[]string
 	skippedIndices   *bitset

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -32,10 +32,54 @@ import (
 type decoderType interface {
 	irType() ir.Type
 	encodeValueFields(
-		d *Decoder,
+		c *encodingContext,
 		enc *jsontext.Encoder,
 		data []byte,
 	) error
+}
+
+type encodingContext struct {
+	typesByID            map[ir.TypeID]decoderType
+	typesByGoRuntimeType map[uint32]ir.TypeID
+	currentlyEncoding    map[typeAndAddr]struct{}
+	dataItems            map[typeAndAddr]output.DataItem
+	typeResolver         TypeNameResolver
+}
+
+// ResolveTypeName implements encodingContext.
+func (e *encodingContext) ResolveTypeName(typeID gotype.TypeID) (string, error) {
+	return e.typeResolver.ResolveTypeName(typeID)
+}
+
+// getPtr implements encodingContext.
+func (e *encodingContext) getPtr(addr uint64, typeID ir.TypeID) (output.DataItem, bool) {
+	di, ok := e.dataItems[typeAndAddr{addr: addr, irType: uint32(typeID)}]
+	return di, ok
+}
+
+// getType implements encodingContext.
+func (e *encodingContext) getType(typeID ir.TypeID) (decoderType, bool) {
+	t, ok := e.typesByID[typeID]
+	return t, ok
+}
+
+// getTypeIDByGoRuntimeType implements encodingContext.
+func (e *encodingContext) getTypeIDByGoRuntimeType(runtimeType uint32) (ir.TypeID, bool) {
+	typeID, ok := e.typesByGoRuntimeType[runtimeType]
+	return typeID, ok
+}
+
+// recordPointer implements encodingContext.
+func (e *encodingContext) recordPointer(addr uint64, typeID ir.TypeID) (release func(), ok bool) {
+	key := typeAndAddr{addr: addr, irType: uint32(typeID)}
+	_, ok = e.currentlyEncoding[typeAndAddr{addr: addr, irType: uint32(typeID)}]
+	if ok {
+		return nil, false
+	}
+	e.currentlyEncoding[typeAndAddr{addr: addr, irType: uint32(typeID)}] = struct{}{}
+	return func() {
+		delete(e.currentlyEncoding, key)
+	}, true
 }
 
 // Type equivalent definitions
@@ -367,7 +411,7 @@ func newDecoderType(
 
 func (b *baseType) irType() ir.Type { return (*ir.BaseType)(b) }
 func (b *baseType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -472,7 +516,7 @@ func (b *baseType) encodeValueFields(
 
 func (e *eventRootType) irType() ir.Type { return (*ir.EventRootType)(e) }
 func (e *eventRootType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -484,17 +528,17 @@ func (e *eventRootType) encodeValueFields(
 
 func (m *goMapType) irType() ir.Type { return (*ir.GoMapType)(m) }
 func (m *goMapType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
 	const encodeAddress = false
-	return encodePointer(data, encodeAddress, m.HeaderType.GetID(), enc, d)
+	return encodePointer(c, data, encodeAddress, m.HeaderType.GetID(), enc)
 }
 
 func (h *goHMapHeaderType) irType() ir.Type { return h.GoHMapHeaderType }
 func (h *goHMapHeaderType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -524,7 +568,7 @@ func (h *goHMapHeaderType) encodeValueFields(
 		for i := range numBuckets {
 			bucketOffset := uint32(i) * h.bucketByteSize
 			bucketData := data[bucketOffset : bucketOffset+h.bucketByteSize]
-			bucketItems, err := encodeHMapBucket(d, enc, h, bucketData)
+			bucketItems, err := encodeHMapBucket(c, enc, h, bucketData)
 			if err != nil {
 				return 0, fmt.Errorf("error encoding bucket: %w", err)
 			}
@@ -538,10 +582,7 @@ func (h *goHMapHeaderType) encodeValueFields(
 		if addr == 0 {
 			continue
 		}
-		item, ok := d.dataItems[typeAndAddr{
-			irType: uint32(h.bucketsTypeID),
-			addr:   addr,
-		}]
+		item, ok := c.getPtr(addr, h.bucketsTypeID)
 		if !ok {
 			continue
 		}
@@ -566,7 +607,7 @@ func (h *goHMapHeaderType) encodeValueFields(
 }
 
 func encodeHMapBucket(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	h *goHMapHeaderType,
 	bucketData []byte,
@@ -606,11 +647,15 @@ func encodeHMapBucket(
 			return encodedItems, err
 		}
 		keyData := bucketData[keyOffset : keyOffset+h.keyTypeSize]
-		if err := d.encodeValue(enc, h.keyTypeID, keyData, h.keyTypeName); err != nil {
+		if err := encodeValue(
+			c, enc, h.keyTypeID, keyData, h.keyTypeName,
+		); err != nil {
 			return encodedItems, err
 		}
 		valueData := bucketData[valueOffset : valueOffset+h.valueTypeSize]
-		if err := d.encodeValue(enc, h.valueTypeID, valueData, h.valueTypeName); err != nil {
+		if err := encodeValue(
+			c, enc, h.valueTypeID, valueData, h.valueTypeName,
+		); err != nil {
 			return encodedItems, err
 		}
 		if err := writeTokens(enc, jsontext.EndArray); err != nil {
@@ -619,16 +664,13 @@ func encodeHMapBucket(
 	}
 	overflowAddr := binary.NativeEndian.Uint64(bucketData[h.overflowOffset : h.overflowOffset+8])
 	if overflowAddr != 0 {
-		overflowDataItem, ok := d.dataItems[typeAndAddr{
-			irType: uint32(h.bucketTypeID),
-			addr:   overflowAddr,
-		}]
+		overflowDataItem, ok := c.getPtr(overflowAddr, h.bucketTypeID)
 		var overflowData []byte
 		if ok {
 			overflowData, ok = overflowDataItem.Data()
 		}
 		if ok {
-			overflowItems, err := encodeHMapBucket(d, enc, h, overflowData)
+			overflowItems, err := encodeHMapBucket(c, enc, h, overflowData)
 			if err != nil {
 				return encodedItems, err
 			}
@@ -640,14 +682,14 @@ func encodeHMapBucket(
 
 func (b *goHMapBucketType) irType() ir.Type { return (*ir.GoHMapBucketType)(b) }
 func (*goHMapBucketType) encodeValueFields(
-	*Decoder, *jsontext.Encoder, []byte,
+	*encodingContext, *jsontext.Encoder, []byte,
 ) error {
 	return fmt.Errorf("hmap bucket type is never directly encoded")
 }
 
 func (s *goSwissMapHeaderType) irType() ir.Type { return s.GoSwissMapHeaderType }
 func (s *goSwissMapHeaderType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -663,10 +705,7 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 	if dirLen == 0 {
 		// This is a 'small' swiss map where there's only one group.
 		// We can collect the data item for the group directly.
-		groupDataItem, ok := d.dataItems[typeAndAddr{
-			irType: uint32(s.groupTypeID),
-			addr:   dirPtr,
-		}]
+		groupDataItem, ok := c.getPtr(dirPtr, s.groupTypeID)
 		if !ok {
 			return writeTokens(enc,
 				tokenNotCapturedReason,
@@ -687,14 +726,13 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 		); err != nil {
 			return err
 		}
-		totalElementsEncoded, err := s.encodeSwissMapGroup(d, enc, groupData)
+		totalElementsEncoded, err := s.encodeSwissMapGroup(c, enc, groupData)
 		if err != nil {
 			return err
 		}
 		if used > int64(totalElementsEncoded) {
-			if err := writeTokens(enc,
-				tokenNotCapturedReason,
-				tokenNotCapturedReasonPruned,
+			if err := writeTokens(
+				enc, tokenNotCapturedReason, tokenNotCapturedReasonPruned,
 			); err != nil {
 				return err
 			}
@@ -702,10 +740,7 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 	} else {
 		// This is a 'large' swiss map where there are multiple groups of data/control words
 		// We need to collect the data items for the table pointers first.
-		tablePtrSliceDataItem, ok := d.dataItems[typeAndAddr{
-			irType: uint32(s.TablePtrSliceType.GetID()),
-			addr:   dirPtr,
-		}]
+		tablePtrSliceDataItem, ok := c.getPtr(dirPtr, s.TablePtrSliceType.GetID())
 		if !ok {
 			return writeTokens(enc,
 				tokenNotCapturedReason,
@@ -724,7 +759,9 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 		); err != nil {
 			return err
 		}
-		totalElementsEncoded, err := s.encodeSwissMapTables(d, enc, tablePtrSliceData)
+		totalElementsEncoded, err := s.encodeSwissMapTables(
+			c, enc, tablePtrSliceData,
+		)
 		if err != nil {
 			return err
 		}
@@ -741,7 +778,7 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 
 func (s *goSwissMapGroupsType) irType() ir.Type { return (*ir.GoSwissMapGroupsType)(s) }
 func (s *goSwissMapGroupsType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -753,7 +790,7 @@ func (s *goSwissMapGroupsType) encodeValueFields(
 
 func (v *voidPointerType) irType() ir.Type { return (*ir.VoidPointerType)(v) }
 func (v *voidPointerType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -768,7 +805,7 @@ func (v *voidPointerType) encodeValueFields(
 
 func (p *pointerType) irType() ir.Type { return (*ir.PointerType)(p) }
 func (p *pointerType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -780,15 +817,15 @@ func (p *pointerType) encodeValueFields(
 	// find a go kind.
 	goKind, ok := p.Pointee.GetGoKind()
 	writeAddress := ok && goKind != reflect.Pointer
-	return encodePointer(data, writeAddress, p.Pointee.GetID(), enc, d)
+	return encodePointer(c, data, writeAddress, p.Pointee.GetID(), enc)
 }
 
 func encodePointer(
+	c *encodingContext,
 	data []byte,
 	writeAddress bool,
 	pointee ir.TypeID,
 	enc *jsontext.Encoder,
-	d *Decoder,
 ) error {
 	if len(data) < 8 {
 		return errors.New("passed data not long enough for pointer: need 8 bytes")
@@ -808,7 +845,7 @@ func encodePointer(
 		return nil
 	}
 
-	pointeeDecoderType, ok := d.decoderTypes[pointee]
+	pointeeType, ok := c.getType(pointee)
 	if !ok {
 		return fmt.Errorf("no decoder type found for pointee type (ID: %d)", pointee)
 	}
@@ -819,9 +856,9 @@ func encodePointer(
 		pointedValue   output.DataItem
 		dataItemExists bool
 	)
-	isZeroSized := pointeeDecoderType.irType().GetByteSize() == 0
+	isZeroSized := pointeeType.irType().GetByteSize() == 0
 	if !isZeroSized {
-		pointedValue, dataItemExists = d.dataItems[pointeeKey]
+		pointedValue, dataItemExists = c.getPtr(addr, pointee)
 	} else {
 		dataItemExists = true
 	}
@@ -840,9 +877,8 @@ func encodePointer(
 		}
 	}
 
-	if _, alreadyEncoding := d.currentlyEncoding[pointeeKey]; !alreadyEncoding {
-		d.currentlyEncoding[pointeeKey] = struct{}{}
-		defer delete(d.currentlyEncoding, pointeeKey)
+	if release, ok := c.recordPointer(addr, pointee); ok {
+		defer release()
 		var pointedData []byte
 		if !isZeroSized {
 			if pointedData, ok = pointedValue.Data(); !ok {
@@ -852,9 +888,7 @@ func encodePointer(
 				)
 			}
 		}
-		if err := pointeeDecoderType.encodeValueFields(
-			d, enc, pointedData,
-		); err != nil {
+		if err := pointeeType.encodeValueFields(c, enc, pointedData); err != nil {
 			return fmt.Errorf("could not encode referenced value: %w", err)
 		}
 	} else {
@@ -869,7 +903,7 @@ func encodePointer(
 
 func (s *structureType) irType() ir.Type { return (*ir.StructureType)(s) }
 func (s *structureType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -884,13 +918,15 @@ func (s *structureType) encodeValueFields(
 		}
 		fieldEnd := field.Offset + field.Type.GetByteSize()
 		if fieldEnd > uint32(len(data)) {
-			return fmt.Errorf("field %s extends beyond data bounds: need %d bytes, have %d", field.Name, fieldEnd, len(data))
+			return fmt.Errorf(
+				"field %s extends beyond data bounds: need %d bytes, have %d",
+				field.Name, fieldEnd, len(data),
+			)
 		}
 
-		if err := d.encodeValue(enc,
-			field.Type.GetID(),
-			data[field.Offset:field.Offset+field.Type.GetByteSize()],
-			field.Type.GetName(),
+		fieldData := data[field.Offset : field.Offset+field.Type.GetByteSize()]
+		if err := encodeValue(
+			c, enc, field.Type.GetID(), fieldData, field.Type.GetName(),
 		); err != nil {
 			return err
 		}
@@ -900,7 +936,7 @@ func (s *structureType) encodeValueFields(
 
 func (a *arrayType) irType() ir.Type { return (*ir.ArrayType)(a) }
 func (a *arrayType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -916,6 +952,8 @@ func (a *arrayType) encodeValueFields(
 	}
 
 	var notCaptured = false
+	elementID := a.Element.GetID()
+	elementName := a.Element.GetName()
 	for i := range numElements {
 		offset := i * elementSize
 		endIdx := offset + elementSize
@@ -923,11 +961,8 @@ func (a *arrayType) encodeValueFields(
 			notCaptured = true
 			break
 		}
-		elementData := data[offset:endIdx]
-		if err := d.encodeValue(enc,
-			a.Element.GetID(),
-			elementData,
-			a.Element.GetName(),
+		if err := encodeValue(
+			c, enc, elementID, data[offset:endIdx], elementName,
 		); err != nil {
 			return err
 		}
@@ -946,10 +981,8 @@ func (a *arrayType) encodeValueFields(
 
 func (s *goSliceHeaderType) irType() ir.Type { return (*ir.GoSliceHeaderType)(s) }
 func (s *goSliceHeaderType) encodeValueFields(
-	d *Decoder,
-	enc *jsontext.Encoder,
-	data []byte) error {
-
+	c *encodingContext, enc *jsontext.Encoder, data []byte,
+) error {
 	if len(data) < int(s.ByteSize) {
 		return writeTokens(enc,
 			tokenNotCapturedReason,
@@ -984,11 +1017,7 @@ func (s *goSliceHeaderType) encodeValueFields(
 	}
 
 	elementSize := int(s.Data.Element.GetByteSize())
-	taa := typeAndAddr{
-		addr:   address,
-		irType: uint32(s.Data.GetID()),
-	}
-	sliceDataItem, ok := d.dataItems[taa]
+	sliceDataItem, ok := c.getPtr(address, s.Data.GetID())
 	if !ok {
 		return writeTokens(enc,
 			tokenNotCapturedReason,
@@ -1013,8 +1042,8 @@ func (s *goSliceHeaderType) encodeValueFields(
 	elementID := s.Data.Element.GetID()
 	for i := range int(sliceLength) {
 		elementData := sliceData[i*elementByteSize : (i+1)*elementByteSize]
-		if err := d.encodeValue(
-			enc, elementID, elementData, elementName,
+		if err := encodeValue(
+			c, enc, elementID, elementData, elementName,
 		); err != nil {
 			return fmt.Errorf(
 				"could not encode %s slice element of %s: %w",
@@ -1037,7 +1066,7 @@ func (s *goSliceHeaderType) encodeValueFields(
 
 func (s *goSliceDataType) irType() ir.Type { return (*ir.GoSliceDataType)(s) }
 func (s *goSliceDataType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -1049,7 +1078,7 @@ func (s *goSliceDataType) encodeValueFields(
 
 func (s *goStringHeaderType) irType() ir.Type { return s.GoStringHeaderType }
 func (s *goStringHeaderType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -1068,10 +1097,7 @@ func (s *goStringHeaderType) encodeValueFields(
 			jsontext.String(""),
 		)
 	}
-	stringValue, ok := d.dataItems[typeAndAddr{
-		irType: uint32(s.Data.GetID()),
-		addr:   address,
-	}]
+	stringValue, ok := c.getPtr(address, s.Data.GetID())
 	if !ok {
 		return writeTokens(enc,
 			jsontext.String("size"),
@@ -1102,9 +1128,7 @@ func (s *goStringHeaderType) encodeValueFields(
 			return err
 		}
 	}
-	if err := writeTokens(enc,
-		jsontext.String("value"),
-	); err != nil {
+	if err := writeTokens(enc, jsontext.String("value")); err != nil {
 		return err
 	}
 	str := unsafe.String(unsafe.SliceData(stringData), int(length))
@@ -1113,7 +1137,7 @@ func (s *goStringHeaderType) encodeValueFields(
 
 func (s *goStringDataType) irType() ir.Type { return (*ir.GoStringDataType)(s) }
 func (s *goStringDataType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -1125,7 +1149,7 @@ func (s *goStringDataType) encodeValueFields(
 
 func (c *goChannelType) irType() ir.Type { return (*ir.GoChannelType)(c) }
 func (c *goChannelType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -1140,24 +1164,24 @@ const goInterfaceDataOffset = 0x08
 
 func (e *goEmptyInterfaceType) irType() ir.Type { return (*ir.GoEmptyInterfaceType)(e) }
 func (e *goEmptyInterfaceType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
-	return encodeInterface(d, enc, data)
+	return encodeInterface(c, enc, data)
 }
 
 func (i *goInterfaceType) irType() ir.Type { return (*ir.GoInterfaceType)(i) }
 func (i *goInterfaceType) encodeValueFields(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
-	return encodeInterface(d, enc, data)
+	return encodeInterface(c, enc, data)
 }
 
 func encodeInterface(
-	d *Decoder,
+	c *encodingContext,
 	enc *jsontext.Encoder,
 	data []byte,
 ) error {
@@ -1174,7 +1198,8 @@ func encodeInterface(
 		return err
 	}
 
-	runtimeType := binary.NativeEndian.Uint64(data[goRuntimeTypeOffset : goRuntimeTypeOffset+8])
+	runtimeTypeData := data[goRuntimeTypeOffset : goRuntimeTypeOffset+8]
+	runtimeType := binary.NativeEndian.Uint64(runtimeTypeData)
 	if runtimeType == 0 {
 		return writeTokens(enc,
 			jsontext.String("isNull"),
@@ -1184,9 +1209,9 @@ func encodeInterface(
 		)
 	}
 
-	typeID, ok := d.typesByGoRuntimeType[uint32(runtimeType)]
+	typeID, ok := c.getTypeIDByGoRuntimeType(uint32(runtimeType))
 	if !ok {
-		name, err := d.typeNameResolver.ResolveTypeName(gotype.TypeID(runtimeType))
+		name, err := c.ResolveTypeName(gotype.TypeID(runtimeType))
 		if err != nil {
 			name = fmt.Sprintf("UnknownType(0x%x): %v", runtimeType, err)
 		}
@@ -1203,26 +1228,27 @@ func encodeInterface(
 		return nil
 	}
 	// We know the concrete type; include it even for dynamic interfaces.
-	t, ok := d.program.Types[typeID]
+	t, ok := c.getType(typeID)
 	if !ok {
 		return fmt.Errorf("no type found for type ID: %d", typeID)
 	}
+	tt := t.irType()
 	if err := writeTokens(
-		enc, jsontext.String("type"), jsontext.String(t.GetName()),
+		enc, jsontext.String("type"), jsontext.String(tt.GetName()),
 	); err != nil {
 		return err
 	}
 	ptrData := data[goInterfaceDataOffset : goInterfaceDataOffset+8]
 	var err error
-	if pt, ok := t.(*ir.PointerType); ok {
-		err = (*pointerType)(pt).encodeValueFields(d, enc, ptrData)
+	if pt, ok := tt.(*ir.PointerType); ok {
+		err = (*pointerType)(pt).encodeValueFields(c, enc, ptrData)
 	} else {
-		switch t := t.(type) {
+		switch t := tt.(type) {
 		// Reference types need to be indirected appropriately
 		case *ir.GoMapType /* *ir.GoChannelType, *ir.GoSubroutineType */ :
 			typeID = t.HeaderType.GetID()
 		}
-		err = encodePointer(ptrData, false, typeID, enc, d)
+		err = encodePointer(c, ptrData, false, typeID, enc)
 	}
 	if err != nil {
 		return err
@@ -1232,7 +1258,7 @@ func encodeInterface(
 
 func (s *goSubroutineType) irType() ir.Type { return (*ir.GoSubroutineType)(s) }
 func (s *goSubroutineType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {
@@ -1244,7 +1270,7 @@ func (s *goSubroutineType) encodeValueFields(
 
 func (u *unresolvedPointeeType) irType() ir.Type { return (*ir.UnresolvedPointeeType)(u) }
 func (u *unresolvedPointeeType) encodeValueFields(
-	_ *Decoder,
+	_ *encodingContext,
 	enc *jsontext.Encoder,
 	_ []byte,
 ) error {

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -394,9 +394,36 @@ type RootExpression struct {
 	Name string
 	// Offset is the offset of the expression in the event output.
 	Offset uint32
+	// Kind is the kind of the expression.
+	Kind RootExpressionKind
 	// Expression is the logical operations to be evaluated to produce the
 	// value of the event.
 	Expression Expression
+}
+
+// RootExpressionKind is the kind of a root expression.
+type RootExpressionKind uint8
+
+const (
+	_ RootExpressionKind = iota
+	// RootExpressionKindArgument corresponds to an argument of the event.
+	RootExpressionKindArgument
+	// RootExpressionKindLocal corresponds to a local variable of the event.
+	RootExpressionKindLocal
+	// RootExpressionKindTemplateSegment means that this expression is part of a
+	// template segment.
+	// RootExpressionKindTemplateSegment
+)
+
+func (k RootExpressionKind) String() string {
+	switch k {
+	case RootExpressionKindArgument:
+		return "argument"
+	case RootExpressionKindLocal:
+		return "local"
+	default:
+		return fmt.Sprintf("RootExpressionKind(%d)", k)
+	}
 }
 
 // UnresolvedPointeeType is a placeholder type that represents an unresolved

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1377,6 +1377,7 @@ func populateEventExpressions(
 		expr := &ir.RootExpression{
 			Name:   variable.Name,
 			Offset: uint32(0),
+			Kind:   ir.RootExpressionKindArgument,
 			Expression: ir.Expression{
 				Type: variable.Type,
 				Operations: []ir.ExpressionOp{

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -249,6 +249,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -258,6 +259,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -267,6 +269,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 93 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -256,6 +256,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -265,6 +266,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -274,6 +276,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 98 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -274,6 +274,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -283,6 +284,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -292,6 +294,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 99 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -249,6 +249,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -258,6 +259,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -267,6 +269,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 94 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -256,6 +256,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -265,6 +266,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -274,6 +276,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 99 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -274,6 +274,7 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -283,6 +284,7 @@ Types:
                   ByteSize: 16
         - Name: s2
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -292,6 +294,7 @@ Types:
                   ByteSize: 16
         - Name: i
           Offset: 33
+          Kind: argument
           Expression:
             Type: 100 PointerType *int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -493,6 +493,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -502,6 +503,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 103 PointerType *net/http.Request
             Operations:
@@ -517,6 +519,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -513,6 +513,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -522,6 +523,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 108 PointerType *net/http.Request
             Operations:
@@ -537,6 +539,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -531,6 +531,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -540,6 +541,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 110 PointerType *net/http.Request
             Operations:
@@ -555,6 +557,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -493,6 +493,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -502,6 +503,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 103 PointerType *net/http.Request
             Operations:
@@ -517,6 +519,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -513,6 +513,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -522,6 +523,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 108 PointerType *net/http.Request
             Operations:
@@ -537,6 +539,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -531,6 +531,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -540,6 +541,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 110 PointerType *net/http.Request
             Operations:
@@ -555,6 +557,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -493,6 +493,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -502,6 +503,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 103 PointerType *net/http.Request
             Operations:
@@ -517,6 +519,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -513,6 +513,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -522,6 +523,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 108 PointerType *net/http.Request
             Operations:
@@ -537,6 +539,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -531,6 +531,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -540,6 +541,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 110 PointerType *net/http.Request
             Operations:
@@ -555,6 +557,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -493,6 +493,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -502,6 +503,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 103 PointerType *net/http.Request
             Operations:
@@ -517,6 +519,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -513,6 +513,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -522,6 +523,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 108 PointerType *net/http.Request
             Operations:
@@ -537,6 +539,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -531,6 +531,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoInterfaceType net/http.ResponseWriter
             Operations:
@@ -540,6 +541,7 @@ Types:
                   ByteSize: 16
         - Name: r
           Offset: 17
+          Kind: argument
           Expression:
             Type: 110 PointerType *net/http.Request
             Operations:
@@ -555,6 +557,7 @@ Types:
       Expressions:
         - Name: path
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -6362,6 +6362,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 154 PointerType *interface {}
             Operations:
@@ -6377,6 +6378,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
@@ -6392,6 +6394,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -6407,6 +6410,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -6422,6 +6426,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 182 ArrayType [2]map[string]int
             Operations:
@@ -6437,6 +6442,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -6452,6 +6458,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 StructureType main.bigStruct
             Operations:
@@ -6467,6 +6474,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -6482,6 +6490,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -6497,6 +6506,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 219 GoChannelType chan bool
             Operations:
@@ -6512,6 +6522,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6521,6 +6532,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6530,6 +6542,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -6545,6 +6558,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 224 PointerType *main.t
             Operations:
@@ -6560,6 +6574,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 132 StructureType main.deepMap1
             Operations:
@@ -6575,6 +6590,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 140 PointerType *main.deepMap7
             Operations:
@@ -6590,6 +6606,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 StructureType main.deepPtr1
             Operations:
@@ -6605,6 +6622,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 124 PointerType *main.deepPtr7
             Operations:
@@ -6620,6 +6638,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 StructureType main.deepSlice1
             Operations:
@@ -6635,6 +6654,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 130 PointerType *main.deepSlice7
             Operations:
@@ -6650,6 +6670,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6659,6 +6680,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6674,6 +6696,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -6689,6 +6712,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -6704,6 +6728,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 286 PointerType *main.emptyStruct
             Operations:
@@ -6719,6 +6744,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 285 StructureType main.emptyStruct
             Operations:
@@ -6734,6 +6760,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -6749,6 +6776,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 150 PointerType *main.esotericHeap
             Operations:
@@ -6764,6 +6792,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 146 StructureType main.esotericStack
             Operations:
@@ -6779,6 +6808,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 152 ArrayType [5]int
             Operations:
@@ -6794,6 +6824,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6809,6 +6840,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6824,6 +6856,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6842,6 +6875,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6851,6 +6885,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6875,6 +6910,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6890,6 +6926,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6905,6 +6942,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 152 ArrayType [5]int
             Operations:
@@ -6920,6 +6958,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -6935,6 +6974,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -6950,6 +6990,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -6965,6 +7006,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -6980,6 +7022,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -6995,6 +7038,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 GoInterfaceType main.behavior
             Operations:
@@ -7010,6 +7054,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 222 StructureType main.node
             Operations:
@@ -7025,6 +7070,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[[4]string][2]int
             Operations:
@@ -7040,6 +7086,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7055,6 +7102,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 GoMapType map[int]int
             Operations:
@@ -7070,6 +7118,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[[4]int][4]int
             Operations:
@@ -7085,6 +7134,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[[4]int]uint8
             Operations:
@@ -7100,6 +7150,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7115,6 +7166,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7130,6 +7182,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8][4]int
             Operations:
@@ -7145,6 +7198,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7160,6 +7214,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]int
             Operations:
@@ -7175,6 +7230,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string][]string
             Operations:
@@ -7190,6 +7246,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 162 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7205,6 +7262,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[bool]main.node
             Operations:
@@ -7220,6 +7278,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7235,6 +7294,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7250,6 +7310,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[int]uint8
             Operations:
@@ -7265,6 +7326,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[int]uint8
             Operations:
@@ -7280,6 +7342,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7295,6 +7358,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7310,6 +7374,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7319,6 +7384,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7328,6 +7394,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7337,6 +7404,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -7346,6 +7414,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7361,6 +7430,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 5 PointerType *bool
             Operations:
@@ -7370,6 +7440,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -7385,6 +7456,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7394,6 +7466,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7409,6 +7482,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 BaseType int8
             Operations:
@@ -7418,6 +7492,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 233 GoSliceHeaderType []bool
             Operations:
@@ -7427,6 +7502,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -7442,6 +7518,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []uint16
             Operations:
@@ -7457,6 +7534,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 PointerType *main.oneStringStruct
             Operations:
@@ -7472,6 +7550,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 223 PointerType *main.node
             Operations:
@@ -7487,6 +7566,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 183 PointerType *map[string]int
             Operations:
@@ -7502,6 +7582,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 220 PointerType *main.structWithTwoValues
             Operations:
@@ -7517,6 +7598,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -7532,6 +7614,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7547,6 +7630,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7562,6 +7646,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -7577,6 +7662,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType float64
             Operations:
@@ -7592,6 +7678,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 97 BaseType int16
             Operations:
@@ -7607,6 +7694,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7622,6 +7710,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -7637,6 +7726,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 BaseType int8
             Operations:
@@ -7652,6 +7742,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7667,6 +7758,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7682,6 +7774,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7697,6 +7790,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -7712,6 +7806,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -7727,6 +7822,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -7742,6 +7838,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7757,6 +7854,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -7772,6 +7870,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 GoSliceHeaderType [][]uint
             Operations:
@@ -7787,6 +7886,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]int
             Operations:
@@ -7802,6 +7902,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -7817,6 +7918,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -7832,6 +7934,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []string
             Operations:
@@ -7847,6 +7950,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 142 PointerType *main.stringType1
             Operations:
@@ -7862,6 +7966,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 144 PointerType **main.stringType2
             Operations:
@@ -7877,6 +7982,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7886,6 +7992,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7901,6 +8008,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 StructureType main.structWithAny
             Operations:
@@ -7916,6 +8024,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 252 StructureType main.structWithCyclicMaps
             Operations:
@@ -7931,6 +8040,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 StructureType main.structWithCyclicSlices
             Operations:
@@ -7946,6 +8056,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 156 StructureType main.structWithMap
             Operations:
@@ -7961,6 +8072,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 283 StructureType main.aStruct
             Operations:
@@ -7976,6 +8088,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 236 PointerType *main.threeStringStruct
             Operations:
@@ -7991,6 +8104,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 235 StructureType main.threeStringStruct
             Operations:
@@ -8006,6 +8120,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8015,6 +8130,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8024,6 +8140,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8039,6 +8156,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 BaseType main.typeAlias
             Operations:
@@ -8054,6 +8172,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -8069,6 +8188,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -8084,6 +8204,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -8099,6 +8220,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -8114,6 +8236,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -8129,6 +8252,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -8144,6 +8268,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -8159,6 +8284,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8174,6 +8300,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -8189,6 +8316,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [100]uint
             Operations:
@@ -8204,6 +8332,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -8219,6 +8348,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -6637,6 +6637,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 PointerType *interface {}
             Operations:
@@ -6652,6 +6653,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
@@ -6667,6 +6669,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -6682,6 +6685,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -6697,6 +6701,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 185 ArrayType [2]map[string]int
             Operations:
@@ -6712,6 +6717,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -6727,6 +6733,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 122 StructureType main.bigStruct
             Operations:
@@ -6742,6 +6749,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -6757,6 +6765,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -6772,6 +6781,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 222 GoChannelType chan bool
             Operations:
@@ -6787,6 +6797,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6796,6 +6807,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6805,6 +6817,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -6820,6 +6833,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 PointerType *main.t
             Operations:
@@ -6835,6 +6849,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 137 StructureType main.deepMap1
             Operations:
@@ -6850,6 +6865,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 143 PointerType *main.deepMap7
             Operations:
@@ -6865,6 +6881,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 StructureType main.deepPtr1
             Operations:
@@ -6880,6 +6897,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 129 PointerType *main.deepPtr7
             Operations:
@@ -6895,6 +6913,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 131 StructureType main.deepSlice1
             Operations:
@@ -6910,6 +6929,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 135 PointerType *main.deepSlice7
             Operations:
@@ -6925,6 +6945,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6934,6 +6955,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -6949,6 +6971,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -6964,6 +6987,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6979,6 +7003,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 289 PointerType *main.emptyStruct
             Operations:
@@ -6994,6 +7019,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 288 StructureType main.emptyStruct
             Operations:
@@ -7009,6 +7035,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -7024,6 +7051,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 PointerType *main.esotericHeap
             Operations:
@@ -7039,6 +7067,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 149 StructureType main.esotericStack
             Operations:
@@ -7054,6 +7083,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 ArrayType [5]int
             Operations:
@@ -7069,6 +7099,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7084,6 +7115,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7099,6 +7131,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7117,6 +7150,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7126,6 +7160,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7150,6 +7185,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7165,6 +7201,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7180,6 +7217,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 ArrayType [5]int
             Operations:
@@ -7195,6 +7233,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -7210,6 +7249,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -7225,6 +7265,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -7240,6 +7281,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -7255,6 +7297,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -7270,6 +7313,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 156 GoInterfaceType main.behavior
             Operations:
@@ -7285,6 +7329,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 225 StructureType main.node
             Operations:
@@ -7300,6 +7345,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 180 GoMapType map[[4]string][2]int
             Operations:
@@ -7315,6 +7361,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7330,6 +7377,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 160 GoMapType map[int]int
             Operations:
@@ -7345,6 +7393,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 217 GoMapType map[[4]int][4]int
             Operations:
@@ -7360,6 +7409,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 212 GoMapType map[[4]int]uint8
             Operations:
@@ -7375,6 +7425,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7390,6 +7441,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7405,6 +7457,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 207 GoMapType map[uint8][4]int
             Operations:
@@ -7420,6 +7473,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7435,6 +7489,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 170 GoMapType map[string]int
             Operations:
@@ -7450,6 +7505,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 175 GoMapType map[string][]string
             Operations:
@@ -7465,6 +7521,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 165 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7480,6 +7537,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 192 GoMapType map[bool]main.node
             Operations:
@@ -7495,6 +7553,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7510,6 +7569,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7525,6 +7585,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 197 GoMapType map[int]uint8
             Operations:
@@ -7540,6 +7601,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 197 GoMapType map[int]uint8
             Operations:
@@ -7555,6 +7617,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7570,6 +7633,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7585,6 +7649,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7594,6 +7659,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7603,6 +7669,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -7612,6 +7679,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -7621,6 +7689,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7636,6 +7705,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 PointerType *bool
             Operations:
@@ -7645,6 +7715,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -7660,6 +7731,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7669,6 +7741,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7684,6 +7757,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -7693,6 +7767,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 236 GoSliceHeaderType []bool
             Operations:
@@ -7702,6 +7777,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -7717,6 +7793,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 GoSliceHeaderType []uint16
             Operations:
@@ -7732,6 +7809,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 240 PointerType *main.oneStringStruct
             Operations:
@@ -7747,6 +7825,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 PointerType *main.node
             Operations:
@@ -7762,6 +7841,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 186 PointerType *map[string]int
             Operations:
@@ -7777,6 +7857,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 223 PointerType *main.structWithTwoValues
             Operations:
@@ -7792,6 +7873,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -7807,6 +7889,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7822,6 +7905,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7837,6 +7921,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -7852,6 +7937,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 BaseType float64
             Operations:
@@ -7867,6 +7953,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 BaseType int16
             Operations:
@@ -7882,6 +7969,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -7897,6 +7985,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -7912,6 +8001,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -7927,6 +8017,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7942,6 +8033,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -7957,6 +8049,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7972,6 +8065,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -7987,6 +8081,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -8002,6 +8097,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -8017,6 +8113,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -8032,6 +8129,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -8047,6 +8145,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 230 GoSliceHeaderType [][]uint
             Operations:
@@ -8062,6 +8161,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 170 GoMapType map[string]int
             Operations:
@@ -8077,6 +8177,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -8092,6 +8193,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -8107,6 +8209,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 235 GoSliceHeaderType []string
             Operations:
@@ -8122,6 +8225,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 145 PointerType *main.stringType1
             Operations:
@@ -8137,6 +8241,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 147 PointerType **main.stringType2
             Operations:
@@ -8152,6 +8257,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -8161,6 +8267,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8176,6 +8283,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 158 StructureType main.structWithAny
             Operations:
@@ -8191,6 +8299,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 255 StructureType main.structWithCyclicMaps
             Operations:
@@ -8206,6 +8315,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 242 StructureType main.structWithCyclicSlices
             Operations:
@@ -8221,6 +8331,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 159 StructureType main.structWithMap
             Operations:
@@ -8236,6 +8347,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 286 StructureType main.aStruct
             Operations:
@@ -8251,6 +8363,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 PointerType *main.threeStringStruct
             Operations:
@@ -8266,6 +8379,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 238 StructureType main.threeStringStruct
             Operations:
@@ -8281,6 +8395,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8290,6 +8405,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8299,6 +8415,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8314,6 +8431,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 BaseType main.typeAlias
             Operations:
@@ -8329,6 +8447,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -8344,6 +8463,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -8359,6 +8479,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -8374,6 +8495,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -8389,6 +8511,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -8404,6 +8527,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -8419,6 +8543,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -8434,6 +8559,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8449,6 +8575,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -8464,6 +8591,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 120 ArrayType [100]uint
             Operations:
@@ -8479,6 +8607,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -8494,6 +8623,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -6702,6 +6702,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 159 PointerType *interface {}
             Operations:
@@ -6717,6 +6718,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
@@ -6732,6 +6734,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -6747,6 +6750,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -6762,6 +6766,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 ArrayType [2]map[string]int
             Operations:
@@ -6777,6 +6782,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -6792,6 +6798,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 124 StructureType main.bigStruct
             Operations:
@@ -6807,6 +6814,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -6822,6 +6830,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -6837,6 +6846,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 224 GoChannelType chan bool
             Operations:
@@ -6852,6 +6862,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6861,6 +6872,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6870,6 +6882,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -6885,6 +6898,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 PointerType *main.t
             Operations:
@@ -6900,6 +6914,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 139 StructureType main.deepMap1
             Operations:
@@ -6915,6 +6930,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 145 PointerType *main.deepMap7
             Operations:
@@ -6930,6 +6946,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 128 StructureType main.deepPtr1
             Operations:
@@ -6945,6 +6962,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 131 PointerType *main.deepPtr7
             Operations:
@@ -6960,6 +6978,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 133 StructureType main.deepSlice1
             Operations:
@@ -6975,6 +6994,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 137 PointerType *main.deepSlice7
             Operations:
@@ -6990,6 +7010,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6999,6 +7020,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7014,6 +7036,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -7029,6 +7052,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7044,6 +7068,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 291 PointerType *main.emptyStruct
             Operations:
@@ -7059,6 +7084,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 290 StructureType main.emptyStruct
             Operations:
@@ -7074,6 +7100,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -7089,6 +7116,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 PointerType *main.esotericHeap
             Operations:
@@ -7104,6 +7132,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 151 StructureType main.esotericStack
             Operations:
@@ -7119,6 +7148,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 ArrayType [5]int
             Operations:
@@ -7134,6 +7164,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7149,6 +7180,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7164,6 +7196,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7182,6 +7215,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7191,6 +7225,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7215,6 +7250,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7230,6 +7266,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7245,6 +7282,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 ArrayType [5]int
             Operations:
@@ -7260,6 +7298,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -7275,6 +7314,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -7290,6 +7330,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -7305,6 +7346,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -7320,6 +7362,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -7335,6 +7378,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 158 GoInterfaceType main.behavior
             Operations:
@@ -7350,6 +7394,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 StructureType main.node
             Operations:
@@ -7365,6 +7410,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[[4]string][2]int
             Operations:
@@ -7380,6 +7426,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7395,6 +7442,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 162 GoMapType map[int]int
             Operations:
@@ -7410,6 +7458,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 219 GoMapType map[[4]int][4]int
             Operations:
@@ -7425,6 +7474,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[[4]int]uint8
             Operations:
@@ -7440,6 +7490,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7455,6 +7506,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7470,6 +7522,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[uint8][4]int
             Operations:
@@ -7485,6 +7538,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7500,6 +7554,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string]int
             Operations:
@@ -7515,6 +7570,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[string][]string
             Operations:
@@ -7530,6 +7586,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7545,6 +7602,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[bool]main.node
             Operations:
@@ -7560,6 +7618,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7575,6 +7634,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7590,6 +7650,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[int]uint8
             Operations:
@@ -7605,6 +7666,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[int]uint8
             Operations:
@@ -7620,6 +7682,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7635,6 +7698,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7650,6 +7714,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7659,6 +7724,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7668,6 +7734,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -7677,6 +7744,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -7686,6 +7754,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7701,6 +7770,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 PointerType *bool
             Operations:
@@ -7710,6 +7780,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -7725,6 +7796,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7734,6 +7806,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7749,6 +7822,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -7758,6 +7832,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 238 GoSliceHeaderType []bool
             Operations:
@@ -7767,6 +7842,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -7782,6 +7858,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 GoSliceHeaderType []uint16
             Operations:
@@ -7797,6 +7874,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.oneStringStruct
             Operations:
@@ -7812,6 +7890,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 228 PointerType *main.node
             Operations:
@@ -7827,6 +7906,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 188 PointerType *map[string]int
             Operations:
@@ -7842,6 +7922,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 225 PointerType *main.structWithTwoValues
             Operations:
@@ -7857,6 +7938,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -7872,6 +7954,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7887,6 +7970,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7902,6 +7986,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -7917,6 +8002,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType float64
             Operations:
@@ -7932,6 +8018,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 BaseType int16
             Operations:
@@ -7947,6 +8034,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -7962,6 +8050,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -7977,6 +8066,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -7992,6 +8082,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8007,6 +8098,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -8022,6 +8114,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8037,6 +8130,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -8052,6 +8146,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -8067,6 +8162,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -8082,6 +8178,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -8097,6 +8194,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -8112,6 +8210,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType [][]uint
             Operations:
@@ -8127,6 +8226,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string]int
             Operations:
@@ -8142,6 +8242,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -8157,6 +8258,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -8172,6 +8274,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 GoSliceHeaderType []string
             Operations:
@@ -8187,6 +8290,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.stringType1
             Operations:
@@ -8202,6 +8306,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 149 PointerType **main.stringType2
             Operations:
@@ -8217,6 +8322,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -8226,6 +8332,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8241,6 +8348,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 160 StructureType main.structWithAny
             Operations:
@@ -8256,6 +8364,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 257 StructureType main.structWithCyclicMaps
             Operations:
@@ -8271,6 +8380,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 244 StructureType main.structWithCyclicSlices
             Operations:
@@ -8286,6 +8396,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 161 StructureType main.structWithMap
             Operations:
@@ -8301,6 +8412,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 288 StructureType main.aStruct
             Operations:
@@ -8316,6 +8428,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 241 PointerType *main.threeStringStruct
             Operations:
@@ -8331,6 +8444,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 240 StructureType main.threeStringStruct
             Operations:
@@ -8346,6 +8460,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8355,6 +8470,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8364,6 +8480,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8379,6 +8496,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 123 BaseType main.typeAlias
             Operations:
@@ -8394,6 +8512,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -8409,6 +8528,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -8424,6 +8544,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -8439,6 +8560,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -8454,6 +8576,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -8469,6 +8592,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -8484,6 +8608,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -8499,6 +8624,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8514,6 +8640,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -8529,6 +8656,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 122 ArrayType [100]uint
             Operations:
@@ -8544,6 +8672,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -8559,6 +8688,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -6362,6 +6362,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 154 PointerType *interface {}
             Operations:
@@ -6377,6 +6378,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 148 GoEmptyInterfaceType interface {}
             Operations:
@@ -6392,6 +6394,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -6407,6 +6410,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -6422,6 +6426,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 182 ArrayType [2]map[string]int
             Operations:
@@ -6437,6 +6442,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -6452,6 +6458,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 StructureType main.bigStruct
             Operations:
@@ -6467,6 +6474,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -6482,6 +6490,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -6497,6 +6506,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 219 GoChannelType chan bool
             Operations:
@@ -6512,6 +6522,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6521,6 +6532,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6530,6 +6542,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -6545,6 +6558,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 224 PointerType *main.t
             Operations:
@@ -6560,6 +6574,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 132 StructureType main.deepMap1
             Operations:
@@ -6575,6 +6590,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 140 PointerType *main.deepMap7
             Operations:
@@ -6590,6 +6606,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 StructureType main.deepPtr1
             Operations:
@@ -6605,6 +6622,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 124 PointerType *main.deepPtr7
             Operations:
@@ -6620,6 +6638,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 StructureType main.deepSlice1
             Operations:
@@ -6635,6 +6654,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 130 PointerType *main.deepSlice7
             Operations:
@@ -6650,6 +6670,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6659,6 +6680,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6674,6 +6696,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -6689,6 +6712,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -6704,6 +6728,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 286 PointerType *main.emptyStruct
             Operations:
@@ -6719,6 +6744,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 285 StructureType main.emptyStruct
             Operations:
@@ -6734,6 +6760,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -6749,6 +6776,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 150 PointerType *main.esotericHeap
             Operations:
@@ -6764,6 +6792,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 146 StructureType main.esotericStack
             Operations:
@@ -6779,6 +6808,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 152 ArrayType [5]int
             Operations:
@@ -6794,6 +6824,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6809,6 +6840,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6824,6 +6856,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6842,6 +6875,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6851,6 +6885,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6875,6 +6910,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6890,6 +6926,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -6905,6 +6942,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 152 ArrayType [5]int
             Operations:
@@ -6920,6 +6958,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -6935,6 +6974,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -6950,6 +6990,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -6965,6 +7006,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -6980,6 +7022,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -6995,6 +7038,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 GoInterfaceType main.behavior
             Operations:
@@ -7010,6 +7054,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 222 StructureType main.node
             Operations:
@@ -7025,6 +7070,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[[4]string][2]int
             Operations:
@@ -7040,6 +7086,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7055,6 +7102,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 GoMapType map[int]int
             Operations:
@@ -7070,6 +7118,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[[4]int][4]int
             Operations:
@@ -7085,6 +7134,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[[4]int]uint8
             Operations:
@@ -7100,6 +7150,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7115,6 +7166,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7130,6 +7182,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8][4]int
             Operations:
@@ -7145,6 +7198,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7160,6 +7214,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]int
             Operations:
@@ -7175,6 +7230,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string][]string
             Operations:
@@ -7190,6 +7246,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 162 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7205,6 +7262,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[bool]main.node
             Operations:
@@ -7220,6 +7278,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7235,6 +7294,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[uint8]uint8
             Operations:
@@ -7250,6 +7310,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[int]uint8
             Operations:
@@ -7265,6 +7326,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[int]uint8
             Operations:
@@ -7280,6 +7342,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7295,6 +7358,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7310,6 +7374,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7319,6 +7384,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7328,6 +7394,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -7337,6 +7404,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -7346,6 +7414,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7361,6 +7430,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 5 PointerType *bool
             Operations:
@@ -7370,6 +7440,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -7385,6 +7456,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7394,6 +7466,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7409,6 +7482,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -7418,6 +7492,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 233 GoSliceHeaderType []bool
             Operations:
@@ -7427,6 +7502,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -7442,6 +7518,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []uint16
             Operations:
@@ -7457,6 +7534,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 PointerType *main.oneStringStruct
             Operations:
@@ -7472,6 +7550,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 223 PointerType *main.node
             Operations:
@@ -7487,6 +7566,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 183 PointerType *map[string]int
             Operations:
@@ -7502,6 +7582,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 220 PointerType *main.structWithTwoValues
             Operations:
@@ -7517,6 +7598,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -7532,6 +7614,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7547,6 +7630,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7562,6 +7646,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType float32
             Operations:
@@ -7577,6 +7662,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType float64
             Operations:
@@ -7592,6 +7678,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 89 BaseType int16
             Operations:
@@ -7607,6 +7694,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -7622,6 +7710,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 BaseType int64
             Operations:
@@ -7637,6 +7726,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -7652,6 +7742,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7667,6 +7758,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -7682,6 +7774,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -7697,6 +7790,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -7712,6 +7806,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -7727,6 +7822,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -7742,6 +7838,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7757,6 +7854,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -7772,6 +7870,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 GoSliceHeaderType [][]uint
             Operations:
@@ -7787,6 +7886,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]int
             Operations:
@@ -7802,6 +7902,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -7817,6 +7918,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -7832,6 +7934,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []string
             Operations:
@@ -7847,6 +7950,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 142 PointerType *main.stringType1
             Operations:
@@ -7862,6 +7966,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 144 PointerType **main.stringType2
             Operations:
@@ -7877,6 +7982,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7886,6 +7992,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -7901,6 +8008,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 StructureType main.structWithAny
             Operations:
@@ -7916,6 +8024,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 252 StructureType main.structWithCyclicMaps
             Operations:
@@ -7931,6 +8040,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 StructureType main.structWithCyclicSlices
             Operations:
@@ -7946,6 +8056,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 156 StructureType main.structWithMap
             Operations:
@@ -7961,6 +8072,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 283 StructureType main.aStruct
             Operations:
@@ -7976,6 +8088,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 236 PointerType *main.threeStringStruct
             Operations:
@@ -7991,6 +8104,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 235 StructureType main.threeStringStruct
             Operations:
@@ -8006,6 +8120,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8015,6 +8130,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8024,6 +8140,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8039,6 +8156,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 BaseType main.typeAlias
             Operations:
@@ -8054,6 +8172,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -8069,6 +8188,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -8084,6 +8204,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -8099,6 +8220,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -8114,6 +8236,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -8129,6 +8252,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -8144,6 +8268,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -8159,6 +8284,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -8174,6 +8300,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -8189,6 +8316,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [100]uint
             Operations:
@@ -8204,6 +8332,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:
@@ -8219,6 +8348,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -6637,6 +6637,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 PointerType *interface {}
             Operations:
@@ -6652,6 +6653,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 151 GoEmptyInterfaceType interface {}
             Operations:
@@ -6667,6 +6669,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -6682,6 +6685,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -6697,6 +6701,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 185 ArrayType [2]map[string]int
             Operations:
@@ -6712,6 +6717,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -6727,6 +6733,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 122 StructureType main.bigStruct
             Operations:
@@ -6742,6 +6749,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -6757,6 +6765,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -6772,6 +6781,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 222 GoChannelType chan bool
             Operations:
@@ -6787,6 +6797,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6796,6 +6807,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6805,6 +6817,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -6820,6 +6833,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 PointerType *main.t
             Operations:
@@ -6835,6 +6849,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 137 StructureType main.deepMap1
             Operations:
@@ -6850,6 +6865,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 143 PointerType *main.deepMap7
             Operations:
@@ -6865,6 +6881,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 StructureType main.deepPtr1
             Operations:
@@ -6880,6 +6897,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 129 PointerType *main.deepPtr7
             Operations:
@@ -6895,6 +6913,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 131 StructureType main.deepSlice1
             Operations:
@@ -6910,6 +6929,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 135 PointerType *main.deepSlice7
             Operations:
@@ -6925,6 +6945,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6934,6 +6955,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -6949,6 +6971,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -6964,6 +6987,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6979,6 +7003,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 289 PointerType *main.emptyStruct
             Operations:
@@ -6994,6 +7019,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 288 StructureType main.emptyStruct
             Operations:
@@ -7009,6 +7035,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -7024,6 +7051,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 PointerType *main.esotericHeap
             Operations:
@@ -7039,6 +7067,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 149 StructureType main.esotericStack
             Operations:
@@ -7054,6 +7083,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 ArrayType [5]int
             Operations:
@@ -7069,6 +7099,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7084,6 +7115,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7099,6 +7131,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7117,6 +7150,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7126,6 +7160,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7150,6 +7185,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7165,6 +7201,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7180,6 +7217,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 ArrayType [5]int
             Operations:
@@ -7195,6 +7233,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -7210,6 +7249,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -7225,6 +7265,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -7240,6 +7281,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -7255,6 +7297,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -7270,6 +7313,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 156 GoInterfaceType main.behavior
             Operations:
@@ -7285,6 +7329,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 225 StructureType main.node
             Operations:
@@ -7300,6 +7345,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 180 GoMapType map[[4]string][2]int
             Operations:
@@ -7315,6 +7361,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7330,6 +7377,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 160 GoMapType map[int]int
             Operations:
@@ -7345,6 +7393,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 217 GoMapType map[[4]int][4]int
             Operations:
@@ -7360,6 +7409,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 212 GoMapType map[[4]int]uint8
             Operations:
@@ -7375,6 +7425,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7390,6 +7441,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7405,6 +7457,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 207 GoMapType map[uint8][4]int
             Operations:
@@ -7420,6 +7473,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7435,6 +7489,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 170 GoMapType map[string]int
             Operations:
@@ -7450,6 +7505,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 175 GoMapType map[string][]string
             Operations:
@@ -7465,6 +7521,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 165 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7480,6 +7537,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 192 GoMapType map[bool]main.node
             Operations:
@@ -7495,6 +7553,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7510,6 +7569,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 202 GoMapType map[uint8]uint8
             Operations:
@@ -7525,6 +7585,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 197 GoMapType map[int]uint8
             Operations:
@@ -7540,6 +7601,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 197 GoMapType map[int]uint8
             Operations:
@@ -7555,6 +7617,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7570,6 +7633,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7585,6 +7649,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7594,6 +7659,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7603,6 +7669,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7612,6 +7679,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7621,6 +7689,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7636,6 +7705,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 PointerType *bool
             Operations:
@@ -7645,6 +7715,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7660,6 +7731,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7669,6 +7741,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7684,6 +7757,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -7693,6 +7767,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 236 GoSliceHeaderType []bool
             Operations:
@@ -7702,6 +7777,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7717,6 +7793,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 GoSliceHeaderType []uint16
             Operations:
@@ -7732,6 +7809,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 240 PointerType *main.oneStringStruct
             Operations:
@@ -7747,6 +7825,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 226 PointerType *main.node
             Operations:
@@ -7762,6 +7841,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 186 PointerType *map[string]int
             Operations:
@@ -7777,6 +7857,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 223 PointerType *main.structWithTwoValues
             Operations:
@@ -7792,6 +7873,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -7807,6 +7889,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7822,6 +7905,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7837,6 +7921,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType float32
             Operations:
@@ -7852,6 +7937,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 BaseType float64
             Operations:
@@ -7867,6 +7953,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 94 BaseType int16
             Operations:
@@ -7882,6 +7969,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7897,6 +7985,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -7912,6 +8001,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -7927,6 +8017,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7942,6 +8033,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7957,6 +8049,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7972,6 +8065,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -7987,6 +8081,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -8002,6 +8097,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -8017,6 +8113,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -8032,6 +8129,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -8047,6 +8145,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 230 GoSliceHeaderType [][]uint
             Operations:
@@ -8062,6 +8161,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 170 GoMapType map[string]int
             Operations:
@@ -8077,6 +8177,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -8092,6 +8193,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -8107,6 +8209,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 235 GoSliceHeaderType []string
             Operations:
@@ -8122,6 +8225,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 145 PointerType *main.stringType1
             Operations:
@@ -8137,6 +8241,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 147 PointerType **main.stringType2
             Operations:
@@ -8152,6 +8257,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -8161,6 +8267,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8176,6 +8283,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 158 StructureType main.structWithAny
             Operations:
@@ -8191,6 +8299,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 255 StructureType main.structWithCyclicMaps
             Operations:
@@ -8206,6 +8315,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 242 StructureType main.structWithCyclicSlices
             Operations:
@@ -8221,6 +8331,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 159 StructureType main.structWithMap
             Operations:
@@ -8236,6 +8347,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 286 StructureType main.aStruct
             Operations:
@@ -8251,6 +8363,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 PointerType *main.threeStringStruct
             Operations:
@@ -8266,6 +8379,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 238 StructureType main.threeStringStruct
             Operations:
@@ -8281,6 +8395,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8290,6 +8405,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8299,6 +8415,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8314,6 +8431,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 BaseType main.typeAlias
             Operations:
@@ -8329,6 +8447,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -8344,6 +8463,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -8359,6 +8479,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -8374,6 +8495,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -8389,6 +8511,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -8404,6 +8527,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -8419,6 +8543,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -8434,6 +8559,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8449,6 +8575,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -8464,6 +8591,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 120 ArrayType [100]uint
             Operations:
@@ -8479,6 +8607,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:
@@ -8494,6 +8623,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -6702,6 +6702,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 159 PointerType *interface {}
             Operations:
@@ -6717,6 +6718,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 153 GoEmptyInterfaceType interface {}
             Operations:
@@ -6732,6 +6734,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -6747,6 +6750,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -6762,6 +6766,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 187 ArrayType [2]map[string]int
             Operations:
@@ -6777,6 +6782,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -6792,6 +6798,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 124 StructureType main.bigStruct
             Operations:
@@ -6807,6 +6814,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -6822,6 +6830,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -6837,6 +6846,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
+          Kind: argument
           Expression:
             Type: 224 GoChannelType chan bool
             Operations:
@@ -6852,6 +6862,7 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6861,6 +6872,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -6870,6 +6882,7 @@ Types:
                   ByteSize: 1
         - Name: y
           Offset: 3
+          Kind: argument
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -6885,6 +6898,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
+          Kind: argument
           Expression:
             Type: 229 PointerType *main.t
             Operations:
@@ -6900,6 +6914,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 139 StructureType main.deepMap1
             Operations:
@@ -6915,6 +6930,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 145 PointerType *main.deepMap7
             Operations:
@@ -6930,6 +6946,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 128 StructureType main.deepPtr1
             Operations:
@@ -6945,6 +6962,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 131 PointerType *main.deepPtr7
             Operations:
@@ -6960,6 +6978,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 133 StructureType main.deepSlice1
             Operations:
@@ -6975,6 +6994,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 137 PointerType *main.deepSlice7
             Operations:
@@ -6990,6 +7010,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -6999,6 +7020,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7014,6 +7036,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -7029,6 +7052,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7044,6 +7068,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 291 PointerType *main.emptyStruct
             Operations:
@@ -7059,6 +7084,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 290 StructureType main.emptyStruct
             Operations:
@@ -7074,6 +7100,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -7089,6 +7116,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 155 PointerType *main.esotericHeap
             Operations:
@@ -7104,6 +7132,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
+          Kind: argument
           Expression:
             Type: 151 StructureType main.esotericStack
             Operations:
@@ -7119,6 +7148,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 ArrayType [5]int
             Operations:
@@ -7134,6 +7164,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7149,6 +7180,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7164,6 +7196,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7182,6 +7215,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7191,6 +7225,7 @@ Types:
                   ByteSize: 8
         - Name: y
           Offset: 9
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7215,6 +7250,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7230,6 +7266,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7245,6 +7282,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 157 ArrayType [5]int
             Operations:
@@ -7260,6 +7298,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -7275,6 +7314,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -7290,6 +7330,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -7305,6 +7346,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -7320,6 +7362,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -7335,6 +7378,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
+          Kind: argument
           Expression:
             Type: 158 GoInterfaceType main.behavior
             Operations:
@@ -7350,6 +7394,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 227 StructureType main.node
             Operations:
@@ -7365,6 +7410,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[[4]string][2]int
             Operations:
@@ -7380,6 +7426,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7395,6 +7442,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 162 GoMapType map[int]int
             Operations:
@@ -7410,6 +7458,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 219 GoMapType map[[4]int][4]int
             Operations:
@@ -7425,6 +7474,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[[4]int]uint8
             Operations:
@@ -7440,6 +7490,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7455,6 +7506,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 189 GoMapType map[string][]main.structWithMap
             Operations:
@@ -7470,6 +7522,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[uint8][4]int
             Operations:
@@ -7485,6 +7538,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7500,6 +7554,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string]int
             Operations:
@@ -7515,6 +7570,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[string][]string
             Operations:
@@ -7530,6 +7586,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 167 GoMapType map[string]main.nestedStruct
             Operations:
@@ -7545,6 +7602,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 194 GoMapType map[bool]main.node
             Operations:
@@ -7560,6 +7618,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7575,6 +7634,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[uint8]uint8
             Operations:
@@ -7590,6 +7650,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[int]uint8
             Operations:
@@ -7605,6 +7666,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[int]uint8
             Operations:
@@ -7620,6 +7682,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7635,6 +7698,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7650,6 +7714,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7659,6 +7724,7 @@ Types:
                   ByteSize: 1
         - Name: b
           Offset: 2
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7668,6 +7734,7 @@ Types:
                   ByteSize: 1
         - Name: c
           Offset: 3
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7677,6 +7744,7 @@ Types:
                   ByteSize: 4
         - Name: d
           Offset: 7
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7686,6 +7754,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 15
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -7701,6 +7770,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 11 PointerType *bool
             Operations:
@@ -7710,6 +7780,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7725,6 +7796,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -7734,6 +7806,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -7749,6 +7822,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType int8
             Operations:
@@ -7758,6 +7832,7 @@ Types:
                   ByteSize: 1
         - Name: s
           Offset: 2
+          Kind: argument
           Expression:
             Type: 238 GoSliceHeaderType []bool
             Operations:
@@ -7767,6 +7842,7 @@ Types:
                   ByteSize: 24
         - Name: x
           Offset: 26
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -7782,6 +7858,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 239 GoSliceHeaderType []uint16
             Operations:
@@ -7797,6 +7874,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.oneStringStruct
             Operations:
@@ -7812,6 +7890,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 228 PointerType *main.node
             Operations:
@@ -7827,6 +7906,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 188 PointerType *map[string]int
             Operations:
@@ -7842,6 +7922,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 225 PointerType *main.structWithTwoValues
             Operations:
@@ -7857,6 +7938,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -7872,6 +7954,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -7887,6 +7970,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -7902,6 +7986,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 18 BaseType float32
             Operations:
@@ -7917,6 +8002,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 16 BaseType float64
             Operations:
@@ -7932,6 +8018,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 96 BaseType int16
             Operations:
@@ -7947,6 +8034,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -7962,6 +8050,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -7977,6 +8066,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 17 BaseType int8
             Operations:
@@ -7992,6 +8082,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8007,6 +8098,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -8022,6 +8114,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8037,6 +8130,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -8052,6 +8146,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -8067,6 +8162,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -8082,6 +8178,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -8097,6 +8194,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -8112,6 +8210,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 232 GoSliceHeaderType [][]uint
             Operations:
@@ -8127,6 +8226,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[string]int
             Operations:
@@ -8142,6 +8242,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -8157,6 +8258,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
+          Kind: argument
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -8172,6 +8274,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 237 GoSliceHeaderType []string
             Operations:
@@ -8187,6 +8290,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.stringType1
             Operations:
@@ -8202,6 +8306,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 149 PointerType **main.stringType2
             Operations:
@@ -8217,6 +8322,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 234 GoSliceHeaderType []main.structWithNoStrings
             Operations:
@@ -8226,6 +8332,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -8241,6 +8348,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 160 StructureType main.structWithAny
             Operations:
@@ -8256,6 +8364,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 257 StructureType main.structWithCyclicMaps
             Operations:
@@ -8271,6 +8380,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 244 StructureType main.structWithCyclicSlices
             Operations:
@@ -8286,6 +8396,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 161 StructureType main.structWithMap
             Operations:
@@ -8301,6 +8412,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 288 StructureType main.aStruct
             Operations:
@@ -8316,6 +8428,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 241 PointerType *main.threeStringStruct
             Operations:
@@ -8331,6 +8444,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 240 StructureType main.threeStringStruct
             Operations:
@@ -8346,6 +8460,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8355,6 +8470,7 @@ Types:
                   ByteSize: 16
         - Name: y
           Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8364,6 +8480,7 @@ Types:
                   ByteSize: 16
         - Name: z
           Offset: 33
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8379,6 +8496,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 123 BaseType main.typeAlias
             Operations:
@@ -8394,6 +8512,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -8409,6 +8528,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -8424,6 +8544,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -8439,6 +8560,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -8454,6 +8576,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -8469,6 +8592,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -8484,6 +8608,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -8499,6 +8624,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -8514,6 +8640,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -8529,6 +8656,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
+          Kind: argument
           Expression:
             Type: 122 ArrayType [100]uint
             Operations:
@@ -8544,6 +8672,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:
@@ -8559,6 +8688,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
+          Kind: argument
           Expression:
             Type: 231 GoSliceHeaderType []uint
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -660,6 +660,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 120 PointerType *****int
             Operations:
@@ -675,6 +676,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 122 PointerType **int
             Operations:
@@ -690,6 +692,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 GoMapType map[string]main.bigStruct
             Operations:
@@ -705,6 +708,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -720,6 +724,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -735,6 +740,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 100 ArrayType [3]int
             Operations:
@@ -750,6 +756,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 99 GoSliceHeaderType []int
             Operations:
@@ -765,6 +772,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 GoMapType map[string]int
             Operations:
@@ -783,6 +791,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -798,6 +807,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [3]string
             Operations:
@@ -813,6 +823,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 ArrayType [3]string
             Operations:
@@ -828,6 +839,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 101 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -700,6 +700,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 123 PointerType *****int
             Operations:
@@ -715,6 +716,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 125 PointerType **int
             Operations:
@@ -730,6 +732,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 113 GoMapType map[string]main.bigStruct
             Operations:
@@ -745,6 +748,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -760,6 +764,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -775,6 +780,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 ArrayType [3]int
             Operations:
@@ -790,6 +796,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 GoSliceHeaderType []int
             Operations:
@@ -805,6 +812,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 GoMapType map[string]int
             Operations:
@@ -823,6 +831,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -838,6 +847,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [3]string
             Operations:
@@ -853,6 +863,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [3]string
             Operations:
@@ -868,6 +879,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 106 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -718,6 +718,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 125 PointerType *****int
             Operations:
@@ -733,6 +734,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 127 PointerType **int
             Operations:
@@ -748,6 +750,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 115 GoMapType map[string]main.bigStruct
             Operations:
@@ -763,6 +766,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -778,6 +782,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -793,6 +798,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 ArrayType [3]int
             Operations:
@@ -808,6 +814,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 106 GoSliceHeaderType []int
             Operations:
@@ -823,6 +830,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 GoMapType map[string]int
             Operations:
@@ -841,6 +849,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -856,6 +865,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [3]string
             Operations:
@@ -871,6 +881,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 ArrayType [3]string
             Operations:
@@ -886,6 +897,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -660,6 +660,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 121 PointerType *****int
             Operations:
@@ -675,6 +676,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 123 PointerType **int
             Operations:
@@ -690,6 +692,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]main.bigStruct
             Operations:
@@ -705,6 +708,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -720,6 +724,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -735,6 +740,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 101 ArrayType [3]int
             Operations:
@@ -750,6 +756,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 100 GoSliceHeaderType []int
             Operations:
@@ -765,6 +772,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 104 GoMapType map[string]int
             Operations:
@@ -783,6 +791,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -798,6 +807,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [3]string
             Operations:
@@ -813,6 +823,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 103 ArrayType [3]string
             Operations:
@@ -828,6 +839,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 102 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -700,6 +700,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 124 PointerType *****int
             Operations:
@@ -715,6 +716,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 PointerType **int
             Operations:
@@ -730,6 +732,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 114 GoMapType map[string]main.bigStruct
             Operations:
@@ -745,6 +748,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -760,6 +764,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -775,6 +780,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 106 ArrayType [3]int
             Operations:
@@ -790,6 +796,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 105 GoSliceHeaderType []int
             Operations:
@@ -805,6 +812,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoMapType map[string]int
             Operations:
@@ -823,6 +831,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -838,6 +847,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [3]string
             Operations:
@@ -853,6 +863,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [3]string
             Operations:
@@ -868,6 +879,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -718,6 +718,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 126 PointerType *****int
             Operations:
@@ -733,6 +734,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
+          Kind: argument
           Expression:
             Type: 128 PointerType **int
             Operations:
@@ -748,6 +750,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 116 GoMapType map[string]main.bigStruct
             Operations:
@@ -763,6 +766,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -778,6 +782,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -793,6 +798,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 108 ArrayType [3]int
             Operations:
@@ -808,6 +814,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 107 GoSliceHeaderType []int
             Operations:
@@ -823,6 +830,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]int
             Operations:
@@ -841,6 +849,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -856,6 +865,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [3]string
             Operations:
@@ -871,6 +881,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 110 ArrayType [3]string
             Operations:
@@ -886,6 +897,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
+          Kind: argument
           Expression:
             Type: 109 GoSliceHeaderType []string
             Operations:

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -92,7 +92,11 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 			default:
 				return fmt.Errorf("unknown dynamic size class: %d", v)
 			}
-		}))
+		}),
+		json.MarshalToFunc(func(enc *jsontext.Encoder, v ir.RootExpressionKind) error {
+			return enc.WriteToken(jsontext.String(v.String()))
+		}),
+	)
 	probeMarshalers := json.JoinMarshalers(
 		basicMarshalers,
 		json.MarshalToFunc(func(enc *jsontext.Encoder, v *ir.Subprogram) error {

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -57,11 +57,7 @@
             "method": "main.stackC"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBBB.json
@@ -57,11 +57,7 @@
             "method": "main.testInlinedBBB"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBC.json
@@ -52,11 +52,7 @@
             "method": "main.testInlinedBC"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCA.json
@@ -57,11 +57,7 @@
             "method": "main.testInlinedBCA"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedBCB.json
@@ -57,11 +57,7 @@
             "method": "main.testInlinedBCB"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -42,11 +42,7 @@
             "method": "main.noArgs"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -42,11 +42,7 @@
             "method": "main.usesMapsOfMapsThatDoNotAppearAsArguments"
           }
         },
-        "captures": {
-          "entry": {
-            "arguments": {}
-          }
-        }
+        "captures": {}
       }
     },
     "timestamp": "[ts]"


### PR DESCRIPTION
### What does this PR do?

This reworks some of the Decoder internals to make it more straightforward to accommodate
outputting variables that are not arguments, and to make it possible to create messages that
draw from more than one event (and thus more than one universe of pointers).

### Motivation

This is pulled out of work for https://datadoghq.atlassian.net/browse/DEBUG-4031 because it's also going to
be important for template expressions and line probes.

### Describe how you validated your changes

The tests all pass and I'm using these changes elsewhere.
