### PR TITLE
[EBPF-824] gpu: fix TestConsumerProcessExitViaCheckClosedProcesses flaky test

### DIFF
--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -159,16 +159,10 @@ func BenchmarkConsumer(b *testing.B) {
 func TestConsumerProcessExitChannel(t *testing.T) {
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	handler := ddebpf.NewRingBufferHandler(consumerChannelSize)
-	cfg := config.New()
-	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
-	streamHandlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), cfg)
-	consumer := newCudaEventConsumer(ctx, streamHandlers, handler, cfg, testutil.GetTelemetryMock(t))
 
-	// Create fake procfs with a process
+	// Create fake procfs
 	pid := uint32(5001)
 	streamID := uint64(1)
-
-	// Create fake procfs entry for the process
 	fakeProcFS := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{
 		{
 			Pid:     pid,
@@ -177,13 +171,18 @@ func TestConsumerProcessExitChannel(t *testing.T) {
 			Exe:     "/usr/bin/test-process",
 			Maps:    "00400000-00401000 r-xp 00000000 08:01 123456 /usr/bin/test-process",
 			Env:     map[string]string{"PATH": "/usr/bin", "HOME": "/home/test"},
-		},
-	})
+		}},
+		kernel.WithRealUptime(), // Required for the ktime resolver to work
+		kernel.WithRealStat(),
+	)
 
 	// Set up the fake procfs
 	kernel.WithFakeProcFS(t, fakeProcFS)
-	ctx.procRoot = fakeProcFS
-	consumer.cfg.ProcRoot = fakeProcFS
+
+	cfg := config.New()
+	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
+	streamHandlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), cfg)
+	consumer := newCudaEventConsumer(ctx, streamHandlers, handler, cfg, testutil.GetTelemetryMock(t))
 
 	// Start the consumer
 	consumer.Start()
@@ -214,17 +213,10 @@ func TestConsumerProcessExitChannel(t *testing.T) {
 func TestConsumerProcessExitViaCheckClosedProcesses(t *testing.T) {
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	handler := ddebpf.NewRingBufferHandler(consumerChannelSize)
-	cfg := config.New()
-	cfg.ScanProcessesInterval = 100 * time.Millisecond // don't wait too long
-	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
-	streamHandlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), cfg)
-	consumer := newCudaEventConsumer(ctx, streamHandlers, handler, cfg, testutil.GetTelemetryMock(t))
 
-	// Create fake procfs with a process that will disappear
+	// Create fake procfs with a process that we will remove later
 	pid := uint32(6001)
 	streamID := uint64(1)
-
-	// Create fake procfs entry for the process
 	fakeProcFS := kernel.CreateFakeProcFS(t, []kernel.FakeProcFSEntry{
 		{
 			Pid:     pid,
@@ -233,13 +225,19 @@ func TestConsumerProcessExitViaCheckClosedProcesses(t *testing.T) {
 			Exe:     "/usr/bin/test-process",
 			Maps:    "00400000-00401000 r-xp 00000000 08:01 123456 /usr/bin/test-process",
 			Env:     map[string]string{"PATH": "/usr/bin", "HOME": "/home/test"},
-		},
-	})
+		}},
+		kernel.WithRealUptime(), // Required for the ktime resolver to work
+		kernel.WithRealStat(),
+	)
 
 	// Set up the fake procfs
 	kernel.WithFakeProcFS(t, fakeProcFS)
-	ctx.procRoot = fakeProcFS
-	consumer.cfg.ProcRoot = fakeProcFS
+
+	cfg := config.New()
+	cfg.ScanProcessesInterval = 100 * time.Millisecond // don't wait too long
+	ctx := getTestSystemContext(t, withFatbinParsingEnabled(true))
+	streamHandlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t), cfg)
+	consumer := newCudaEventConsumer(ctx, streamHandlers, handler, cfg, testutil.GetTelemetryMock(t))
 
 	// Start the consumer
 	consumer.Start()

--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -183,6 +183,7 @@ func TestConsumerProcessExitChannel(t *testing.T) {
 	// Set up the fake procfs
 	kernel.WithFakeProcFS(t, fakeProcFS)
 	ctx.procRoot = fakeProcFS
+	consumer.cfg.ProcRoot = fakeProcFS
 
 	// Start the consumer
 	consumer.Start()
@@ -238,6 +239,7 @@ func TestConsumerProcessExitViaCheckClosedProcesses(t *testing.T) {
 	// Set up the fake procfs
 	kernel.WithFakeProcFS(t, fakeProcFS)
 	ctx.procRoot = fakeProcFS
+	consumer.cfg.ProcRoot = fakeProcFS
 
 	// Start the consumer
 	consumer.Start()


### PR DESCRIPTION
### What does this PR do?

Fixes a low frequency flaky test. The way the test was written, the `procRoot` with the fake data was not being actually used to check for the closed processes (it was being passed to the context but not the consumer), and instead it was using the real `/proc` path. This made the test work most of the time, except when we had a real process with the PID of our fake process. 

### Motivation

Eliminate flaky tests.

### Describe how you validated your changes

Fixed the unit test.

### Additional Notes
