### PR TITLE
[CONTP-990] chore(workloadfilter): Include service type in cel type naming convension 

### DIFF
--- a/comp/core/workloadfilter/catalog/utils_test.go
+++ b/comp/core/workloadfilter/catalog/utils_test.go
@@ -73,13 +73,13 @@ func TestConvertOldToNewFilter_Success(t *testing.T) {
 			"exclude omitted image key in service",
 			workloadfilter.ServiceType,
 			[]string{"name:foo-.*", "image:nginx.*"},
-			`service.name.matches("foo-.*")`,
+			`kube_service.name.matches("foo-.*")`,
 		},
 		{
 			"exclude omitted image key in endpoint",
 			workloadfilter.EndpointType,
 			[]string{"name:foo-.*", "image:nginx.*"},
-			`endpoint.name.matches("foo-.*")`,
+			`kube_endpoint.name.matches("foo-.*")`,
 		},
 		{
 			"image filter on image type",

--- a/comp/core/workloadfilter/def/types.go
+++ b/comp/core/workloadfilter/def/types.go
@@ -58,8 +58,8 @@ type ResourceType string
 const (
 	ContainerType ResourceType = "container"
 	PodType       ResourceType = "pod"
-	ServiceType   ResourceType = "service"
-	EndpointType  ResourceType = "endpoint"
+	ServiceType   ResourceType = "kube_service"
+	EndpointType  ResourceType = "kube_endpoint"
 	ImageType     ResourceType = "image"
 	ProcessType   ResourceType = "process"
 )


### PR DESCRIPTION
### What does this PR do?

Adds a `kube_` prefix to serialized names of `Endpoint` and `Service` CEL types. Both types are renamed to `kube_endpoint` and `kube_service` respectively.

### Motivation

We want to reduce ambiguity regarding the type of service that the filter is referencing. In this case, endpoint and service reference k8s services so adding `kube_` provides more clarity.

### Describe how you validated your changes

- [x] Updated tests and CI is 🟢

#### Configure a service & endpoint check on a mock service.
```
apiVersion: v1
kind: Service
metadata:
  name: nginx-svc-checks
  namespace: default
  labels:
    app: nginx-checks
  annotations:
    ad.datadoghq.com/service.checks: |
      {
        "http_check": {
          "init_config": {},
          "instances": [
            {
              "url":"http://%%host%%",
              "name": "My Nginx",
              "timeout": 1
            }
          ]
        }
      }
    ad.datadoghq.com/endpoints.checks: |
      {
        "nginx": {
          "init_config": {},
          "instances": [
            {
              "name": "My Nginx Service Endpoints",
              "nginx_status_url": "http://%%host%%:%%port%%/status/",
            }
          ]
        }
      }
spec:
  selector:
    app: nginx-checks
  ports:
  - port: 80
    protocol: TCP
  type: ClusterIP
```

#### Add exclude the service checks based on the svc name
```
# ....
clusterAgent:
   # ...
   envDict:
      DD_CONTAINER_EXCLUDE_METRICS: "name:nginx-svc-checks"
# ...
```

#### Validate that no check is scheduled
<img width="607" height="190" alt="image" src="https://github.com/user-attachments/assets/0fcd675d-7e9b-48f0-88c5-2595f856e5c6" />

### Additional Notes

- [RFC comment](https://datadoghq.atlassian.net/wiki/spaces/CONTP/pages/5314806144/Exposing+CEL+Filtering+Capabilities?focusedCommentId=5471470929) suggesting the name change