### PR TITLE
Parse extended memory metric config option

### DIFF
--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -68,8 +68,13 @@ func (c *ContainerCheck) Configure(senderManager sender.SenderManager, _ uint64,
 		return err
 	}
 
+	err = c.instance.Parse(config)
+	if err != nil {
+		return err
+	}
+
 	c.processor = NewProcessor(metrics.GetProvider(option.New(c.store)), NewMetadataContainerAccessor(c.store), GenericMetricsAdapter{}, LegacyContainerFilter{ContainerFilter: c.filterStore.GetContainerSharedMetricFilters(), Store: c.store}, c.tagger, c.instance.ExtendedMemoryMetrics)
-	return c.instance.Parse(config)
+	return nil
 }
 
 // Run executes the check


### PR DESCRIPTION
### What does this PR do?

Fixes the generic container corecheck processor to receive the parsed value for ExtendedMemory collection

### Motivation

Address bug with the parsing and configuration of extended memory metric collection in the containers processor

### Describe how you validated your changes

Deploy Agent locally with container check enabled with extended memory metric collection enabled:

```
datadog:
  confd:
    container.yaml: |-
      ad_identifiers:
        - _container
      init_config:
      instances:
        - extended_memory_metrics: true
```

Run the container corecheck and expect extended memory metrics like `container.memory.active_file` to be outputted.
```
k exec -it datadog-agent-linux-bj667 -n datadog-agent -- agent check container | grep container.memory.active_file
Defaulted container "agent" out of: agent, trace-agent, process-agent, init-volume (init), init-config (init)
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
```

### Additional Notes

Follow up e2e tests can be added for detecting the presence of extended memory metrics