### PR TITLE
Bump again timeout too short when pulling a fresh Windows image

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -25,7 +25,7 @@
 
 .bazel:ext:windows:
   extends: .windows_docker_default
-  timeout: 20m
+  timeout: 30m # pulling images alone takes between 10m and 20m
   allow_failure: true
   retry: 0
   variables:


### PR DESCRIPTION
### Motivation
As seen in numerous cases like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1149315881, bumping the timeout from 15m to 20m in #41262 turned out to be too conservative as image pulling frequently takes 18m or more, leaving too few time for the payload (`bazel` execution) and postamble (caching).

### What does this PR do?
Let's go for 30m. (i.e. twice the initial value)

### Additional Notes
See #41262 for additional links.
