### PR TITLE
[Serverless-Init] Drop `ReadString` Allocation 

### DIFF
--- a/cmd/serverless-init/log/channel_writer.go
+++ b/cmd/serverless-init/log/channel_writer.go
@@ -46,10 +46,10 @@ func (cw *ChannelWriter) Write(p []byte) (n int, err error) {
 	}
 
 	for {
-		line, err := cw.Buffer.ReadString('\n')
+		line, err := cw.Buffer.ReadBytes('\n')
 		if err == io.EOF {
 			// If EOF, push the line back to buffer and wait for more data
-			cw.Buffer.WriteString(line)
+			cw.Buffer.Write(line)
 			break
 		}
 		if err != nil {
@@ -61,7 +61,7 @@ func (cw *ChannelWriter) Write(p []byte) (n int, err error) {
 			continue
 		}
 
-		cw.sendPayload([]byte(line[:len(line)-1]))
+		cw.sendPayload(line[:len(line)-1])
 	}
 	return n, nil
 }

--- a/releasenotes/notes/serverless-init-avoid-readstring-allocation-6c7af5564180850e.yaml
+++ b/releasenotes/notes/serverless-init-avoid-readstring-allocation-6c7af5564180850e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Avoid ReadString allocation in serverless-init log processing for improved efficiency.


### PR DESCRIPTION
### What does this PR do?

In `channel_writer.go`, we were converting `[]byte -> string -> []bytes`

This was creating an unnecessary copy of the bytes in memory. If we just keep everything in `[]byte` world, we can improve performance.

This change brings the cum% of my profile in Google Cloud Run from 1.14% to 0.34%:
```bash
% go tool pprof ./saved-profiles/cpu-bytes-before.pb.gz 
(pprof) top -cum ChannelWriter
      flat  flat%   sum%        cum   cum%
         0     0%     0%      0.16s  1.14%  github.com/DataDog/datadog-agent/cmd/serverless-init/log.(*ChannelWriter).Write
         0     0%     0%      0.16s  1.14%  io.(*multiWriter).Write
         0     0%     0%      0.16s  1.14%  io.Copy (inline)
         0     0%     0%      0.16s  1.14%  io.copyBuffer

% go tool pprof ./saved-profiles/cpu-bytes-after.pb.gz
(pprof) top -cum ChannelWriter
      flat  flat%   sum%        cum   cum%
         0     0%     0%      0.05s  0.34%  github.com/DataDog/datadog-agent/cmd/serverless-init/log.(*ChannelWriter).Write
         0     0%     0%      0.05s  0.34%  io.(*multiWriter).Write
         0     0%     0%      0.05s  0.34%  io.Copy (inline)
         0     0%     0%      0.05s  0.34%  io.copyBuffer
```

See https://github.com/DataDog/serverless-init-performance-testing/tree/main/saved-profiles if you want to view the profiles yourself.

### Motivation

Making serverless-init more efficient

### Describe how you validated your changes

Unit tests
Manual tests
We always run [e2e tests](https://github.com/DataDog/serverless-e2e-serverless-init-gcp-tests) before doing a release of serverless-init.

### Additional Notes
