### PR TITLE
Add LLM Observability Environment Variables for Fleet Installer (SSI)

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -256,6 +256,9 @@ type APMConfigurationDefault struct {
 	IastEnabled                   *bool   `yaml:"DD_IAST_ENABLED,omitempty"`
 	DataJobsEnabled               *bool   `yaml:"DD_DATA_JOBS_ENABLED,omitempty"`
 	AppsecScaEnabled              *bool   `yaml:"DD_APPSEC_SCA_ENABLED,omitempty"`
+	LlmObsEnabled                 *bool   `yaml:"DD_LLM_OBS_ENABLED,omitempty"`
+	LlmObsMlAppEnabled            *bool   `yaml:"DD_LLM_OBS_ML_APP_ENABLED,omitempty"`
+	LlmObsAgentlessEnabled        *bool   `yaml:"DD_LLM_OBS_AGENTLESS_ENABLED,omitempty"`
 }
 
 // DelayedAgentRestartConfig represents the config to restart the agent with a delay at the end of the install


### PR DESCRIPTION
### What does this PR do?

Adds the following LLM Observability environment variables to be parsed when installing the agent via fleet install/for SSI:
- `DD_LLMOBS_ENABLED` - llm observability enabled
- `DD_LLMOBS_ML_APP` - llm observability ml application for submitting traces
- `DD_LLMOBS_AGENTLESS_ENABLED` - whether or not to submit traces to intake directly or agent-proxy. seeing as this is the agent, the Datadog UI will likely hardcode this to `false`, as other wise SDKs are configured to poll the agent's `/info` and see if it is supported. Overriding this to `false` directly will skip that check, since we know we can as the agent is running as part of the fleet 😛 

### Motivation

LLM Observability should be compatible with SSI/Fleet/Stable Config

### Describe how you validated your changes

WIP
