### PR TITLE
feat: [SVLS-5162] fix serverless-init trace stats

### DIFF
--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -9,6 +9,7 @@ package tag
 import (
 	"maps"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
@@ -66,7 +67,7 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string, versionMode string) 
 	// Only set compute_stats tag if explicitly enabled. This is known to be
 	// incorrect since it does not include traces that get sampled out in the
 	// agent and don't get sent to the backend.
-	if os.Getenv(enableBackendTraceStatsEnvVar) == "true" {
+	if enabled, _ := strconv.ParseBool(os.Getenv(enableBackendTraceStatsEnvVar)); enabled {
 		tagsMap[tags.ComputeStatsKey] = tags.ComputeStatsValue
 	}
 

--- a/cmd/serverless-init/tag/tag.go
+++ b/cmd/serverless-init/tag/tag.go
@@ -14,6 +14,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 )
 
+const (
+	// enableBackendTraceStatsEnvVar is the environment variable to enable backend trace stats computation
+	// This computation is known to be incorrect since it does not account for traces that get
+	// sampled out in the agent and don't get sent to the backend.
+	enableBackendTraceStatsEnvVar = "DD_SERVERLESS_INIT_ENABLE_BACKEND_TRACE_STATS"
+)
+
 // TagPair contains a pair of tag key and value
 //
 //nolint:revive // TODO(SERV) Fix revive linter
@@ -56,7 +63,12 @@ func GetBaseTagsMapWithMetadata(metadata map[string]string, versionMode string) 
 	maps.Copy(tagsMap, metadata)
 
 	tagsMap[versionMode] = tags.GetExtensionVersion()
-	tagsMap[tags.ComputeStatsKey] = tags.ComputeStatsValue
+	// Only set compute_stats tag if explicitly enabled. This is known to be
+	// incorrect since it does not include traces that get sampled out in the
+	// agent and don't get sent to the backend.
+	if os.Getenv(enableBackendTraceStatsEnvVar) == "true" {
+		tagsMap[tags.ComputeStatsKey] = tags.ComputeStatsValue
+	}
 
 	return tagsMap
 }

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetBaseTagsArrayNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 2, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0), "")))
+	assert.Equal(t, 1, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0), "")))
 }
 
 func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
@@ -28,12 +28,11 @@ func TestGetBaseTagsArrayWithMetadataTagsNoMetadata(t *testing.T) {
 	t.Setenv("DD_VERSION", "123.4")
 	tags := serverlessTag.MapToArray(GetBaseTagsMapWithMetadata(make(map[string]string, 0), "_dd.datadog_init_version"))
 	sort.Strings(tags)
-	assert.Equal(t, 5, len(tags))
-	assert.Contains(t, tags[0], "_dd.compute_stats:1")
-	assert.Contains(t, tags[1], "_dd.datadog_init_version")
-	assert.Equal(t, "env:myenv", tags[2])
-	assert.Equal(t, "service:superservice", tags[3])
-	assert.Equal(t, "version:123.4", tags[4])
+	assert.Equal(t, 4, len(tags))
+	assert.Contains(t, tags[0], "_dd.datadog_init_version")
+	assert.Equal(t, "env:myenv", tags[1])
+	assert.Equal(t, "service:superservice", tags[2])
+	assert.Equal(t, "version:123.4", tags[3])
 }
 
 func TestGetTagFound(t *testing.T) {
@@ -50,7 +49,7 @@ func TestGetTagNotFound(t *testing.T) {
 }
 
 func TestGetBaseTagsMapNoEnvNoMetadata(t *testing.T) {
-	assert.Equal(t, 2, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0), "")))
+	assert.Equal(t, 1, len(GetBaseTagsMapWithMetadata(make(map[string]string, 0), "")))
 }
 
 func TestGetBaseTagsMapNoMetadata(t *testing.T) {
@@ -59,8 +58,8 @@ func TestGetBaseTagsMapNoMetadata(t *testing.T) {
 	t.Setenv("DD_ENV", "myEnv")
 	t.Setenv("DD_SERVICE", "superService")
 	t.Setenv("DD_VERSION", "123.4")
-	tags := GetBaseTagsMapWithMetadata(make(map[string]string, 0), "")
-	assert.Equal(t, 5, len(tags))
+	tags := GetBaseTagsMapWithMetadata(make(map[string]string, 0), "_dd.version")
+	assert.Equal(t, 4, len(tags))
 	assert.Equal(t, "myenv", tags["env"])
 	assert.Equal(t, "superservice", tags["service"])
 	assert.Equal(t, "123.4", tags["version"])
@@ -71,8 +70,8 @@ func TestGetBaseTagsMapWithMetadata(t *testing.T) {
 	tags := GetBaseTagsMapWithMetadata(map[string]string{
 		"location":      "mysuperlocation",
 		"othermetadata": "mysuperothermetadatavalue",
-	}, "")
-	assert.Equal(t, 4, len(tags))
+	}, "_dd.version")
+	assert.Equal(t, 3, len(tags))
 	assert.Equal(t, "mysuperlocation", tags["location"])
 	assert.Equal(t, "mysuperothermetadatavalue", tags["othermetadata"])
 }
@@ -84,11 +83,10 @@ func TestGetBaseTagsArrayWithMetadataTags(t *testing.T) {
 		"othermetadata": "mysuperothermetadatavalue",
 	}, "_dd.datadog_sidecar_version"))
 	sort.Strings(tags)
-	assert.Equal(t, 4, len(tags))
-	assert.Contains(t, tags[0], "_dd.compute_stats:1")
-	assert.Contains(t, tags[1], "_dd.datadog_sidecar_version")
-	assert.Equal(t, "location:mysuperlocation", tags[2])
-	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[3])
+	assert.Equal(t, 3, len(tags))
+	assert.Contains(t, tags[0], "_dd.datadog_sidecar_version")
+	assert.Equal(t, "location:mysuperlocation", tags[1])
+	assert.Equal(t, "othermetadata:mysuperothermetadatavalue", tags[2])
 }
 
 func TestDdTags(t *testing.T) {
@@ -110,4 +108,50 @@ func TestWithoutHighCardinalityTags(t *testing.T) {
 	tags := map[string]string{"key1": "value1", "key2": "value2", "container_id": "abc", "replica_name": "abc"}
 	filteredTags := WithoutHighCardinalityTags(tags)
 	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, filteredTags)
+}
+
+func TestBackendTraceStatsTag(t *testing.T) {
+	tests := []struct {
+		name                  string
+		envValue              string
+		expectComputeStatsTag bool
+	}{
+		{
+			name:                  "disabled by default",
+			envValue:              "",
+			expectComputeStatsTag: false,
+		},
+		{
+			name:                  "enabled with true",
+			envValue:              "true",
+			expectComputeStatsTag: true,
+		},
+		{
+			name:                  "disabled with false",
+			envValue:              "false",
+			expectComputeStatsTag: false,
+		},
+		{
+			name:                  "disabled with other value",
+			envValue:              "yes",
+			expectComputeStatsTag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(enableBackendTraceStatsEnvVar, tt.envValue)
+			}
+
+			tags := GetBaseTagsMapWithMetadata(make(map[string]string, 0), "_dd.datadog_init_version")
+
+			if tt.expectComputeStatsTag {
+				assert.Equal(t, serverlessTag.ComputeStatsValue, tags[serverlessTag.ComputeStatsKey])
+			} else {
+				_, hasComputeStats := tags[serverlessTag.ComputeStatsKey]
+				assert.False(t, hasComputeStats, "compute_stats should not be present")
+			}
+		})
+	}
 }

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -404,4 +404,3 @@ func TestCleanRuntimeInvalid(t *testing.T) {
 	}
 	assert.Equal(t, "", cleanRuntimes(runtimes))
 }
-

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -404,3 +404,4 @@ func TestCleanRuntimeInvalid(t *testing.T) {
 	}
 	assert.Equal(t, "", cleanRuntimes(runtimes))
 }
+

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -137,7 +138,7 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 
 			// Check if trace stats should be disabled for serverless
-			if os.Getenv(disableTraceStatsEnvVar) == "true" {
+			if disabled, _ := strconv.ParseBool(os.Getenv(disableTraceStatsEnvVar)); disabled {
 				log.Debug("Trace stats computation disabled for serverless via DD_SERVERLESS_INIT_DISABLE_TRACE_STATS")
 				ta.Concentrator = &noopConcentrator{}
 			}

--- a/releasenotes/notes/serverless-init-trace-stats-fix-3fd9582e448bb0eb.yaml
+++ b/releasenotes/notes/serverless-init-trace-stats-fix-3fd9582e448bb0eb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Trace Stats with serverless-init are computed in the agent only. Backend
+    trace stats computation is disabled now.

--- a/releasenotes/notes/serverless-init-trace-stats-fix-3fd9582e448bb0eb.yaml
+++ b/releasenotes/notes/serverless-init-trace-stats-fix-3fd9582e448bb0eb.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Trace Stats with serverless-init are computed in the agent only. Backend
-    trace stats computation is disabled now.
+    Trace Stats with serverless-init are computed in the Agent only. Backend
+    trace stats computation is disabled.


### PR DESCRIPTION
### What does this PR do?
`serverless-init` relies on agent-side trace stats computation. Backend trace stats computation is now disabled by default.

This PR includes a way to turn off agent-side trace stats and re-enable backend trace stats in case that becomes necessary.

### Motivation
Trace stats have been computed incorrectly for a long time. Now that we have confirmed that the agent-side logic is correct in various deployments, let's fix them.

### Describe how you validated your changes
Added end to end tests for serverless-init and confirmed that the numbers are correct.

