### PR TITLE
[Stackcleaner] Do not fail if issue when triggering stack delete, send event

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -735,11 +735,11 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout-error")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				bs.T().Logf("Unable to destroy stack %s: %s", stackName, out)
+				bs.T().Logf("WARNING: Unable to destroy stack %s: %s", stackName, out)
 				_, err := bs.datadogClient.PostEvent(&datadog.Event{
 					Title: pointer.Ptr(fmt.Sprintf("Unable to destroy stack %s", stackName)),
 					Text:  pointer.Ptr(fmt.Sprintf("Unable to destroy stack %s: %s", stackName, out)),
-					Tags:  []string{"test:e2e", "stack:destroy", "stack_name:" + stackName},
+					Tags:  []string{"test:e2e", "stack:destroy", "stack_name:" + stackName, "service:stackcleaner-worker", "ci.job.name:" + os.Getenv("CI_JOB_NAME"), "ci.job.id:" + os.Getenv("CI_JOB_ID"), "ci.pipeline.id:" + os.Getenv("CI_PIPELINE_ID")},
 				})
 				if err != nil {
 					bs.T().Logf("Unable to post event: %v", err)


### PR DESCRIPTION
…

### What does this PR do?

Make sure the call to stack cleaner cannot fail the test.
It makes no sense to fail the test on clean up step.  To avoid flakiness we should ignore such error. An event is sent to datadog so that we can be aware of such issues

### Motivation

Prevent flakiness on steps that does not indicate anything about the test result

### Describe how you validated your changes

### Additional Notes
