### PR TITLE
don't include system-probe based checks in iot-agent

### DIFF
--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -31,9 +31,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/discovery"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/oomkill"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/tcpqueuelength"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/apm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/process"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu"
@@ -93,11 +90,8 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(ksm.CheckName, ksm.Factory(tagger, store))
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(pod.CheckName, pod.Factory(store, cfg, tagger))
-	corecheckLoader.RegisterCheck(ebpf.CheckName, ebpf.Factory())
 	corecheckLoader.RegisterCheck(gpu.CheckName, gpu.Factory(tagger, telemetry, store))
 	corecheckLoader.RegisterCheck(ecs.CheckName, ecs.Factory(store, tagger))
-	corecheckLoader.RegisterCheck(oomkill.CheckName, oomkill.Factory(tagger))
-	corecheckLoader.RegisterCheck(tcpqueuelength.CheckName, tcpqueuelength.Factory(tagger))
 	corecheckLoader.RegisterCheck(apm.CheckName, apm.Factory())
 	corecheckLoader.RegisterCheck(process.CheckName, process.Factory())
 	if cfg.GetBool("use_networkv2_check") {
@@ -128,4 +122,6 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(discovery.CheckName, discovery.Factory())
 	corecheckLoader.RegisterCheck(versa.CheckName, versa.Factory())
 	corecheckLoader.RegisterCheck(ncm.CheckName, ncm.Factory(cfg))
+
+	registerSystemProbeChecks(tagger)
 }

--- a/pkg/commonchecks/corechecks_no_sysprobe.go
+++ b/pkg/commonchecks/corechecks_no_sysprobe.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// This combination of build tags ensures that this file is only included Agents that are not the Cluster Agent
+//go:build !(clusterchecks && kubeapiserver) && !systemprobechecks
+
+// Package commonchecks contains shared checks for multiple agent components
+package commonchecks
+
+import tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+
+func registerSystemProbeChecks(_ tagger.Component) {
+	// nothing to do here, this build doesn't include system-probe based checks
+}

--- a/pkg/commonchecks/corechecks_sysprobe.go
+++ b/pkg/commonchecks/corechecks_sysprobe.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// This combination of build tags ensures that this file is only included Agents that are not the Cluster Agent
+//go:build !(clusterchecks && kubeapiserver) && systemprobechecks
+
+// Package commonchecks contains shared checks for multiple agent components
+package commonchecks
+
+import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/oomkill"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/tcpqueuelength"
+)
+
+func registerSystemProbeChecks(tagger tagger.Component) {
+	corecheckLoader.RegisterCheck(ebpf.CheckName, ebpf.Factory())
+	corecheckLoader.RegisterCheck(oomkill.CheckName, oomkill.Factory(tagger))
+	corecheckLoader.RegisterCheck(tcpqueuelength.CheckName, tcpqueuelength.Factory(tagger))
+}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -58,6 +58,7 @@ ALL_TAGS = {
     "serverless",
     "serverlessfips",  # used for FIPS mode in the serverless build in datadog-lambda-extension
     "systemd",
+    "systemprobechecks",  # used to include system-probe based checks in the agent build
     "test",  # used for unit-tests
     "trivy",
     "trivy_no_javadb",
@@ -96,6 +97,7 @@ AGENT_TAGS = {
     "podman",
     "python",
     "systemd",
+    "systemprobechecks",
     "trivy",
     "trivy_no_javadb",
     "zk",


### PR DESCRIPTION
### What does this PR do?

This PR adds a new build tag, `systemprobechecks` (happy to change it for a better name, it's currently inspired by `clusterchecks`) to skip the inclusion of checks requiring the system-probe in builds that don't include it, especially the iot-agent.

### Motivation

### Describe how you validated your changes

### Additional Notes
