### PR TITLE
[AGENTRUN-734] Adding JSON output option to health command

### DIFF
--- a/releasenotes/notes/adding-json-output-to-health-command-9d4ae63e73a15c5a.yaml
+++ b/releasenotes/notes/adding-json-output-to-health-command-9d4ae63e73a15c5a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``--json`` and ``--pretty-json`` flags to the ``health`` command that will
+    output the health status as JSON.


### PR DESCRIPTION
### What does this PR do?
Adds support for JSON output (both raw and pretty formats) to the `agent health` command.

### Motivation
Providing JSON output offers users a structured alternative to directly consuming the Agent API, which is a behavior we want to discourage.

### Describe how you validated your changes
Tested manually by running the command and verifying the output.