### PR TITLE
Parse extended memory metric config option (#41388)

### DIFF
--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -68,8 +68,13 @@ func (c *ContainerCheck) Configure(senderManager sender.SenderManager, _ uint64,
 		return err
 	}
 
+	err = c.instance.Parse(config)
+	if err != nil {
+		return err
+	}
+
 	c.processor = NewProcessor(metrics.GetProvider(option.New(c.store)), NewMetadataContainerAccessor(c.store), GenericMetricsAdapter{}, LegacyContainerFilter{FilterStore: c.filterStore, Store: c.store}, c.tagger, c.instance.ExtendedMemoryMetrics)
-	return c.instance.Parse(config)
+	return nil
 }
 
 // Run executes the check

--- a/releasenotes/notes/fix-container-extended-metrics-d28e0048ff88ecc1.yaml
+++ b/releasenotes/notes/fix-container-extended-metrics-d28e0048ff88ecc1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes configuration parsing for extended container metric 
+    collection on the container core check.


### PR DESCRIPTION
Fixes the generic container corecheck processor to receive the parsed value for ExtendedMemory collection

Address bug with the parsing and configuration of extended memory metric collection in the containers processor

Deploy Agent locally with container check enabled with extended memory metric collection enabled:

```
datadog:
  confd:
    container.yaml: |-
      ad_identifiers:
        - _container
      init_config:
      instances:
        - extended_memory_metrics: true
```

Run the container corecheck and expect extended memory metrics like `container.memory.active_file` to be outputted.
```
k exec -it datadog-agent-linux-bj667 -n datadog-agent -- agent check container | grep container.memory.active_file
Defaulted container "agent" out of: agent, trace-agent, process-agent, init-volume (init), init-config (init)
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
    "metric": "container.memory.active_file",
```

Follow up e2e tests can be added for detecting the presence of extended memory metrics

(cherry picked from commit 8f75bfd6bc368053e480e2e825effd1ed8195edd)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
