### PR TITLE
discovery: Do not re-walk fds for tracer metadata

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -346,7 +346,11 @@ func TestValidInvalidTracerMetadata(t *testing.T) {
 
 		createTracerMemfd(t, data)
 
-		info, err := discovery.getServiceInfo(int32(self))
+		buf := make([]byte, readlinkBufferSize)
+		openFiles, err := getOpenFilesInfo(int32(self), buf)
+		require.NoError(t, err)
+
+		info, err := discovery.getServiceInfo(int32(self), openFiles)
 		require.NoError(t, err)
 		require.Equal(t, language.CPlusPlus, language.Language(info.Language))
 		require.Equal(t, apm.Provided, apm.Instrumentation(info.APMInstrumentation))
@@ -355,7 +359,11 @@ func TestValidInvalidTracerMetadata(t *testing.T) {
 	t.Run("invalid metadata", func(t *testing.T) {
 		createTracerMemfd(t, []byte("invalid data"))
 
-		info, err := discovery.getServiceInfo(int32(self))
+		buf := make([]byte, readlinkBufferSize)
+		openFiles, err := getOpenFilesInfo(int32(self), buf)
+		require.NoError(t, err)
+
+		info, err := discovery.getServiceInfo(int32(self), openFiles)
 		require.NoError(t, err)
 		require.Equal(t, apm.None, apm.Instrumentation(info.APMInstrumentation))
 	})

--- a/pkg/util/kernel/proc.go
+++ b/pkg/util/kernel/proc.go
@@ -113,14 +113,9 @@ func GetProcessEnvVariable(pid int, procRoot string, envVar string) (string, err
 // found for a given process.
 var ErrMemFdFileNotFound = errors.New("memfd file not found")
 
-// GetProcessMemFdFile reads a maximum amount of bytes from the
-// memFdFileName if it was found.
-func GetProcessMemFdFile(pid int, procRoot string, memFdFileName string, memFdMaxSize int) ([]byte, error) {
-	path, found := findMemFdFilePath(pid, procRoot, memFdFileName)
-	if !found {
-		return nil, ErrMemFdFileNotFound
-	}
-
+// ReadMemFdFile reads a maximum amount of bytes from the memfd file at the given path.
+// The path should be a full path to an fd (e.g., /proc/1234/fd/5).
+func ReadMemFdFile(path string, memFdMaxSize int) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -133,7 +128,7 @@ func GetProcessMemFdFile(pid int, procRoot string, memFdFileName string, memFdMa
 	}
 
 	if !fileInfo.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s: not a regular file", memFdFileName)
+		return nil, fmt.Errorf("%s: not a regular file", path)
 	}
 
 	data, err := io.ReadAll(io.LimitReader(file, int64(memFdMaxSize+1)))
@@ -146,6 +141,17 @@ func GetProcessMemFdFile(pid int, procRoot string, memFdFileName string, memFdMa
 	}
 
 	return data, nil
+}
+
+// GetProcessMemFdFile reads a maximum amount of bytes from the
+// memFdFileName if it was found.
+func GetProcessMemFdFile(pid int, procRoot string, memFdFileName string, memFdMaxSize int) ([]byte, error) {
+	path, found := findMemFdFilePath(pid, procRoot, memFdFileName)
+	if !found {
+		return nil, ErrMemFdFileNotFound
+	}
+
+	return ReadMemFdFile(path, memFdMaxSize)
 }
 
 // findMemfdFilePath searches for the file in the process open file descriptors.


### PR DESCRIPTION
### What does this PR do?

The Service Discovery code walks the process' fd list once to get the
sockets and log files, and then (if it's a service) walks the list again
to find the memfd for the tracer metadata.  Eliminate the latter walk
and have the former walk note the location of the metadata memfd for
re-use by the metadata parsing code.

### Motivation

Remove redundant operations to reduce overhead.

### Describe how you validated your changes

Covered by existing tests.
