### PR TITLE
Mark TestScripts in installer/script as flaky

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -26,5 +26,8 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
+test/new-e2e/tests/installer/script:
+  - test: TestScripts
+
 on-log:
   - "panic: Expected to find a single pod" # K8s Agent Executor can be flaky with the current implementation


### PR DESCRIPTION
### What does this PR do?

Marks test/new-e2e/tests/installer/script TestScripts as flaky to prevent CI failures.

### Motivation

Broken tests on `main`

