### PR TITLE
[CWS] use SBOM collector v2 by default

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -85,7 +85,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.analyzers", []string{"os"})
-	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.use_v2_collector", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.use_v2_collector", true)
 
 	// CWS - Security Profiles
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)


### PR DESCRIPTION
### What does this PR do?

This PR enables the SBOM collector v2 in the CWS code path. The collector v1 support (using trivy) will be removed in next release.

N.B: the SBOM collection for CWS is still disabled by default at this point.

### Motivation

### Describe how you validated your changes

### Additional Notes
