### PR TITLE
Autoscaling: fix infinite update loop when spec hashes do not match

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/pod_watcher_fake.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher_fake.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package workload
+
+import (
+	"context"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/stretchr/testify/mock"
+)
+
+type fakePodWatcher struct {
+	mock.Mock
+}
+
+func newFakePodWatcher() *fakePodWatcher {
+	return &fakePodWatcher{}
+}
+
+func (f *fakePodWatcher) Run(ctx context.Context) {
+	f.Called(ctx)
+}
+
+func (f *fakePodWatcher) GetPodsForOwner(owner NamespacedPodOwner) []*workloadmeta.KubernetesPod {
+	return f.Called(owner).Get(0).([]*workloadmeta.KubernetesPod)
+}
+
+func (f *fakePodWatcher) GetReadyPodsForOwner(owner NamespacedPodOwner) int32 {
+	return f.Called(owner).Get(0).(int32)
+}
+
+func (f *fakePodWatcher) mockGetPodsForOwner(owner NamespacedPodOwner, pods []*workloadmeta.KubernetesPod) {
+	mockCall := f.On("GetPodsForOwner", owner)
+	mockCall.Return(pods)
+}

--- a/pkg/clusteragent/autoscaling/workload/scaler_fake.go
+++ b/pkg/clusteragent/autoscaling/workload/scaler_fake.go
@@ -36,7 +36,7 @@ func (fs *fakeScaler) update(ctx context.Context, gr schema.GroupResource, scale
 }
 
 func (fs *fakeScaler) mockGet(pai model.FakePodAutoscalerInternal, specReplicas, statusReplicas int32, err error) {
-	mockCall := fs.On("get", mock.Anything, pai.Namespace, pai.Name, pai.TargetGVK)
+	mockCall := fs.On("get", mock.Anything, pai.Namespace, pai.Spec.TargetRef.Name, pai.TargetGVK)
 	if err != nil {
 		mockCall.Return(nil, schema.GroupResource{}, err)
 		return


### PR DESCRIPTION
### What does this PR do?

This PR fixes the behaviour of the Cluster Agent when the `.Spec` retrieved _after_ a DPA has been created/updated with values not originating from the Cluster Agent itself.

The discrepancy can come from different sources: admission controller, CRD defaulting, etc. which are not necessarily expected but should not break the overall feature either.

### Motivation

Fixing inactive remote Autoscalers when Remote Spec hash is different from actual object Spec hash after update.

### Describe how you validated your changes

Change validate in a testing Kubernetes cluster. It can be reproduced by creating a remote autoscaler with a recent version of the Cluster Agent/CRD that has defaulting for local fallback values.

Added a unit test to cover this specific case.

### Additional Notes

The current solution is not optimal and we cannot cope with differences manually done in case Cluster Agent leader was not available at the time of the update.