### PR TITLE
[CWS] use `ReadDir` instead of `Readdir`

### DIFF
--- a/pkg/security/resolvers/sbom/collectorv2/dpkg.go
+++ b/pkg/security/resolvers/sbom/collectorv2/dpkg.go
@@ -78,7 +78,7 @@ func (s *dpkgScanner) listInstalledPkgs(root *os.Root) ([]sbomtypes.Package, err
 	defer statusDDir.Close()
 
 	for {
-		statusFiles, err := statusDDir.Readdir(readDirBatchSize)
+		statusFiles, err := statusDDir.ReadDir(readDirBatchSize)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -138,7 +138,7 @@ func (s *dpkgScanner) listInstalledFilesFromDir(root *os.Root, baseDir string) (
 	res := make(map[string][]string)
 
 	for {
-		infoFiles, err := infoDir.Readdir(readDirBatchSize)
+		infoFiles, err := infoDir.ReadDir(readDirBatchSize)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/pkg/security/security_profile/rules.go
+++ b/pkg/security/security_profile/rules.go
@@ -209,7 +209,7 @@ func LoadActivityDumpsFromFiles(path string) ([]*profile.Profile, error) {
 		defer dir.Close()
 
 		// Read the directory contents
-		files, err := dir.Readdir(-1)
+		files, err := dir.ReadDir(-1)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read directory: %s", err)
 		}


### PR DESCRIPTION


### What does this PR do?

[As suggested by the upstream documentation](https://pkg.go.dev/os#File.Readdir:~:text=Most%20clients%20are%20better%20served%20by%20the%20more%20efficient%20ReadDir%20method)

### Motivation

### Describe how you validated your changes

### Additional Notes
