### PR TITLE
[EBPF] gpu: add logs to identify method used to patch cgroup permissions

### DIFF
--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -42,8 +42,10 @@ func ConfigureDeviceCgroups(pid uint32, hostRoot string) error {
 
 	// Now configure the cgroup device allow, depending on the cgroup version
 	if cgroupMode == cgroups.Legacy {
+		log.Infof("Configuring PID %d cgroupv1 device allow, cgroup path %s", pid, cgroupPath)
 		err = configureCgroupV1DeviceAllow(hostRoot, cgroupPath, nvidiaDeviceMajor)
 	} else {
+		log.Infof("Configuring PID %d cgroupv2 device programs, cgroup path %s", pid, cgroupPath)
 		err = detachAllDeviceCgroupPrograms(hostRoot, cgroupPath)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds extra logs to debug method used to patch cgroup permissions.

### Motivation

We have detected some issues in our own clusters where the cgroup permissions were not being patched correctly. This happens sporadically and on different clusters, so we cannot enable debug logs. These logs will allow us to debug the method being used and understand why the permissions are not being patched.

### Describe how you validated your changes

CI passing.

### Additional Notes
