### PR TITLE
Revert "test(fleet): Update E2E for new install script before release"

### DIFF
--- a/pkg/fleet/installer/packages/embedded/scripts/dd-container-install
+++ b/pkg/fleet/installer/packages/embedded/scripts/dd-container-install
@@ -47,7 +47,7 @@ done
 if [ -x /opt/datadog-packages/run/datadog-installer-ssi ]; then
     installerPath="/opt/datadog-packages/run/datadog-installer-ssi"
 else
-    installerPath="/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer"
+    installerPath="/opt/datadog-packages/datadog-installer/stable/bin/installer/installer"
 fi
 
 if [ -z "$uninstall_flag" ]; then

--- a/pkg/fleet/installer/packages/embedded/scripts/dd-host-install
+++ b/pkg/fleet/installer/packages/embedded/scripts/dd-host-install
@@ -47,7 +47,7 @@ done
 if [ -x /opt/datadog-packages/run/datadog-installer-ssi ]; then
     installerPath="/opt/datadog-packages/run/datadog-installer-ssi"
 else
-    installerPath="/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer"
+    installerPath="/opt/datadog-packages/datadog-installer/stable/bin/installer/installer"
 fi
 
 if [ -z "$uninstall_flag" ]; then

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -10,9 +10,11 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
@@ -44,22 +46,28 @@ func testAgent(os e2eos.Descriptor, arch e2eos.Architecture, method InstallMetho
 }
 
 func (s *packageAgentSuite) TestInstall() {
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
-	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit)
 
 	state := s.host.State()
-	s.assertUnits(state, true)
+	s.assertUnits(state, false)
 
 	state.AssertFileExistsAnyUser("/etc/datadog-agent/install_info", 0644)
 	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
 
 	agentVersion := s.host.AgentStableVersion()
-	agentDir := "/opt/datadog-agent"
-	agentRunSymlink := fmt.Sprintf("/opt/datadog-packages/run/datadog-agent/%s", agentVersion)
-	installerSymlink := path.Join(agentDir, "embedded/bin/installer")
-	agentSymlink := path.Join(agentDir, "bin/agent/agent")
+	agentDir := fmt.Sprintf("/opt/datadog-packages/datadog-agent/%s", agentVersion)
+	installerSymlink := "/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer"
+	agentSymlink := "/opt/datadog-packages/datadog-agent/stable/bin/agent/agent"
+	agentRunSymlink := agentDir
+	if s.installMethod == InstallMethodAnsible {
+		agentDir = "/opt/datadog-agent"
+		agentRunSymlink = fmt.Sprintf("/opt/datadog-packages/run/datadog-agent/%s", agentVersion)
+		installerSymlink = path.Join(agentDir, "embedded/bin/installer")
+		agentSymlink = path.Join(agentDir, "bin/agent/agent")
+	}
 
 	state.AssertDirExists(agentDir, 0755, "dd-agent", "dd-agent")
 
@@ -103,8 +111,63 @@ func (s *packageAgentSuite) assertUnits(state host.State, oldUnits bool) {
 	}
 }
 
+// TestUpgrade_AgentDebRPM_to_OCI tests the upgrade from DEB/RPM agent to the OCI one.
+func (s *packageAgentSuite) TestUpgrade_AgentDebRPM_to_OCI() {
+	if s.installMethod == InstallMethodAnsible {
+		s.T().Skip("Ansible doesn't install OCI packages")
+	}
+
+	// install deb/rpm agent
+	s.RunInstallScript(envForceNoInstall("datadog-agent"))
+	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
+
+	defer s.Purge()
+	defer s.purgeAgentDebInstall()
+
+	state := s.host.State()
+	s.assertUnits(state, true)
+	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
+
+	// install OCI agent
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
+
+	state = s.host.State()
+	s.assertUnits(state, false)
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent")
+}
+
+// TestUpgrade_Agent_OCI_then_DebRpm agent deb/rpm install while OCI one is installed
+func (s *packageAgentSuite) TestUpgrade_Agent_OCI_then_DebRpm() {
+	if s.installMethod == InstallMethodAnsible {
+		s.T().Skip("Ansible doesn't install OCI packages")
+	}
+
+	// install OCI agent
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
+	defer s.Purge()
+
+	state := s.host.State()
+	s.assertUnits(state, false)
+	state.AssertPathDoesNotExist("/opt/datadog-agent")
+
+	// is_installed avoids a re-install of datadog-agent with the install script
+	s.RunInstallScript(envForceNoInstall("datadog-agent"))
+	state.AssertPathDoesNotExist("/opt/datadog-agent")
+
+	// install deb/rpm manually
+	s.installDebRPMAgent()
+	defer s.purgeAgentDebInstall()
+	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
+
+	state = s.host.State()
+	s.assertUnits(state, true)
+	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
+	s.host.AssertPackageNotInstalledByInstaller("datadog-agent")
+}
+
 func (s *packageAgentSuite) TestExperimentTimeout() {
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), "datadog-agent.service", "datadog-agent-trace.service")
@@ -154,7 +217,7 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 }
 
 func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), "datadog-agent.service", "datadog-agent-trace.service")
@@ -219,7 +282,7 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 }
 
 func (s *packageAgentSuite) TestExperimentExits() {
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), "datadog-agent.service", "datadog-agent-trace.service")
@@ -272,7 +335,7 @@ func (s *packageAgentSuite) TestExperimentExits() {
 }
 
 func (s *packageAgentSuite) TestExperimentStopped() {
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), "datadog-agent.service", "datadog-agent-trace.service")
@@ -314,12 +377,82 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 	}
 }
 
+func (s *packageAgentSuite) TestRunPath() {
+	if s.installMethod == InstallMethodAnsible {
+		s.T().Skip("Ansible doesn't install OCI packages")
+	}
+
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
+	defer s.Purge()
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.WaitForUnitActive(s.T(), "datadog-agent.service", "datadog-agent-trace.service")
+
+	var rawConfig string
+	var err error
+	assert.Eventually(s.T(), func() bool {
+		rawConfig, err = s.host.AgentRuntimeConfig()
+		return err == nil
+	}, 30*time.Second, 5*time.Second, "failed to get agent runtime config: %v", err)
+	var config map[string]interface{}
+	err = yaml.Unmarshal([]byte(rawConfig), &config)
+	assert.NoError(s.T(), err)
+	runPath, ok := config["run_path"].(string)
+	assert.True(s.T(), ok, "run_path not found in runtime config: %v", config)
+	assert.True(s.T(), strings.HasPrefix(runPath, "/opt/datadog-packages/datadog-agent/"), "run_path is not in the expected location: %s", runPath)
+}
+
+func (s *packageAgentSuite) TestUpgrade_DisabledAgentDebRPM_to_OCI() {
+	if s.installMethod == InstallMethodAnsible {
+		s.T().Skip("Ansible doesn't install OCI packages")
+	}
+
+	// install deb/rpm agent
+	s.RunInstallScript(envForceNoInstall("datadog-agent"))
+	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
+
+	defer s.Purge()
+	defer s.purgeAgentDebInstall()
+
+	state := s.host.State()
+	s.assertUnits(state, true)
+	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
+
+	// disable the unit
+	s.host.Run("sudo systemctl disable datadog-agent")
+
+	// install OCI agent
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
+
+	state = s.host.State()
+	s.assertUnits(state, false)
+	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-agent")
+
+	s.host.Run("sudo systemctl show datadog-agent -p ExecStart | grep /opt/datadog-packages")
+}
+
+func (s *packageAgentSuite) TestInstallWithLeftoverDebDir() {
+	if s.installMethod == InstallMethodAnsible {
+		s.T().Skip("Ansible doesn't install OCI packages")
+	}
+	// create /opt/datadog-agent to simulate a disabled agent
+	s.host.Run("sudo mkdir -p /opt/datadog-agent")
+	defer func() { s.host.Run("sudo rm -rf /opt/datadog-agent") }()
+
+	// install OCI agent
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
+
+	state := s.host.State()
+	s.assertUnits(state, false)
+	s.host.Run("sudo systemctl show datadog-agent -p ExecStart | grep /opt/datadog-packages")
+}
+
 func (s *packageAgentSuite) TestInstallWithGroupPreviouslyCreated() {
 	s.host.Run("sudo userdel dd-agent || true")
 	s.host.Run("sudo groupdel dd-agent || true")
 	s.host.Run("sudo groupadd --system datadog")
 
-	s.RunInstallScript("DD_REMOTE_UPDATES=true")
+	s.RunInstallScript("DD_REMOTE_UPDATES=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
 	assert.True(s.T(), s.host.UserExists("dd-agent"), "dd-agent user should exist")
@@ -351,4 +484,36 @@ func (s *packageAgentSuite) TestNoWorldWritableFiles() {
 			s.T().Fatalf("file %v is world writable", path)
 		}
 	}
+}
+
+func (s *packageAgentSuite) purgeAgentDebInstall() {
+	pkgManager := s.host.GetPkgManager()
+	switch pkgManager {
+	case "apt":
+		s.Env().RemoteHost.Execute("sudo apt-get remove -y --purge datadog-agent")
+	case "yum":
+		s.Env().RemoteHost.Execute("sudo yum remove -y datadog-agent")
+	case "zypper":
+		s.Env().RemoteHost.Execute("sudo zypper remove -y datadog-agent")
+	default:
+		s.T().Fatalf("unsupported package manager: %s", pkgManager)
+	}
+	// Make sure everything is cleaned up -- there are tests where the package is
+	// removed but not purged so the directory remains
+	s.Env().RemoteHost.Execute("sudo rm -rf /opt/datadog-agent")
+}
+
+func (s *packageAgentSuite) installDebRPMAgent() {
+	pkgManager := s.host.GetPkgManager()
+	switch pkgManager {
+	case "apt":
+		s.Env().RemoteHost.Execute("sudo apt-get install -y --force-yes datadog-agent")
+	case "yum":
+		s.Env().RemoteHost.Execute("sudo yum -y install --disablerepo=* --enablerepo=datadog datadog-agent")
+	case "zypper":
+		s.Env().RemoteHost.Execute("sudo zypper install -y datadog-agent")
+	default:
+		s.T().Fatalf("unsupported package manager: %s", pkgManager)
+	}
+
 }

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -410,6 +410,13 @@ func (s *packageApmInjectSuite) TestInstrumentDockerInactive() {
 	s.assertDockerdInstrumented(injectOCIPath)
 }
 
+func (s *packageApmInjectSuite) TestInstallStandaloneLib() {
+	s.RunInstallScript("DD_INSTALLER=true", "DD_APM_INSTRUMENTATION_LIBRARIES=python")
+	defer s.Purge()
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-library-python")
+	s.host.AssertPackageInstalledByInstaller("datadog-apm-library-python")
+}
+
 func (s *packageApmInjectSuite) TestDefaultPackageVersion() {
 	s.RunInstallScript(
 		"DD_APM_INSTRUMENTATION_ENABLED=host",

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -9,14 +9,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/stretchr/testify/require"
 
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
@@ -27,46 +23,6 @@ type packageDDOTSuite struct {
 func testDDOT(os e2eos.Descriptor, arch e2eos.Architecture, method InstallMethodOption) packageSuite {
 	return &packageDDOTSuite{
 		packageBaseSuite: newPackageSuite("ddot", os, arch, method, awshost.WithoutFakeIntake()),
-	}
-}
-
-func (s *packageDDOTSuite) RunInstallScriptWithError(params ...string) error {
-	hasOTelCollector := false
-	for _, param := range params {
-		if param == "DD_OTELCOLLECTOR_ENABLED=true" {
-			hasOTelCollector = true
-			break
-		}
-	}
-	if hasOTelCollector {
-		// This is temporary until the install script is updated to support calling the installer script
-		var scriptURLPrefix string
-		if pipelineID, ok := os.LookupEnv("E2E_PIPELINE_ID"); ok {
-			scriptURLPrefix = fmt.Sprintf("https://s3.amazonaws.com/installtesting.datad0g.com/pipeline-%s/scripts/", pipelineID)
-		} else if commitHash, ok := os.LookupEnv("CI_COMMIT_SHA"); ok {
-			scriptURLPrefix = fmt.Sprintf("https://s3.amazonaws.com/installtesting.datad0g.com/%s/scripts/", commitHash)
-		} else {
-			require.FailNowf(nil, "missing script identifier", "CI_COMMIT_SHA or CI_PIPELINE_ID must be set")
-		}
-		_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L %sinstall.sh)" > /tmp/datadog-installer-stdout.log 2> /tmp/datadog-installer-stderr.log`, strings.Join(params, " "), scriptURLPrefix), client.WithEnvVariables(InstallInstallerScriptEnvWithPackages()))
-		return err
-	}
-
-	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://storage.googleapis.com/updater-dev/install_script_agent7_test_ci.sh)"`, strings.Join(params, " ")), client.WithEnvVariables(InstallScriptEnv(s.arch)))
-	return err
-}
-
-func (s *packageDDOTSuite) RunInstallScript(params ...string) {
-	switch s.installMethod {
-	case InstallMethodInstallScript:
-		// bugfix for https://major.io/p/systemd-in-fedora-22-failed-to-restart-service-access-denied/
-		if s.os.Flavor == e2eos.CentOS && s.os.Version == e2eos.CentOS7.Version {
-			s.Env().RemoteHost.MustExecute("sudo systemctl daemon-reexec")
-		}
-		err := s.RunInstallScriptWithError(params...)
-		require.NoErrorf(s.T(), err, "installer not properly installed. logs: \n%s\n%s", s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stdout.log || true"), s.Env().RemoteHost.MustExecute("cat /tmp/datadog-installer-stderr.log || true"))
-	default:
-		s.T().Fatal("unsupported install method")
 	}
 }
 
@@ -115,7 +71,7 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 
 	state := s.host.State()
 	// Verify running
-	s.assertCoreUnits(state, true)
+	s.assertCoreUnits(state, false)
 	s.assertDDOTUnits(state, false)
 
 	// Verify files exist

--- a/test/new-e2e/tests/installer/unix/package_definitions.go
+++ b/test/new-e2e/tests/installer/unix/package_definitions.go
@@ -89,7 +89,6 @@ func installScriptPackageManagerEnv(env map[string]string, arch e2eos.Architectu
 	env["TESTING_APT_REPO_VERSION"] = fmt.Sprintf("stable-%s 7", arch)
 	env["TESTING_YUM_URL"] = "s3.amazonaws.com/yumtesting.datad0g.com"
 	env["TESTING_YUM_VERSION_PATH"] = fmt.Sprintf("testing/pipeline-%s-a7/7", os.Getenv("E2E_PIPELINE_ID"))
-	env["DD_APM_INSTRUMENTATION_PIPELINE_ID"] = os.Getenv("E2E_PIPELINE_ID")
 }
 
 func installScriptInstallerEnv(env map[string]string, packagesConfig []TestPackageConfig) {


### PR DESCRIPTION
Reverts DataDog/datadog-agent#41196.
This broke many e2e tests (step-by-step tests, example [error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1149049747#L193))