### PR TITLE
[CWS] remove allocation from pattern index/hasPrefix in case insensitive case

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -704,6 +704,9 @@ core,github.com/cenkalti/backoff,MIT,Copyright (c) 2014 Cenk Altı
 core,github.com/cenkalti/backoff/v4,MIT,Copyright (c) 2014 Cenk Altı
 core,github.com/cenkalti/backoff/v5,MIT,Copyright (c) 2014 Cenk Altı
 core,github.com/cespare/xxhash/v2,MIT,Copyright (c) 2016 Caleb Spare
+core,github.com/charlievieth/strcase,MIT,Copyright 2024 Charlie Vieth
+core,github.com/charlievieth/strcase/internal/bytealg,MIT,Copyright 2024 Charlie Vieth
+core,github.com/charlievieth/strcase/internal/tables,MIT,Copyright 2024 Charlie Vieth
 core,github.com/chrusty/protoc-gen-jsonschema,Apache-2.0,Copyright (c) 2017 The Authors
 core,github.com/cihub/seelog,BSD-3-Clause,"Copyright (c) 2012, Cloud Instruments Co., Ltd. <info@cin.io>"
 core,github.com/cilium/ebpf,MIT,"Copyright (c) 2017 Nathan Sweet | Copyright (c) 2018, 2019 Cloudflare | Copyright (c) 2019 Authors of Cilium"

--- a/go.mod
+++ b/go.mod
@@ -960,6 +960,7 @@ require (
 
 require (
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
+	github.com/charlievieth/strcase v0.0.5 // indirect
 	github.com/elastic/go-freelru v0.16.0 // indirect
 	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -433,6 +433,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/charlievieth/strcase v0.0.5 h1:gV4iXVyD6eI5KdfOV+/vIVCKXZwtCWOmDMcu7Uy00Rs=
+github.com/charlievieth/strcase v0.0.5/go.mod h1:FIOYY1aDBMSIOFqmVomHBpoK+bteGlESRsgsdWjrhx8=
 github.com/cheggaaa/pb v1.0.10/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=

--- a/pkg/security/secl/compiler/eval/pattern.go
+++ b/pkg/security/secl/compiler/eval/pattern.go
@@ -8,6 +8,8 @@ package eval
 
 import (
 	"strings"
+
+	"github.com/charlievieth/strcase"
 )
 
 func nextSegment(str string) (bool, string, int) {
@@ -40,18 +42,16 @@ func nextSegment(str string) (bool, string, int) {
 	return star, str[start:end], end
 }
 
-func index(s, subtr string, caseInsensitive bool) int {
+func index(s, substr string, caseInsensitive bool) int {
 	if caseInsensitive {
-		s = strings.ToLower(s)
-		subtr = strings.ToLower(subtr)
+		return strcase.Index(s, substr)
 	}
-	return strings.Index(s, subtr)
+	return strings.Index(s, substr)
 }
 
 func hasPrefix(s, prefix string, caseInsensitive bool) bool {
 	if caseInsensitive {
-		s = strings.ToLower(s)
-		prefix = strings.ToLower(prefix)
+		return strcase.HasPrefix(s, prefix)
 	}
 	return strings.HasPrefix(s, prefix)
 }

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/participle v0.7.1
+	github.com/charlievieth/strcase v0.0.5
 	github.com/google/go-cmp v0.7.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/uuid v1.6.0

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -3,6 +3,8 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/charlievieth/strcase v0.0.5 h1:gV4iXVyD6eI5KdfOV+/vIVCKXZwtCWOmDMcu7Uy00Rs=
+github.com/charlievieth/strcase v0.0.5/go.mod h1:FIOYY1aDBMSIOFqmVomHBpoK+bteGlESRsgsdWjrhx8=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -6,8 +6,10 @@ require github.com/DataDog/datadog-agent/pkg/security/secl v0.56.0-rc.3
 
 require (
 	github.com/alecthomas/participle v0.7.1 // indirect
+	github.com/charlievieth/strcase v0.0.5 // indirect
 	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
 )
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/pkg/security/seclwin/go.sum
+++ b/pkg/security/seclwin/go.sum
@@ -1,6 +1,8 @@
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/charlievieth/strcase v0.0.5 h1:gV4iXVyD6eI5KdfOV+/vIVCKXZwtCWOmDMcu7Uy00Rs=
+github.com/charlievieth/strcase v0.0.5/go.mod h1:FIOYY1aDBMSIOFqmVomHBpoK+bteGlESRsgsdWjrhx8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -18,6 +20,8 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### What does this PR do?

When doing some string matching on DNS names, hostnames, or Windows path we want to do the operation in a case insensitive way. We currently do it by first `strings.ToLower`-ing the needle and the haystack, and then doing the operation regularly. The issue with this is that it allocates (the 2 lowered string versions). To improve this, this PR uses https://github.com/charlievieth/strcase to do the case sensitive operations in an allocation free manner, speeding things up greatly.

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval
cpu: Apple M1 Max
                                 │  before.txt  │              after.txt              │
                                 │    sec/op    │   sec/op     vs base                │
PatternMatchesCaseInsensitive-10   177.65n ± 2%   89.92n ± 1%  -49.38% (p=0.000 n=10)

                                 │ before.txt │             after.txt              │
                                 │    B/op    │    B/op     vs base                │
PatternMatchesCaseInsensitive-10   96.00 ± 0%   72.00 ± 0%  -25.00% (p=0.000 n=10)

                                 │ before.txt │             after.txt              │
                                 │ allocs/op  │ allocs/op   vs base                │
PatternMatchesCaseInsensitive-10   5.000 ± 0%   2.000 ± 0%  -60.00% (p=0.000 n=10)
```

### Motivation

### Describe how you validated your changes

### Additional Notes
