### PR TITLE
[CWS] add config option for mountlister snapshotting

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -338,6 +338,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "span_tracking.cache_size"), 4096)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "capabilities_monitoring.enabled"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "capabilities_monitoring.period"), "5s")
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "snapshot_using_listmount"), false)
 	cfg.BindEnvAndSetDefault(join(evNS, "socket"), defaultEventMonitorAddress)
 	cfg.BindEnvAndSetDefault(join(evNS, "event_server.burst"), 40)
 	cfg.BindEnvAndSetDefault(join(evNS, "env_vars_resolution.enabled"), true)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -178,6 +178,9 @@ type Config struct {
 	CapabilitiesMonitoringEnabled bool
 	// CapabilitiesMonitoringPeriod defines the period at which process capabilities usage events should be reported back to userspace
 	CapabilitiesMonitoringPeriod time.Duration
+
+	// SnapshotUsingListmount enables the use of listmount to take filesystem mount snapshots
+	SnapshotUsingListmount bool
 }
 
 // NewConfig returns a new Config object
@@ -240,6 +243,9 @@ func NewConfig() (*Config, error) {
 		// Process capabilities monitoring
 		CapabilitiesMonitoringEnabled: getBool("capabilities_monitoring.enabled"),
 		CapabilitiesMonitoringPeriod:  getDuration("capabilities_monitoring.period"),
+
+		// Mount resolver
+		SnapshotUsingListmount: getBool("snapshot_using_listmount"),
 	}
 
 	if err := c.sanitize(); err != nil {

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -11,9 +11,10 @@ package resolvers
 import (
 	"context"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"os"
 	"sort"
+
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dns"
 
@@ -215,10 +216,10 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		SyscallCtxResolver:     syscallctx.NewResolver(),
 		DNSResolver:            dnsResolver,
 		FileMetadataResolver:   fileMetadataResolver,
-		SnapshotUsingListmount: true,
+		SnapshotUsingListmount: config.Probe.SnapshotUsingListmount,
 	}
 
-	if !mountResolver.HasListMount() {
+	if resolvers.SnapshotUsingListmount && !mountResolver.HasListMount() {
 		seclog.Warnf("listmount not found in this system, will default to procfs")
 		resolvers.SnapshotUsingListmount = false
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new configuration option to configure the usage of "listmount" by the CWS mount resolver. This feature added in https://github.com/DataDog/datadog-agent/pull/40772 has a risk profile slightly higher than usual features and should be configurable by the user, which is what this PR is doing (in addition to disabling by default).

### Motivation

### Describe how you validated your changes

### Additional Notes
