### PR TITLE
process: Add process entity tags

### DIFF
--- a/comp/process/processcheck/processcheckimpl/check.go
+++ b/comp/process/processcheck/processcheckimpl/check.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	taggerdef "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	gpusubscriber "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/def"
 	"github.com/DataDog/datadog-agent/comp/process/processcheck"
@@ -42,6 +43,7 @@ type dependencies struct {
 	GpuSubscriber gpusubscriber.Component
 	Statsd        statsd.ClientInterface
 	IPC           ipc.Component
+	Tagger        taggerdef.Component
 }
 
 type result struct {
@@ -53,7 +55,7 @@ type result struct {
 
 func newCheck(deps dependencies) result {
 	c := &check{
-		processCheck: checks.NewProcessCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.GpuSubscriber, deps.Statsd, deps.IPC.GetTLSServerConfig()),
+		processCheck: checks.NewProcessCheck(deps.Config, deps.Sysconfig, deps.WMmeta, deps.GpuSubscriber, deps.Statsd, deps.IPC.GetTLSServerConfig(), deps.Tagger),
 	}
 	return result{
 		Check: types.ProvidesCheck{

--- a/comp/process/processcheck/processcheckimpl/check_linux_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_linux_test.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	taggerfxnoop "github.com/DataDog/datadog-agent/comp/core/tagger/fx-noop"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
@@ -64,6 +65,7 @@ func TestProcessCheckEnablementOnCoreAgent(t *testing.T) {
 				sysprobeconfigimpl.MockModule(),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 				gpusubscriberfxmock.MockModule(),
+				taggerfxnoop.Module(),
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}
 				}),

--- a/comp/process/processcheck/processcheckimpl/check_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_test.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	taggerfxnoop "github.com/DataDog/datadog-agent/comp/core/tagger/fx-noop"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
@@ -98,6 +99,7 @@ func TestProcessChecksIsEnabled(t *testing.T) {
 				fx.Replace(sysprobeconfigimpl.MockParams{Overrides: tc.sysProbeConfigs}),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 				gpusubscriberfxmock.MockModule(),
+				taggerfxnoop.Module(),
 				fx.Provide(func() statsd.ClientInterface {
 					return &statsd.NoOpClient{}
 				}),


### PR DESCRIPTION
### What does this PR do?

Get the tags for the Process entity from the tagger and add them to the
process' tags.  If service discovery is enabled, this will include
things like UST and process tags from tracer metadata.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-197
