### PR TITLE
fix(cws): nil pointer dereference in DirectEventMsgSender.GetEndpointsStatus()

### DIFF
--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -132,7 +132,8 @@ func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.
 	}
 
 	return &DirectEventMsgSender{
-		reporter: reporter,
+		reporter:  reporter,
+		endpoints: endpoints,
 	}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix nil pointer dereference panic in system-probe security module

### Motivation
The `DirectEventMsgSender.GetEndpointsStatus()` method was panicking due to a nil pointer dereference. The `endpoints` field was not being initialized in `NewDirectEventMsgSender()` constructor, causing crashes when the system-probe module collected stats.

### Describe how you validated your changes
- Run it locally with and without the `runtime_security_config.direct_send_from_system_probe: true`

### Additional Notes
