### PR TITLE
Bumping bouncycastle dependencies to remove vulnerabilities

### DIFF
--- a/Dockerfiles/agent/bouncycastle-fips/pom.xml
+++ b/Dockerfiles/agent/bouncycastle-fips/pom.xml
@@ -19,22 +19,22 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bc-fips</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bctls-fips</artifactId>
-            <version>2.0.19</version>
+            <version>2.0.20</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-fips</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.5</version>
         </dependency>
     </dependencies>
 

--- a/releasenotes/notes/bouncycastle-CVE-2025-8916-fix-bfb2600d3ccdb2b1.yaml
+++ b/releasenotes/notes/bouncycastle-CVE-2025-8916-fix-bfb2600d3ccdb2b1.yaml
@@ -1,5 +1,5 @@
 ---
 security:
   - |
-    Bumped Bouncy Castle dependecies to mitigate agains CVE-2025-8885 and CVE-2025-8916
+    Bumped Bouncy Castle dependencies to mitigate against CVE-2025-8885 and CVE-2025-8916
     in FIPS images.

--- a/releasenotes/notes/bouncycastle-CVE-2025-8916-fix-bfb2600d3ccdb2b1.yaml
+++ b/releasenotes/notes/bouncycastle-CVE-2025-8916-fix-bfb2600d3ccdb2b1.yaml
@@ -1,0 +1,5 @@
+---
+security:
+  - |
+    Bumped Bouncy Castle dependecies to mitigate agains CVE-2025-8885 and CVE-2025-8916
+    in FIPS images.


### PR DESCRIPTION
### What does this PR do?

Updates the [Bouncy Castle](https://www.bouncycastle.org/) dependencies to the latest versions.

### Motivation

This was done to mitigate against CVE-2025-8885 and CVE-2025-8916 in FIPS images.

### Describe how you validated your changes

There is an e2e test that checks JMXFetch still works in the FIPS images.
