### PR TITLE
[incident-43631] Fix missing osDesc entry

### DIFF
--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -54,6 +54,8 @@ func ExecuteWithoutError(_ *testing.T, client *common.TestClient, cmd string, ar
 }
 
 func TestStepByStepScript(t *testing.T) {
+	t.Logf("CELIAN: osdescriptors: %s", *osDescriptors)
+	t.Logf("CELIAN: cws-supported-osdescriptors: %s", *cwsSupportedOsDescriptors)
 	osDescriptors, err := platforms.ParseOSDescriptors(*osDescriptors)
 	if err != nil {
 		t.Fatalf("failed to parse os descriptors: %v", err)
@@ -71,6 +73,8 @@ func TestStepByStepScript(t *testing.T) {
 
 	for _, osDesc := range osDescriptors {
 		osDesc := osDesc
+
+		t.Logf("CELIAN: osDesc: %s", osDesc.String())
 
 		cwsSupported := false
 		for _, cwsSupportedOs := range cwsSupportedOsDescriptorsList {

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -54,8 +54,6 @@ func ExecuteWithoutError(_ *testing.T, client *common.TestClient, cmd string, ar
 }
 
 func TestStepByStepScript(t *testing.T) {
-	t.Logf("CELIAN: osdescriptors: %s", *osDescriptors)
-	t.Logf("CELIAN: cws-supported-osdescriptors: %s", *cwsSupportedOsDescriptors)
 	osDescriptors, err := platforms.ParseOSDescriptors(*osDescriptors)
 	if err != nil {
 		t.Fatalf("failed to parse os descriptors: %v", err)
@@ -73,8 +71,6 @@ func TestStepByStepScript(t *testing.T) {
 
 	for _, osDesc := range osDescriptors {
 		osDesc := osDesc
-
-		t.Logf("CELIAN: osDesc: %s", osDesc.String())
 
 		cwsSupported := false
 		for _, cwsSupportedOs := range cwsSupportedOsDescriptorsList {

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -105,7 +105,7 @@ func TestStepByStepScript(t *testing.T) {
 			vmOpts = append(vmOpts, ec2.WithOS(osDesc))
 
 			e2e.Run(tt,
-				&stepByStepSuite{cwsSupported: cwsSupported, osVersion: version},
+				&stepByStepSuite{cwsSupported: cwsSupported, osVersion: version, osDesc: osDesc},
 				e2e.WithProvisioner(awshost.ProvisionerNoAgentNoFakeIntake(
 					awshost.WithEC2InstanceOptions(vmOpts...),
 				)),


### PR DESCRIPTION
### What does this PR do?

E2e tests were broken since a field was uninitialized, fixed this.

[Example error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1151811620#L485).

### Motivation

### Describe how you validated your changes

### Additional Notes
