### PR TITLE
Add option to obfuscate SQL bind parameters

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -331,6 +331,10 @@ type sqlConfig struct {
 	// By default, JSON paths are treated as literals and are obfuscated to ?, e.g. "data::jsonb -> 'name'" -> "data::jsonb -> ?".
 	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepJSONPath bool `json:"keep_json_path" yaml:"keep_json_path"`
+
+	// ReplaceBindParameter specifies whether to replace SQL bind parameters such as @P1 with ?.
+	// By default, bind parameters are not replaced.
+	ReplaceBindParameter bool `json:"replace_bind_parameter"`
 }
 
 // ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -231,6 +231,10 @@ type SQLConfig struct {
 	// This option is only valid when ObfuscationMode is "normalize_only" or "obfuscate_and_normalize".
 	KeepJSONPath bool `json:"keep_json_path" yaml:"keep_json_path"`
 
+	// ReplaceBindParameter specifies whether to replace SQL bind parameters such as @P1 with ?.
+	// By default, bind parameters are not replaced.
+	ReplaceBindParameter bool `json:"replace_bind_parameter" yaml:"replace_bind_parameter"`
+
 	// Cache is deprecated. Please use `apm_config.obfuscation.cache` instead.
 	Cache bool `json:"cache" yaml:"cache"`
 }

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -482,6 +482,7 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 			sqllexer.WithReplaceBoolean(!opts.KeepBoolean),
 			sqllexer.WithReplaceNull(!opts.KeepNull),
 			sqllexer.WithKeepJsonPath(opts.KeepJSONPath),
+			sqllexer.WithReplaceBindParameter(opts.ReplaceBindParameter),
 		)
 	}
 

--- a/pkg/obfuscate/sql_fuzz_test.go
+++ b/pkg/obfuscate/sql_fuzz_test.go
@@ -29,6 +29,7 @@ type FuzzSQLConfig struct {
 	KeepTrailingSemicolon         bool
 	KeepIdentifierQuotation       bool
 	KeepJSONPath                  bool
+	ReplaceBindParameter          bool
 }
 
 func fuzzConfigToSQLConfig(fc FuzzSQLConfig) SQLConfig {
@@ -57,6 +58,7 @@ func fuzzConfigToSQLConfig(fc FuzzSQLConfig) SQLConfig {
 		KeepTrailingSemicolon:         fc.KeepTrailingSemicolon,
 		KeepIdentifierQuotation:       fc.KeepIdentifierQuotation,
 		KeepJSONPath:                  fc.KeepJSONPath,
+		ReplaceBindParameter:          fc.ReplaceBindParameter,
 	}
 }
 
@@ -190,6 +192,7 @@ func FuzzObfuscateSQLWithConfig(f *testing.F) {
 				KeepTrailingSemicolon:         true,
 				KeepIdentifierQuotation:       true,
 				KeepJSONPath:                  true,
+				ReplaceBindParameter:          true,
 			},
 		},
 	}
@@ -220,7 +223,7 @@ func FuzzObfuscateSQLWithConfig(f *testing.F) {
 			tc.config.KeepSQLAlias, tc.config.DollarQuotedFunc, tc.config.ObfuscationMode,
 			tc.config.RemoveSpaceBetweenParentheses, tc.config.KeepNull, tc.config.KeepBoolean,
 			tc.config.KeepPositionalParameter, tc.config.KeepTrailingSemicolon,
-			tc.config.KeepIdentifierQuotation, tc.config.KeepJSONPath)
+			tc.config.KeepIdentifierQuotation, tc.config.KeepJSONPath, tc.config.ReplaceBindParameter)
 	}
 
 	o := NewObfuscator(Config{})
@@ -228,7 +231,7 @@ func FuzzObfuscateSQLWithConfig(f *testing.F) {
 	f.Fuzz(func(t *testing.T, query string, dbms uint8, tableNames, collectCommands,
 		collectComments, collectProcedures, replaceDigits, keepSQLAlias, dollarQuotedFunc bool,
 		obfuscationMode uint8, removeSpaceBetweenParentheses, keepNull, keepBoolean,
-		keepPositionalParameter, keepTrailingSemicolon, keepIdentifierQuotation, keepJSONPath bool) {
+		keepPositionalParameter, keepTrailingSemicolon, keepIdentifierQuotation, keepJSONPath, replaceBindParameter bool) {
 
 		fuzzConfig := FuzzSQLConfig{
 			DBMS:                          dbms,
@@ -247,6 +250,7 @@ func FuzzObfuscateSQLWithConfig(f *testing.F) {
 			KeepTrailingSemicolon:         keepTrailingSemicolon,
 			KeepIdentifierQuotation:       keepIdentifierQuotation,
 			KeepJSONPath:                  keepJSONPath,
+			ReplaceBindParameter:          replaceBindParameter,
 		}
 
 		sqlConfig := fuzzConfigToSQLConfig(fuzzConfig)

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -2146,6 +2146,7 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 		keepTrailingSemicolon         bool
 		keepIdentifierQuotation       bool
 		KeepJSONPath                  bool
+		replaceBindParameter          bool
 		metadata                      SQLMetadata
 	}{
 		{
@@ -2400,6 +2401,21 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 			},
 		},
 		{
+			name:                 "obfuscation with replace bind parameter",
+			query:                `SELECT * FROM users WHERE id = @P1 AND name = @P2`,
+			expected:             `SELECT * FROM users WHERE id = ? AND name = ?`,
+			replaceBindParameter: true,
+			metadata: SQLMetadata{
+				Size:      11,
+				TablesCSV: "users",
+				Commands: []string{
+					"SELECT",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
 			name:     "PostgreSQL Select Only",
 			query:    `SELECT * FROM ONLY users WHERE id = 1`,
 			expected: `SELECT * FROM ONLY users WHERE id = ?`,
@@ -2492,6 +2508,7 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 					KeepTrailingSemicolon:         tt.keepTrailingSemicolon,
 					KeepIdentifierQuotation:       tt.keepIdentifierQuotation,
 					KeepJSONPath:                  tt.KeepJSONPath,
+					ReplaceBindParameter:          tt.replaceBindParameter,
 				},
 			}).ObfuscateSQLString(tt.query)
 			require.NoError(t, err)
@@ -2512,6 +2529,7 @@ func TestSQLLexerNormalization(t *testing.T) {
 		keepTrailingSemicolon         bool
 		keepIdentifierQuotation       bool
 		keepSQLAlias                  bool
+		replaceBindParameter          bool
 		metadata                      SQLMetadata
 	}{
 		{
@@ -2687,6 +2705,7 @@ func TestSQLLexerNormalization(t *testing.T) {
 					RemoveSpaceBetweenParentheses: tt.removeSpaceBetweenParentheses,
 					KeepTrailingSemicolon:         tt.keepTrailingSemicolon,
 					KeepIdentifierQuotation:       tt.keepIdentifierQuotation,
+					ReplaceBindParameter:          tt.replaceBindParameter,
 				},
 			}).ObfuscateSQLString(tt.query)
 			require.NoError(t, err)

--- a/releasenotes/notes/sql-obfuscator-bind-parameters-obfuscation-37f37e0f5352a850.yaml
+++ b/releasenotes/notes/sql-obfuscator-bind-parameters-obfuscation-37f37e0f5352a850.yaml
@@ -6,6 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
+enhancements:
   - |
     dbm: add SQL obfuscation `ReplaceBindParameter` option to support obfuscating SQL bind parameters.

--- a/releasenotes/notes/sql-obfuscator-bind-parameters-obfuscation-37f37e0f5352a850.yaml
+++ b/releasenotes/notes/sql-obfuscator-bind-parameters-obfuscation-37f37e0f5352a850.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    dbm: add SQL obfuscation `ReplaceBindParameter` option to support obfuscating SQL bind parameters.


### PR DESCRIPTION
### What does this PR do?
This PR adds option `ReplaceBindParameter` to support obfuscating SQL bind parameters. When the option is set to true, SQL with bind parameters such as `SELECT * FROM users WHERE id = @P1 AND name = @P2` will be obfuscated to `SELECT * FROM users WHERE id = ? AND name = ?`.

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-2069

### Describe how you validated your changes

### Additional Notes
