### PR TITLE
fix: environment variable can be unset, which results in nil host field

### DIFF
--- a/comp/otelcol/converter/impl/prometheus.go
+++ b/comp/otelcol/converter/impl/prometheus.go
@@ -337,10 +337,14 @@ func findInternalMetricsAddress(conf *confmap.Conf) string {
 		host := "0.0.0.0"
 		port := 8888
 		if h, ok := promExpMap["host"]; ok {
-			host = h.(string)
+			if hStr, ok := h.(string); ok {
+				host = hStr
+			}
 		}
 		if p, ok := promExpMap["port"]; ok {
-			port = p.(int)
+			if pInt, ok := p.(int); ok {
+				port = pInt
+			}
 		}
 		return fmt.Sprintf("%s:%d", host, port)
 	}

--- a/comp/otelcol/converter/impl/prometheus_test.go
+++ b/comp/otelcol/converter/impl/prometheus_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+package converterimpl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestFindInternalMetricsAddress(t *testing.T) {
+	tests := []struct {
+		host   any
+		port   any
+		result string
+	}{
+		{
+			host:   nil,
+			port:   9999,
+			result: "0.0.0.0:9999",
+		},
+		{
+			host:   nil,
+			port:   nil,
+			result: "0.0.0.0:8888",
+		},
+		{
+			host:   "1.2.3.4",
+			port:   nil,
+			result: "1.2.3.4:8888",
+		},
+		{
+			host:   "1.2.3.4",
+			port:   "9999",
+			result: "1.2.3.4:8888",
+		},
+		{
+			host:   5,
+			port:   9999,
+			result: "0.0.0.0:9999",
+		},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf("findInternalMetricsAddress(%v,%v)", tc.host, tc.port)
+
+		t.Run(name, func(t *testing.T) {
+			conf := confmap.NewFromStringMap(map[string]any{
+				"service": map[string]any{
+					"telemetry": map[string]any{
+						"metrics": map[string]any{
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": tc.host,
+												"port": tc.port,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			addr := findInternalMetricsAddress(conf)
+			assert.Equal(t, tc.result, addr)
+		})
+	}
+
+}


### PR DESCRIPTION
### What does this PR do?

During a deployment of the datadog agent, I came across a panic error. I was unsure what caused it I dove a little deeper.

From testing, if an environment variable is not set and the config is like this:

```yaml
service:
  telemetry:
    metrics:
      readers:
      - pull:
          exporter:
            prometheus:
              host: ${env:MY_POD_IP}
              port: 8888
```

The field ends up as nil, and the code in question then checks if the field exists, which it does. But it's not of type string and causes a panic:

```
panic: interface conversion: interface {} is nil, not string
```

[playground](https://go.dev/play/p/TGZ44Z6EdMz?v=goprev)

### Motivation

Made the code more resilient against possible edge cases. Stops from entire crashing pod and services.

