### PR TITLE
[flakefinder] Fix pipeline generation with more than 50 jobs matrixes

### DIFF
--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -275,6 +275,9 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
     updated_jobs = update_child_job_variables(kept_job)
     # Create n jobs with the same configuration
     for job in kept_job:
+        n_needs = 0
+        if "needs" in updated_jobs[job]:
+            n_needs = len(updated_jobs[job]["needs"])
         for i in range(n):
             new_jobs[f"{job}-{i}"] = copy.deepcopy(updated_jobs[job])
             new_jobs[f"{job}-{i}"]["stage"] = f"flake-finder-{i}"
@@ -284,6 +287,17 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
 
             new_jobs[f"{job}-{i}"]["rules"] = [{"when": "always"}]
             if i > 0:
+                if "parallel" in updated_jobs[job] and "matrix" in updated_jobs[job]["parallel"]:
+                    if len(updated_jobs[job]["parallel"]["matrix"]) + n_needs > 50:  # Max 50 needs in a job
+                        # We only keep the first matrix entry to avoid reaching the limit and to still make sure all the jobs are not executed at the exactly same time
+                        new_jobs[f"{job}-{i}"]["needs"].append(
+                            {
+                                "job": f"{job}-{i - 1}",
+                                "artifacts": False,
+                                "parallel": {"matrix": [copy.deepcopy(updated_jobs[job]["parallel"]["matrix"][0])]},
+                            }
+                        )
+                        continue
                 new_jobs[f"{job}-{i}"]["needs"].append({"job": f"{job}-{i - 1}", "artifacts": False})
 
     with open("flake-finder-gitlab-ci.yml", "w") as f:


### PR DESCRIPTION
### What does this PR do?

The following error happened when generating the flake finder pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/77611250
It happened because new-e2e-windows-installer defines a matrix with more than 50 jobs. Adding a needs on that job is not possible because the limit is at max 50 needs.
To prevent that from happening again, just take the first element of the matrix if it would create a needs with more than 50 jobs. It changes a bit the need of the generated job, but the main goal is to make sure they do not run all at the same time, not because they really have a dependency between them

### Motivation

Fix flakefinder

### Describe how you validated your changes

### Additional Notes
