### PR TITLE
[dynamic test] Run all tests on more path, to keep same behavior as Gitlab rules + index consolidation only on success

### DIFF
--- a/.gitlab/dynamic_test/consolidate.yml
+++ b/.gitlab/dynamic_test/consolidate.yml
@@ -4,7 +4,7 @@ index-consolidation:
   tags: ["arch:arm64"]
   dependencies: []
   rules:
-    - !reference [.always_on_coverage_pipeline]
+    - !reference [.on_coverage_pipeline]
   script:
     - pip install boto3==1.38.8 # TODO: Remove this before merging, after dda is bumped in test-infra-definitions
     - dda inv -- -e dyntest.consolidate-index-in-s3 --commit-sha $CI_COMMIT_SHA --bucket-uri $S3_PERMANENT_ARTIFACTS_URI

--- a/.gitlab/dynamic_test/evaluate.yml
+++ b/.gitlab/dynamic_test/evaluate.yml
@@ -5,7 +5,7 @@ dynamic_test-evaluate-e2e:
   dependencies: []
   rules:
     - !reference [.except_coverage_pipeline]
-    - !reference [.except_e2e_main_release_or_rc]
+    - !reference [.except_main_release_or_mq]
     - when: always
   script:
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY

--- a/tasks/dyntest.py
+++ b/tasks/dyntest.py
@@ -24,7 +24,11 @@ from tasks.libs.dynamic_test.indexers.e2e import (
 def compute_and_upload_job_index(ctx: Context, bucket_uri: str, coverage_folder: str, commit_sha: str, job_id: str):
     uploader = S3Backend(bucket_uri)
     run_all_paths = [
-        "test/new-e2e/pkg/*",  # Modification to the framework should trigger all tests
+        "test/new-e2e/pkg/**/*",  # Modification to the framework should trigger all tests
+        "test/new-e2e/go.mod",
+        "flakes.yaml",
+        "release.json",
+        ".gitlab/e2e/e2e.yml",
     ]
     for target in os.getenv("TARGETS").split(","):
         run_all_paths.append(os.path.normpath(os.path.join("test/new-e2e", target) + "/*"))


### PR DESCRIPTION
### What does this PR do?

Include some more paths that should trigger all tests, to have a similar behavior than the Gitlab rule

Make sure the index consolidation is done only on pipeline success. To avoid uploading incomplete index

### Motivation

### Describe how you validated your changes

### Additional Notes
