### PR TITLE
usm, cnm: Add process tags from tagger

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"runtime"
 	"sort"
+	"strconv"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -186,8 +187,9 @@ func (c *ConnectionsCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResu
 	c.npCollector.ScheduleConns(conns.Conns, conns.Dns)
 
 	getContainersCB := c.getContainerTagsCallback(c.getContainersForExplicitTagging(conns.Conns))
+	getProcessTagsCB := c.getProcessTagsCallback()
 	groupID := nextGroupID()
-	messages := batchConnections(c.hostInfo, c.hostTagProvider, getContainersCB, c.maxConnsPerMessage, groupID, conns.Conns, conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.KernelHeaderFetchResult, conns.CORETelemetryByAsset, conns.PrebuiltEBPFAssets, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration, c.serviceExtractor)
+	messages := batchConnections(c.hostInfo, c.hostTagProvider, getContainersCB, getProcessTagsCB, c.maxConnsPerMessage, groupID, conns.Conns, conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.KernelHeaderFetchResult, conns.CORETelemetryByAsset, conns.PrebuiltEBPFAssets, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration, c.serviceExtractor)
 	return StandardRunResult(messages), nil
 }
 
@@ -241,6 +243,17 @@ func (c *ConnectionsCheck) getContainerTagsCallback(relevantContainers map[strin
 		}
 		// If the container is not relevant for explicit tagging, we return an empty slice.
 		return nil, nil
+	}
+}
+
+// getProcessTagsCallback returns a callback that returns the process tags for the given pid.
+func (c *ConnectionsCheck) getProcessTagsCallback() func(int32) ([]string, error) {
+	return func(pid int32) ([]string, error) {
+		if pid <= 0 {
+			return nil, nil
+		}
+		processEntityID := types.NewEntityID(types.Process, strconv.Itoa(int(pid)))
+		return c.tagger.Tag(processEntityID, types.HighCardinality)
 	}
 }
 
@@ -374,6 +387,7 @@ func batchConnections(
 	hostInfo *HostInfo,
 	hostTagProvider *hosttags.HostTagProvider,
 	containerTagProvider func(string) ([]string, error),
+	processTagProvider func(int32) ([]string, error),
 	maxConnsPerMessage int,
 	groupID int32,
 	cxs []*model.Connection,
@@ -448,6 +462,13 @@ func batchConnections(
 			// tags remap
 			serviceCtx := serviceExtractor.GetServiceContext(c.Pid)
 			tagsStr := convertAndEnrichWithServiceCtx(tags, c.Tags, serviceCtx...)
+
+			// Get process tags and add them to the connection tags
+			if processTagProvider != nil {
+				if processTags, err := processTagProvider(c.Pid); err == nil {
+					tagsStr = append(tagsStr, processTags...)
+				}
+			}
 
 			if len(tagsStr) > 0 {
 				c.Tags = nil

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -465,7 +465,9 @@ func batchConnections(
 
 			// Get process tags and add them to the connection tags
 			if processTagProvider != nil {
-				if processTags, err := processTagProvider(c.Pid); err == nil {
+				if processTags, err := processTagProvider(c.Pid); err != nil {
+					log.Debugf("error getting tags for process %v: %v", c.Pid, err)
+				} else {
 					tagsStr = append(tagsStr, processTags...)
 				}
 			}

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -7,6 +7,7 @@ package checks
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,8 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/hosttags"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
@@ -62,7 +65,7 @@ func TestDNSNameEncoding(t *testing.T) {
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	maxConnsPerMessage := 10
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 	assert.Equal(t, len(chunks), 1)
 
 	chunk := chunks[0]
@@ -131,7 +134,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		useImprovedAlgorithm := false
 		ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 		hostTagsProvider := hosttags.NewHostTagProvider()
-		chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, tc.maxSize, 0, tc.cur, map[string]*model.DNSEntry{}, "nid", ctm, rctm, khfr, coretm, nil, nil, nil, nil, nil, ex)
+		chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, tc.maxSize, 0, tc.cur, map[string]*model.DNSEntry{}, "nid", ctm, rctm, khfr, coretm, nil, nil, nil, nil, nil, ex)
 
 		assert.Len(t, chunks, tc.expectedChunks, "len %d", i)
 		total := 0
@@ -175,7 +178,7 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, p, dns, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -219,7 +222,7 @@ func TestBatchSimilarConnectionsTogether(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 3)
 	total := 0
@@ -307,7 +310,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -429,7 +432,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, conns, dnsmap, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, domains, nil, nil, nil, ex)
 
 	assert.Len(t, chunks, 4)
 	total := 0
@@ -542,7 +545,7 @@ func TestNetworkConnectionBatchingWithRoutes(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, routes, nil, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, routes, nil, nil, ex)
 
 	assert.Len(t, chunks, 2)
 	total := 0
@@ -614,7 +617,7 @@ func TestNetworkConnectionTags(t *testing.T) {
 	useImprovedAlgorithm := false
 	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
 
 	assert.Len(t, chunks, 2)
 	total := 0
@@ -658,7 +661,7 @@ func TestNetworkConnectionTagsWithService(t *testing.T) {
 	ex.Extract(procsByPid)
 
 	hostTagsProvider := hosttags.NewHostTagProvider()
-	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, nil, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, tags, nil, ex)
 
 	assert.Len(t, chunks, 1)
 	connections := chunks[0].(*model.CollectorConnections)
@@ -705,4 +708,67 @@ func TestConvertAndEnrichWithServiceTags(t *testing.T) {
 			assert.Equal(t, tt.expected, convertAndEnrichWithServiceCtx(tags, tt.tagOffsets, tt.serviceTag))
 		})
 	}
+}
+
+func TestNetworkConnectionProcessTags(t *testing.T) {
+	conns := makeConnections(4)
+
+	// Set up mock tagger
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+
+	// Configure process tags for specific PIDs
+	pid1EntityID := taggertypes.NewEntityID(taggertypes.Process, strconv.Itoa(int(conns[0].Pid)))
+	pid2EntityID := taggertypes.NewEntityID(taggertypes.Process, strconv.Itoa(int(conns[1].Pid)))
+	pid3EntityID := taggertypes.NewEntityID(taggertypes.Process, strconv.Itoa(int(conns[2].Pid)))
+	// Intentionally leave conns[3].Pid without tags to test empty case
+
+	fakeTagger.SetTags(pid1EntityID, "process", nil, nil, []string{"env:prod", "service:web"}, nil)
+	fakeTagger.SetTags(pid2EntityID, "process", nil, nil, []string{"env:staging", "team:backend"}, nil)
+	fakeTagger.SetTags(pid3EntityID, "process", nil, nil, []string{"env:dev"}, nil)
+
+	// Create process tag provider using the mock tagger
+	processTagProvider := func(pid int32) ([]string, error) {
+		if pid <= 0 {
+			return nil, nil
+		}
+		processEntityID := taggertypes.NewEntityID(taggertypes.Process, strconv.Itoa(int(pid)))
+		return fakeTagger.Tag(processEntityID, taggertypes.HighCardinality)
+	}
+
+	maxConnsPerMessage := 2
+	serviceExtractorEnabled := false
+	useWindowsServiceName := false
+	useImprovedAlgorithm := false
+	ex := parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm)
+	hostTagsProvider := hosttags.NewHostTagProvider()
+	chunks := batchConnections(&HostInfo{}, hostTagsProvider, nil, processTagProvider, maxConnsPerMessage, 0, conns, nil, "nid", nil, nil, model.KernelHeaderFetchResult_FetchNotAttempted, nil, nil, nil, nil, nil, nil, ex)
+
+	assert.Len(t, chunks, 2)
+
+	// Verify first chunk (connections 0 and 1)
+	connections0 := chunks[0].(*model.CollectorConnections)
+	assert.Len(t, connections0.Connections, 2)
+
+	// Check tags for first connection (PID 1)
+	conn0Tags := connections0.GetConnectionsTags(connections0.Connections[0].TagsIdx)
+	expectedTags0 := []string{"env:prod", "service:web"}
+	assert.ElementsMatch(t, expectedTags0, conn0Tags)
+
+	// Check tags for second connection (PID 2)
+	conn1Tags := connections0.GetConnectionsTags(connections0.Connections[1].TagsIdx)
+	expectedTags1 := []string{"env:staging", "team:backend"}
+	assert.ElementsMatch(t, expectedTags1, conn1Tags)
+
+	// Verify second chunk (connections 2 and 3)
+	connections1 := chunks[1].(*model.CollectorConnections)
+	assert.Len(t, connections1.Connections, 2)
+
+	// Check tags for third connection (PID 3)
+	conn2Tags := connections1.GetConnectionsTags(connections1.Connections[0].TagsIdx)
+	expectedTags2 := []string{"env:dev"}
+	assert.ElementsMatch(t, expectedTags2, conn2Tags)
+
+	// Check tags for fourth connection (PID 4, no tags configured)
+	conn3Tags := connections1.GetConnectionsTags(connections1.Connections[1].TagsIdx)
+	assert.Empty(t, conn3Tags, "Connection with no configured process tags should have no tags")
 }


### PR DESCRIPTION
### What does this PR do?

Get the tags for the Process entity from the tagger and add them to the
connection tags.  If service discovery is enabled, this will include
things like UST (will be de-duplicated in the encoder since system-probe
also gets it directly for USM/CNM) as well as process tags from tracer
metadata.

Without service discovery enabled, this will currently not add any tags.

There are races to be addressed in the future regarding during process startup and for short-lived processes where the workloadmeta may not have the process information, but the other cases should work.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-197

### Describe how you validated your changes

Tests added.  Also checked manually with debug prints that the connection check
gets the tags.
