### PR TITLE
tagger: process: Include standard tags from tracer metadata

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -285,6 +285,9 @@ func (c *WorkloadMetaCollector) handleProcess(ev workloadmeta.Event) []*types.Ta
 	}
 
 	for _, tracerMeta := range process.Service.TracerMetadata {
+		tagList.AddStandard(tags.Service, tracerMeta.ServiceName)
+		tagList.AddStandard(tags.Env, tracerMeta.ServiceEnv)
+		tagList.AddStandard(tags.Version, tracerMeta.ServiceVersion)
 		parseProcessTags(tagList, tracerMeta.ProcessTags)
 	}
 

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -3042,6 +3042,70 @@ func TestHandleProcess(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "process with TracerMetadata service tags and multiple entries",
+			process: &workloadmeta.Process{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindProcess,
+					ID:   pid,
+				},
+				Pid: 12345,
+				Service: &workloadmeta.Service{
+					UST: workloadmeta.UST{
+						Service: serviceNameFromDD,
+						Env:     envFromDD,
+						Version: versionFromDD,
+					},
+					TracerMetadata: []tracermetadata.TracerMetadata{
+						{
+							ServiceName:    "first-tracer-service",
+							ServiceEnv:     "dev",
+							ServiceVersion: "1.0.0",
+							ProcessTags:    "framework:express",
+						},
+						{
+							ServiceEnv: "test",
+						},
+						{
+							ServiceName:    "second-tracer-service",
+							ServiceEnv:     envFromDD,
+							ServiceVersion: "2.0.0",
+							ProcessTags:    "runtime:nodejs",
+						},
+					},
+				},
+			},
+			expectedTagInfo: &types.TagInfo{
+				Source:   processSource,
+				EntityID: types.NewEntityID(types.Process, pid),
+				LowCardTags: []string{
+					fmt.Sprintf("env:%s", envFromDD),
+					"env:dev",
+					"env:test",
+					"framework:express",
+					"runtime:nodejs",
+					fmt.Sprintf("service:%s", serviceNameFromDD),
+					"service:first-tracer-service",
+					"service:second-tracer-service",
+					fmt.Sprintf("version:%s", versionFromDD),
+					"version:1.0.0",
+					"version:2.0.0",
+				},
+				OrchestratorCardTags: []string{},
+				HighCardTags:         []string{},
+				StandardTags: []string{
+					fmt.Sprintf("env:%s", envFromDD),
+					"env:dev",
+					"env:test",
+					fmt.Sprintf("service:%s", serviceNameFromDD),
+					"service:first-tracer-service",
+					"service:second-tracer-service",
+					fmt.Sprintf("version:%s", versionFromDD),
+					"version:1.0.0",
+					"version:2.0.0",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

For applications which are traced with APM, the standard Service,
Environment and Version tags may be set using APIs directly in the
traced application and can thus potentially differ from the tags set by
UST.  Include the tags provided by the tracer too in the process tags.

### Describe how you validated your changes

Unit test added.  Also tested manually against a test application created
following the instructions on
https://docs.datadoghq.com/tracing/trace_collection/library_config/go/ which
set the service/env/version via the tracer's API.
