### PR TITLE
[EBPF-775] update(gpu): support cudaDeviceSynchronize

### DIFF
--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -170,6 +170,18 @@ int BPF_URETPROBE(uretprobe__cudaStreamSynchronize) {
     return 0;
 }
 
+SEC("uretprobe/cudaDeviceSynchronize")
+int BPF_URETPROBE(uretprobe__cudaDeviceSynchronize) {
+    cuda_sync_device_event_t event = { 0 };
+
+    fill_header(&event.header, 0, cuda_sync_device);
+
+    log_debug("cudaDeviceSynchronize[ret]: EMIT cudaSync pid_tgid=%llu", event.header.pid_tgid);
+
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    return 0;
+}
+
 SEC("uprobe/cudaSetDevice")
 int BPF_UPROBE(uprobe__cudaSetDevice, int device) {
     __u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/gpu/ebpf/c/types.h
+++ b/pkg/gpu/ebpf/c/types.h
@@ -13,6 +13,7 @@ typedef enum {
     cuda_sync,
     cuda_set_device,
     cuda_visible_devices_set,
+    cuda_sync_device,
     cuda_event_type_count,
 } cuda_event_type_t;
 
@@ -61,6 +62,10 @@ typedef struct {
     cuda_event_header_t header;
     int device;
 } cuda_set_device_event_t;
+
+typedef struct {
+    cuda_event_header_t header;
+} cuda_sync_device_event_t;
 
 typedef struct {
     __u64 event;

--- a/pkg/gpu/ebpf/kprobe_types.go
+++ b/pkg/gpu/ebpf/kprobe_types.go
@@ -26,6 +26,7 @@ type CudaMemEvent C.cuda_memory_event_t
 type CudaMemEventType C.cuda_memory_event_type_t
 
 type CudaSetDeviceEvent C.cuda_set_device_event_t
+type CudaSyncDeviceEvent C.cuda_sync_device_event_t
 
 type CudaVisibleDevicesSetEvent C.cuda_visible_devices_set_t
 
@@ -37,6 +38,7 @@ const CudaEventTypeMemory CudaEventType = C.cuda_memory_event
 const CudaEventTypeSync CudaEventType = C.cuda_sync
 const CudaEventTypeSetDevice CudaEventType = C.cuda_set_device
 const CudaEventTypeVisibleDevicesSet CudaEventType = C.cuda_visible_devices_set
+const CudaEventTypeSyncDevice CudaEventType = C.cuda_sync_device
 const CudaEventTypeCount CudaEventType = C.cuda_event_type_count
 
 const CudaMemAlloc = C.cudaMalloc
@@ -48,3 +50,4 @@ const SizeofCudaEventHeader = C.sizeof_cuda_event_header_t
 const SizeofCudaSync = C.sizeof_cuda_sync_t
 const SizeofCudaSetDeviceEvent = C.sizeof_cuda_set_device_event_t
 const SizeofCudaVisibleDevicesSetEvent = C.sizeof_cuda_visible_devices_set_t
+const SizeofCudaSyncDeviceEvent = C.sizeof_cuda_sync_device_event_t

--- a/pkg/gpu/ebpf/kprobe_types_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux.go
@@ -45,6 +45,9 @@ type CudaSetDeviceEvent struct {
 	Device    int32
 	Pad_cgo_0 [4]byte
 }
+type CudaSyncDeviceEvent struct {
+	Header CudaEventHeader
+}
 
 type CudaVisibleDevicesSetEvent struct {
 	Header  CudaEventHeader
@@ -66,7 +69,8 @@ const CudaEventTypeMemory CudaEventType = 0x1
 const CudaEventTypeSync CudaEventType = 0x2
 const CudaEventTypeSetDevice CudaEventType = 0x3
 const CudaEventTypeVisibleDevicesSet CudaEventType = 0x4
-const CudaEventTypeCount CudaEventType = 0x5
+const CudaEventTypeSyncDevice CudaEventType = 0x5
+const CudaEventTypeCount CudaEventType = 0x6
 
 const CudaMemAlloc = 0x0
 const CudaMemFree = 0x1
@@ -77,3 +81,4 @@ const SizeofCudaEventHeader = 0xa8
 const SizeofCudaSync = 0xa8
 const SizeofCudaSetDeviceEvent = 0xb0
 const SizeofCudaVisibleDevicesSetEvent = 0x1a8
+const SizeofCudaSyncDeviceEvent = 0xa8

--- a/pkg/gpu/ebpf/kprobe_types_linux_test.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux_test.go
@@ -32,6 +32,10 @@ func TestCgoAlignment_CudaSetDeviceEvent(t *testing.T) {
 	ebpftest.TestCgoAlignment[CudaSetDeviceEvent](t)
 }
 
+func TestCgoAlignment_CudaSyncDeviceEvent(t *testing.T) {
+	ebpftest.TestCgoAlignment[CudaSyncDeviceEvent](t)
+}
+
 func TestCgoAlignment_CudaVisibleDevicesSetEvent(t *testing.T) {
 	ebpftest.TestCgoAlignment[CudaVisibleDevicesSetEvent](t)
 }

--- a/pkg/gpu/ebpf/kprobe_types_string_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_string_linux.go
@@ -13,12 +13,13 @@ func _() {
 	_ = x[CudaEventTypeSync-2]
 	_ = x[CudaEventTypeSetDevice-3]
 	_ = x[CudaEventTypeVisibleDevicesSet-4]
-	_ = x[CudaEventTypeCount-5]
+	_ = x[CudaEventTypeSyncDevice-5]
+	_ = x[CudaEventTypeCount-6]
 }
 
-const _CudaEventType_name = "CudaEventTypeKernelLaunchCudaEventTypeMemoryCudaEventTypeSyncCudaEventTypeSetDeviceCudaEventTypeVisibleDevicesSetCudaEventTypeCount"
+const _CudaEventType_name = "CudaEventTypeKernelLaunchCudaEventTypeMemoryCudaEventTypeSyncCudaEventTypeSetDeviceCudaEventTypeVisibleDevicesSetCudaEventTypeSyncDeviceCudaEventTypeCount"
 
-var _CudaEventType_index = [...]uint8{0, 25, 44, 61, 83, 113, 131}
+var _CudaEventType_index = [...]uint8{0, 25, 44, 61, 83, 113, 136, 154}
 
 func (i CudaEventType) String() string {
 	if i >= CudaEventType(len(_CudaEventType_index)-1) {

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -80,6 +80,7 @@ const (
 	cudaFreeProbe                probeFuncName = "uprobe__cudaFree"
 	cudaSetDeviceProbe           probeFuncName = "uprobe__cudaSetDevice"
 	cudaSetDeviceRetProbe        probeFuncName = "uretprobe__cudaSetDevice"
+	cudaDeviceSyncRetProbe       probeFuncName = "uretprobe__cudaDeviceSynchronize"
 	cudaEventRecordProbe         probeFuncName = "uprobe__cudaEventRecord"
 	cudaEventQueryProbe          probeFuncName = "uprobe__cudaEventQuery"
 	cudaEventQueryRetProbe       probeFuncName = "uretprobe__cudaEventQuery"
@@ -381,6 +382,7 @@ func getCudaLibraryAttacherRule() *uprobes.AttachRule {
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaFreeProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceRetProbe}},
+					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaDeviceSyncRetProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -118,11 +118,12 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	}
 
 	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String():      1,
+		ebpf.CudaEventTypeKernelLaunch.String():      2,
 		ebpf.CudaEventTypeSetDevice.String():         1,
 		ebpf.CudaEventTypeMemory.String():            2,
 		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
 		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
+		ebpf.CudaEventTypeSyncDevice.String():        1,
 	}
 
 	for evName, value := range expectedEvents {
@@ -140,11 +141,13 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 
 	streamPastData := handlerStream.getPastData()
 	require.NotNil(t, streamPastData)
-	require.Equal(t, 1, len(streamPastData.kernels))
-	span := streamPastData.kernels[0]
-	require.Equal(t, uint64(1), span.numKernels)
-	require.Equal(t, uint64(1*2*3*4*5*6), span.avgThreadCount)
-	require.Greater(t, span.endKtime, span.startKtime)
+	require.Equal(t, 2, len(streamPastData.kernels))
+	for i := range 2 {
+		span := streamPastData.kernels[i]
+		require.Equal(t, uint64(1), span.numKernels)
+		require.Equal(t, uint64(1*2*3*4*5*6), span.avgThreadCount)
+		require.Greater(t, span.endKtime, span.startKtime)
+	}
 
 	globalPastData := handlerGlobal.getPastData()
 	require.NotNil(t, globalPastData)
@@ -180,11 +183,12 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	require.NoError(t, err)
 
 	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String():      1,
+		ebpf.CudaEventTypeKernelLaunch.String():      2,
 		ebpf.CudaEventTypeSetDevice.String():         1,
 		ebpf.CudaEventTypeMemory.String():            2,
 		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
 		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
+		ebpf.CudaEventTypeSyncDevice.String():        1,
 	}
 
 	actualEvents := make(map[string]int)

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -137,7 +137,7 @@ func (sc *streamCollection) getGlobalStream(header *gpuebpf.CudaEventHeader) (*S
 	return stream, nil
 }
 
-// getNonGlobalStream returns the non-global stream associated to the given PID and and stream ID (extraded from header).
+// getNonGlobalStream returns the non-global stream associated to the given PID and and stream ID (extracted from header).
 // This does not depend on the active device on the given PID. If non-existing, he stream gets created and added to collection.
 func (sc *streamCollection) getNonGlobalStream(header *gpuebpf.CudaEventHeader) (*StreamHandler, error) {
 	pid, _ := getPidTidFromHeader(header)

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -57,6 +57,10 @@ cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, int kind) {
     return 0;
 }
 
+cudaError_t cudaDeviceSynchronize() {
+    return 0;
+}
+
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
     cudaEvent_t event = 42;
@@ -93,12 +97,15 @@ int main(int argc, char **argv) {
 
     cudaEventDestroy(event);
 
+    cudaLaunchKernel((void *)0x1234, (dim3){ 1, 2, 3 }, (dim3){ 4, 5, 6 }, NULL, 10, stream);
+    cudaDeviceSynchronize();
+
     setenv("CUDA_VISIBLE_DEVICES", "42", 1);
 
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
 
-    //this line is used as a market by patternScanner to indicate the end of the program
+    //this line is used as a marker by patternScanner to indicate the end of the program
     fprintf(stderr, "CUDA calls made.\n");
     pause(); // Wait for signal to finish the process
 


### PR DESCRIPTION
### What does this PR do?

Adds support to tracing calls to `cudaDeviceSynchronize`. This is used for further improve the kernel execution time calculations for programs using device-level synchronization.

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-775

### Describe how you validated your changes

### Additional Notes
