### PR TITLE
tagger: Add tracer metadata process tags to Process

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -989,22 +989,21 @@ func parseProcessTags(tags *taglist.TagList, processTags string) {
 		return
 	}
 
-	tagList := strings.Split(processTags, ",")
-	for _, tag := range tagList {
+	for tag := range strings.SplitSeq(processTags, ",") {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {
 			continue
 		}
 
 		// Split each tag into key:value format
-		tagParts := strings.SplitN(tag, ":", 2)
-		if len(tagParts) != 2 {
+		key, value, ok := strings.Cut(tag, ":")
+		if !ok {
 			log.Debugf("Process tag %q is not in k:v format, skipping", tag)
 			continue
 		}
 
-		key := strings.TrimSpace(tagParts[0])
-		value := strings.TrimSpace(tagParts[1])
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
 
 		if key == "" || value == "" {
 			log.Debugf("Process tag %q has empty key or value, skipping", tag)

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -999,7 +999,7 @@ func parseProcessTags(tags *taglist.TagList, processTags string) {
 		// Split each tag into key:value format
 		tagParts := strings.SplitN(tag, ":", 2)
 		if len(tagParts) != 2 {
-			log.Debugf("Process tag '%s' is not in k:v format, skipping", tag)
+			log.Debugf("Process tag %q is not in k:v format, skipping", tag)
 			continue
 		}
 
@@ -1007,7 +1007,7 @@ func parseProcessTags(tags *taglist.TagList, processTags string) {
 		value := strings.TrimSpace(tagParts[1])
 
 		if key == "" || value == "" {
-			log.Debugf("Process tag '%s' has empty key or value, skipping", tag)
+			log.Debugf("Process tag %q has empty key or value, skipping", tag)
 			continue
 		}
 

--- a/pkg/discovery/tracermetadata/tracer_metadata.go
+++ b/pkg/discovery/tracermetadata/tracer_metadata.go
@@ -10,7 +10,7 @@
 package tracermetadata
 
 // TracerMetadata as defined in
-// https://github.com/DataDog/libdatadog/blob/99056cf717cfe9/ddcommon/src/tracer_metadata.rs#L7-L29
+// https://github.com/DataDog/libdatadog/blob/0b59f64c4fc08105e5b73c5a0752ced3cf8f653e/datadog-library-config/src/tracer_metadata.rs#L7-L34
 type TracerMetadata struct {
 	SchemaVersion  uint8  `json:"schema_version"`
 	RuntimeID      string `json:"runtime_id,omitempty"`
@@ -20,4 +20,6 @@ type TracerMetadata struct {
 	ServiceName    string `json:"service_name,omitempty"`
 	ServiceEnv     string `json:"service_env,omitempty"`
 	ServiceVersion string `json:"service_version,omitempty"`
+	ProcessTags    string `json:"process_tags,omitempty"`
+	ContainerID    string `json:"container_id,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Propagate any process tags found in the tracer metadata (read by Service
Discovery) to the Process object.

The field was added to the tracer metadata by
https://github.com/DataDog/libdatadog/pull/1226.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-195

### Describe how you validated your changes

Unit tests added.

Currently, no tracer exposes process tags via the metadata so no end-to-end
test has been done yet.
