### PR TITLE
dyninst/irgen: use Go ABI for return value locations

### DIFF
--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a6046]
 	PrepareEventRoot b8 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6090]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a6553]
 	PrepareEventRoot b0 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 03 00 00 // ProcessType[[3]string]
+	Call c4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6400]
 	PrepareEventRoot ad 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0a 04 00 00 // ProcessType[[]int]
+	Call 10 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a620a]
 	PrepareEventRoot a5 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[string]int]
+	Call 1c 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a64ea]
 	PrepareEventRoot ae 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a618a]
 	PrepareEventRoot a3 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 03 00 00 // ProcessType[[3]string]
+	Call c4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a638a]
 	PrepareEventRoot ab 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 24 04 00 00 // ProcessType[[]string]
+	Call 2a 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a630a]
 	PrepareEventRoot a9 00 00 00 19 00 00 00 
@@ -172,297 +172,297 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 28 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a682e]
 	PrepareEventRoot b5 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a682e.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<string,int>]
+// 0x30c: ProcessType[*bucket<string,int>]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,main.bigStruct>]
+// 0x312: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 72 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x31e: ProcessType[*error]
+// 0x324: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x324: ProcessType[*float32]
+// 0x32a: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float64]
+// 0x330: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x330: ProcessType[*int]
+// 0x336: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x336: ProcessType[*int32]
+// 0x33c: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int64]
+// 0x342: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x342: ProcessType[*main.bigStruct]
+// 0x348: ProcessType[*main.bigStruct]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime._defer]
+// 0x34e: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._panic]
+// 0x354: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.cgoCallers]
+// 0x35a: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.coro]
+// 0x360: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.g]
+// 0x366: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.m]
+// 0x36c: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.mapextra]
+// 0x372: ProcessType[*runtime.mapextra]
 	ProcessPointer 6d 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.sudog]
+// 0x378: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.timer]
+// 0x37e: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.traceBuf]
+// 0x384: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x384: ProcessType[*string]
+// 0x38a: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x390: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x396: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x39c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x3a2: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x3a8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x3ae: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x3b4: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[3]string]
+// 0x3c4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6e 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3da: ProcessType[[]bucket<string,int>.array]
+// 0x3e0: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 79 04 00 00 // ProcessType[bucket<string,int>]
+	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e6: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 8e 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f2: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fe: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call b8 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40a: ProcessType[[]int]
+// 0x410: ProcessType[[]int]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x414: ProcessType[[]key<string>]
+// 0x41a: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x424: ProcessType[[]string]
+// 0x42a: ProcessType[[]string]
 	ProcessSlice 88 00 00 00 10 00 00 00 
 	Return 
-// 0x42e: ProcessType[[]string.array]
+// 0x434: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x43a: ProcessType[[]uint8]
+// 0x440: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x444: ProcessType[[]uintptr]
+// 0x44a: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x44e: ProcessType[[]val<main.bigStruct>]
+// 0x454: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 42 03 00 00 // ProcessType[*main.bigStruct]
+	Call 48 03 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x45e: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 10 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x46e: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 00 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x479: ProcessType[bucket<string,int>]
+// 0x47f: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x48e: ProcessType[bucket<string,main.bigStruct>]
+// 0x494: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
-	Call 4e 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 0c 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a3: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
-	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4b8: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4c8: ProcessType[error]
+// 0x4ce: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4ca: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9e 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4d8: ProcessType[hash<string,int>]
+// 0x4de: ProcessType[hash<string,int>]
 	ProcessGoHmap 8d 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4e6: ProcessType[hash<string,main.bigStruct>]
+// 0x4ec: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4f4: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x502: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 99 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x510: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x516: ProcessType[map[string]int]
+// 0x51c: ProcessType[map[string]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]main.bigStruct]
+// 0x522: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x528: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x52e: ProcessType[runtime.g]
+// 0x534: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._panic]
+	Call 54 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime._defer]
+	Call 4e 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 3a 04 00 00 // ProcessType[[]uint8]
+	Call 40 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 72 03 00 00 // ProcessType[*runtime.sudog]
+	Call 78 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.timer]
+	Call 7e 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.coro]
+	Call 60 03 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x589: ProcessType[runtime.m]
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+// 0x58f: ProcessType[runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call e9 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f4 05 00 00 // ProcessType[runtime.mTraceState]
+	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5e9: ProcessType[runtime.mLockProfile]
+// 0x5ef: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5f4: ProcessType[runtime.mTraceState]
+// 0x5fa: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x604: ProcessType[string]
+// 0x60a: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +484,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 762
-ID: 6 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 768
+ID: 6 Len: 8 Enqueue: 936
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 942
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1540
+ID: 10 Len: 16 Enqueue: 1546
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -497,18 +497,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1224
+ID: 18 Len: 16 Enqueue: 1230
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 822
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 432 Enqueue: 1326
+ID: 20 Len: 8 Enqueue: 828
+ID: 21 Len: 8 Enqueue: 924
+ID: 22 Len: 432 Enqueue: 1332
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 846
+ID: 24 Len: 8 Enqueue: 852
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 840
+ID: 26 Len: 8 Enqueue: 846
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 870
-ID: 29 Len: 1760 Enqueue: 1417
+ID: 28 Len: 8 Enqueue: 876
+ID: 29 Len: 1760 Enqueue: 1423
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +517,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1082
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1088
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 882
+ID: 41 Len: 8 Enqueue: 888
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1092
-ID: 44 Len: 8 Enqueue: 888
+ID: 43 Len: 24 Enqueue: 1098
+ID: 44 Len: 8 Enqueue: 894
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 858
+ID: 47 Len: 8 Enqueue: 864
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 864
+ID: 53 Len: 8 Enqueue: 870
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 852
+ID: 60 Len: 8 Enqueue: 858
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1513
+ID: 64 Len: 64 Enqueue: 1519
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1524
+ID: 69 Len: 32 Enqueue: 1530
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 942
-ID: 72 Len: 8 Enqueue: 894
+ID: 71 Len: 16 Enqueue: 948
+ID: 72 Len: 8 Enqueue: 900
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,46 +567,46 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 900
+ID: 88 Len: 8 Enqueue: 906
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 810
-ID: 92 Len: 8 Enqueue: 828
-ID: 93 Len: 8 Enqueue: 816
-ID: 94 Len: 8 Enqueue: 924
-ID: 95 Len: 8 Enqueue: 798
-ID: 96 Len: 8 Enqueue: 804
-ID: 97 Len: 8 Enqueue: 906
-ID: 98 Len: 8 Enqueue: 912
-ID: 99 Len: 24 Enqueue: 1034
+ID: 91 Len: 8 Enqueue: 816
+ID: 92 Len: 8 Enqueue: 834
+ID: 93 Len: 8 Enqueue: 822
+ID: 94 Len: 8 Enqueue: 930
+ID: 95 Len: 8 Enqueue: 804
+ID: 96 Len: 8 Enqueue: 810
+ID: 97 Len: 8 Enqueue: 912
+ID: 98 Len: 8 Enqueue: 918
+ID: 99 Len: 24 Enqueue: 1040
 ID: 100 Len: 24 Enqueue: 0
-ID: 101 Len: 24 Enqueue: 1060
-ID: 102 Len: 48 Enqueue: 958
-ID: 103 Len: 8 Enqueue: 1302
+ID: 101 Len: 24 Enqueue: 1066
+ID: 102 Len: 48 Enqueue: 964
+ID: 103 Len: 8 Enqueue: 1308
 ID: 104 Len: 8 Enqueue: 0
-ID: 105 Len: 48 Enqueue: 1240
-ID: 106 Len: 8 Enqueue: 774
-ID: 107 Len: 208 Enqueue: 1145
-ID: 108 Len: 8 Enqueue: 876
+ID: 105 Len: 48 Enqueue: 1246
+ID: 106 Len: 8 Enqueue: 780
+ID: 107 Len: 208 Enqueue: 1151
+ID: 108 Len: 8 Enqueue: 882
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 8 Enqueue: 1308
+ID: 110 Len: 8 Enqueue: 1314
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1254
-ID: 113 Len: 8 Enqueue: 780
-ID: 114 Len: 208 Enqueue: 1166
-ID: 115 Len: 8 Enqueue: 1320
+ID: 112 Len: 48 Enqueue: 1260
+ID: 113 Len: 8 Enqueue: 786
+ID: 114 Len: 208 Enqueue: 1172
+ID: 115 Len: 8 Enqueue: 1326
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1282
-ID: 118 Len: 8 Enqueue: 792
-ID: 119 Len: 88 Enqueue: 1208
-ID: 120 Len: 8 Enqueue: 1314
+ID: 117 Len: 48 Enqueue: 1288
+ID: 118 Len: 8 Enqueue: 798
+ID: 119 Len: 88 Enqueue: 1214
+ID: 120 Len: 8 Enqueue: 1320
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1268
-ID: 123 Len: 8 Enqueue: 786
-ID: 124 Len: 208 Enqueue: 1187
-ID: 125 Len: 8 Enqueue: 732
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 750
+ID: 122 Len: 48 Enqueue: 1274
+ID: 123 Len: 8 Enqueue: 792
+ID: 124 Len: 208 Enqueue: 1193
+ID: 125 Len: 8 Enqueue: 738
+ID: 126 Len: 8 Enqueue: 744
+ID: 127 Len: 8 Enqueue: 756
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -615,30 +615,30 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 16 Enqueue: 1070
+ID: 136 Len: 16 Enqueue: 1076
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 128 Enqueue: 1044
+ID: 139 Len: 128 Enqueue: 1050
 ID: 140 Len: 64 Enqueue: 0
-ID: 141 Len: 208 Enqueue: 986
-ID: 142 Len: 64 Enqueue: 1102
-ID: 143 Len: 8 Enqueue: 834
+ID: 141 Len: 208 Enqueue: 992
+ID: 142 Len: 64 Enqueue: 1108
+ID: 143 Len: 8 Enqueue: 840
 ID: 144 Len: 184 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 998
+ID: 145 Len: 208 Enqueue: 1004
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 64 Enqueue: 1118
-ID: 148 Len: 8 Enqueue: 1296
+ID: 147 Len: 64 Enqueue: 1124
+ID: 148 Len: 8 Enqueue: 1302
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 48 Enqueue: 1226
-ID: 151 Len: 8 Enqueue: 768
-ID: 152 Len: 144 Enqueue: 1134
-ID: 153 Len: 88 Enqueue: 1022
-ID: 154 Len: 208 Enqueue: 1010
+ID: 150 Len: 48 Enqueue: 1232
+ID: 151 Len: 8 Enqueue: 774
+ID: 152 Len: 144 Enqueue: 1140
+ID: 153 Len: 88 Enqueue: 1028
+ID: 154 Len: 208 Enqueue: 1016
 ID: 155 Len: 64 Enqueue: 0
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 144 Enqueue: 974
-ID: 159 Len: 8 Enqueue: 744
+ID: 158 Len: 144 Enqueue: 980
+ID: 159 Len: 8 Enqueue: 750
 ID: 160 Len: 128 Enqueue: 0
 ID: 161 Len: 9 Enqueue: 0
 ID: 162 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4a8046]
 	PrepareEventRoot c9 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8090]
 	PrepareEventRoot ca 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4a8553]
 	PrepareEventRoot c1 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c8 03 00 00 // ProcessType[[3]string]
+	Call ce 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8400]
 	PrepareEventRoot be 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 04 00 00 // ProcessType[[]int]
+	Call 0e 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4a820a]
 	PrepareEventRoot b6 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[string]int]
+	Call ce 04 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4a84ea]
 	PrepareEventRoot bf 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4a818a]
 	PrepareEventRoot b4 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c8 03 00 00 // ProcessType[[3]string]
+	Call ce 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4a838a]
 	PrepareEventRoot bc 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 36 04 00 00 // ProcessType[[]string]
+	Call 3c 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4a830a]
 	PrepareEventRoot ba 00 00 00 19 00 00 00 
@@ -172,331 +172,331 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a883c]
 	PrepareEventRoot c6 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a883c.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*error]
+// 0x306: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x306: ProcessType[*float32]
+// 0x30c: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*int]
+// 0x318: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x318: ProcessType[*int32]
+// 0x31e: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int64]
+// 0x324: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*main.bigStruct]
+// 0x32a: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x32a: ProcessType[*runtime._defer]
+// 0x330: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._panic]
+// 0x336: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime.cgoCallers]
+// 0x33c: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.coro]
+// 0x342: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.g]
+// 0x348: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.m]
+// 0x34e: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.sudog]
+// 0x354: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.synctestGroup]
+// 0x35a: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.timer]
+// 0x360: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.traceBuf]
+// 0x366: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x366: ProcessType[*string]
+// 0x36c: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x36c: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<string,int>]
+// 0x378: ProcessType[*table<string,int>]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,main.bigStruct>]
+// 0x37e: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 90 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9a 00 00 00 
 	Return 
-// 0x384: ProcessType[*uint]
+// 0x38a: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint16]
+// 0x390: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint32]
+// 0x396: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint64]
+// 0x39c: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint8]
+// 0x3a2: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uintptr]
+// 0x3a8: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3a8: ProcessType[[2]*runtime.traceBuf]
+// 0x3ae: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3b8: ProcessType[[2][2]*runtime.traceBuf]
+// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call a8 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3c8: ProcessType[[3]string]
+// 0x3ce: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d8: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*table<string,int>.array]
+// 0x3ea: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<string,int>]
+	Call 78 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f0: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fc: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x408: ProcessType[[]int]
+// 0x40e: ProcessType[[]int]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]noalg.map.group[string]int.array]
+// 0x418: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 0a 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 15 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 20 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x436: ProcessType[[]string]
+// 0x43c: ProcessType[[]string]
 	ProcessSlice 86 00 00 00 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]string.array]
+// 0x446: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]uint8]
+// 0x452: ProcessType[[]uint8]
 	ProcessSlice 80 00 00 00 01 00 00 00 
 	Return 
-// 0x456: ProcessType[[]uintptr]
+// 0x45c: ProcessType[[]uintptr]
 	ProcessSlice 82 00 00 00 08 00 00 00 
 	Return 
-// 0x460: ProcessType[error]
+// 0x466: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x462: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x46e: ProcessType[groupReference<string,int>]
+// 0x474: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 8f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x47a: ProcessType[groupReference<string,main.bigStruct>]
+// 0x480: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 99 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x486: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x492: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 aa 00 00 00 10 18 
 	Return 
-// 0x49e: ProcessType[map<string,int>]
+// 0x4a4: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8e 00 00 00 8b 00 00 00 10 18 
 	Return 
-// 0x4aa: ProcessType[map<string,main.bigStruct>]
+// 0x4b0: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 98 00 00 00 93 00 00 00 10 18 
 	Return 
-// 0x4b6: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a5 00 00 00 9d 00 00 00 10 18 
 	Return 
-// 0x4c2: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a2 00 00 00 
 	Return 
-// 0x4c8: ProcessType[map[string]int]
+// 0x4ce: ProcessType[map[string]int]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]main.bigStruct]
+// 0x4d4: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x4da: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2b 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4ea: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3b 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x4fa: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50a: ProcessType[noalg.map.group[string]int]
+// 0x510: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ea 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x515: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call da 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x520: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x52b: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2c 06 00 00 // ProcessType[string]
+// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 32 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 03 00 00 // ProcessType[*main.bigStruct]
+	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x53b: ProcessType[noalg.struct { key string; elem int }]
-	Call 2c 06 00 00 // ProcessType[string]
+// 0x541: ProcessType[noalg.struct { key string; elem int }]
+	Call 32 06 00 00 // ProcessType[string]
 	Return 
-// 0x541: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x54c: ProcessType[runtime.g]
+// 0x552: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._panic]
+	Call 36 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*runtime._defer]
+	Call 30 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 4c 04 00 00 // ProcessType[[]uint8]
+	Call 52 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.sudog]
+	Call 54 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.timer]
+	Call 60 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.coro]
+	Call 42 03 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b1: ProcessType[runtime.m]
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+// 0x5b7: ProcessType[runtime.m]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 11 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x611: ProcessType[runtime.mLockProfile]
+// 0x617: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x61c: ProcessType[runtime.mTraceState]
+// 0x622: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b8 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x62c: ProcessType[string]
+// 0x632: ProcessType[string]
 	ProcessString 7e 00 00 00 
 	Return 
-// 0x632: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 62 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x63d: ProcessType[table<string,int>]
+// 0x643: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6e 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x648: ProcessType[table<string,main.bigStruct>]
+// 0x64e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7a 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x653: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 86 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +517,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 924
+ID: 5 Len: 8 Enqueue: 930
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1580
+ID: 9 Len: 16 Enqueue: 1586
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 762
+ID: 11 Len: 8 Enqueue: 768
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1120
+ID: 13 Len: 16 Enqueue: 1126
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 930
-ID: 20 Len: 8 Enqueue: 792
-ID: 21 Len: 8 Enqueue: 912
-ID: 22 Len: 440 Enqueue: 1356
+ID: 19 Len: 8 Enqueue: 936
+ID: 20 Len: 8 Enqueue: 798
+ID: 21 Len: 8 Enqueue: 918
+ID: 22 Len: 440 Enqueue: 1362
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 816
+ID: 24 Len: 8 Enqueue: 822
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 810
+ID: 26 Len: 8 Enqueue: 816
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 840
-ID: 29 Len: 1808 Enqueue: 1457
+ID: 28 Len: 8 Enqueue: 846
+ID: 29 Len: 1808 Enqueue: 1463
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +550,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1100
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1106
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 846
+ID: 41 Len: 8 Enqueue: 852
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1110
-ID: 44 Len: 8 Enqueue: 858
+ID: 43 Len: 24 Enqueue: 1116
+ID: 44 Len: 8 Enqueue: 864
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 828
+ID: 47 Len: 8 Enqueue: 834
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 852
+ID: 49 Len: 8 Enqueue: 858
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 834
+ID: 55 Len: 8 Enqueue: 840
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 822
+ID: 62 Len: 8 Enqueue: 828
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1553
+ID: 67 Len: 64 Enqueue: 1559
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1564
+ID: 72 Len: 56 Enqueue: 1570
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 952
-ID: 75 Len: 16 Enqueue: 936
-ID: 76 Len: 8 Enqueue: 864
+ID: 74 Len: 32 Enqueue: 958
+ID: 75 Len: 16 Enqueue: 942
+ID: 76 Len: 8 Enqueue: 870
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,39 +605,39 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 870
+ID: 93 Len: 8 Enqueue: 876
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 780
-ID: 97 Len: 8 Enqueue: 798
-ID: 98 Len: 8 Enqueue: 786
-ID: 99 Len: 8 Enqueue: 918
-ID: 100 Len: 8 Enqueue: 768
-ID: 101 Len: 8 Enqueue: 774
-ID: 102 Len: 8 Enqueue: 900
-ID: 103 Len: 8 Enqueue: 906
-ID: 104 Len: 24 Enqueue: 1032
+ID: 96 Len: 8 Enqueue: 786
+ID: 97 Len: 8 Enqueue: 804
+ID: 98 Len: 8 Enqueue: 792
+ID: 99 Len: 8 Enqueue: 924
+ID: 100 Len: 8 Enqueue: 774
+ID: 101 Len: 8 Enqueue: 780
+ID: 102 Len: 8 Enqueue: 906
+ID: 103 Len: 8 Enqueue: 912
+ID: 104 Len: 24 Enqueue: 1038
 ID: 105 Len: 24 Enqueue: 0
-ID: 106 Len: 24 Enqueue: 1078
-ID: 107 Len: 48 Enqueue: 968
-ID: 108 Len: 8 Enqueue: 1224
+ID: 106 Len: 24 Enqueue: 1084
+ID: 107 Len: 48 Enqueue: 974
+ID: 108 Len: 8 Enqueue: 1230
 ID: 109 Len: 8 Enqueue: 0
-ID: 110 Len: 48 Enqueue: 1182
+ID: 110 Len: 48 Enqueue: 1188
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 8 Enqueue: 882
-ID: 113 Len: 8 Enqueue: 1230
+ID: 112 Len: 8 Enqueue: 888
+ID: 113 Len: 8 Enqueue: 1236
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 48 Enqueue: 1194
+ID: 115 Len: 48 Enqueue: 1200
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 8 Enqueue: 888
-ID: 118 Len: 8 Enqueue: 1236
+ID: 117 Len: 8 Enqueue: 894
+ID: 118 Len: 8 Enqueue: 1242
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 48 Enqueue: 1206
+ID: 120 Len: 48 Enqueue: 1212
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 8 Enqueue: 894
-ID: 123 Len: 8 Enqueue: 732
-ID: 124 Len: 8 Enqueue: 738
-ID: 125 Len: 8 Enqueue: 750
+ID: 122 Len: 8 Enqueue: 900
+ID: 123 Len: 8 Enqueue: 738
+ID: 124 Len: 8 Enqueue: 744
+ID: 125 Len: 8 Enqueue: 756
 ID: 126 Len: 1 Enqueue: 0
 ID: 127 Len: 8 Enqueue: 0
 ID: 128 Len: 1 Enqueue: 0
@@ -646,49 +646,49 @@ ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 16 Enqueue: 1088
+ID: 134 Len: 16 Enqueue: 1094
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 32 Enqueue: 1597
-ID: 137 Len: 16 Enqueue: 1134
+ID: 136 Len: 32 Enqueue: 1603
+ID: 137 Len: 16 Enqueue: 1140
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 200 Enqueue: 1290
-ID: 140 Len: 192 Enqueue: 1258
-ID: 141 Len: 24 Enqueue: 1339
-ID: 142 Len: 8 Enqueue: 996
-ID: 143 Len: 200 Enqueue: 1042
-ID: 144 Len: 32 Enqueue: 1608
-ID: 145 Len: 16 Enqueue: 1146
+ID: 139 Len: 200 Enqueue: 1296
+ID: 140 Len: 192 Enqueue: 1264
+ID: 141 Len: 24 Enqueue: 1345
+ID: 142 Len: 8 Enqueue: 1002
+ID: 143 Len: 200 Enqueue: 1048
+ID: 144 Len: 32 Enqueue: 1614
+ID: 145 Len: 16 Enqueue: 1152
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 200 Enqueue: 1301
-ID: 148 Len: 192 Enqueue: 1242
-ID: 149 Len: 24 Enqueue: 1323
-ID: 150 Len: 8 Enqueue: 804
+ID: 147 Len: 200 Enqueue: 1307
+ID: 148 Len: 192 Enqueue: 1248
+ID: 149 Len: 24 Enqueue: 1329
+ID: 150 Len: 8 Enqueue: 810
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 8 Enqueue: 1008
-ID: 153 Len: 200 Enqueue: 1054
-ID: 154 Len: 32 Enqueue: 1619
-ID: 155 Len: 16 Enqueue: 1158
+ID: 152 Len: 8 Enqueue: 1014
+ID: 153 Len: 200 Enqueue: 1060
+ID: 154 Len: 32 Enqueue: 1625
+ID: 155 Len: 16 Enqueue: 1164
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 136 Enqueue: 1312
-ID: 158 Len: 128 Enqueue: 1274
-ID: 159 Len: 16 Enqueue: 1345
-ID: 160 Len: 8 Enqueue: 1218
+ID: 157 Len: 136 Enqueue: 1318
+ID: 158 Len: 128 Enqueue: 1280
+ID: 159 Len: 16 Enqueue: 1351
+ID: 160 Len: 8 Enqueue: 1224
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 48 Enqueue: 1170
+ID: 162 Len: 48 Enqueue: 1176
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 876
-ID: 165 Len: 8 Enqueue: 1020
-ID: 166 Len: 136 Enqueue: 1066
-ID: 167 Len: 32 Enqueue: 1586
-ID: 168 Len: 16 Enqueue: 1122
+ID: 164 Len: 8 Enqueue: 882
+ID: 165 Len: 8 Enqueue: 1026
+ID: 166 Len: 136 Enqueue: 1072
+ID: 167 Len: 32 Enqueue: 1592
+ID: 168 Len: 16 Enqueue: 1128
 ID: 169 Len: 8 Enqueue: 0
 ID: 170 Len: 136 Enqueue: 0
 ID: 171 Len: 128 Enqueue: 0
 ID: 172 Len: 16 Enqueue: 0
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 8 Enqueue: 984
+ID: 174 Len: 8 Enqueue: 990
 ID: 175 Len: 136 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 744
+ID: 176 Len: 8 Enqueue: 750
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 9 Enqueue: 0
 ID: 179 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@4ae646]
 	PrepareEventRoot ce 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae690]
 	PrepareEventRoot cf 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@4aeb53]
 	PrepareEventRoot c6 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call d4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4aea00]
 	PrepareEventRoot c3 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 24 04 00 00 // ProcessType[[]int]
+	Call 2a 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@4ae80a]
 	PrepareEventRoot bb 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[string]int]
+	Call ea 04 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@4aeaea]
 	PrepareEventRoot c4 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@4ae78a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call d4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@4ae98a]
 	PrepareEventRoot c1 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]string]
+	Call 58 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@4ae90a]
 	PrepareEventRoot bf 00 00 00 19 00 00 00 
@@ -172,344 +172,344 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4aee44]
 	PrepareEventRoot cb 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4aee44.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*error]
+// 0x306: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x306: ProcessType[*float32]
+// 0x30c: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x312: ProcessType[*int]
+// 0x318: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x318: ProcessType[*int32]
+// 0x31e: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int64]
+// 0x324: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x324: ProcessType[*main.bigStruct]
+// 0x32a: ProcessType[*main.bigStruct]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x32a: ProcessType[*runtime._defer]
+// 0x330: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._panic]
+// 0x336: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime.cgoCallers]
+// 0x33c: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.coro]
+// 0x342: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.g]
+// 0x348: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.m]
+// 0x34e: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.p]
+// 0x354: ProcessType[*runtime.p]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x35a: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestBubble]
+// 0x360: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x366: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x36c: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x372: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ac 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x37e: ProcessType[*table<string,int>]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x384: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 95 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x390: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x396: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x39c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x3a2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x3a8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x3ae: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x3b4: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x3d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*runtime.p]
+// 0x3e4: ProcessType[[]*runtime.p]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x3e8: ProcessType[[]*runtime.p.array]
+// 0x3ee: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 4e 03 00 00 // ProcessType[*runtime.p]
+	Call 54 03 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x400: ProcessType[[]*table<string,int>.array]
+// 0x406: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call 7e 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x424: ProcessType[[]int]
+// 0x42a: ProcessType[[]int]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x42e: ProcessType[[]noalg.map.group[string]int.array]
+// 0x434: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 31 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x446: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 3c 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x452: ProcessType[[]string]
+// 0x458: ProcessType[[]string]
 	ProcessSlice 8b 00 00 00 10 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]string.array]
+// 0x462: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x468: ProcessType[[]uint8]
+// 0x46e: ProcessType[[]uint8]
 	ProcessSlice 82 00 00 00 01 00 00 00 
 	Return 
-// 0x472: ProcessType[[]uintptr]
+// 0x478: ProcessType[[]uintptr]
 	ProcessSlice 84 00 00 00 08 00 00 00 
 	Return 
-// 0x47c: ProcessType[error]
+// 0x482: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x47e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x48a: ProcessType[groupReference<string,int>]
+// 0x490: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 94 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x496: ProcessType[groupReference<string,main.bigStruct>]
+// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9e 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a2: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ab 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4ae: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 af 00 00 00 10 18 
 	Return 
-// 0x4ba: ProcessType[map<string,int>]
+// 0x4c0: ProcessType[map<string,int>]
 	ProcessGoSwissMap 93 00 00 00 90 00 00 00 10 18 
 	Return 
-// 0x4c6: ProcessType[map<string,main.bigStruct>]
+// 0x4cc: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9d 00 00 00 98 00 00 00 10 18 
 	Return 
-// 0x4d2: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap aa 00 00 00 a2 00 00 00 10 18 
 	Return 
-// 0x4de: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a7 00 00 00 
 	Return 
-// 0x4e4: ProcessType[map[string]int]
+// 0x4ea: ProcessType[map[string]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]main.bigStruct]
+// 0x4f0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 75 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x4f6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x506: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 57 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x516: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x526: ProcessType[noalg.map.group[string]int]
+// 0x52c: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x531: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x53c: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 16 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x547: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 52 06 00 00 // ProcessType[string]
+// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 03 00 00 // ProcessType[*main.bigStruct]
+	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x557: ProcessType[noalg.struct { key string; elem int }]
-	Call 52 06 00 00 // ProcessType[string]
+// 0x55d: ProcessType[noalg.struct { key string; elem int }]
+	Call 58 06 00 00 // ProcessType[string]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x568: ProcessType[runtime.g]
+// 0x56e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._panic]
+	Call 36 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*runtime._defer]
+	Call 30 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 68 04 00 00 // ProcessType[[]uint8]
+	Call 6e 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call 66 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.coro]
+	Call 42 03 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5cd: ProcessType[runtime.m]
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+// 0x5d3: ProcessType[runtime.m]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call de 03 00 00 // ProcessType[[]*runtime.p]
+	Call e4 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 37 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x637: ProcessType[runtime.mLockProfile]
+// 0x63d: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x642: ProcessType[runtime.mTraceState]
+// 0x648: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x652: ProcessType[string]
+// 0x658: ProcessType[string]
 	ProcessString 80 00 00 00 
 	Return 
-// 0x658: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x663: ProcessType[table<string,int>]
+// 0x669: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8a 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x66e: ProcessType[table<string,main.bigStruct>]
+// 0x674: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 96 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x679: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a2 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +530,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 936
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1618
+ID: 9 Len: 16 Enqueue: 1624
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 762
+ID: 11 Len: 8 Enqueue: 768
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 1148
+ID: 13 Len: 16 Enqueue: 1154
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 792
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1384
+ID: 19 Len: 8 Enqueue: 942
+ID: 20 Len: 8 Enqueue: 798
+ID: 21 Len: 8 Enqueue: 924
+ID: 22 Len: 440 Enqueue: 1390
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 816
+ID: 24 Len: 8 Enqueue: 822
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 810
+ID: 26 Len: 8 Enqueue: 816
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 840
-ID: 29 Len: 1816 Enqueue: 1485
+ID: 28 Len: 8 Enqueue: 846
+ID: 29 Len: 1816 Enqueue: 1491
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +563,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1128
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1134
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 858
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1138
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1144
+ID: 44 Len: 8 Enqueue: 870
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 828
+ID: 47 Len: 8 Enqueue: 834
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 864
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 834
+ID: 55 Len: 8 Enqueue: 840
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 990
+ID: 62 Len: 24 Enqueue: 996
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 846
-ID: 65 Len: 8 Enqueue: 822
+ID: 64 Len: 8 Enqueue: 852
+ID: 65 Len: 8 Enqueue: 828
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1591
+ID: 70 Len: 56 Enqueue: 1597
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1602
+ID: 75 Len: 56 Enqueue: 1608
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 958
-ID: 78 Len: 16 Enqueue: 942
-ID: 79 Len: 8 Enqueue: 870
+ID: 77 Len: 32 Enqueue: 964
+ID: 78 Len: 16 Enqueue: 948
+ID: 79 Len: 8 Enqueue: 876
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,39 +620,39 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 876
+ID: 95 Len: 8 Enqueue: 882
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 780
-ID: 99 Len: 8 Enqueue: 786
-ID: 100 Len: 8 Enqueue: 798
-ID: 101 Len: 8 Enqueue: 924
-ID: 102 Len: 8 Enqueue: 768
-ID: 103 Len: 8 Enqueue: 774
-ID: 104 Len: 8 Enqueue: 906
-ID: 105 Len: 8 Enqueue: 912
-ID: 106 Len: 24 Enqueue: 1060
+ID: 98 Len: 8 Enqueue: 786
+ID: 99 Len: 8 Enqueue: 792
+ID: 100 Len: 8 Enqueue: 804
+ID: 101 Len: 8 Enqueue: 930
+ID: 102 Len: 8 Enqueue: 774
+ID: 103 Len: 8 Enqueue: 780
+ID: 104 Len: 8 Enqueue: 912
+ID: 105 Len: 8 Enqueue: 918
+ID: 106 Len: 24 Enqueue: 1066
 ID: 107 Len: 24 Enqueue: 0
-ID: 108 Len: 24 Enqueue: 1106
-ID: 109 Len: 48 Enqueue: 974
-ID: 110 Len: 8 Enqueue: 1252
+ID: 108 Len: 24 Enqueue: 1112
+ID: 109 Len: 48 Enqueue: 980
+ID: 110 Len: 8 Enqueue: 1258
 ID: 111 Len: 8 Enqueue: 0
-ID: 112 Len: 48 Enqueue: 1210
+ID: 112 Len: 48 Enqueue: 1216
 ID: 113 Len: 8 Enqueue: 0
-ID: 114 Len: 8 Enqueue: 888
-ID: 115 Len: 8 Enqueue: 1258
+ID: 114 Len: 8 Enqueue: 894
+ID: 115 Len: 8 Enqueue: 1264
 ID: 116 Len: 8 Enqueue: 0
-ID: 117 Len: 48 Enqueue: 1222
+ID: 117 Len: 48 Enqueue: 1228
 ID: 118 Len: 8 Enqueue: 0
-ID: 119 Len: 8 Enqueue: 894
-ID: 120 Len: 8 Enqueue: 1264
+ID: 119 Len: 8 Enqueue: 900
+ID: 120 Len: 8 Enqueue: 1270
 ID: 121 Len: 8 Enqueue: 0
-ID: 122 Len: 48 Enqueue: 1234
+ID: 122 Len: 48 Enqueue: 1240
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 8 Enqueue: 900
-ID: 125 Len: 8 Enqueue: 732
-ID: 126 Len: 8 Enqueue: 738
-ID: 127 Len: 8 Enqueue: 750
+ID: 124 Len: 8 Enqueue: 906
+ID: 125 Len: 8 Enqueue: 738
+ID: 126 Len: 8 Enqueue: 744
+ID: 127 Len: 8 Enqueue: 756
 ID: 128 Len: 1 Enqueue: 0
 ID: 129 Len: 8 Enqueue: 0
 ID: 130 Len: 1 Enqueue: 0
@@ -660,53 +660,53 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 1000
+ID: 135 Len: 8 Enqueue: 1006
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 16 Enqueue: 1116
+ID: 139 Len: 16 Enqueue: 1122
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 32 Enqueue: 1635
-ID: 142 Len: 16 Enqueue: 1162
+ID: 141 Len: 32 Enqueue: 1641
+ID: 142 Len: 16 Enqueue: 1168
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 200 Enqueue: 1318
-ID: 145 Len: 192 Enqueue: 1286
-ID: 146 Len: 24 Enqueue: 1367
-ID: 147 Len: 8 Enqueue: 1024
-ID: 148 Len: 200 Enqueue: 1070
-ID: 149 Len: 32 Enqueue: 1646
-ID: 150 Len: 16 Enqueue: 1174
+ID: 144 Len: 200 Enqueue: 1324
+ID: 145 Len: 192 Enqueue: 1292
+ID: 146 Len: 24 Enqueue: 1373
+ID: 147 Len: 8 Enqueue: 1030
+ID: 148 Len: 200 Enqueue: 1076
+ID: 149 Len: 32 Enqueue: 1652
+ID: 150 Len: 16 Enqueue: 1180
 ID: 151 Len: 8 Enqueue: 0
-ID: 152 Len: 200 Enqueue: 1329
-ID: 153 Len: 192 Enqueue: 1270
-ID: 154 Len: 24 Enqueue: 1351
-ID: 155 Len: 8 Enqueue: 804
+ID: 152 Len: 200 Enqueue: 1335
+ID: 153 Len: 192 Enqueue: 1276
+ID: 154 Len: 24 Enqueue: 1357
+ID: 155 Len: 8 Enqueue: 810
 ID: 156 Len: 184 Enqueue: 0
-ID: 157 Len: 8 Enqueue: 1036
-ID: 158 Len: 200 Enqueue: 1082
-ID: 159 Len: 32 Enqueue: 1657
-ID: 160 Len: 16 Enqueue: 1186
+ID: 157 Len: 8 Enqueue: 1042
+ID: 158 Len: 200 Enqueue: 1088
+ID: 159 Len: 32 Enqueue: 1663
+ID: 160 Len: 16 Enqueue: 1192
 ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 136 Enqueue: 1340
-ID: 163 Len: 128 Enqueue: 1302
-ID: 164 Len: 16 Enqueue: 1373
-ID: 165 Len: 8 Enqueue: 1246
+ID: 162 Len: 136 Enqueue: 1346
+ID: 163 Len: 128 Enqueue: 1308
+ID: 164 Len: 16 Enqueue: 1379
+ID: 165 Len: 8 Enqueue: 1252
 ID: 166 Len: 8 Enqueue: 0
-ID: 167 Len: 48 Enqueue: 1198
+ID: 167 Len: 48 Enqueue: 1204
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 882
-ID: 170 Len: 8 Enqueue: 1048
-ID: 171 Len: 136 Enqueue: 1094
-ID: 172 Len: 32 Enqueue: 1624
-ID: 173 Len: 16 Enqueue: 1150
+ID: 169 Len: 8 Enqueue: 888
+ID: 170 Len: 8 Enqueue: 1054
+ID: 171 Len: 136 Enqueue: 1100
+ID: 172 Len: 32 Enqueue: 1630
+ID: 173 Len: 16 Enqueue: 1156
 ID: 174 Len: 8 Enqueue: 0
 ID: 175 Len: 136 Enqueue: 0
 ID: 176 Len: 128 Enqueue: 0
 ID: 177 Len: 16 Enqueue: 0
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 8 Enqueue: 1012
+ID: 179 Len: 8 Enqueue: 1018
 ID: 180 Len: 136 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 744
+ID: 181 Len: 8 Enqueue: 750
 ID: 182 Len: 128 Enqueue: 0
 ID: 183 Len: 9 Enqueue: 0
 ID: 184 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b5388]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b53c0]
 	PrepareEventRoot ba 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 1c 05 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 22 05 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b5880]
 	PrepareEventRoot b1 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 03 00 00 // ProcessType[[3]string]
+	Call c4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5720]
 	PrepareEventRoot ae 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0a 04 00 00 // ProcessType[[]int]
+	Call 10 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b5518]
 	PrepareEventRoot a6 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 16 05 00 00 // ProcessType[map[string]int]
+	Call 1c 05 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5808]
 	PrepareEventRoot af 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5498]
 	PrepareEventRoot a4 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call be 03 00 00 // ProcessType[[3]string]
+	Call c4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b56b8]
 	PrepareEventRoot ac 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 24 04 00 00 // ProcessType[[]string]
+	Call 2a 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b5628]
 	PrepareEventRoot aa 00 00 00 19 00 00 00 
@@ -172,297 +172,297 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 28 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 2e 05 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b5b24]
 	PrepareEventRoot b6 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb5b24.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x306: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x306: ProcessType[*bucket<string,int>]
+// 0x30c: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x30c: ProcessType[*bucket<string,main.bigStruct>]
+// 0x312: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x312: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x318: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x318: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x31e: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 78 00 00 00 
 	Return 
-// 0x31e: ProcessType[*error]
+// 0x324: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x324: ProcessType[*float32]
+// 0x32a: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x32a: ProcessType[*float64]
+// 0x330: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x330: ProcessType[*int]
+// 0x336: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x336: ProcessType[*int32]
+// 0x33c: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x33c: ProcessType[*int64]
+// 0x342: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x342: ProcessType[*main.bigStruct]
+// 0x348: ProcessType[*main.bigStruct]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime._defer]
+// 0x34e: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime._panic]
+// 0x354: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.cgoCallers]
+// 0x35a: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.coro]
+// 0x360: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.g]
+// 0x366: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.m]
+// 0x36c: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x36c: ProcessType[*runtime.mapextra]
+// 0x372: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x372: ProcessType[*runtime.sudog]
+// 0x378: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x378: ProcessType[*runtime.timer]
+// 0x37e: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x37e: ProcessType[*runtime.traceBuf]
+// 0x384: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x384: ProcessType[*string]
+// 0x38a: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x390: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x396: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x39c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x3a2: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x3a8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x3ae: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x3b4: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 7e 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 84 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[3]string]
+// 0x3c4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3d4: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6e 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 74 04 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3da: ProcessType[[]bucket<string,int>.array]
+// 0x3e0: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 79 04 00 00 // ProcessType[bucket<string,int>]
+	Call 7f 04 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e6: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3ec: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 8e 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 94 04 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f2: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x3f8: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a9 04 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fe: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x404: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call b8 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call be 04 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40a: ProcessType[[]int]
+// 0x410: ProcessType[[]int]
 	ProcessSlice 87 00 00 00 08 00 00 00 
 	Return 
-// 0x414: ProcessType[[]key<string>]
+// 0x41a: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x424: ProcessType[[]string]
+// 0x42a: ProcessType[[]string]
 	ProcessSlice 89 00 00 00 10 00 00 00 
 	Return 
-// 0x42e: ProcessType[[]string.array]
+// 0x434: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x43a: ProcessType[[]uint8]
+// 0x440: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x444: ProcessType[[]uintptr]
+// 0x44a: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x44e: ProcessType[[]val<main.bigStruct>]
+// 0x454: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 42 03 00 00 // ProcessType[*main.bigStruct]
+	Call 48 03 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x45e: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x464: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 10 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 16 05 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x46e: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x474: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 00 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 06 03 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x479: ProcessType[bucket<string,int>]
+// 0x47f: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 06 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 0c 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x48e: ProcessType[bucket<string,main.bigStruct>]
+// 0x494: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
-	Call 4e 04 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 0c 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 54 04 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 12 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x4a3: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a9: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 14 04 00 00 // ProcessType[[]key<string>]
-	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 12 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1a 04 00 00 // ProcessType[[]key<string>]
+	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 18 03 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4b8: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4be: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 5e 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 18 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 64 04 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 03 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x4c8: ProcessType[error]
+// 0x4ce: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x4ca: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x4d0: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9f 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x4d8: ProcessType[hash<string,int>]
+// 0x4de: ProcessType[hash<string,int>]
 	ProcessGoHmap 8e 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4e6: ProcessType[hash<string,main.bigStruct>]
+// 0x4ec: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 92 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x4f4: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4fa: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9b 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x502: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x508: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap 9a 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x510: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x516: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x516: ProcessType[map[string]int]
+// 0x51c: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x51c: ProcessType[map[string]main.bigStruct]
+// 0x522: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x522: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x528: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x528: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x52e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x52e: ProcessType[runtime.g]
+// 0x534: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime._panic]
+	Call 54 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime._defer]
+	Call 4e 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 3a 04 00 00 // ProcessType[[]uint8]
+	Call 40 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 72 03 00 00 // ProcessType[*runtime.sudog]
+	Call 78 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 78 03 00 00 // ProcessType[*runtime.timer]
+	Call 7e 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.coro]
+	Call 60 03 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x589: ProcessType[runtime.m]
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+// 0x58f: ProcessType[runtime.m]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.g]
+	Call 66 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 04 06 00 00 // ProcessType[string]
+	Call 0a 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5a 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call e9 05 00 00 // ProcessType[runtime.mLockProfile]
+	Call ef 05 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f4 05 00 00 // ProcessType[runtime.mTraceState]
+	Call fa 05 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x5e9: ProcessType[runtime.mLockProfile]
+// 0x5ef: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 04 00 00 // ProcessType[[]uintptr]
+	Call 4a 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x5f4: ProcessType[runtime.mTraceState]
+// 0x5fa: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 66 03 00 00 // ProcessType[*runtime.m]
+	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 6c 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x604: ProcessType[string]
+// 0x60a: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -484,12 +484,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 762
-ID: 6 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 768
+ID: 6 Len: 8 Enqueue: 936
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 936
+ID: 8 Len: 8 Enqueue: 942
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 1540
+ID: 10 Len: 16 Enqueue: 1546
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -497,18 +497,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 1224
+ID: 18 Len: 16 Enqueue: 1230
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 822
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 432 Enqueue: 1326
+ID: 20 Len: 8 Enqueue: 828
+ID: 21 Len: 8 Enqueue: 924
+ID: 22 Len: 432 Enqueue: 1332
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 846
+ID: 24 Len: 8 Enqueue: 852
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 840
+ID: 26 Len: 8 Enqueue: 846
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 870
-ID: 29 Len: 1760 Enqueue: 1417
+ID: 28 Len: 8 Enqueue: 876
+ID: 29 Len: 1760 Enqueue: 1423
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -517,41 +517,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1082
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1088
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 882
+ID: 41 Len: 8 Enqueue: 888
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1092
-ID: 44 Len: 8 Enqueue: 888
+ID: 43 Len: 24 Enqueue: 1098
+ID: 44 Len: 8 Enqueue: 894
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 858
+ID: 47 Len: 8 Enqueue: 864
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 864
+ID: 53 Len: 8 Enqueue: 870
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 852
+ID: 60 Len: 8 Enqueue: 858
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 1513
+ID: 64 Len: 64 Enqueue: 1519
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 1524
+ID: 69 Len: 32 Enqueue: 1530
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 942
-ID: 72 Len: 8 Enqueue: 894
+ID: 71 Len: 16 Enqueue: 948
+ID: 72 Len: 8 Enqueue: 900
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -567,47 +567,47 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 900
+ID: 88 Len: 8 Enqueue: 906
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 810
-ID: 93 Len: 8 Enqueue: 828
-ID: 94 Len: 8 Enqueue: 816
-ID: 95 Len: 8 Enqueue: 924
-ID: 96 Len: 8 Enqueue: 798
-ID: 97 Len: 8 Enqueue: 804
-ID: 98 Len: 8 Enqueue: 906
-ID: 99 Len: 8 Enqueue: 912
-ID: 100 Len: 24 Enqueue: 1034
+ID: 92 Len: 8 Enqueue: 816
+ID: 93 Len: 8 Enqueue: 834
+ID: 94 Len: 8 Enqueue: 822
+ID: 95 Len: 8 Enqueue: 930
+ID: 96 Len: 8 Enqueue: 804
+ID: 97 Len: 8 Enqueue: 810
+ID: 98 Len: 8 Enqueue: 912
+ID: 99 Len: 8 Enqueue: 918
+ID: 100 Len: 24 Enqueue: 1040
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 1060
-ID: 103 Len: 48 Enqueue: 958
-ID: 104 Len: 8 Enqueue: 1302
+ID: 102 Len: 24 Enqueue: 1066
+ID: 103 Len: 48 Enqueue: 964
+ID: 104 Len: 8 Enqueue: 1308
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 1240
-ID: 107 Len: 8 Enqueue: 774
-ID: 108 Len: 208 Enqueue: 1145
-ID: 109 Len: 8 Enqueue: 876
+ID: 106 Len: 48 Enqueue: 1246
+ID: 107 Len: 8 Enqueue: 780
+ID: 108 Len: 208 Enqueue: 1151
+ID: 109 Len: 8 Enqueue: 882
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 1308
+ID: 111 Len: 8 Enqueue: 1314
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1254
-ID: 114 Len: 8 Enqueue: 780
-ID: 115 Len: 208 Enqueue: 1166
-ID: 116 Len: 8 Enqueue: 1320
+ID: 113 Len: 48 Enqueue: 1260
+ID: 114 Len: 8 Enqueue: 786
+ID: 115 Len: 208 Enqueue: 1172
+ID: 116 Len: 8 Enqueue: 1326
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1282
-ID: 119 Len: 8 Enqueue: 792
-ID: 120 Len: 88 Enqueue: 1208
-ID: 121 Len: 8 Enqueue: 1314
+ID: 118 Len: 48 Enqueue: 1288
+ID: 119 Len: 8 Enqueue: 798
+ID: 120 Len: 88 Enqueue: 1214
+ID: 121 Len: 8 Enqueue: 1320
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1268
-ID: 124 Len: 8 Enqueue: 786
-ID: 125 Len: 208 Enqueue: 1187
-ID: 126 Len: 8 Enqueue: 732
-ID: 127 Len: 8 Enqueue: 738
-ID: 128 Len: 8 Enqueue: 750
+ID: 123 Len: 48 Enqueue: 1274
+ID: 124 Len: 8 Enqueue: 792
+ID: 125 Len: 208 Enqueue: 1193
+ID: 126 Len: 8 Enqueue: 738
+ID: 127 Len: 8 Enqueue: 744
+ID: 128 Len: 8 Enqueue: 756
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -616,30 +616,30 @@ ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 16 Enqueue: 1070
+ID: 137 Len: 16 Enqueue: 1076
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 128 Enqueue: 1044
+ID: 140 Len: 128 Enqueue: 1050
 ID: 141 Len: 64 Enqueue: 0
-ID: 142 Len: 208 Enqueue: 986
-ID: 143 Len: 64 Enqueue: 1102
-ID: 144 Len: 8 Enqueue: 834
+ID: 142 Len: 208 Enqueue: 992
+ID: 143 Len: 64 Enqueue: 1108
+ID: 144 Len: 8 Enqueue: 840
 ID: 145 Len: 184 Enqueue: 0
-ID: 146 Len: 208 Enqueue: 998
+ID: 146 Len: 208 Enqueue: 1004
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 64 Enqueue: 1118
-ID: 149 Len: 8 Enqueue: 1296
+ID: 148 Len: 64 Enqueue: 1124
+ID: 149 Len: 8 Enqueue: 1302
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 48 Enqueue: 1226
-ID: 152 Len: 8 Enqueue: 768
-ID: 153 Len: 144 Enqueue: 1134
-ID: 154 Len: 88 Enqueue: 1022
-ID: 155 Len: 208 Enqueue: 1010
+ID: 151 Len: 48 Enqueue: 1232
+ID: 152 Len: 8 Enqueue: 774
+ID: 153 Len: 144 Enqueue: 1140
+ID: 154 Len: 88 Enqueue: 1028
+ID: 155 Len: 208 Enqueue: 1016
 ID: 156 Len: 64 Enqueue: 0
 ID: 157 Len: 64 Enqueue: 0
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 144 Enqueue: 974
-ID: 160 Len: 8 Enqueue: 744
+ID: 159 Len: 144 Enqueue: 980
+ID: 160 Len: 8 Enqueue: 750
 ID: 161 Len: 128 Enqueue: 0
 ID: 162 Len: 9 Enqueue: 0
 ID: 163 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b520c]
 	PrepareEventRoot ca 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b5244]
 	PrepareEventRoot cb 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ce 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d4 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b56f0]
 	PrepareEventRoot c2 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c8 03 00 00 // ProcessType[[3]string]
+	Call ce 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5590]
 	PrepareEventRoot bf 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 08 04 00 00 // ProcessType[[]int]
+	Call 0e 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b53a8]
 	PrepareEventRoot b7 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c8 04 00 00 // ProcessType[map[string]int]
+	Call ce 04 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b5678]
 	PrepareEventRoot c0 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b5328]
 	PrepareEventRoot b5 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c8 03 00 00 // ProcessType[[3]string]
+	Call ce 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b5528]
 	PrepareEventRoot bd 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 36 04 00 00 // ProcessType[[]string]
+	Call 3c 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b54a8]
 	PrepareEventRoot bb 00 00 00 19 00 00 00 
@@ -172,331 +172,331 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d4 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call da 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b59a0]
 	PrepareEventRoot c7 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb59a0.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7d 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer b1 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*error]
+// 0x306: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x306: ProcessType[*float32]
+// 0x30c: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x312: ProcessType[*int]
+// 0x318: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x318: ProcessType[*int32]
+// 0x31e: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int64]
+// 0x324: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x324: ProcessType[*main.bigStruct]
+// 0x32a: ProcessType[*main.bigStruct]
 	ProcessPointer 98 00 00 00 
 	Return 
-// 0x32a: ProcessType[*runtime._defer]
+// 0x330: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._panic]
+// 0x336: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime.cgoCallers]
+// 0x33c: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.coro]
+// 0x342: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.g]
+// 0x348: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.m]
+// 0x34e: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.sudog]
+// 0x354: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.synctestGroup]
+// 0x35a: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.timer]
+// 0x360: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.traceBuf]
+// 0x366: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x366: ProcessType[*string]
+// 0x36c: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x36c: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<string,int>]
+// 0x378: ProcessType[*table<string,int>]
 	ProcessPointer 89 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,main.bigStruct>]
+// 0x37e: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x384: ProcessType[*uint]
+// 0x38a: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint16]
+// 0x390: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint32]
+// 0x396: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint64]
+// 0x39c: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint8]
+// 0x3a2: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uintptr]
+// 0x3a8: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3a8: ProcessType[[2]*runtime.traceBuf]
+// 0x3ae: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3b8: ProcessType[[2][2]*runtime.traceBuf]
+// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call a8 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3c8: ProcessType[[3]string]
+// 0x3ce: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3d8: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3de: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 6c 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3e4: ProcessType[[]*table<string,int>.array]
+// 0x3ea: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<string,int>]
+	Call 78 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f0: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x3f6: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3fc: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x402: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x408: ProcessType[[]int]
+// 0x40e: ProcessType[[]int]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x412: ProcessType[[]noalg.map.group[string]int.array]
+// 0x418: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 0a 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 10 05 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x41e: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x424: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 15 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 1b 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x42a: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x430: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 20 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 26 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x436: ProcessType[[]string]
+// 0x43c: ProcessType[[]string]
 	ProcessSlice 87 00 00 00 10 00 00 00 
 	Return 
-// 0x440: ProcessType[[]string.array]
+// 0x446: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x44c: ProcessType[[]uint8]
+// 0x452: ProcessType[[]uint8]
 	ProcessSlice 81 00 00 00 01 00 00 00 
 	Return 
-// 0x456: ProcessType[[]uintptr]
+// 0x45c: ProcessType[[]uintptr]
 	ProcessSlice 83 00 00 00 08 00 00 00 
 	Return 
-// 0x460: ProcessType[error]
+// 0x466: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x462: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x468: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x46e: ProcessType[groupReference<string,int>]
+// 0x474: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 90 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x47a: ProcessType[groupReference<string,main.bigStruct>]
+// 0x480: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x486: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x48c: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups a7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x492: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x498: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap af 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x49e: ProcessType[map<string,int>]
+// 0x4a4: ProcessType[map<string,int>]
 	ProcessGoSwissMap 8f 00 00 00 8c 00 00 00 10 18 
 	Return 
-// 0x4aa: ProcessType[map<string,main.bigStruct>]
+// 0x4b0: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 99 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x4b6: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4bc: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a6 00 00 00 9e 00 00 00 10 18 
 	Return 
-// 0x4c2: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x4c8: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x4c8: ProcessType[map[string]int]
+// 0x4ce: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x4ce: ProcessType[map[string]main.bigStruct]
+// 0x4d4: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x4d4: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x4da: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x4da: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x4e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 2b 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 31 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x4ea: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x4f0: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 3b 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 41 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x4fa: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x500: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 41 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 47 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x50a: ProcessType[noalg.map.group[string]int]
+// 0x510: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ea 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call f0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x515: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x51b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call da 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call e0 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x520: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x526: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 04 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 00 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x52b: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 2c 06 00 00 // ProcessType[string]
+// 0x531: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 32 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 03 00 00 // ProcessType[*main.bigStruct]
+	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x53b: ProcessType[noalg.struct { key string; elem int }]
-	Call 2c 06 00 00 // ProcessType[string]
+// 0x541: ProcessType[noalg.struct { key string; elem int }]
+	Call 32 06 00 00 // ProcessType[string]
 	Return 
-// 0x541: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x547: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call c2 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call c8 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x54c: ProcessType[runtime.g]
+// 0x552: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._panic]
+	Call 36 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*runtime._defer]
+	Call 30 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 4c 04 00 00 // ProcessType[[]uint8]
+	Call 52 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 03 00 00 // ProcessType[*runtime.sudog]
+	Call 54 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.timer]
+	Call 60 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.coro]
+	Call 42 03 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 5a 03 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x5b1: ProcessType[runtime.m]
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+// 0x5b7: ProcessType[runtime.m]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 2c 06 00 00 // ProcessType[string]
+	Call 32 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 11 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 17 06 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 22 06 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x611: ProcessType[runtime.mLockProfile]
+// 0x617: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 56 04 00 00 // ProcessType[[]uintptr]
+	Call 5c 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x61c: ProcessType[runtime.mTraceState]
+// 0x622: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b8 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x62c: ProcessType[string]
+// 0x632: ProcessType[string]
 	ProcessString 7f 00 00 00 
 	Return 
-// 0x632: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x638: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 62 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 68 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x63d: ProcessType[table<string,int>]
+// 0x643: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6e 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 74 04 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x648: ProcessType[table<string,main.bigStruct>]
+// 0x64e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7a 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 80 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x653: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x659: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 86 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8c 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -517,31 +517,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 924
+ID: 5 Len: 8 Enqueue: 930
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1580
+ID: 9 Len: 16 Enqueue: 1586
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 762
+ID: 11 Len: 8 Enqueue: 768
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1120
+ID: 14 Len: 16 Enqueue: 1126
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 930
-ID: 20 Len: 8 Enqueue: 792
-ID: 21 Len: 8 Enqueue: 912
-ID: 22 Len: 440 Enqueue: 1356
+ID: 19 Len: 8 Enqueue: 936
+ID: 20 Len: 8 Enqueue: 798
+ID: 21 Len: 8 Enqueue: 918
+ID: 22 Len: 440 Enqueue: 1362
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 816
+ID: 24 Len: 8 Enqueue: 822
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 810
+ID: 26 Len: 8 Enqueue: 816
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 840
-ID: 29 Len: 1808 Enqueue: 1457
+ID: 28 Len: 8 Enqueue: 846
+ID: 29 Len: 1808 Enqueue: 1463
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -550,45 +550,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1100
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1106
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 846
+ID: 41 Len: 8 Enqueue: 852
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1110
-ID: 44 Len: 8 Enqueue: 858
+ID: 43 Len: 24 Enqueue: 1116
+ID: 44 Len: 8 Enqueue: 864
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 828
+ID: 47 Len: 8 Enqueue: 834
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 852
+ID: 49 Len: 8 Enqueue: 858
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 834
+ID: 55 Len: 8 Enqueue: 840
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 822
+ID: 62 Len: 8 Enqueue: 828
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 1553
+ID: 67 Len: 64 Enqueue: 1559
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 1564
+ID: 72 Len: 56 Enqueue: 1570
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 952
-ID: 75 Len: 16 Enqueue: 936
-ID: 76 Len: 8 Enqueue: 864
+ID: 74 Len: 32 Enqueue: 958
+ID: 75 Len: 16 Enqueue: 942
+ID: 76 Len: 8 Enqueue: 870
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -605,40 +605,40 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 870
+ID: 93 Len: 8 Enqueue: 876
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 780
-ID: 98 Len: 8 Enqueue: 798
-ID: 99 Len: 8 Enqueue: 786
-ID: 100 Len: 8 Enqueue: 918
-ID: 101 Len: 8 Enqueue: 768
-ID: 102 Len: 8 Enqueue: 774
-ID: 103 Len: 8 Enqueue: 900
-ID: 104 Len: 8 Enqueue: 906
-ID: 105 Len: 24 Enqueue: 1032
+ID: 97 Len: 8 Enqueue: 786
+ID: 98 Len: 8 Enqueue: 804
+ID: 99 Len: 8 Enqueue: 792
+ID: 100 Len: 8 Enqueue: 924
+ID: 101 Len: 8 Enqueue: 774
+ID: 102 Len: 8 Enqueue: 780
+ID: 103 Len: 8 Enqueue: 906
+ID: 104 Len: 8 Enqueue: 912
+ID: 105 Len: 24 Enqueue: 1038
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 1078
-ID: 108 Len: 48 Enqueue: 968
-ID: 109 Len: 8 Enqueue: 1224
+ID: 107 Len: 24 Enqueue: 1084
+ID: 108 Len: 48 Enqueue: 974
+ID: 109 Len: 8 Enqueue: 1230
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 1182
+ID: 111 Len: 48 Enqueue: 1188
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 882
-ID: 114 Len: 8 Enqueue: 1230
+ID: 113 Len: 8 Enqueue: 888
+ID: 114 Len: 8 Enqueue: 1236
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 1194
+ID: 116 Len: 48 Enqueue: 1200
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 888
-ID: 119 Len: 8 Enqueue: 1236
+ID: 118 Len: 8 Enqueue: 894
+ID: 119 Len: 8 Enqueue: 1242
 ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 1206
+ID: 121 Len: 48 Enqueue: 1212
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 894
-ID: 124 Len: 8 Enqueue: 732
-ID: 125 Len: 8 Enqueue: 738
-ID: 126 Len: 8 Enqueue: 750
+ID: 123 Len: 8 Enqueue: 900
+ID: 124 Len: 8 Enqueue: 738
+ID: 125 Len: 8 Enqueue: 744
+ID: 126 Len: 8 Enqueue: 756
 ID: 127 Len: 1 Enqueue: 0
 ID: 128 Len: 8 Enqueue: 0
 ID: 129 Len: 1 Enqueue: 0
@@ -647,49 +647,49 @@ ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 16 Enqueue: 1088
+ID: 135 Len: 16 Enqueue: 1094
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 32 Enqueue: 1597
-ID: 138 Len: 16 Enqueue: 1134
+ID: 137 Len: 32 Enqueue: 1603
+ID: 138 Len: 16 Enqueue: 1140
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 200 Enqueue: 1290
-ID: 141 Len: 192 Enqueue: 1258
-ID: 142 Len: 24 Enqueue: 1339
-ID: 143 Len: 8 Enqueue: 996
-ID: 144 Len: 200 Enqueue: 1042
-ID: 145 Len: 32 Enqueue: 1608
-ID: 146 Len: 16 Enqueue: 1146
+ID: 140 Len: 200 Enqueue: 1296
+ID: 141 Len: 192 Enqueue: 1264
+ID: 142 Len: 24 Enqueue: 1345
+ID: 143 Len: 8 Enqueue: 1002
+ID: 144 Len: 200 Enqueue: 1048
+ID: 145 Len: 32 Enqueue: 1614
+ID: 146 Len: 16 Enqueue: 1152
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 1301
-ID: 149 Len: 192 Enqueue: 1242
-ID: 150 Len: 24 Enqueue: 1323
-ID: 151 Len: 8 Enqueue: 804
+ID: 148 Len: 200 Enqueue: 1307
+ID: 149 Len: 192 Enqueue: 1248
+ID: 150 Len: 24 Enqueue: 1329
+ID: 151 Len: 8 Enqueue: 810
 ID: 152 Len: 184 Enqueue: 0
-ID: 153 Len: 8 Enqueue: 1008
-ID: 154 Len: 200 Enqueue: 1054
-ID: 155 Len: 32 Enqueue: 1619
-ID: 156 Len: 16 Enqueue: 1158
+ID: 153 Len: 8 Enqueue: 1014
+ID: 154 Len: 200 Enqueue: 1060
+ID: 155 Len: 32 Enqueue: 1625
+ID: 156 Len: 16 Enqueue: 1164
 ID: 157 Len: 8 Enqueue: 0
-ID: 158 Len: 136 Enqueue: 1312
-ID: 159 Len: 128 Enqueue: 1274
-ID: 160 Len: 16 Enqueue: 1345
-ID: 161 Len: 8 Enqueue: 1218
+ID: 158 Len: 136 Enqueue: 1318
+ID: 159 Len: 128 Enqueue: 1280
+ID: 160 Len: 16 Enqueue: 1351
+ID: 161 Len: 8 Enqueue: 1224
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 48 Enqueue: 1170
+ID: 163 Len: 48 Enqueue: 1176
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 8 Enqueue: 876
-ID: 166 Len: 8 Enqueue: 1020
-ID: 167 Len: 136 Enqueue: 1066
-ID: 168 Len: 32 Enqueue: 1586
-ID: 169 Len: 16 Enqueue: 1122
+ID: 165 Len: 8 Enqueue: 882
+ID: 166 Len: 8 Enqueue: 1026
+ID: 167 Len: 136 Enqueue: 1072
+ID: 168 Len: 32 Enqueue: 1592
+ID: 169 Len: 16 Enqueue: 1128
 ID: 170 Len: 8 Enqueue: 0
 ID: 171 Len: 136 Enqueue: 0
 ID: 172 Len: 128 Enqueue: 0
 ID: 173 Len: 16 Enqueue: 0
 ID: 174 Len: 8 Enqueue: 0
-ID: 175 Len: 8 Enqueue: 984
+ID: 175 Len: 8 Enqueue: 990
 ID: 176 Len: 136 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 744
+ID: 177 Len: 8 Enqueue: 750
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 9 Enqueue: 0
 ID: 180 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,7 +7,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dc 02 00 00 // ProcessType[*****int]
+	Call e2 02 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessEvent[Probe[main.PointerChainArg]@b7da0]
 	PrepareEventRoot cf 00 00 00 09 00 00 00 
@@ -17,7 +17,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ee 02 00 00 // ProcessType[**int]
+	Call f4 02 00 00 // ProcessType[**int]
 	Return 
 // 0x48: ProcessEvent[Probe[main.PointerSmallChainArg]@b7dd4]
 	PrepareEventRoot d0 00 00 00 09 00 00 00 
@@ -27,7 +27,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ea 04 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 04 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x72: ProcessEvent[Probe[main.bigMapArg]@b8240]
 	PrepareEventRoot c7 00 00 00 09 00 00 00 
@@ -85,7 +85,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call d4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b80e0]
 	PrepareEventRoot c4 00 00 00 31 00 00 00 
@@ -97,7 +97,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 24 04 00 00 // ProcessType[[]int]
+	Call 2a 04 00 00 // ProcessType[[]int]
 	Return 
 // 0x196: ProcessEvent[Probe[main.intSliceArg]@b7f18]
 	PrepareEventRoot bc 00 00 00 19 00 00 00 
@@ -110,7 +110,7 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e4 04 00 00 // ProcessType[map[string]int]
+	Call ea 04 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1ca: ProcessEvent[Probe[main.mapArg]@b81c8]
 	PrepareEventRoot c5 00 00 00 09 00 00 00 
@@ -130,7 +130,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	Return 
 // 0x219: ProcessEvent[Probe[main.stringArg]@b7ea8]
 	PrepareEventRoot ba 00 00 00 11 00 00 00 
@@ -143,7 +143,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ce 03 00 00 // ProcessType[[3]string]
+	Call d4 03 00 00 // ProcessType[[3]string]
 	Return 
 // 0x253: ProcessEvent[Probe[main.stringArrayArg]@b8088]
 	PrepareEventRoot c2 00 00 00 31 00 00 00 
@@ -158,7 +158,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 52 04 00 00 // ProcessType[[]string]
+	Call 58 04 00 00 // ProcessType[[]string]
 	Return 
 // 0x295: ProcessEvent[Probe[main.stringSliceArg]@b8008]
 	PrepareEventRoot c0 00 00 00 19 00 00 00 
@@ -172,344 +172,344 @@
 	Return 
 // 0x2b8: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	ExprPrepare 
-	Return 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f0 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f6 04 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2cd: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
+// 0x2d3: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b84d8]
 	PrepareEventRoot cc 00 00 00 09 00 00 00 
 	Call b8 02 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb84d8.expr[0]]
 	Return 
-// 0x2dc: ProcessType[*****int]
+// 0x2e2: ProcessType[*****int]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x2e2: ProcessType[****int]
+// 0x2e8: ProcessType[****int]
 	ProcessPointer b6 00 00 00 
 	Return 
-// 0x2e8: ProcessType[***int]
+// 0x2ee: ProcessType[***int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x2ee: ProcessType[**int]
+// 0x2f4: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x2f4: ProcessType[*[]runtime.ancestorInfo]
+// 0x2fa: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x2fa: ProcessType[*bool]
+// 0x300: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x300: ProcessType[*error]
+// 0x306: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x306: ProcessType[*float32]
+// 0x30c: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x30c: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x312: ProcessType[*int]
+// 0x318: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x318: ProcessType[*int32]
+// 0x31e: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x31e: ProcessType[*int64]
+// 0x324: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x324: ProcessType[*main.bigStruct]
+// 0x32a: ProcessType[*main.bigStruct]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x32a: ProcessType[*runtime._defer]
+// 0x330: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x330: ProcessType[*runtime._panic]
+// 0x336: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x336: ProcessType[*runtime.cgoCallers]
+// 0x33c: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x33c: ProcessType[*runtime.coro]
+// 0x342: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x342: ProcessType[*runtime.g]
+// 0x348: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x348: ProcessType[*runtime.m]
+// 0x34e: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x34e: ProcessType[*runtime.p]
+// 0x354: ProcessType[*runtime.p]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x354: ProcessType[*runtime.sudog]
+// 0x35a: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x35a: ProcessType[*runtime.synctestBubble]
+// 0x360: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x360: ProcessType[*runtime.timer]
+// 0x366: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x366: ProcessType[*runtime.traceBuf]
+// 0x36c: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x36c: ProcessType[*string]
+// 0x372: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x372: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x378: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ad 00 00 00 
 	Return 
-// 0x378: ProcessType[*table<string,int>]
+// 0x37e: ProcessType[*table<string,int>]
 	ProcessPointer 8e 00 00 00 
 	Return 
-// 0x37e: ProcessType[*table<string,main.bigStruct>]
+// 0x384: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x384: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x38a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x38a: ProcessType[*uint]
+// 0x390: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x390: ProcessType[*uint16]
+// 0x396: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x396: ProcessType[*uint32]
+// 0x39c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x39c: ProcessType[*uint64]
+// 0x3a2: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x3a2: ProcessType[*uint8]
+// 0x3a8: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x3a8: ProcessType[*uintptr]
+// 0x3ae: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x3ae: ProcessType[[2]*runtime.traceBuf]
+// 0x3b4: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 66 03 00 00 // ProcessType[*runtime.traceBuf]
+	Call 6c 03 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3be: ProcessType[[2][2]*runtime.traceBuf]
+// 0x3c4: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ae 03 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call b4 03 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3ce: ProcessType[[3]string]
+// 0x3d4: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x3de: ProcessType[[]*runtime.p]
+// 0x3e4: ProcessType[[]*runtime.p]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x3e8: ProcessType[[]*runtime.p.array]
+// 0x3ee: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 4e 03 00 00 // ProcessType[*runtime.p]
+	Call 54 03 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x3f4: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x3fa: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 72 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 78 03 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x400: ProcessType[[]*table<string,int>.array]
+// 0x406: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 78 03 00 00 // ProcessType[*table<string,int>]
+	Call 7e 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x40c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x412: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7e 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 84 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x418: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x41e: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 84 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8a 03 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x424: ProcessType[[]int]
+// 0x42a: ProcessType[[]int]
 	ProcessSlice 8a 00 00 00 08 00 00 00 
 	Return 
-// 0x42e: ProcessType[[]noalg.map.group[string]int.array]
+// 0x434: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 26 05 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 2c 05 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x43a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x440: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 31 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 37 05 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x446: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x44c: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 3c 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 42 05 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x452: ProcessType[[]string]
+// 0x458: ProcessType[[]string]
 	ProcessSlice 8c 00 00 00 10 00 00 00 
 	Return 
-// 0x45c: ProcessType[[]string.array]
+// 0x462: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x468: ProcessType[[]uint8]
+// 0x46e: ProcessType[[]uint8]
 	ProcessSlice 83 00 00 00 01 00 00 00 
 	Return 
-// 0x472: ProcessType[[]uintptr]
+// 0x478: ProcessType[[]uintptr]
 	ProcessSlice 85 00 00 00 08 00 00 00 
 	Return 
-// 0x47c: ProcessType[error]
+// 0x482: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x47e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x484: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b5 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x48a: ProcessType[groupReference<string,int>]
+// 0x490: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 95 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x496: ProcessType[groupReference<string,main.bigStruct>]
+// 0x49c: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9f 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x4a2: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4a8: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ac 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x4ae: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x4b4: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b4 00 00 00 b0 00 00 00 10 18 
 	Return 
-// 0x4ba: ProcessType[map<string,int>]
+// 0x4c0: ProcessType[map<string,int>]
 	ProcessGoSwissMap 94 00 00 00 91 00 00 00 10 18 
 	Return 
-// 0x4c6: ProcessType[map<string,main.bigStruct>]
+// 0x4cc: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9e 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x4d2: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x4d8: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ab 00 00 00 a3 00 00 00 10 18 
 	Return 
-// 0x4de: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x4e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x4e4: ProcessType[map[string]int]
+// 0x4ea: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x4ea: ProcessType[map[string]main.bigStruct]
+// 0x4f0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x4f0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x4f6: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x4f6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x4fc: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 47 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 4d 05 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x506: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x50c: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 57 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 5d 05 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x516: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x51c: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 5d 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 63 05 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x526: ProcessType[noalg.map.group[string]int]
+// 0x52c: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 06 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 0c 05 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x531: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x537: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call f6 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call fc 04 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x53c: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x542: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 16 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 1c 05 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x547: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 52 06 00 00 // ProcessType[string]
+// 0x54d: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 58 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 24 03 00 00 // ProcessType[*main.bigStruct]
+	Call 2a 03 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x557: ProcessType[noalg.struct { key string; elem int }]
-	Call 52 06 00 00 // ProcessType[string]
+// 0x55d: ProcessType[noalg.struct { key string; elem int }]
+	Call 58 06 00 00 // ProcessType[string]
 	Return 
-// 0x55d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x563: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call e4 04 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x568: ProcessType[runtime.g]
+// 0x56e: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 30 03 00 00 // ProcessType[*runtime._panic]
+	Call 36 03 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 03 00 00 // ProcessType[*runtime._defer]
+	Call 30 03 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 68 04 00 00 // ProcessType[[]uint8]
+	Call 6e 04 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call f4 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call fa 02 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 03 00 00 // ProcessType[*runtime.sudog]
+	Call 5a 03 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 60 03 00 00 // ProcessType[*runtime.timer]
+	Call 66 03 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 3c 03 00 00 // ProcessType[*runtime.coro]
+	Call 42 03 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 03 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 60 03 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x5cd: ProcessType[runtime.m]
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+// 0x5d3: ProcessType[runtime.m]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 42 03 00 00 // ProcessType[*runtime.g]
+	Call 48 03 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 52 06 00 00 // ProcessType[string]
+	Call 58 06 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call de 03 00 00 // ProcessType[[]*runtime.p]
+	Call e4 03 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 36 03 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3c 03 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 37 06 00 00 // ProcessType[runtime.mLockProfile]
+	Call 3d 06 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 42 06 00 00 // ProcessType[runtime.mTraceState]
+	Call 48 06 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x637: ProcessType[runtime.mLockProfile]
+// 0x63d: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 72 04 00 00 // ProcessType[[]uintptr]
+	Call 78 04 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x642: ProcessType[runtime.mTraceState]
+// 0x648: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call be 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 48 03 00 00 // ProcessType[*runtime.m]
+	Call c4 03 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4e 03 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x652: ProcessType[string]
+// 0x658: ProcessType[string]
 	ProcessString 81 00 00 00 
 	Return 
-// 0x658: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x65e: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7e 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 84 04 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x663: ProcessType[table<string,int>]
+// 0x669: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8a 04 00 00 // ProcessType[groupReference<string,int>]
+	Call 90 04 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x66e: ProcessType[table<string,main.bigStruct>]
+// 0x674: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 96 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9c 04 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x679: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x67f: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a2 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a8 04 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -530,31 +530,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 930
+ID: 5 Len: 8 Enqueue: 936
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 1618
+ID: 9 Len: 16 Enqueue: 1624
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 762
+ID: 11 Len: 8 Enqueue: 768
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 1148
+ID: 14 Len: 16 Enqueue: 1154
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 936
-ID: 20 Len: 8 Enqueue: 792
-ID: 21 Len: 8 Enqueue: 918
-ID: 22 Len: 440 Enqueue: 1384
+ID: 19 Len: 8 Enqueue: 942
+ID: 20 Len: 8 Enqueue: 798
+ID: 21 Len: 8 Enqueue: 924
+ID: 22 Len: 440 Enqueue: 1390
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 816
+ID: 24 Len: 8 Enqueue: 822
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 810
+ID: 26 Len: 8 Enqueue: 816
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 840
-ID: 29 Len: 1816 Enqueue: 1485
+ID: 28 Len: 8 Enqueue: 846
+ID: 29 Len: 1816 Enqueue: 1491
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -563,48 +563,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 1128
-ID: 39 Len: 8 Enqueue: 756
+ID: 38 Len: 24 Enqueue: 1134
+ID: 39 Len: 8 Enqueue: 762
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 852
+ID: 41 Len: 8 Enqueue: 858
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 1138
-ID: 44 Len: 8 Enqueue: 864
+ID: 43 Len: 24 Enqueue: 1144
+ID: 44 Len: 8 Enqueue: 870
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 828
+ID: 47 Len: 8 Enqueue: 834
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 858
+ID: 49 Len: 8 Enqueue: 864
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 834
+ID: 55 Len: 8 Enqueue: 840
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 990
+ID: 62 Len: 24 Enqueue: 996
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 846
-ID: 65 Len: 8 Enqueue: 822
+ID: 64 Len: 8 Enqueue: 852
+ID: 65 Len: 8 Enqueue: 828
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 1591
+ID: 70 Len: 56 Enqueue: 1597
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 1602
+ID: 75 Len: 56 Enqueue: 1608
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 958
-ID: 78 Len: 16 Enqueue: 942
-ID: 79 Len: 8 Enqueue: 870
+ID: 77 Len: 32 Enqueue: 964
+ID: 78 Len: 16 Enqueue: 948
+ID: 79 Len: 8 Enqueue: 876
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -620,40 +620,40 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 876
+ID: 95 Len: 8 Enqueue: 882
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 780
-ID: 100 Len: 8 Enqueue: 786
-ID: 101 Len: 8 Enqueue: 924
-ID: 102 Len: 8 Enqueue: 798
-ID: 103 Len: 8 Enqueue: 768
-ID: 104 Len: 8 Enqueue: 774
-ID: 105 Len: 8 Enqueue: 906
-ID: 106 Len: 8 Enqueue: 912
-ID: 107 Len: 24 Enqueue: 1060
+ID: 99 Len: 8 Enqueue: 786
+ID: 100 Len: 8 Enqueue: 792
+ID: 101 Len: 8 Enqueue: 930
+ID: 102 Len: 8 Enqueue: 804
+ID: 103 Len: 8 Enqueue: 774
+ID: 104 Len: 8 Enqueue: 780
+ID: 105 Len: 8 Enqueue: 912
+ID: 106 Len: 8 Enqueue: 918
+ID: 107 Len: 24 Enqueue: 1066
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 1106
-ID: 110 Len: 48 Enqueue: 974
-ID: 111 Len: 8 Enqueue: 1252
+ID: 109 Len: 24 Enqueue: 1112
+ID: 110 Len: 48 Enqueue: 980
+ID: 111 Len: 8 Enqueue: 1258
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 1210
+ID: 113 Len: 48 Enqueue: 1216
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 888
-ID: 116 Len: 8 Enqueue: 1258
+ID: 115 Len: 8 Enqueue: 894
+ID: 116 Len: 8 Enqueue: 1264
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 1222
+ID: 118 Len: 48 Enqueue: 1228
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 894
-ID: 121 Len: 8 Enqueue: 1264
+ID: 120 Len: 8 Enqueue: 900
+ID: 121 Len: 8 Enqueue: 1270
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 1234
+ID: 123 Len: 48 Enqueue: 1240
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 900
-ID: 126 Len: 8 Enqueue: 732
-ID: 127 Len: 8 Enqueue: 738
-ID: 128 Len: 8 Enqueue: 750
+ID: 125 Len: 8 Enqueue: 906
+ID: 126 Len: 8 Enqueue: 738
+ID: 127 Len: 8 Enqueue: 744
+ID: 128 Len: 8 Enqueue: 756
 ID: 129 Len: 1 Enqueue: 0
 ID: 130 Len: 8 Enqueue: 0
 ID: 131 Len: 1 Enqueue: 0
@@ -661,53 +661,53 @@ ID: 132 Len: 8 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 1000
+ID: 136 Len: 8 Enqueue: 1006
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 1116
+ID: 140 Len: 16 Enqueue: 1122
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 32 Enqueue: 1635
-ID: 143 Len: 16 Enqueue: 1162
+ID: 142 Len: 32 Enqueue: 1641
+ID: 143 Len: 16 Enqueue: 1168
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 200 Enqueue: 1318
-ID: 146 Len: 192 Enqueue: 1286
-ID: 147 Len: 24 Enqueue: 1367
-ID: 148 Len: 8 Enqueue: 1024
-ID: 149 Len: 200 Enqueue: 1070
-ID: 150 Len: 32 Enqueue: 1646
-ID: 151 Len: 16 Enqueue: 1174
+ID: 145 Len: 200 Enqueue: 1324
+ID: 146 Len: 192 Enqueue: 1292
+ID: 147 Len: 24 Enqueue: 1373
+ID: 148 Len: 8 Enqueue: 1030
+ID: 149 Len: 200 Enqueue: 1076
+ID: 150 Len: 32 Enqueue: 1652
+ID: 151 Len: 16 Enqueue: 1180
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 1329
-ID: 154 Len: 192 Enqueue: 1270
-ID: 155 Len: 24 Enqueue: 1351
-ID: 156 Len: 8 Enqueue: 804
+ID: 153 Len: 200 Enqueue: 1335
+ID: 154 Len: 192 Enqueue: 1276
+ID: 155 Len: 24 Enqueue: 1357
+ID: 156 Len: 8 Enqueue: 810
 ID: 157 Len: 184 Enqueue: 0
-ID: 158 Len: 8 Enqueue: 1036
-ID: 159 Len: 200 Enqueue: 1082
-ID: 160 Len: 32 Enqueue: 1657
-ID: 161 Len: 16 Enqueue: 1186
+ID: 158 Len: 8 Enqueue: 1042
+ID: 159 Len: 200 Enqueue: 1088
+ID: 160 Len: 32 Enqueue: 1663
+ID: 161 Len: 16 Enqueue: 1192
 ID: 162 Len: 8 Enqueue: 0
-ID: 163 Len: 136 Enqueue: 1340
-ID: 164 Len: 128 Enqueue: 1302
-ID: 165 Len: 16 Enqueue: 1373
-ID: 166 Len: 8 Enqueue: 1246
+ID: 163 Len: 136 Enqueue: 1346
+ID: 164 Len: 128 Enqueue: 1308
+ID: 165 Len: 16 Enqueue: 1379
+ID: 166 Len: 8 Enqueue: 1252
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 48 Enqueue: 1198
+ID: 168 Len: 48 Enqueue: 1204
 ID: 169 Len: 8 Enqueue: 0
-ID: 170 Len: 8 Enqueue: 882
-ID: 171 Len: 8 Enqueue: 1048
-ID: 172 Len: 136 Enqueue: 1094
-ID: 173 Len: 32 Enqueue: 1624
-ID: 174 Len: 16 Enqueue: 1150
+ID: 170 Len: 8 Enqueue: 888
+ID: 171 Len: 8 Enqueue: 1054
+ID: 172 Len: 136 Enqueue: 1100
+ID: 173 Len: 32 Enqueue: 1630
+ID: 174 Len: 16 Enqueue: 1156
 ID: 175 Len: 8 Enqueue: 0
 ID: 176 Len: 136 Enqueue: 0
 ID: 177 Len: 128 Enqueue: 0
 ID: 178 Len: 16 Enqueue: 0
 ID: 179 Len: 8 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 1012
+ID: 180 Len: 8 Enqueue: 1018
 ID: 181 Len: 136 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 744
+ID: 182 Len: 8 Enqueue: 750
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 9 Enqueue: 0
 ID: 185 Len: 0 Enqueue: 0

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -269,6 +269,7 @@ int probe_run_with_cookie(struct pt_regs* regs) {
       .stack_idx = 0,
   };
   frame_data.cfa = calculate_cfa(global_ctx.regs, params->frameless);
+  LOG(5, "cfa: %llx %d %llx %llx", frame_data.cfa, params->frameless, regs->DWARF_BP_REG, regs->DWARF_SP_REG);
   if (params->stack_machine_pc != 0) {
     process_steps = stack_machine_process_frame(&global_ctx, &frame_data,
                                                 params->stack_machine_pc);

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -387,7 +389,12 @@ func validateAndSaveOutputs(
 	}
 	for testName, testOutputs := range byTest {
 		for id, out := range testOutputs {
-			marshaled, err := json.MarshalIndent(out, "", "  ")
+			marshaled, err := jsonv2.Marshal(
+				out,
+				jsontext.WithIndent("  "),
+				jsontext.EscapeForHTML(false),
+				jsontext.EscapeForJS(false),
+			)
 			require.NoError(t, err)
 			prev, ok := byProbe[id]
 			if !ok {

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -108,6 +108,7 @@ func TestDyninst(t *testing.T) {
 func testDyninst(
 	t *testing.T,
 	service string,
+	testProgConfig testprogs.Config,
 	servicePath string,
 	probes []ir.ProbeDefinition,
 	rewriteEnabled bool,
@@ -256,8 +257,10 @@ func testDyninst(
 	m.Close()
 	retMap := make(map[string][]json.RawMessage)
 	debugEnabled := os.Getenv("DEBUG") != ""
+	redactors := append(defaultRedactors[:len(defaultRedactors):len(defaultRedactors)],
+		makeRedactorForManyFloats(testProgConfig.GOARCH))
 	for _, log := range testServer.getLogs() {
-		redacted := redactJSON(t, "", log.body, defaultRedactors)
+		redacted := redactJSON(t, "", log.body, redactors)
 		if debugEnabled {
 			t.Logf("Output: %v\n", string(log.body))
 			t.Logf("Sorted and redacted: %v\n", string(redacted))
@@ -321,7 +324,7 @@ func runIntegrationTestSuite(
 				runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) map[string][]json.RawMessage {
 					t.Parallel()
 					actual := testDyninst(
-						t, service, bin, probeSlice, rewrite, expectedOutput,
+						t, service, cfg, bin, probeSlice, rewrite, expectedOutput,
 						debug, sem,
 					)
 					if t.Failed() {
@@ -693,3 +696,40 @@ func (f *fakeScraper) putUpdates(outputs []rcscrape.ProcessUpdate) {
 }
 
 var _ module.Scraper = (*fakeScraper)(nil)
+
+// Make a redactor for the onlyOnAmd64_17 float
+// return value in the testReturnsManyFloats function. This function is expected
+// to have different behavior based on the architecture, and we need to
+// compensate for that.
+func makeRedactorForManyFloats(arch string) jsonRedactor {
+	return redactor(
+		exactMatcher(
+			"/debugger/snapshot/captures/return/locals/onlyOnAmd64_16",
+		),
+		replacerFunc(func(v jsontext.Value) jsontext.Value {
+			// If we've already redacted this, don't do it again.
+			if v.Kind() == '"' {
+				return v
+			}
+			// Try to read the value.
+			var value struct {
+				Value             string `json:"value"`
+				NotCapturedReason string `json:"notCapturedReason"`
+			}
+			if err := json.Unmarshal(v, &value); err != nil {
+				marshaled, _ := json.Marshal(err.Error())
+				return jsontext.Value(marshaled)
+			}
+			if arch == "amd64" {
+				if value.Value != "16" {
+					return v
+				}
+			} else {
+				if value.NotCapturedReason != "unavailable" {
+					return v
+				}
+			}
+			return jsontext.Value(`"[onlyOnAmd64]"`)
+		}),
+	)
+}

--- a/pkg/dyninst/irgen/abi.go
+++ b/pkg/dyninst/irgen/abi.go
@@ -1,0 +1,499 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen
+
+import (
+	"cmp"
+	"fmt"
+	"reflect"
+	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+)
+
+// abiConfig holds architecture-specific ABI details.
+type abiConfig struct {
+	// intRegs maps logical register numbers (0, 1, 2...) to physical DWARF
+	// register numbers.
+	intRegs []uint8
+	// maxIntRegs is the number of integer registers available for
+	// arguments/returns.
+	maxIntRegs int
+	// maxFPRegs is the number of floating-point registers available for
+	// arguments/returns.
+	maxFPRegs int
+	// stackBase is the architecture-specific offset from CFA to the start
+	// of the caller-allocated argument space.
+	stackBase int32
+}
+
+// amd64ABI defines the ABI configuration for amd64.
+// See https://github.com/golang/go/blob/62deaf4f/src/cmd/compile/abi-internal.md?plain=1#L390
+var amd64ABI = &abiConfig{
+	intRegs:    []uint8{0, 3, 2, 5, 4, 8, 9, 10, 11},
+	maxIntRegs: 9,  // RAX, RBX, RCX, RDI, RSI, R8, R9, R10, R11
+	maxFPRegs:  15, // X0-X14
+	stackBase:  0,
+}
+
+// arm64ABI defines the ABI configuration for arm64.
+// See https://github.com/golang/go/blob/62deaf4f/src/cmd/compile/abi-internal.md?plain=1#L516
+// R0-R15 are used for integer arguments/returns.
+var arm64ABI = &abiConfig{
+	intRegs:    []uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	maxIntRegs: 16,
+	maxFPRegs:  16, // F0-F15
+	stackBase:  8,  // Link register storage
+}
+
+// augmentReturnLocationsFromABI adds ABI-derived location information for
+// return variables at return probe points. It computes register and stack
+// assignments based on the Go internal ABI and updates variable locations
+// to include this information at return PCs.
+//
+// See https://github.com/golang/go/blob/62deaf4f/src/cmd/compile/abi-internal.md#function-call-argument-and-result-passing
+func augmentReturnLocationsFromABI(
+	arch object.Architecture,
+	subprogram *ir.Subprogram,
+	probes []*ir.Probe,
+) error {
+	// Select architecture-specific ABI configuration.
+	var abi *abiConfig
+	switch arch {
+	case "amd64":
+		abi = amd64ABI
+	case "arm64":
+		abi = arm64ABI
+	default:
+		return fmt.Errorf("unsupported architecture: %s", arch)
+	}
+	ptrSize := int32(arch.PointerSize())
+
+	align := func(offset int32) int32 {
+		return ((offset + ptrSize - 1) / ptrSize) * ptrSize
+	}
+
+	// Collect return PCs from all return events in probes.
+	var returnPCs []uint64
+	for _, probe := range probes {
+		for _, event := range probe.Events {
+			if event.Kind != ir.EventKindReturn {
+				continue
+			}
+			for _, ip := range event.InjectionPoints {
+				returnPCs = append(returnPCs, ip.PC)
+			}
+		}
+	}
+	if len(returnPCs) == 0 {
+		return nil
+	}
+
+	// Sort return PCs for efficient range operations.
+	slices.Sort(returnPCs)
+	returnPCs = slices.Compact(returnPCs)
+
+	// Stack layout:
+	//  ┌─────────────────────────────────────┐  Lower addresses ↑
+	//  │ Callee's local variables            │  ← Callee's frame
+	//  │ (negative CFA offsets in DWARF)     │
+	//  ├─────────────────────────────────────┤
+	//  │ Frame pointer                       │
+	//  ├─────────────────────────────────────┤
+	//  │ CFA                                 │  ← Offset 0
+	//  │ [link register] (ARM64 only)        │
+	//  │ [stack-assigned receiver & args]    │
+	//  │ [pointer-alignment]                 │
+	//  │ [stack-assigned results]            │
+	//  │ [pointer-alignment]                 │
+	//  │ [spill space for reg-assigned args] │
+	//  ├─────────────────────────────────────┤
+	//  │ Caller's local variables            │  ← Caller's frame
+	//  └─────────────────────────────────────┘  Higher addresses ↓
+
+	// Pass 1: compute stack-assigned argument size.
+	// We don't augment arguments, but need this to compute result offsets.
+	argRegs := &registerState{}
+	var argStackSize int32
+	for _, v := range subprogram.Variables {
+		if !v.IsParameter || v.IsReturn {
+			continue
+		}
+
+		_, ok, err := tryRegisterAssign(v.Type, argRegs, abi)
+		if err != nil {
+			return fmt.Errorf(
+				"computing ABI for argument %q: %w", v.Name, err,
+			)
+		}
+		if !ok {
+			// Stack-assigned argument.
+			argStackSize += align(int32(v.Type.GetByteSize()))
+		}
+		// Note: we don't track spill space for register-assigned arguments
+		// because it comes AFTER results in the frame layout, so it doesn't
+		// affect result offsets.
+	}
+	argStackSize = align(argStackSize)
+
+	// Pass 2: process return values and determine assignment.
+	type returnInfo struct {
+		variable *ir.Variable
+		pieces   []abiPiece
+		onStack  bool
+	}
+	var returnVars []returnInfo
+
+	resultRegs := &registerState{} // reset per ABI step 4
+	var resultStackSize int32
+	for _, v := range subprogram.Variables {
+		if !v.IsReturn {
+			continue
+		}
+
+		pieces, ok, err := tryRegisterAssign(v.Type, resultRegs, abi)
+		if err != nil {
+			return fmt.Errorf("computing ABI for return %q: %w", v.Name, err)
+		}
+
+		info := returnInfo{variable: v}
+		if ok {
+			info.pieces = pieces
+		} else {
+			info.onStack = true
+			resultStackSize += align(int32(v.Type.GetByteSize()))
+		}
+		returnVars = append(returnVars, info)
+	}
+
+	// Pass 3: create IR pieces and update variable locations.
+	cfaOffset := abi.stackBase + align(argStackSize)
+
+	containsFloatingPointRegisters := func(pieces []abiPiece) bool {
+		return slices.ContainsFunc(pieces, func(p abiPiece) bool {
+			return !p.isIntReg
+		})
+	}
+	for _, info := range returnVars {
+		if !info.onStack && containsFloatingPointRegisters(info.pieces) {
+			// Skip it, as we don't support partial struct availability yet.
+			continue
+		}
+
+		var pieces []ir.Piece
+		if info.onStack {
+			// Stack-assigned: CFA offset is always available.
+			byteSize := info.variable.Type.GetByteSize()
+			pieces = []ir.Piece{{
+				Size: byteSize,
+				Op:   ir.Cfa{CfaOffset: cfaOffset},
+			}}
+			cfaOffset += align(int32(byteSize))
+		} else {
+			// Register-assigned with all pieces available.
+			pieces = make([]ir.Piece, len(info.pieces))
+			for i, p := range info.pieces {
+				pieces[i] = ir.Piece{
+					Size: p.size,
+					Op:   ir.Register{RegNo: abi.intRegs[p.regNo]},
+				}
+			}
+		}
+
+		// Remove existing locations that overlap with return PCs.
+		locs := make(
+			[]ir.Location, 0, len(info.variable.Locations)+len(returnPCs),
+		)
+		for _, loc := range info.variable.Locations {
+			locs = append(locs, subtractPCsFromLocation(loc, returnPCs)...)
+		}
+
+		// Add ABI-derived locations at each return PC.
+		for _, pc := range returnPCs {
+			locs = append(locs, ir.Location{
+				Range: ir.PCRange{pc, pc + 1}, Pieces: pieces,
+			})
+		}
+
+		// Sort by start PC for efficient lookups.
+		slices.SortFunc(locs, func(a, b ir.Location) int {
+			return cmp.Compare(a.Range[0], b.Range[0])
+		})
+		info.variable.Locations = locs
+	}
+
+	return nil
+}
+
+// subtractPCsFromLocation removes PCs from a location's range, potentially
+// splitting it into multiple non-overlapping ranges.
+func subtractPCsFromLocation(
+	loc ir.Location, pcs []uint64,
+) []ir.Location {
+	if len(pcs) == 0 {
+		return []ir.Location{loc}
+	}
+
+	var result []ir.Location
+	start, end := loc.Range[0], loc.Range[1]
+
+	for _, pc := range pcs {
+		if pc+1 <= start || pc >= end {
+			continue
+		}
+		// Split: add segment before PC.
+		if pc > start {
+			result = append(result, ir.Location{
+				Range:  ir.PCRange{start, pc},
+				Pieces: loc.Pieces,
+			})
+		}
+		start = pc + 1
+	}
+
+	// Add remaining segment after last PC.
+	if start < end {
+		result = append(result, ir.Location{
+			Range:  ir.PCRange{start, end},
+			Pieces: loc.Pieces,
+		})
+	}
+
+	return result
+}
+
+// abiPiece represents a piece of a value in the ABI.
+type abiPiece struct {
+	size  uint32
+	regNo int
+	// isIntReg indicates whether this is an integer register (true) or
+	// floating-point register (false).
+	isIntReg bool
+}
+
+// tryRegisterAssign attempts to register-assign a type per the Go ABI.
+// Returns (pieces, true, nil) on success, (nil, false, nil) if assignment
+// fails per ABI rules, or (nil, false, error) on unexpected conditions.
+// Register assignment is all-or-nothing per value.
+func tryRegisterAssign(
+	t ir.Type, regs *registerState, abi *abiConfig,
+) ([]abiPiece, bool, error) {
+	saved := *regs
+	pieces, ok, err := registerAssign(t, regs, abi)
+	if !ok && err == nil {
+		*regs = saved // backtrack on normal failure
+	}
+	return pieces, ok, err
+}
+
+// registerAssign recursively assigns registers for a type per the Go ABI.
+// Returns pieces and true on success, nil and false if assignment fails per
+// ABI rules, or an error if an unexpected condition is encountered.
+func registerAssign(
+	t ir.Type, regs *registerState, abi *abiConfig,
+) ([]abiPiece, bool, error) {
+	maxIntRegs := abi.maxIntRegs
+	maxFPRegs := abi.maxFPRegs
+
+	switch typ := t.(type) {
+	case *ir.BaseType:
+		// Check if type has Go kind information.
+		kind, ok := typ.GetGoKind()
+		if !ok {
+			// Unexpected: base type with no Go kind.
+			return nil, false, fmt.Errorf(
+				"base type %q has no Go kind", typ.GetName(),
+			)
+		}
+
+		// Handle each kind appropriately.
+		switch kind {
+		case reflect.Bool, reflect.Int, reflect.Uint, reflect.Uintptr,
+			reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			regNo, ok := regs.allocInt(maxIntRegs)
+			if !ok {
+				return nil, false, nil
+			}
+			return []abiPiece{{
+				size:     typ.GetByteSize(),
+				regNo:    regNo,
+				isIntReg: true,
+			}}, true, nil
+
+		case reflect.Float32, reflect.Float64:
+			regNo, ok := regs.allocFP(maxFPRegs)
+			if !ok {
+				return nil, false, nil
+			}
+			return []abiPiece{{
+				size:     typ.GetByteSize(),
+				regNo:    regNo,
+				isIntReg: false,
+			}}, true, nil
+
+		case reflect.Complex64, reflect.Complex128:
+			fpRegs, ok := regs.allocFPN(2, maxFPRegs)
+			if !ok {
+				return nil, false, nil
+			}
+			halfSize := typ.GetByteSize() / 2
+			return []abiPiece{
+				{size: halfSize, regNo: fpRegs[0], isIntReg: false},
+				{size: halfSize, regNo: fpRegs[1], isIntReg: false},
+			}, true, nil
+
+		default:
+			return nil, false, fmt.Errorf(
+				"unsupported base type kind: %s (%v)", typ.GetName(), kind,
+			)
+		}
+
+	case *ir.PointerType, *ir.VoidPointerType, *ir.GoChannelType,
+		*ir.GoSubroutineType, *ir.GoMapType:
+		regNo, ok := regs.allocInt(maxIntRegs)
+		if !ok {
+			return nil, false, nil
+		}
+		return []abiPiece{{
+			size: typ.GetByteSize(), regNo: regNo, isIntReg: true,
+		}}, true, nil
+
+	case *ir.GoStringHeaderType, *ir.GoEmptyInterfaceType,
+		*ir.GoInterfaceType:
+		intRegs, ok := regs.allocIntN(2, maxIntRegs)
+		if !ok {
+			return nil, false, nil
+		}
+		return []abiPiece{
+			{size: 8, regNo: intRegs[0], isIntReg: true},
+			{size: 8, regNo: intRegs[1], isIntReg: true},
+		}, true, nil
+
+	case *ir.GoSliceHeaderType:
+		intRegs, ok := regs.allocIntN(3, maxIntRegs)
+		if !ok {
+			return nil, false, nil
+		}
+		return []abiPiece{
+			{size: 8, regNo: intRegs[0], isIntReg: true},
+			{size: 8, regNo: intRegs[1], isIntReg: true},
+			{size: 8, regNo: intRegs[2], isIntReg: true},
+		}, true, nil
+
+	case *ir.StructureType:
+		var pieces []abiPiece
+		for _, field := range typ.RawFields {
+			fieldPieces, ok, err := registerAssign(field.Type, regs, abi)
+			if err != nil {
+				return nil, false, fmt.Errorf(
+					"struct %s field %s: %w", typ.GetName(), field.Name, err,
+				)
+			}
+			if !ok {
+				return nil, false, nil
+			}
+			pieces = append(pieces, fieldPieces...)
+		}
+		return pieces, true, nil
+
+	case *ir.ArrayType:
+		if !typ.HasCount {
+			return nil, false, fmt.Errorf(
+				"array type %s has no count", typ.GetName(),
+			)
+		}
+		switch typ.Count {
+		case 0:
+			return []abiPiece{}, true, nil
+		case 1:
+			return registerAssign(typ.Element, regs, abi)
+		default:
+			return nil, false, nil
+		}
+
+	case *ir.UnresolvedPointeeType:
+		return nil, false, fmt.Errorf(
+			"unresolved pointee type %s", typ.GetName(),
+		)
+
+	case *ir.EventRootType:
+		return nil, false, fmt.Errorf(
+			"unexpected event root type %s", typ.GetName(),
+		)
+
+	case *ir.GoSliceDataType, *ir.GoStringDataType:
+		return nil, false, fmt.Errorf(
+			"unexpected dynamically-sized type %s", typ.GetName(),
+		)
+
+	case *ir.GoHMapHeaderType, *ir.GoHMapBucketType,
+		*ir.GoSwissMapHeaderType, *ir.GoSwissMapGroupsType:
+		return nil, false, fmt.Errorf(
+			"unexpected internal map type %s", typ.GetName(),
+		)
+
+	default:
+		return nil, false, fmt.Errorf(
+			"unknown type for ABI: %T (%s)", typ, t.GetName(),
+		)
+	}
+}
+
+// registerState tracks available registers during ABI assignment.
+type registerState struct {
+	intReg int
+	fpReg  int
+}
+
+// allocInt allocates one integer register if available.
+func (r *registerState) allocInt(max int) (int, bool) {
+	if r.intReg >= max {
+		return 0, false
+	}
+	reg := r.intReg
+	r.intReg++
+	return reg, true
+}
+
+// allocIntN allocates N consecutive integer registers if available.
+func (r *registerState) allocIntN(n, max int) ([]int, bool) {
+	if r.intReg+n-1 >= max {
+		return nil, false
+	}
+	regs := make([]int, n)
+	for i := 0; i < n; i++ {
+		regs[i] = r.intReg + i
+	}
+	r.intReg += n
+	return regs, true
+}
+
+// allocFP allocates one floating-point register if available.
+func (r *registerState) allocFP(max int) (int, bool) {
+	if r.fpReg >= max {
+		return 0, false
+	}
+	reg := r.fpReg
+	r.fpReg++
+	return reg, true
+}
+
+// allocFPN allocates N consecutive floating-point registers if available.
+func (r *registerState) allocFPN(n, max int) ([]int, bool) {
+	if r.fpReg+n-1 >= max {
+		return nil, false
+	}
+	regs := make([]int, n)
+	for i := 0; i < n; i++ {
+		regs[i] = r.fpReg + i
+	}
+	r.fpReg += n
+	return regs, true
+}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1257 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd08a0a", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd0a46a", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1258 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xd08a45", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xd0a4a5", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1184 EventRootType Probe[main.testAny]
+          Type: 1191 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd04dea", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1185 EventRootType Probe[main.testAny]Return
+          Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xd04e25", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1187 EventRootType Probe[main.testAnyPtr]
+          Type: 1194 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xd04e8a", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1188 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xd04ebd", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1135 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1131 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1133 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1196 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd05600", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1132 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1134 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1153 EventRootType Probe[main.testBigStruct]
+          Type: 1160 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd03740", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1154 EventRootType Probe[main.testBigStruct]Return
+          Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xd0375e", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1120 EventRootType Probe[main.testBoolArray]
+          Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd02e60", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1117 EventRootType Probe[main.testByteArray]
+          Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02e00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1216 EventRootType Probe[main.testChannel]
+          Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1214 EventRootType Probe[main.testCombinedByte]
+          Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1224 EventRootType Probe[main.testCycle]
+          Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1159 EventRootType Probe[main.testDeepMap1]
+          Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xd03b20", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1160 EventRootType Probe[main.testDeepMap7]
+          Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xd03b40", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1155 EventRootType Probe[main.testDeepPtr1]
+          Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xd03800", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1156 EventRootType Probe[main.testDeepPtr7]
+          Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xd03820", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1157 EventRootType Probe[main.testDeepSlice1]
+          Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xd039a0", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1158 EventRootType Probe[main.testDeepSlice7]
+          Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xd039c0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1246 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd085a0", Frameless: true}]
+          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1249 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd08600", Frameless: true}]
+          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd08b40", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd08f80", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd0a9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1275 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd08fa0", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd0aa00", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1186 EventRootType Probe[main.testError]
+          Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04e60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1168 EventRootType Probe[main.testEsotericHeap]
+          Type: 1175 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0436a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1169 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xd043ac", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1166 EventRootType Probe[main.testEsotericStack]
+          Type: 1173 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0424e", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1167 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xd042db", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1178 EventRootType Probe[main.testFrameless]
+          Type: 1185 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd04ac0", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1179 EventRootType Probe[main.testFrameless]Return
+          Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xd04ac5", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1180 EventRootType Probe[main.testFramelessArray]
+          Type: 1187 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd04ae4", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1181 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xd04b1d", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1182 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xd04ae8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1170 EventRootType Probe[main.testInlinedBA]
+          Type: 1177 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd047aa", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1171 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xd0480e", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1172 EventRootType Probe[main.testInlinedBB]
+          Type: 1179 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd0484e", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1173 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xd048de", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1174 EventRootType Probe[main.testInlinedBBA]
+          Type: 1181 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd0492a", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1175 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xd0496b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1279 EventRootType Probe[main.testInlinedBBB]
+          Type: 1334 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1176 EventRootType Probe[main.testInlinedBC]
+          Type: 1183 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd049ae", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1177 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xd04a9e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testInlinedBCA]
+          Type: 1335 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1281 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testInlinedBCB]
+          Type: 1337 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1283 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testInlinedPrint]
+          Type: 1331 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0xd0492f"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1278 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testInlinedSq]
+          Type: 1339 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1285 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1123 EventRootType Probe[main.testInt16Array]
+          Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02ec0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1124 EventRootType Probe[main.testInt32Array]
+          Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02ee0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1125 EventRootType Probe[main.testInt64Array]
+          Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1122 EventRootType Probe[main.testInt8Array]
+          Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02ea0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1121 EventRootType Probe[main.testIntArray]
+          Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02e80", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1183 EventRootType Probe[main.testInterface]
+          Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd04dc0", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1218 EventRootType Probe[main.testLinkedList]
+          Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07500", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1163 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03bba", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1164 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03c6d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1165 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xd03d34", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xd09253", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xd09462", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1194 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd055c0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1201 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd05680", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xd057c0", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xd05800", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xd057e0", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1198 EventRootType Probe[main.testMapIntToInt]
+          Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd05640", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd057a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1209 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd05780", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1199 EventRootType Probe[main.testMapMassive]
+          Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1200 EventRootType Probe[main.testMapMassive]
+          Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd05660", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1208 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd05760", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1207 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd05740", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1192 EventRootType Probe[main.testMapStringToInt]
+          Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd05580", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1193 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd055a0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1191 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd05560", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1202 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd056a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd05700", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd05720", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd056c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd056e0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd08b00", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1321 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xd09936", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd08b00", Frameless: true}]
+          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1241 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd0812e", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1242 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd081be", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd0808a", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1240 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd080f2", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1223 EventRootType Probe[main.testNilPointer]
+          Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd08680", Frameless: true}]
+          Type: 1308 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd08620", Frameless: true}]
+          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd08660", Frameless: true}]
+          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd08ae0", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1219 EventRootType Probe[main.testPointerLoop]
+          Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1197 EventRootType Probe[main.testPointerToMap]
+          Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd05620", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1217 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd074e0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1235 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xd07eca", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xd07fae", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1236 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xd07f27", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0xd08064"
+              Frameless: false
+            - PC: "0xd0809f"
+              Frameless: false
+            - PC: "0xd08162"
+              Frameless: false
+            - PC: "0xd0816c"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1233 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xd07e4a", Frameless: false}]
+          Type: 1240 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xd07e4e", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1234 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1241 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xd07e88"
+            - PC: "0xd07eb8"
               Frameless: false
-            - PC: "0xd07e92"
+            - PC: "0xd07ef3"
               Frameless: false
+            - PC: "0xd07f27"
+              Frameless: false
+            - PC: "0xd07f59"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xd08966", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xd08766", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,12 +1754,12 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1231 EventRootType Probe[main.testReturnsError]
+          Type: 1238 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07dea", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1232 EventRootType Probe[main.testReturnsError]Return
+          Type: 1239 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07e1a"
               Frameless: false
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1225 EventRootType Probe[main.testReturnsInt]
+          Type: 1232 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd07bea", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1226 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xd07c34", Frameless: false}]
+          Type: 1233 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xd07c3b", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1229 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1236 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07d0e", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1230 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xd07db1", Frameless: false}]
+          Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xd07dc4", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1227 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1234 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07c6a", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1228 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xd07cd3", Frameless: false}]
+          Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xd07cdb", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1237 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xd07f6e", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xd081ae", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1238 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1245 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xd08008"
+            - PC: "0xd08291"
               Frameless: false
-            - PC: "0xd08012"
+            - PC: "0xd0829b"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xd08813", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1118 EventRootType Probe[main.testRuneArray]
+          Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd02e20", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1139 EventRootType Probe[main.testSingleBool]
+          Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd03440", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1137 EventRootType Probe[main.testSingleByte]
+          Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd03400", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1150 EventRootType Probe[main.testSingleFloat32]
+          Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd035a0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1151 EventRootType Probe[main.testSingleFloat64]
+          Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd035c0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1140 EventRootType Probe[main.testSingleInt]
+          Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd03460", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1142 EventRootType Probe[main.testSingleInt16]
+          Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd034a0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1143 EventRootType Probe[main.testSingleInt32]
+          Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd034c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1144 EventRootType Probe[main.testSingleInt64]
+          Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd034e0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1141 EventRootType Probe[main.testSingleInt8]
+          Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd03480", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1138 EventRootType Probe[main.testSingleRune]
+          Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd03420", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1259 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd08a60", Frameless: true}]
+          Type: 1314 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd0a4c0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1145 EventRootType Probe[main.testSingleUint]
+          Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03500", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1147 EventRootType Probe[main.testSingleUint16]
+          Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd03540", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1148 EventRootType Probe[main.testSingleUint32]
+          Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd03560", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1149 EventRootType Probe[main.testSingleUint64]
+          Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd03580", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1146 EventRootType Probe[main.testSingleUint8]
+          Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03520", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xd086c0", Frameless: true}]
+          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1247 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd085c0", Frameless: true}]
+          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1195 EventRootType Probe[main.testSmallMap]
+          Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd055e0", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1243 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xd081ee", Frameless: false}]
+          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1244 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0827f", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1119 EventRootType Probe[main.testStringArray]
+          Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd02e40", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1222 EventRootType Probe[main.testStringPointer]
+          Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd07660", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1251 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd08640", Frameless: true}]
+          Type: 1306 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1161 EventRootType Probe[main.testStringType1]
+          Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xd03b60", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1162 EventRootType Probe[main.testStringType2]
+          Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xd03b80", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd08e00", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd0a860", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xd08e22", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd0a882", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd085e0", Frameless: true}]
+          Type: 1303 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1189 EventRootType Probe[main.testStructWithAny]
+          Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xd04ee0", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xd08cc0", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xd0a720", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xd08cde", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xd0a73e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1269 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xd08ca0", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xd0a700", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1190 EventRootType Probe[main.testStructWithMap]
+          Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd05540", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd08a80", Frameless: true}]
+          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd0a4e0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1261 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd08aa0", Frameless: true}]
+          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd0a500", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1262 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd08abe", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0a51e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1263 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd08ac0", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd0a520", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1152 EventRootType Probe[main.testTypeAlias]
+          Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd035e0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1128 EventRootType Probe[main.testUint16Array]
+          Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1129 EventRootType Probe[main.testUint32Array]
+          Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1130 EventRootType Probe[main.testUint64Array]
+          Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1127 EventRootType Probe[main.testUint8Array]
+          Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1126 EventRootType Probe[main.testUintArray]
+          Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1221 EventRootType Probe[main.testUintPointer]
+          Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1245 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd08580", Frameless: true}]
+          Type: 1300 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1267 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd08b20", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1220 EventRootType Probe[main.testUnsafePointer]
+          Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1136 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd086a0", Frameless: true}]
+          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1255 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd086a0", Frameless: true}]
+          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3737,32 +4205,39 @@ Subprograms:
           IsReturn: false
     - ID: 94
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd07be0..0xd07c4c]
+      OutOfLinePCRanges: [0xd07be0..0xd07c52]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07be0..0xd07bfe
+            - Range: 0xd07be0..0xd07bf2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07bfe..0xd07c4c
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07be0..0xd07c34
+            - Range: 0xd07be0..0xd07c3b
               Pieces: []
-            - Range: 0xd07c34..0xd07c35
+            - Range: 0xd07c3b..0xd07c3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c35..0xd07c4c
+            - Range: 0xd07c3c..0xd07c52
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd07bf2..0xd07c05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07c05..0xd07c52
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd07c60..0xd07cef]
+      OutOfLinePCRanges: [0xd07c60..0xd07cf5]
       InlinePCRanges: []
       Variables:
         - Name: i
@@ -3770,64 +4245,73 @@ Subprograms:
           Locations:
             - Range: 0xd07c60..0xd07c7a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07c7a..0xd07cf5
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07c60..0xd07cd3
+            - Range: 0xd07c60..0xd07cdb
               Pieces: []
-            - Range: 0xd07cd3..0xd07cd4
+            - Range: 0xd07cdb..0xd07cdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07cd4..0xd07cef
+            - Range: 0xd07cdc..0xd07cf5
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07c7f..0xd07c98
+            - Range: 0xd07c7f..0xd07c9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c98..0xd07cef
+            - Range: 0xd07c9c..0xd07cf5
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd07d00..0xd07dcf]
+      OutOfLinePCRanges: [0xd07d00..0xd07dde]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d00..0xd07d54
+            - Range: 0xd07d00..0xd07d62
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07d54..0xd07dcf
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d00..0xd07db1
+            - Range: 0xd07d00..0xd07dc4
               Pieces: []
-            - Range: 0xd07db1..0xd07db2
+            - Range: 0xd07dc4..0xd07dc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07db2..0xd07dcf
+            - Range: 0xd07dc5..0xd07dde
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd07d00..0xd07dcf, Pieces: []}]
+          Locations: [{Range: 0xd07d00..0xd07dde, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd07d16..0xd07d67
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd07d67..0xd07dde
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd07d1f..0xd07d54
+            - Range: 0xd07d2f..0xd07d67
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd07d54..0xd07dcf
+            - Range: 0xd07d67..0xd07dde
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
@@ -3868,19 +4352,37 @@ Subprograms:
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd07e40..0xd07ebc]
+      OutOfLinePCRanges: [0xd07e40..0xd07f86]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e40..0xd07e63
+            - Range: 0xd07e40..0xd07e91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e63..0xd07e68
+            - Range: 0xd07e91..0xd07e94
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07ed7..0xd07ee5
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07f00..0xd07f05
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07f34..0xd07f39
               Pieces:
                 - Size: 8
                   Op: null
@@ -3891,88 +4393,30 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07e40..0xd07e68
+            - Range: 0xd07e40..0xd07e8f
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e40..0xd07e88
+            - Range: 0xd07e40..0xd07eb8
               Pieces: []
-            - Range: 0xd07e88..0xd07e89
+            - Range: 0xd07eb8..0xd07eb9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e89..0xd07e92
+            - Range: 0xd07eb9..0xd07ef3
               Pieces: []
-            - Range: 0xd07e92..0xd07e93
+            - Range: 0xd07ef3..0xd07ef4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e93..0xd07ebc
-              Pieces: []
-          IsParameter: true
-          IsReturn: true
-        - Name: ~r1
-          Type: 18 GoInterfaceType error
-          Locations:
-            - Range: 0xd07e40..0xd07e88
-              Pieces: []
-            - Range: 0xd07e88..0xd07e89
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07e89..0xd07e92
-              Pieces: []
-            - Range: 0xd07e92..0xd07e93
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07e93..0xd07ebc
-              Pieces: []
-          IsParameter: true
-          IsReturn: true
-    - ID: 99
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd07ec0..0xd07f4b]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xd07ec0..0xd07f15
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f15..0xd07f18
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xd07f18..0xd07f4b
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
-        - Name: ~r0
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xd07ec0..0xd07f27
+            - Range: 0xd07ef4..0xd07f27
               Pieces: []
             - Range: 0xd07f27..0xd07f28
               Pieces:
@@ -3980,259 +4424,1322 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f28..0xd07f4b
+            - Range: 0xd07f28..0xd07f59
               Pieces: []
-          IsParameter: true
-          IsReturn: true
-    - ID: 100
-      Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd07f60..0xd08077]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 152 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xd07f60..0xd07f98
+            - Range: 0xd07f59..0xd07f5a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f98..0xd07ff9
+            - Range: 0xd07f5a..0xd07f86
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 GoInterfaceType error
+          Locations:
+            - Range: 0xd07e40..0xd07eb8
+              Pieces: []
+            - Range: 0xd07eb8..0xd07eb9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07eb9..0xd07ef3
+              Pieces: []
+            - Range: 0xd07ef3..0xd07ef4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07ef4..0xd07f27
+              Pieces: []
+            - Range: 0xd07f27..0xd07f28
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07f28..0xd07f59
+              Pieces: []
+            - Range: 0xd07f59..0xd07f5a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07f5a..0xd07f86
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: val
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd07ed7..0xd07ee0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 99
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0xd07fa0..0xd08194]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd07fa0..0xd07fff
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07fff..0xd08002
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xd08002..0xd08194
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd07fa0..0xd08064
+              Pieces: []
+            - Range: 0xd08064..0xd08065
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd08065..0xd0809f
+              Pieces: []
+            - Range: 0xd0809f..0xd080a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd080a0..0xd08162
+              Pieces: []
+            - Range: 0xd08162..0xd08163
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd08163..0xd0816c
+              Pieces: []
+            - Range: 0xd0816c..0xd0816d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd0816d..0xd08194
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: val
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0808a..0xd08090
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 93 PointerType *int
+          Locations:
+            - Range: 0xd08045..0xd08064
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 100
+      Name: main.testReturnsInterface
+      OutOfLinePCRanges: [0xd081a0..0xd08305]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 152 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd081a0..0xd081e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd081e0..0xd08245
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd07ff9..0xd08018
+            - Range: 0xd08245..0xd082a1
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd08018..0xd08038
+            - Range: 0xd082a1..0xd082c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08038..0xd0803f
+            - Range: 0xd082c1..0xd082c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0803f..0xd08077
+            - Range: 0xd082c8..0xd08305
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd07f60..0xd08008
+            - Range: 0xd081a0..0xd08291
               Pieces: []
-            - Range: 0xd08008..0xd08009
+            - Range: 0xd08291..0xd08292
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08009..0xd08012
+            - Range: 0xd08292..0xd0829b
               Pieces: []
-            - Range: 0xd08012..0xd08013
+            - Range: 0xd0829b..0xd0829c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08013..0xd08077
+            - Range: 0xd0829c..0xd08305
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd07f60..0xd07f98
+            - Range: 0xd081a0..0xd081e0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f98..0xd07fe9
+            - Range: 0xd081e0..0xd08235
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07fe9..0xd07ff9
+            - Range: 0xd08235..0xd08245
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -56}
+                  Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd07ff9..0xd0800e
+            - Range: 0xd08245..0xd08297
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -56}
+                  Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd0800e..0xd08010
+            - Range: 0xd08297..0xd08299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08010..0xd08012
+            - Range: 0xd08299..0xd0829b
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd08012..0xd08077
+            - Range: 0xd0829b..0xd08305
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd08080..0xd0810f]
+      OutOfLinePCRanges: [0xd08320..0xd083af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08080..0xd080bc
+            - Range: 0xd08320..0xd08331
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd080bc..0xd0810f
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08080..0xd080f2
+            - Range: 0xd08320..0xd08395
               Pieces: []
-            - Range: 0xd080f2..0xd080f3
+            - Range: 0xd08395..0xd08396
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd080f3..0xd0810f
+            - Range: 0xd08396..0xd083af
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd08120..0xd081d8]
+      OutOfLinePCRanges: [0xd083c0..0xd08489]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08120..0xd08166
+            - Range: 0xd083c0..0xd08413
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08166..0xd081d8
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08120..0xd081be
+            - Range: 0xd083c0..0xd0846f
               Pieces: []
-            - Range: 0xd081be..0xd081bf
+            - Range: 0xd0846f..0xd08470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd081bf..0xd081d8
+            - Range: 0xd08470..0xd08489
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08120..0xd081be
+            - Range: 0xd083c0..0xd0846f
               Pieces: []
-            - Range: 0xd081be..0xd081bf
+            - Range: 0xd0846f..0xd08470
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd081bf..0xd081d8
+            - Range: 0xd08470..0xd08489
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd081e0..0xd08299]
+      OutOfLinePCRanges: [0xd084a0..0xd08568]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd081e0..0xd08225
+            - Range: 0xd084a0..0xd084e5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08225..0xd08299
+            - Range: 0xd084e5..0xd08568
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd081e0..0xd0827f
+            - Range: 0xd084a0..0xd0854e
               Pieces: []
-            - Range: 0xd0827f..0xd08280
+            - Range: 0xd0854e..0xd0854f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08280..0xd08299
+            - Range: 0xd0854f..0xd08568
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd081e0..0xd0827f
+            - Range: 0xd084a0..0xd0854e
               Pieces: []
-            - Range: 0xd0827f..0xd08280
+            - Range: 0xd0854e..0xd0854f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08280..0xd08299
+            - Range: 0xd0854f..0xd08568
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd081e0..0xd0827f
+            - Range: 0xd084a0..0xd0854e
               Pieces: []
-            - Range: 0xd0827f..0xd08280
+            - Range: 0xd0854e..0xd0854f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd08280..0xd08299
+            - Range: 0xd0854f..0xd08568
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd08580..0xd08581]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0xd08580..0xd085fe]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 245 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 14 BaseType int8
           Locations:
-            - Range: 0xd08580..0xd08581
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 97 BaseType int16
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 13 BaseType int64
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType uint16
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xd08580..0xd085f1
+              Pieces: []
+            - Range: 0xd085f1..0xd085f2
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xd085f2..0xd085fe
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd085a0..0xd085a1]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0xd08600..0xd086f5]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 245 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd085a0..0xd085a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0xd08600..0xd086e5
+              Pieces: []
+            - Range: 0xd086e5..0xd086e6
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xd086e6..0xd086f5
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0xd08600..0xd086e5
+              Pieces: []
+            - Range: 0xd086e5..0xd086e6
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xd086e6..0xd086f5
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd085c0..0xd085c1]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xd08700..0xd08773]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 89 BaseType complex64
+          Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 90 BaseType complex128
+          Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0xd08780..0xd08825]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd08780..0xd08813
+              Pieces: []
+            - Range: 0xd08813..0xd08814
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+            - Range: 0xd08814..0xd08825
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xd08840..0xd088ba]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0xd08840..0xd088ad
+              Pieces: []
+            - Range: 0xd088ad..0xd088ae
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xd088ae..0xd088ba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xd088c0..0xd08918]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 247 ArrayType [1]int
+          Locations:
+            - Range: 0xd088c0..0xd0890b
+              Pieces: []
+            - Range: 0xd0890b..0xd0890c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0890c..0xd08918
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xd08920..0xd08973]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0xd08920..0xd08966
+              Pieces: []
+            - Range: 0xd08966..0xd08967
+              Pieces: []
+            - Range: 0xd08967..0xd08973
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xd08980..0xd089e7]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 StructureType main.mixedStruct
+          Locations: [{Range: 0xd08980..0xd089e7, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0xd08a00..0xd08a9a]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd08a00..0xd08a8a
+              Pieces: []
+            - Range: 0xd08a8a..0xd08a8b
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xd08a8b..0xd08a9a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xd08aa0..0xd08b45]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 StructureType main.wideStruct
+          Locations:
+            - Range: 0xd08aa0..0xd08b34
+              Pieces: []
+            - Range: 0xd08b34..0xd08b35
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xd08b35..0xd08b45
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xd08b60..0xd08bd9]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08b60..0xd08bcc
+              Pieces: []
+            - Range: 0xd08bcc..0xd08bcd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd08bcd..0xd08bd9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd08b60..0xd08bcc
+              Pieces: []
+            - Range: 0xd08bcc..0xd08bcd
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd08bcd..0xd08bd9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd08b60..0xd08bcc
+              Pieces: []
+            - Range: 0xd08bcc..0xd08bcd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd08bcd..0xd08bd9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xd08be0..0xd08c5a]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0xd08be0..0xd08c4d
+              Pieces: []
+            - Range: 0xd08c4d..0xd08c4e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xd08c4e..0xd08c5a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xd08c60..0xd08cbb]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08c60..0xd08cbb, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xd08cc0..0xd08d27]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 16 BaseType float32
+          Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0xd08d40..0xd08d9d]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xd08d40..0xd08d90
+              Pieces: []
+            - Range: 0xd08d90..0xd08d91
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd08d91..0xd08d9d
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0xd08d40..0xd08d90
+              Pieces: []
+            - Range: 0xd08d90..0xd08d91
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd08d91..0xd08d9d
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0xd08da0..0xd08f05]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd08da0..0xd08f05
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd08da0..0xd08ef3
+              Pieces: []
+            - Range: 0xd08ef3..0xd08ef4
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+            - Range: 0xd08ef4..0xd08f05
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0xd08f20..0xd08ff2]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0xd08f20..0xd08ff2
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0xd08f20..0xd08fe2
+              Pieces: []
+            - Range: 0xd08fe2..0xd08fe3
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xd08fe3..0xd08ff2
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0xd09000..0xd0923a]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd09000..0xd0923a
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd09000..0xd0923a
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd09000..0xd0922a
+              Pieces: []
+            - Range: 0xd0922a..0xd0922b
+              Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
+            - Range: 0xd0922b..0xd0923a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0xd09240..0xd094cf]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092b0
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xd092b0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09240..0xd092f0
+              Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
+            - Range: 0xd092f0..0xd094cf
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0xd09240..0xd09462
+              Pieces: []
+            - Range: 0xd09462..0xd09463
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xd09463..0xd094cf
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0xd094e0..0xd097ac]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd09542
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xd09542..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd094e0..0xd0958b
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xd0958b..0xd097ac
+              Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd094e0..0xd097ac
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0xd094e0..0xd0972b
+              Pieces: []
+            - Range: 0xd0972b..0xd0972c
+              Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
+            - Range: 0xd0972c..0xd097ac
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0xd097c0..0xd0984c]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 156 ArrayType [5]int
+          Locations:
+            - Range: 0xd097c0..0xd0984c
+              Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd097c0..0xd0983c
+              Pieces: []
+            - Range: 0xd0983c..0xd0983d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd0983d..0xd0984c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd097c0..0xd0983c
+              Pieces: []
+            - Range: 0xd0983c..0xd0983d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd0983d..0xd0984c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd097c0..0xd0983c
+              Pieces: []
+            - Range: 0xd0983c..0xd0983d
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd0983d..0xd0984c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0xd09860..0xd0994a]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0xd09860..0xd0994a
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0xd09860..0xd0994a
+              Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09860..0xd09936
+              Pieces: []
+            - Range: 0xd09936..0xd09937
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd09937..0xd0994a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0xd09860..0xd09936
+              Pieces: []
+            - Range: 0xd09936..0xd09937
+              Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
+            - Range: 0xd09937..0xd0994a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0xd09960..0xd09a2b]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0xd09960..0xd09a2b
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09960..0xd09a1a
+              Pieces: []
+            - Range: 0xd09a1a..0xd09a1b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd09a1b..0xd09a2b
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0xd09960..0xd09a1a
+              Pieces: []
+            - Range: 0xd09a1a..0xd09a1b
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xd09a1b..0xd09a2b
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd099e6..0xd09a2b
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0xd09a40..0xd09ae6]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 248 ArrayType [0]int
+          Locations: [{Range: 0xd09a40..0xd09ae6, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09a40..0xd09a85
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd09a85..0xd09aa7
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xd09aa7..0xd09ac2
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xd09ac2..0xd09ae6
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd09a40..0xd09acc
+              Pieces: []
+            - Range: 0xd09acc..0xd09acd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd09acd..0xd09ae6
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0xd09a40..0xd09acc
+              Pieces: []
+            - Range: 0xd09acc..0xd09acd
+              Pieces: []
+            - Range: 0xd09acd..0xd09ae6
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd09fe0..0xd09fe1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 246 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd085c0..0xd085c1
+            - Range: 0xd09fe0..0xd09fe1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4242,15 +5749,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd0a000..0xd0a001]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd0a000..0xd0a001
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xd0a020..0xd0a021]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xd0a020..0xd0a021
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd085e0..0xd085e1]
+      OutOfLinePCRanges: [0xd0a040..0xd0a041]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd085e0..0xd085e1
+            - Range: 0xd0a040..0xd0a041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4263,19 +5806,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd085e0..0xd085e1
+            - Range: 0xd0a040..0xd0a041
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd08600..0xd08601]
+      OutOfLinePCRanges: [0xd0a060..0xd0a061]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd08600..0xd08601
+            - Range: 0xd0a060..0xd0a061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4288,19 +5831,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08600..0xd08601
+            - Range: 0xd0a060..0xd0a061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xd08620..0xd08621]
+      OutOfLinePCRanges: [0xd0a080..0xd0a081]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xd08620..0xd08621
+            - Range: 0xd0a080..0xd0a081
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4313,19 +5856,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08620..0xd08621
+            - Range: 0xd0a080..0xd0a081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xd08640..0xd08641]
+      OutOfLinePCRanges: [0xd0a0a0..0xd0a0a1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0xd08640..0xd08641
+            - Range: 0xd0a0a0..0xd0a0a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4335,22 +5878,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xd08660..0xd08661]
+      OutOfLinePCRanges: [0xd0a0c0..0xd0a0c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd08660..0xd08661
+            - Range: 0xd0a0c0..0xd0a0c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 252 GoSliceHeaderType []bool
+          Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd08660..0xd08661
+            - Range: 0xd0a0c0..0xd0a0c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -4363,19 +5906,19 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd08660..0xd08661
+            - Range: 0xd0a0c0..0xd0a0c1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd08680..0xd08681]
+      OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []uint16
+          Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd08680..0xd08681
+            - Range: 0xd0a0e0..0xd0a0e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4385,15 +5928,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd086a0..0xd086a1]
+      OutOfLinePCRanges: [0xd0a100..0xd0a101]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 245 GoSliceHeaderType []uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd086a0..0xd086a1
+            - Range: 0xd0a100..0xd0a101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4403,15 +5946,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xd086c0..0xd086c1]
+      OutOfLinePCRanges: [0xd0a120..0xd0a121]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 254 GoSliceHeaderType []struct {}
+          Type: 261 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xd086c0..0xd086c1
+            - Range: 0xd0a120..0xd0a121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4421,35 +5964,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0xd08a00..0xd08a52]
+      OutOfLinePCRanges: [0xd0a460..0xd0a4b2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a00..0xd08a45
+            - Range: 0xd0a460..0xd0a4a5
               Pieces: []
-            - Range: 0xd08a45..0xd08a46
+            - Range: 0xd0a4a5..0xd0a4a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08a46..0xd08a52
+            - Range: 0xd0a4a6..0xd0a4b2
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd08a60..0xd08a61]
+      OutOfLinePCRanges: [0xd0a4c0..0xd0a4c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a60..0xd08a61
+            - Range: 0xd0a4c0..0xd0a4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4457,15 +6000,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd08a80..0xd08a81]
+      OutOfLinePCRanges: [0xd0a4e0..0xd0a4e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a80..0xd08a81
+            - Range: 0xd0a4e0..0xd0a4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4476,7 +6019,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a80..0xd08a81
+            - Range: 0xd0a4e0..0xd0a4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4487,7 +6030,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a80..0xd08a81
+            - Range: 0xd0a4e0..0xd0a4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4495,15 +6038,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd08aa0..0xd08abf]
+      OutOfLinePCRanges: [0xd0a500..0xd0a51f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 256 StructureType main.threeStringStruct
+          Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd08aa0..0xd08abf
+            - Range: 0xd0a500..0xd0a51f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4519,39 +6062,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd08ac0..0xd08ac1]
+      OutOfLinePCRanges: [0xd0a520..0xd0a521]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 257 PointerType *main.threeStringStruct
+          Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd08ac0..0xd08ac1
+            - Range: 0xd0a520..0xd0a521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd08ae0..0xd08ae1]
+      OutOfLinePCRanges: [0xd0a540..0xd0a541]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 258 PointerType *main.oneStringStruct
+          Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd08ae0..0xd08ae1
+            - Range: 0xd0a540..0xd0a541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd08b00..0xd08b01]
+      OutOfLinePCRanges: [0xd0a560..0xd0a561]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08b00..0xd08b01
+            - Range: 0xd0a560..0xd0a561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4559,15 +6102,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd08b20..0xd08b21]
+      OutOfLinePCRanges: [0xd0a580..0xd0a581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08b20..0xd08b21
+            - Range: 0xd0a580..0xd0a581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4575,15 +6118,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd08b40..0xd08b41]
+      OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08b40..0xd08b41
+            - Range: 0xd0a5a0..0xd0a5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4591,27 +6134,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd08ca0..0xd08ca1]
+      OutOfLinePCRanges: [0xd0a700..0xd0a701]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 260 StructureType main.structWithCyclicSlices
+          Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd08ca0..0xd08ca1
+            - Range: 0xd0a700..0xd0a701
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd08cc0..0xd08cdf]
+      OutOfLinePCRanges: [0xd0a720..0xd0a73f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 273 StructureType main.structWithCyclicMaps
+          Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd08cc0..0xd08cdf
+            - Range: 0xd0a720..0xd0a73f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4627,15 +6170,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd08e00..0xd08e23]
+      OutOfLinePCRanges: [0xd0a860..0xd0a883]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 304 StructureType main.aStruct
+          Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0xd08e00..0xd08e23
+            - Range: 0xd0a860..0xd0a883
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4653,29 +6196,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd08f80..0xd08f81]
+      OutOfLinePCRanges: [0xd0a9e0..0xd0a9e1]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 305 StructureType main.emptyStruct
-          Locations: [{Range: 0xd08f80..0xd08f81, Pieces: []}]
+          Type: 312 StructureType main.emptyStruct
+          Locations: [{Range: 0xd0a9e0..0xd0a9e1, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd08fa0..0xd08fa1]
+      OutOfLinePCRanges: [0xd0aa00..0xd0aa01]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 306 PointerType *main.emptyStruct
+          Type: 313 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd08fa0..0xd08fa1
+            - Range: 0xd0aa00..0xd0aa01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04600..0xd04662]
       InlinePCRanges:
@@ -4705,28 +6248,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd048a6..0xd048de]
           RootRanges: [0xd04840..0xd04905]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd049b3..0xd049f1]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04a66..0xd04a9e]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4740,7 +6283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4765,20 +6308,20 @@ Types:
       ByteSize: 8
       Pointee: 133 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1059
+      ID: 1066
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1060 PointerType *main.deepSlice3
+      Pointee: 1067 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1078
+      ID: 1085
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1079 PointerType *main.deepSlice8
+      Pointee: 1086 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1084
+      ID: 1091
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1085 PointerType *main.deepSlice9
+      Pointee: 1092 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 148
       Name: '**main.stringType2'
@@ -4786,7 +6329,7 @@ Types:
       GoKind: 22
       Pointee: 149 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1055
+      ID: 1062
       Name: '**main.t'
       ByteSize: 8
       Pointee: 243 PointerType *main.t
@@ -4798,115 +6341,115 @@ Types:
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 323 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1063
+      ID: 1070
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1062 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1069 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1082
+      ID: 1089
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1081 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1088 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1087 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1094 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 314
+      ID: 321
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*string.array
+      Pointee: 320 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 383
+      ID: 390
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 382 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 389 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 272
+      ID: 279
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 381
+      ID: 388
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 380 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 387 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 270
+      ID: 277
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 378 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 385 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 268
+      ID: 275
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 377
+      ID: 384
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 376 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 383 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 266
+      ID: 273
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 375
+      ID: 382
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 374 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 381 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 361
+      ID: 368
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType [][]uint.array
+      Pointee: 367 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 367
+      ID: 374
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 366 GoSliceDataType []bool.array
+      Pointee: 373 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 845 GoSliceDataType []float64.array
+      Pointee: 852 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []interface {}.array
+      Pointee: 1097 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 264
+      ID: 271
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 261 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 373
+      ID: 380
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 372 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 379 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 397
+      ID: 404
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 396 GoSliceDataType []main.structWithMap.array
+      Pointee: 403 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 363
+      ID: 370
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 362 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 369 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -4915,101 +6458,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 365
+      ID: 372
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []string.array
+      Pointee: 371 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 371
+      ID: 378
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 370 GoSliceDataType []struct {}.array
+      Pointee: 377 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 247
+      ID: 254
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 245 GoSliceHeaderType []uint
+      Pointee: 252 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 359
+      ID: 366
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 358 GoSliceDataType []uint.array
+      Pointee: 365 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 369
+      ID: 376
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 368 GoSliceDataType []uint16.array
+      Pointee: 375 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 310
+      ID: 317
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 309 GoSliceDataType []uint8.array
+      Pointee: 316 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 312
+      ID: 319
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 311 GoSliceDataType []uintptr.array
+      Pointee: 318 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.849408e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 979 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858496
       GoKind: 22
-      Pointee: 624 GoSliceHeaderType archive/tar.headerError
+      Pointee: 631 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 626
+      ID: 633
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 625 GoSliceDataType archive/tar.headerError.array
+      Pointee: 632 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.253376e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 919 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858688
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 867 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858784
       GoKind: 22
-      Pointee: 862 StructureType archive/zip.dirWriter
+      Pointee: 869 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.773696e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 966 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.016896e+06
       GoKind: 22
-      Pointee: 888 StructureType archive/zip.nopCloser
+      Pointee: 895 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.017152e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 897 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -5043,30 +6586,30 @@ Types:
       ByteSize: 8
       Pointee: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1067
+      ID: 1074
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1113
+      ID: 1120
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1114 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1121 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 231
       Name: '*bucket<int,struct {}>'
@@ -5088,10 +6631,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*bucket<string,int>'
@@ -5108,35 +6651,35 @@ Types:
       ByteSize: 8
       Pointee: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: PointerType
-      ID: 277
+      ID: 284
       Name: '*bucket<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      Pointee: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 282
+      ID: 289
       Name: '*bucket<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 287
+      ID: 294
       Name: '*bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 292
+      ID: 299
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 297
+      ID: 304
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 302
+      ID: 309
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 236
       Name: '*bucket<struct {},struct {}>'
@@ -5153,393 +6696,393 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.029888e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType bufio.Reader
+      Pointee: 943 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.815136e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType bufio.Writer
+      Pointee: 968 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.122848e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1015 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 536
+      ID: 543
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841120
       GoKind: 22
-      Pointee: 431 BaseType compress/flate.CorruptInputError
+      Pointee: 438 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841216
       GoKind: 22
-      Pointee: 432 GoStringHeaderType compress/flate.InternalError
+      Pointee: 439 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 433 GoStringDataType compress/flate.InternalError.str
+      Pointee: 440 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243616e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 917 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 863 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.60032e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 939 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 22
-      Pointee: 768 StructureType context.deadlineExceededError
+      Pointee: 775 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 616
+      ID: 623
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853408
       GoKind: 22
-      Pointee: 445 BaseType crypto/aes.KeySizeError
+      Pointee: 452 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853600
       GoKind: 22
-      Pointee: 446 BaseType crypto/des.KeySizeError
+      Pointee: 453 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.373888e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 929 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.679328e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 954 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 618
+      ID: 625
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853888
       GoKind: 22
-      Pointee: 447 BaseType crypto/rc4.KeySizeError
+      Pointee: 454 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.77088e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 962 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.679776e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 956 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.680224e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 958 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 542
+      ID: 549
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842752
       GoKind: 22
-      Pointee: 435 BaseType crypto/tls.AlertError
+      Pointee: 442 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004736e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 715 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.231968e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1041 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 540
+      ID: 547
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 548 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 538
+      ID: 545
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842464
       GoKind: 22
-      Pointee: 539 StructureType crypto/tls.RecordHeaderError
+      Pointee: 546 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.003072e+06
       GoKind: 22
-      Pointee: 663 BaseType crypto/tls.alert
+      Pointee: 670 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.371008e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 927 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.45008e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 934 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.243936e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 810 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90656e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 825 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 613 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 620 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851872
       GoKind: 22
-      Pointee: 607 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 614 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 608
+      ID: 615
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 851968
       GoKind: 22
-      Pointee: 609 StructureType crypto/x509.HostnameError
+      Pointee: 616 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851776
       GoKind: 22
-      Pointee: 444 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 451 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010624e+06
       GoKind: 22
-      Pointee: 713 StructureType crypto/x509.SystemRootsError
+      Pointee: 720 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 614
+      ID: 621
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 615 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 622 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 610
+      ID: 617
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852256
       GoKind: 22
-      Pointee: 611 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 618 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 858976
       GoKind: 22
-      Pointee: 628 StructureType encoding/asn1.StructuralError
+      Pointee: 635 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859168
       GoKind: 22
-      Pointee: 632 StructureType encoding/asn1.SyntaxError
+      Pointee: 639 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859072
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 637 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839392
       GoKind: 22
-      Pointee: 429 BaseType encoding/base64.CorruptInputError
+      Pointee: 436 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 999872
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 885 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 531
+      ID: 538
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840256
       GoKind: 22
-      Pointee: 430 BaseType encoding/hex.InvalidByteError
+      Pointee: 437 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 499
+      ID: 506
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834112
       GoKind: 22
-      Pointee: 500 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 507 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995520
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 706 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833728
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 499 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 497
+      ID: 504
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 505 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 503 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 493
+      ID: 500
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 501 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.148416e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1021 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 501
+      ID: 508
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834496
       GoKind: 22
-      Pointee: 502 StructureType encoding/json.jsonError
+      Pointee: 509 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.01344e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 893 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 608 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850720
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 606 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 850912
       GoKind: 22
-      Pointee: 441 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 448 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 443
+      ID: 450
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 442 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 449 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 851008
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 611 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.018368e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 999 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -5548,19 +7091,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 469
+      ID: 476
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824416
       GoKind: 22
-      Pointee: 470 UnresolvedPointeeType errors.errorString
+      Pointee: 477 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 665
+      ID: 672
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 980160
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType errors.joinError
+      Pointee: 673 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -5576,806 +7119,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.114144e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType fmt.pp
+      Pointee: 1009 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 667
+      ID: 674
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 980288
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType fmt.wrapError
+      Pointee: 675 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 669
+      ID: 676
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 980416
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 677 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 529
+      ID: 536
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839776
       GoKind: 22
-      Pointee: 530 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 537 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 511 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 518 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 836992
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 520 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837280
       GoKind: 22
-      Pointee: 517 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 524 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 839 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 514
+      ID: 521
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837088
       GoKind: 22
-      Pointee: 423 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 430 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 425
+      ID: 432
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 424 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 509
+      ID: 516
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836608
       GoKind: 22
-      Pointee: 420 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 427 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 421 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 428 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 515
+      ID: 522
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837184
       GoKind: 22
-      Pointee: 426 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 428
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 427 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.123808e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 907 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.921568e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 987 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857440
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 629 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.127136e+06
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 784 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.124384e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1017 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846304
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 557 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 556
+      ID: 563
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 22
-      Pointee: 557 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 564 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847072
       GoKind: 22
-      Pointee: 440 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 447 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 554
+      ID: 561
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847264
       GoKind: 22
-      Pointee: 555 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 562 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847168
       GoKind: 22
-      Pointee: 553 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 560 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 572
+      ID: 579
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 22
-      Pointee: 573 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 580 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 22
-      Pointee: 577 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 584 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 574
+      ID: 581
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 22
-      Pointee: 575 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 582 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 570
+      ID: 577
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849184
       GoKind: 22
-      Pointee: 571 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 578 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 847 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 854 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849856
       GoKind: 22
-      Pointee: 585 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 592 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 578
+      ID: 585
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 22
-      Pointee: 579 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 586 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849760
       GoKind: 22
-      Pointee: 583 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 590 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 580
+      ID: 587
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849664
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 588 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 849952
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 594 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850240
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 600 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850336
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 602 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850144
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 598 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 850048
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 596 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850528
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 604 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 518
+      ID: 525
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 22
-      Pointee: 519 StructureType github.com/cihub/seelog.baseError
+      Pointee: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.676416e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 946 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 22
-      Pointee: 521 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 528 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.369888e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 925 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 998848
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 881 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241696e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 915 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 22
-      Pointee: 525 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 532 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.839616e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 977 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.993024e+06
       GoKind: 22
-      Pointee: 981 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 988 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.99264e+06
       GoKind: 22
-      Pointee: 982 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 989 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 998976
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 883 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 522
+      ID: 529
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838624
       GoKind: 22
-      Pointee: 523 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 530 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 526
+      ID: 533
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838816
       GoKind: 22
-      Pointee: 527 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 534 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.677984e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.875488e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 983 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 985 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255776e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 815 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.024832e+06
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 728 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024704e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 726 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.0288e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 730 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.028928e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 732 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.477728e+06
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 936 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011392e+06
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 722 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 532
+      ID: 539
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840448
       GoKind: 22
-      Pointee: 533 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 540 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.211072e+06
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1033 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.135328e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 786 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 752 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 759 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.113824e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 753 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989376
       GoKind: 22
-      Pointee: 685 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 692 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114592e+06
       GoKind: 22
-      Pointee: 758 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 989248
       GoKind: 22
-      Pointee: 662 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 669 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.11408e+06
       GoKind: 22
-      Pointee: 750 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 757 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.113952e+06
       GoKind: 22
-      Pointee: 748 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 755 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114464e+06
       GoKind: 22
-      Pointee: 756 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 763 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114336e+06
       GoKind: 22
-      Pointee: 754 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 761 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.222112e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1037 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.114976e+06
       GoKind: 22
-      Pointee: 762 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989632
       GoKind: 22
-      Pointee: 689 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 696 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989504
       GoKind: 22
-      Pointee: 687 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 694 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.114848e+06
       GoKind: 22
-      Pointee: 760 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871072
       GoKind: 22
-      Pointee: 452 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 459 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 454
+      ID: 461
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 453 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 460 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476192e+06
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 828 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043776e+06
       GoKind: 22
-      Pointee: 729 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 736 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.17424e+06
       GoKind: 22
-      Pointee: 906 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 913 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.008e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 997 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.04608e+06
       GoKind: 22
-      Pointee: 892 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 899 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872320
       GoKind: 22
-      Pointee: 455 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 462 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.175904e+06
       GoKind: 22
-      Pointee: 787 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 794 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872608
       GoKind: 22
-      Pointee: 648 StructureType golang.org/x/net/http2.connError
+      Pointee: 655 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 646
+      ID: 653
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 459 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 466 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 461
+      ID: 468
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 460 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 467 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872800
       GoKind: 22
-      Pointee: 465 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 466 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 473 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872704
       GoKind: 22
-      Pointee: 462 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 469 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 464
+      ID: 471
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 463 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 470 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 456 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 463 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 458
+      ID: 465
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 457 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 464 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.00608e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 995 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 22
-      Pointee: 652 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 659 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 22
-      Pointee: 468 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 475 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866464
       GoKind: 22
-      Pointee: 640 StructureType google.golang.org/grpc.dropError
+      Pointee: 647 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.172832e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 792 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.263136e+06
       GoKind: 22
-      Pointee: 810 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 817 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869344
       GoKind: 22
-      Pointee: 642 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 649 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.684704e+06
       GoKind: 22
-      Pointee: 953 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 960 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.169376e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 911 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.038016e+06
       GoKind: 22
-      Pointee: 727 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869440
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 871 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855328
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 627 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.014848e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 724 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.141088e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 790 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.140832e+06
       GoKind: 22
-      Pointee: 781 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 788 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 860032
       GoKind: 22
-      Pointee: 634 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 641 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860128
       GoKind: 22
-      Pointee: 636 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 643 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 564
+      ID: 571
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847744
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 572 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.677088e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 948 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 219
       Name: '*hash<[4]int,[4]int>'
@@ -6402,30 +7945,30 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1065
+      ID: 1072
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1066 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1073 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1094 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1101 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1103 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1110 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 162
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1112 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1119 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 229
       Name: '*hash<int,struct {}>'
@@ -6447,10 +7990,10 @@ Types:
       ByteSize: 8
       Pointee: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 814 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 821 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 172
       Name: '*hash<string,int>'
@@ -6467,35 +8010,35 @@ Types:
       ByteSize: 8
       Pointee: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*hash<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 276 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+      Pointee: 283 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '*hash<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 288 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '*hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 234
       Name: '*hash<struct {},struct {}>'
@@ -6512,12 +8055,12 @@ Types:
       ByteSize: 8
       Pointee: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873760
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType html/template.Error
+      Pointee: 662 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -6561,96 +8104,96 @@ Types:
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 534
+      ID: 541
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840832
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 542 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 857 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.113056e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 751 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.226784e+06
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1039 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.112928e+06
       GoKind: 22
-      Pointee: 742 StructureType internal/poll.errNetClosing
+      Pointee: 749 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 471
+      ID: 478
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828160
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 479 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.104352e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType io.PipeWriter
+      Pointee: 903 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.103968e+06
       GoKind: 22
-      Pointee: 894 StructureType io.discard
+      Pointee: 901 StructureType io.discard
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 981184
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType io.multiWriter
+      Pointee: 875 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112672e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType io/fs.PathError
+      Pointee: 747 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.678208e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 952 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 321
+      ID: 328
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356448
       GoKind: 22
-      Pointee: 322 StructureType main.deepMap2
+      Pointee: 329 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356384
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType main.deepMap3
+      Pointee: 1078 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
@@ -6659,19 +8202,19 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 356064
       GoKind: 22
-      Pointee: 1099 StructureType main.deepMap8
+      Pointee: 1106 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1107
+      ID: 1114
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 356000
       GoKind: 22
-      Pointee: 1108 StructureType main.deepMap9
+      Pointee: 1115 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
@@ -6680,12 +8223,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 356960
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1043 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
@@ -6694,33 +8237,33 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356640
       GoKind: 22
-      Pointee: 1074 StructureType main.deepPtr8
+      Pointee: 1081 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356576
       GoKind: 22
-      Pointee: 1076 StructureType main.deepPtr9
+      Pointee: 1083 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357600
       GoKind: 22
-      Pointee: 315 StructureType main.deepSlice2
+      Pointee: 322 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357536
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1068 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
@@ -6729,25 +8272,25 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357216
       GoKind: 22
-      Pointee: 1080 StructureType main.deepSlice8
+      Pointee: 1087 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357152
       GoKind: 22
-      Pointee: 1086 StructureType main.deepSlice9
+      Pointee: 1093 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 306
+      ID: 313
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 305 StructureType main.emptyStruct
+      Pointee: 312 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 154
       Name: '*main.esotericHeap'
@@ -6756,12 +8299,12 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824128
       GoKind: 22
-      Pointee: 1052 StructureType main.firstBehavior
+      Pointee: 1059 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 242
       Name: '*main.node'
@@ -6770,25 +8313,25 @@ Types:
       GoKind: 22
       Pointee: 241 StructureType main.node
     - __kind: PointerType
-      ID: 258
+      ID: 265
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 259 StructureType main.oneStringStruct
+      Pointee: 266 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1053
+      ID: 1060
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824224
       GoKind: 22
-      Pointee: 1054 StructureType main.secondBehavior
+      Pointee: 1061 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824320
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1048 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 146
       Name: '*main.stringType1'
@@ -6796,33 +8339,33 @@ Types:
       GoKind: 22
       Pointee: 147 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1037 GoStringDataType main.stringType1.str
+      Pointee: 1044 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType main.stringType2
+      Pointee: 1046 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 262
+      ID: 269
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 260 StructureType main.structWithCyclicSlices
+      Pointee: 267 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 338
+      ID: 345
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 355936
       GoKind: 22
       Pointee: 160 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 249
+      ID: 256
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 250 StructureType main.structWithNoStrings
+      Pointee: 257 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 239
       Name: '*main.structWithTwoValues'
@@ -6836,16 +8379,16 @@ Types:
       GoKind: 22
       Pointee: 244 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1057
+      ID: 1064
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1056 GoSliceDataType main.t.array
+      Pointee: 1063 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 257
+      ID: 264
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 256 StructureType main.threeStringStruct
+      Pointee: 263 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 187
       Name: '*map[string]int'
@@ -6853,554 +8396,554 @@ Types:
       GoKind: 22
       Pointee: 171 GoMapType map[string]int
     - __kind: PointerType
-      ID: 568
+      ID: 575
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848608
       GoKind: 22
-      Pointee: 569 StructureType math/big.ErrNaN
+      Pointee: 576 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843232
       GoKind: 22
-      Pointee: 858 StructureType mime/multipart.writerOnly·1
+      Pointee: 865 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.121376e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType net.AddrError
+      Pointee: 778 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.239936e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType net.DNSError
+      Pointee: 804 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.086816e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType net.IPConn
+      Pointee: 1003 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239616e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType net.OpError
+      Pointee: 802 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121504e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType net.ParseError
+      Pointee: 780 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.116192e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType net.TCPConn
+      Pointee: 1013 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.161152e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net.UDPConn
+      Pointee: 1023 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.11568e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType net.UnixConn
+      Pointee: 1011 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.120608e+06
       GoKind: 22
-      Pointee: 732 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 739 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 733 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 740 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996288
       GoKind: 22
-      Pointee: 701 StructureType net.canceledError
+      Pointee: 708 StructureType net.canceledError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.873184e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType net.conn
+      Pointee: 981 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.717408e+06
       GoKind: 22
-      Pointee: 839 StructureType net.dialResult·1
+      Pointee: 846 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.165408e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType net.netFD
+      Pointee: 1025 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835456
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType net.notFoundError
+      Pointee: 511 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836128
       GoKind: 22
-      Pointee: 506 StructureType net.result·2
+      Pointee: 513 StructureType net.result·2
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.100704e+06
       GoKind: 22
-      Pointee: 1000 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1007 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.100224e+06
       GoKind: 22
-      Pointee: 998 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1005 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.122144e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType net.temporaryError
+      Pointee: 782 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.240096e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType net.timeoutError
+      Pointee: 806 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 992064
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 698 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831328
       GoKind: 22
-      Pointee: 852 StructureType net/http.bufioFlushWriter
+      Pointee: 859 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 832000
       GoKind: 22
-      Pointee: 401 BaseType net/http.http2ConnectionError
+      Pointee: 408 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 482 StructureType net/http.http2GoAwayError
+      Pointee: 489 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235776e+06
       GoKind: 22
-      Pointee: 791 StructureType net/http.http2StreamError
+      Pointee: 798 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832576
       GoKind: 22
-      Pointee: 486 StructureType net/http.http2connError
+      Pointee: 493 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.366528e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 921 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 484
+      ID: 491
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832480
       GoKind: 22
-      Pointee: 405 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 412 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 407
+      ID: 414
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 406 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 413 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832768
       GoKind: 22
-      Pointee: 411 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 418 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 413
+      ID: 420
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 419 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 487
+      ID: 494
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832672
       GoKind: 22
-      Pointee: 408 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 415 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 410
+      ID: 417
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 409 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 416 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.117152e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 773 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992704
       GoKind: 22
-      Pointee: 697 StructureType net/http.http2noCachedConnError
+      Pointee: 704 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.817184e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 972 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832384
       GoKind: 22
-      Pointee: 402 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 409 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 404
+      ID: 411
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 403 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 410 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832864
       GoKind: 22
-      Pointee: 854 StructureType net/http.http2stickyErrWriter
+      Pointee: 861 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992320
       GoKind: 22
-      Pointee: 693 StructureType net/http.nothingWrittenError
+      Pointee: 700 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.031136e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType net/http.persistConn
+      Pointee: 923 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 992192
       GoKind: 22
-      Pointee: 872 StructureType net/http.persistConnWriter
+      Pointee: 879 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.116128e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.readWriteCloserBody
+      Pointee: 905 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 489
+      ID: 496
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 490 StructureType net/http.requestBodyReadError
+      Pointee: 497 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.236896e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 800 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 22
-      Pointee: 764 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 771 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992448
       GoKind: 22
-      Pointee: 695 StructureType net/http.transportReadFromServerError
+      Pointee: 702 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831232
       GoKind: 22
-      Pointee: 479 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 486 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.81872e+06
       GoKind: 22
-      Pointee: 967 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 974 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.00576e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 889 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 561 StructureType net/netip.parseAddrError
+      Pointee: 568 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 559 StructureType net/netip.parsePrefixError
+      Pointee: 566 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.9808e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/smtp.Client
+      Pointee: 931 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.01088e+06
       GoKind: 22
-      Pointee: 884 StructureType net/smtp.dataCloser
+      Pointee: 891 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 544
+      ID: 551
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843424
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType net/textproto.Error
+      Pointee: 552 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843328
       GoKind: 22
-      Pointee: 436 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 443 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 438
+      ID: 445
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 444 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.00512e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 887 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.240416e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/url.Error
+      Pointee: 808 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 414 GoStringHeaderType net/url.EscapeError
+      Pointee: 421 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 416
+      ID: 423
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 415 GoStringDataType net/url.EscapeError.str
+      Pointee: 422 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 508
+      ID: 515
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 417 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 424 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 419
+      ID: 426
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 418 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 425 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.202656e+06
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType os.File
+      Pointee: 1031 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 671
+      ID: 678
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983232
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType os.LinkError
+      Pointee: 679 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105632e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType os.SyscallError
+      Pointee: 743 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.199712e+06
       GoKind: 22
-      Pointee: 1022 StructureType os.fileWithoutReadFrom
+      Pointee: 1029 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.198976e+06
       GoKind: 22
-      Pointee: 1020 StructureType os.fileWithoutWriteTo
+      Pointee: 1027 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001792e+06
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType os/exec.Error
+      Pointee: 710 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.952768e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 849 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.12816e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 909 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.00192e+06
       GoKind: 22
-      Pointee: 705 StructureType os/exec.wrappedError
+      Pointee: 712 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 638
+      ID: 645
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864544
       GoKind: 22
-      Pointee: 449 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 456 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 451
+      ID: 458
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 450 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 457 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864448
       GoKind: 22
-      Pointee: 448 BaseType os/user.UnknownUserIdError
+      Pointee: 455 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 828928
       GoKind: 22
-      Pointee: 474 UnresolvedPointeeType reflect.ValueError
+      Pointee: 481 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 566
+      ID: 573
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848224
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 574 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984768
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 682 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986688
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 687 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7416,12 +8959,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 984896
       GoKind: 22
-      Pointee: 677 StructureType runtime.boundsError
+      Pointee: 684 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -7437,24 +8980,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.111008e+06
       GoKind: 22
-      Pointee: 738 StructureType runtime.errorAddressString
+      Pointee: 745 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984512
       GoKind: 22
-      Pointee: 656 GoStringHeaderType runtime.errorString
+      Pointee: 663 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 657 GoStringDataType runtime.errorString.str
+      Pointee: 664 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -7477,17 +9020,17 @@ Types:
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986432
       GoKind: 22
-      Pointee: 659 GoStringHeaderType runtime.plainError
+      Pointee: 666 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 661
+      ID: 668
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 660 GoStringDataType runtime.plainError.str
+      Pointee: 667 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7510,12 +9053,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 986944
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType strconv.NumError
+      Pointee: 689 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -7524,83 +9067,83 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 308
+      ID: 315
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType string.str
+      Pointee: 314 GoStringDataType string.str
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.815904e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType strings.Builder
+      Pointee: 970 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 987072
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 877 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 866 StructureType struct { io.Writer }
+      Pointee: 873 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 255
+      ID: 262
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 118 StructureType struct {}
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.235136e+06
       GoKind: 22
-      Pointee: 788 BaseType syscall.Errno
+      Pointee: 795 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.018752e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1001 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047616e+06
       GoKind: 22
-      Pointee: 731 StructureType text/template.ExecError
+      Pointee: 738 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.431648e+06
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType time.Location
+      Pointee: 813 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType time.ParseError
+      Pointee: 484 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829696
       GoKind: 22
-      Pointee: 398 GoStringHeaderType time.fileSizeError
+      Pointee: 405 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 400
+      ID: 407
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 399 GoStringDataType time.fileSizeError.str
+      Pointee: 406 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -7644,59 +9187,59 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.77216e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 964 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 562
+      ID: 569
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847648
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 570 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.995328e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 993 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 546
+      ID: 553
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843808
       GoKind: 22
-      Pointee: 547 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 554 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 843904
       GoKind: 22
-      Pointee: 439 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 446 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005504e+06
       GoKind: 22
-      Pointee: 710 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 717 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005632e+06
       GoKind: 22
-      Pointee: 664 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1257
+      ID: 1312
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1258
+      ID: 1313
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7708,11 +9251,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1187
+      ID: 1194
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7728,7 +9271,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1188
+      ID: 1195
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7744,7 +9287,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1184
+      ID: 1191
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7760,7 +9303,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1185
+      ID: 1192
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7776,7 +9319,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1135
+      ID: 1284
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1285
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1142
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7792,7 +9367,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1133
+      ID: 1140
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7808,7 +9383,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1131
+      ID: 1138
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7824,7 +9399,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1196
+      ID: 1203
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7840,7 +9415,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1139
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7856,7 +9431,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1134
+      ID: 1141
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7872,7 +9447,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1153
+      ID: 1160
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7888,10 +9463,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1154
+      ID: 1161
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1120
+      ID: 1127
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7907,7 +9482,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1117
+      ID: 1124
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7923,7 +9498,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1216
+      ID: 1223
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7939,7 +9514,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1214
+      ID: 1221
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7975,7 +9550,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1224
+      ID: 1231
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7991,7 +9566,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1166
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8007,7 +9582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1167
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8023,7 +9598,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1155
+      ID: 1162
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8039,7 +9614,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1156
+      ID: 1163
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8055,7 +9630,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1164
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8071,7 +9646,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1158
+      ID: 1165
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8087,7 +9662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1304
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8096,10 +9671,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8109,11 +9684,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1301
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8122,14 +9697,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1323
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8141,11 +9716,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1275
+      ID: 1330
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8154,14 +9729,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 306 PointerType *main.emptyStruct
+            Type: 313 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1329
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8170,14 +9745,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 305 StructureType main.emptyStruct
+            Type: 312 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1186
+      ID: 1193
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8193,7 +9768,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1168
+      ID: 1175
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8209,10 +9784,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1176
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1166
+      ID: 1173
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8228,10 +9803,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1167
+      ID: 1174
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1180
+      ID: 1187
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8247,7 +9822,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1182
+      ID: 1189
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8273,7 +9848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1188
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8289,7 +9864,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1185
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8305,7 +9880,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1186
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8321,7 +9896,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1170
+      ID: 1177
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8337,10 +9912,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1178
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1174
+      ID: 1181
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8356,13 +9931,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1279
+      ID: 1334
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1172
+      ID: 1179
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8388,28 +9963,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1173
+      ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1280
+      ID: 1335
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1336
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1282
+      ID: 1337
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1283
+      ID: 1338
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1176
+      ID: 1183
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1177
+      ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1276
+      ID: 1331
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8421,11 +9996,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1278
+      ID: 1333
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8437,14 +10012,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1277
+      ID: 1332
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1284
+      ID: 1339
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8456,11 +10031,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1340
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8472,11 +10047,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1286
+      ID: 1341
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8488,11 +10063,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1123
+      ID: 1130
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8508,7 +10083,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1124
+      ID: 1131
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8524,7 +10099,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1125
+      ID: 1132
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8540,7 +10115,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1122
+      ID: 1129
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8556,7 +10131,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1121
+      ID: 1128
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8572,7 +10147,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1183
+      ID: 1190
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8588,7 +10163,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1218
+      ID: 1282
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1225
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8604,36 +10211,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1163
+      ID: 1170
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1164
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1165
+      ID: 1171
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8659,7 +10240,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1194
+      ID: 1172
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1288
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1289
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1201
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8675,7 +10394,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1208
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8691,7 +10410,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1220
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8707,7 +10426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1218
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8723,7 +10442,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1219
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8739,7 +10458,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1198
+      ID: 1205
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8755,7 +10474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1217
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8771,7 +10490,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1216
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8787,7 +10506,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1206
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8803,7 +10522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1207
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8819,7 +10538,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1208
+      ID: 1215
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8835,7 +10554,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1207
+      ID: 1214
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8851,7 +10570,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1192
+      ID: 1199
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8867,7 +10586,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1200
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8883,7 +10602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1198
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8899,7 +10618,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1202
+      ID: 1209
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8915,7 +10634,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1206
+      ID: 1213
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8931,7 +10650,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1205
+      ID: 1212
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8947,7 +10666,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
+      ID: 1211
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8963,7 +10682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1203
+      ID: 1210
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8979,7 +10698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1320
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8991,11 +10710,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1266
+      ID: 1321
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9007,11 +10726,217 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1241
+      ID: 1290
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1291
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1294
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1295
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1286
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1287
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1248
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9027,7 +10952,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1249
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9053,7 +10978,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1222
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9109,7 +11034,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1239
+      ID: 1246
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9125,7 +11050,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1240
+      ID: 1247
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9141,7 +11066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1230
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9167,7 +11092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1305
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9176,10 +11101,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9189,11 +11114,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1307
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9205,17 +11130,17 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 252 GoSliceHeaderType []bool
+            Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9225,11 +11150,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1308
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9238,14 +11163,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []uint16
+            Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1264
+      ID: 1319
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9254,14 +11179,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 258 PointerType *main.oneStringStruct
+            Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1226
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9277,7 +11202,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1197
+      ID: 1204
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9293,7 +11218,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1224
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9309,7 +11234,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1240
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9335,7 +11260,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1234
+      ID: 1241
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9361,7 +11286,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1242
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9377,7 +11302,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1243
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9393,7 +11318,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1231
+      ID: 1262
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1263
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1264
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1265
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1260
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1261
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1268
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1269
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1257
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 89 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1238
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9409,7 +11548,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1232
+      ID: 1239
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9425,7 +11564,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1229
+      ID: 1236
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9441,7 +11580,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1230
+      ID: 1237
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9467,7 +11606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1227
+      ID: 1234
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9483,7 +11622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1228
+      ID: 1235
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9499,7 +11638,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1232
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9515,7 +11654,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1226
+      ID: 1233
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9531,7 +11670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1237
+      ID: 1244
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9547,7 +11686,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1238
+      ID: 1245
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9563,7 +11702,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1118
+      ID: 1258
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1259
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1254
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1255
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1266
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1267
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1272
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1273
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1278
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1276
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1277
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1252
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 97 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1274
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1275
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1270
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1271
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1125
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9579,7 +12169,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1146
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9595,7 +12185,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1137
+      ID: 1144
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9611,7 +12201,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1150
+      ID: 1157
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9627,7 +12217,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1151
+      ID: 1158
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9643,7 +12233,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1149
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9659,7 +12249,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1143
+      ID: 1150
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9675,7 +12265,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1144
+      ID: 1151
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9691,7 +12281,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1141
+      ID: 1148
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9707,7 +12297,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1140
+      ID: 1147
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9723,7 +12313,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1138
+      ID: 1145
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9739,7 +12329,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1259
+      ID: 1314
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9751,11 +12341,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1147
+      ID: 1154
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9771,7 +12361,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1148
+      ID: 1155
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9787,7 +12377,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1149
+      ID: 1156
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9803,7 +12393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1153
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9819,7 +12409,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1145
+      ID: 1152
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9835,7 +12425,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1311
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9844,14 +12434,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 254 GoSliceHeaderType []struct {}
+            Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1247
+      ID: 1302
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9860,14 +12450,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 246 GoSliceHeaderType [][]uint
+            Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1195
+      ID: 1202
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9883,7 +12473,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1250
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9899,7 +12489,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1251
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9935,7 +12525,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1119
+      ID: 1292
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1293
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1126
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9951,7 +12593,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1222
+      ID: 1229
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9967,7 +12609,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1306
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9976,14 +12618,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []string
+            Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1161
+      ID: 1168
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9999,7 +12641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1169
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10015,7 +12657,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1248
+      ID: 1303
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10024,10 +12666,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10037,11 +12679,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1189
+      ID: 1196
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10057,7 +12699,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1270
+      ID: 1296
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1297
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1325
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10066,17 +12750,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 273 StructureType main.structWithCyclicMaps
+            Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1271
+      ID: 1326
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1269
+      ID: 1324
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10085,14 +12769,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 260 StructureType main.structWithCyclicSlices
+            Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1190
+      ID: 1197
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10108,7 +12792,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1272
+      ID: 1327
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10117,17 +12801,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 304 StructureType main.aStruct
+            Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1273
+      ID: 1328
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1263
+      ID: 1318
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10136,14 +12820,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 257 PointerType *main.threeStringStruct
+            Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1316
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10152,17 +12836,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 StructureType main.threeStringStruct
+            Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1262
+      ID: 1317
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1260
+      ID: 1315
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10174,7 +12858,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10184,7 +12868,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10194,11 +12878,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1159
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10214,7 +12898,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1128
+      ID: 1135
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10230,7 +12914,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1129
+      ID: 1136
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10246,7 +12930,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1137
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10262,7 +12946,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1127
+      ID: 1134
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10278,7 +12962,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1126
+      ID: 1133
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10294,7 +12978,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1221
+      ID: 1228
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10310,7 +12994,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1245
+      ID: 1300
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10319,14 +13003,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1267
+      ID: 1322
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10338,11 +13022,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1220
+      ID: 1227
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10358,7 +13042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1136
+      ID: 1143
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10374,7 +13058,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1254
+      ID: 1309
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10383,14 +13067,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1255
+      ID: 1310
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10399,12 +13083,70 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1298
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 248
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 9 BaseType int
     - __kind: ArrayType
       ID: 119
       Name: '[100]uint'
@@ -10417,16 +13159,25 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 639008
+      GoRuntimeType: 639104
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 247
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 625696
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 638720
+      GoRuntimeType: 638816
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10451,7 +13202,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 638912
+      GoRuntimeType: 639008
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10593,22 +13344,31 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 638528
+      GoRuntimeType: 638624
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 246
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 624640
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 638240
+      GoRuntimeType: 638336
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 348
+      ID: 355
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622720
@@ -10617,7 +13377,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 333
+      ID: 340
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 623008
@@ -10629,7 +13389,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 630208
+      GoRuntimeType: 630304
       GoKind: 17
       Count: 4
       HasCount: true
@@ -10643,7 +13403,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 833
+      ID: 840
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624160
@@ -10655,7 +13415,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 635648
+      GoRuntimeType: 635744
       GoKind: 17
       Count: 6
       HasCount: true
@@ -10664,13 +13424,13 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 638816
+      GoRuntimeType: 638912
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 318
+      ID: 325
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 620128
@@ -10694,15 +13454,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 316 GoSliceDataType []*main.deepSlice2.array
+      Data: 323 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 133 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1058
+      ID: 1065
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 447008
@@ -10710,22 +13470,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1059 PointerType **main.deepSlice3
+          Type: 1066 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1062 GoSliceDataType []*main.deepSlice3.array
+      Data: 1069 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1062
+      ID: 1069
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1060 PointerType *main.deepSlice3
+      Element: 1067 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1077
+      ID: 1084
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446688
@@ -10733,22 +13493,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1078 PointerType **main.deepSlice8
+          Type: 1085 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1081 GoSliceDataType []*main.deepSlice8.array
+      Data: 1088 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1081
+      ID: 1088
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1079 PointerType *main.deepSlice8
+      Element: 1086 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1083
+      ID: 1090
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446624
@@ -10756,20 +13516,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1084 PointerType **main.deepSlice9
+          Type: 1091 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1087 GoSliceDataType []*main.deepSlice9.array
+      Data: 1094 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1087
+      ID: 1094
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1085 PointerType *main.deepSlice9
+      Element: 1092 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 122
       Name: '[]*string'
@@ -10786,147 +13546,147 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 313 GoSliceDataType []*string.array
+      Data: 320 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 320
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 88 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 271
+      ID: 278
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 272 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 279 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 382 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 389 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 389
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 269
+      ID: 276
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 270 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 277 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 380 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 387 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 387
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 267
+      ID: 274
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 268 PointerType *[][][]main.structWithCyclicSlices
+          Type: 275 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 378 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 385 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 385
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 265
+      ID: 272
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 266 PointerType *[][]main.structWithCyclicSlices
+          Type: 273 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 376 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 383 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 383
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 263
+      ID: 270
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 264 PointerType *[]main.structWithCyclicSlices
+          Type: 271 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 374 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 381 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 381
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 261 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 246
+      ID: 253
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType *[]uint
+          Type: 254 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 360 GoSliceDataType [][]uint.array
+      Data: 367 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 360
+      ID: 367
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 245 GoSliceHeaderType []uint
+      Element: 252 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 252
+      ID: 259
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 454368
@@ -10941,177 +13701,177 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 366 GoSliceDataType []bool.array
+      Data: 373 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 373
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 359
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 222 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 358
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 217 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 342
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 185 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 349
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 197 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 323
+      ID: 330
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1072
+      ID: 1079
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1100
+      ID: 1107
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1109
+      ID: 1116
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 325
+      ID: 332
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 165 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1116
+      ID: 1123
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1114 GoHMapBucketType bucket<int,interface {}>
+      Element: 1121 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 363
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 232 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 351
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 202 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 346
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 331
+      ID: 338
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 844
+      ID: 851
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 336
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 175 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 335
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 170 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 361
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 392
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
-      Element: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      Element: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 387
+      ID: 394
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 389
+      ID: 396
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 398
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 400
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 402
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 357
+      ID: 364
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 237 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 349
+      ID: 356
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 212 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 346
+      ID: 353
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 828
+      ID: 835
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454240
@@ -11126,15 +13886,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 845 GoSliceDataType []float64.array
+      Data: 852 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 845
+      ID: 852
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1089
+      ID: 1096
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454688
@@ -11149,85 +13909,85 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []interface {}.array
+      Data: 1097 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1097
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 350
+      ID: 357
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 348 ArrayType [4]int
+      Element: 355 ArrayType [4]int
     - __kind: ArrayType
-      ID: 332
+      ID: 339
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 333 ArrayType [4]string
+      Element: 340 ArrayType [4]string
     - __kind: ArrayType
-      ID: 340
+      ID: 347
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 319
+      ID: 326
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 326
+      ID: 333
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 353
+      ID: 360
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 345
+      ID: 352
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 261
+      ID: 268
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 262 PointerType *main.structWithCyclicSlices
+          Type: 269 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 372 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 379 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 379
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 260 StructureType main.structWithCyclicSlices
+      Element: 267 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 337
+      ID: 344
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447328
@@ -11235,48 +13995,48 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 338 PointerType *main.structWithMap
+          Type: 345 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 396 GoSliceDataType []main.structWithMap.array
+      Data: 403 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 403
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 160 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 255
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 249 PointerType *main.structWithNoStrings
+          Type: 256 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 362 GoSliceDataType []main.structWithNoStrings.array
+      Data: 369 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 369
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 250 StructureType main.structWithNoStrings
+      Element: 257 StructureType main.structWithNoStrings
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 454496
@@ -11291,15 +14051,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 364 GoSliceDataType []string.array
+      Data: 371 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 371
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 254
+      ID: 261
       Name: '[]struct {}'
       ByteSize: 24
       GoRuntimeType: 447648
@@ -11307,21 +14067,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 255 PointerType *struct {}
+          Type: 262 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 370 GoSliceDataType []struct {}.array
+      Data: 377 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 377
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 118 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 245
+      ID: 252
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 453984
@@ -11336,15 +14096,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 358 GoSliceDataType []uint.array
+      Data: 365 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 365
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 253
+      ID: 260
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 453344
@@ -11359,9 +14119,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 368 GoSliceDataType []uint16.array
+      Data: 375 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 375
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11382,9 +14142,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 309 GoSliceDataType []uint8.array
+      Data: 316 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 309
+      ID: 316
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11405,165 +14165,165 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 311 GoSliceDataType []uintptr.array
+      Data: 318 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 311
+      ID: 318
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 320
+      ID: 327
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 321 PointerType *main.deepMap2
+      Element: 328 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1069
+      ID: 1076
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1070 PointerType *main.deepMap3
+      Element: 1077 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1097
+      ID: 1104
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1098 PointerType *main.deepMap8
+      Element: 1105 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1106
+      ID: 1113
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1107 PointerType *main.deepMap9
+      Element: 1114 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 334
+      ID: 341
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 106 ArrayType [2]int
     - __kind: ArrayType
-      ID: 347
+      ID: 354
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 348 ArrayType [4]int
+      Element: 355 ArrayType [4]int
     - __kind: ArrayType
-      ID: 336
+      ID: 343
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 337 GoSliceHeaderType []main.structWithMap
+      Element: 344 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 330
+      ID: 337
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 251 GoSliceHeaderType []string
+      Element: 258 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 843
+      ID: 850
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 324
+      ID: 331
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1115
+      ID: 1122
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 327
+      ID: 334
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 116 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 341
+      ID: 348
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 241 StructureType main.node
     - __kind: ArrayType
-      ID: 384
+      ID: 391
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
-      Element: 273 StructureType main.structWithCyclicMaps
+      Element: 280 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 386
+      ID: 393
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+      Element: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 388
+      ID: 395
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 390
+      ID: 397
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 392
+      ID: 399
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 394
+      ID: 401
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 355
+      ID: 362
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 343
+      ID: 350
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 624
+      ID: 631
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858592
@@ -11578,33 +14338,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 625 GoSliceDataType archive/tar.headerError.array
+      Data: 632 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 632
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.07872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.376608e+06
@@ -11614,7 +14374,7 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11630,18 +14390,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<[4]int>
+          Type: 357 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 347 ArrayType []val<[4]int>
+          Type: 354 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 221 PointerType *bucket<[4]int,[4]int>
-      KeyType: 348 ArrayType [4]int
-      ValueType: 348 ArrayType [4]int
+      KeyType: 355 ArrayType [4]int
+      ValueType: 355 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 217
       Name: bucket<[4]int,uint8>
@@ -11649,17 +14409,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<[4]int>
+          Type: 357 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 216 PointerType *bucket<[4]int,uint8>
-      KeyType: 348 ArrayType [4]int
+      KeyType: 355 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 185
@@ -11668,17 +14428,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 332 ArrayType []key<[4]string>
+          Type: 339 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 334 ArrayType []val<[2]int>
+          Type: 341 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 184 PointerType *bucket<[4]string,[2]int>
-      KeyType: 333 ArrayType [4]string
+      KeyType: 340 ArrayType [4]string
       ValueType: 106 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 197
@@ -11687,13 +14447,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 340 ArrayType []key<bool>
+          Type: 347 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 341 ArrayType []val<main.node>
+          Type: 348 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 196 PointerType *bucket<bool,main.node>
@@ -11706,75 +14466,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 320 ArrayType []val<*main.deepMap2>
+          Type: 327 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 140 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 321 PointerType *main.deepMap2
+      ValueType: 328 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1068
+      ID: 1075
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1069 ArrayType []val<*main.deepMap3>
+          Type: 1076 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1070 PointerType *main.deepMap3
+      ValueType: 1077 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1096
+      ID: 1103
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1097 ArrayType []val<*main.deepMap8>
+          Type: 1104 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1098 PointerType *main.deepMap8
+      ValueType: 1105 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1105
+      ID: 1112
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1106 ArrayType []val<*main.deepMap9>
+          Type: 1113 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1107 PointerType *main.deepMap9
+      ValueType: 1114 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<int,int>
@@ -11782,35 +14542,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 164 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1114
+      ID: 1121
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1115 ArrayType []val<interface {}>
+          Type: 1122 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 152 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -11820,13 +14580,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 355 ArrayType []val<struct {}>
+          Type: 362 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 231 PointerType *bucket<int,struct {}>
@@ -11839,13 +14599,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 201 PointerType *bucket<int,uint8>
@@ -11858,18 +14618,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 336 ArrayType []val<[]main.structWithMap>
+          Type: 343 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 191 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 337 GoSliceHeaderType []main.structWithMap
+      ValueType: 344 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 180
       Name: bucket<string,[]string>
@@ -11877,37 +14637,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 330 ArrayType []val<[]string>
+          Type: 337 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 179 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 251 GoSliceHeaderType []string
+      ValueType: 258 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 816
+      ID: 823
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 843 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 850 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 175
       Name: bucket<string,int>
@@ -11915,13 +14675,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 174 PointerType *bucket<string,int>
@@ -11934,13 +14694,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 327 ArrayType []val<main.nestedStruct>
+          Type: 334 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 169 PointerType *bucket<string,main.nestedStruct>
@@ -11953,132 +14713,132 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 226 PointerType *bucket<struct {},int>
       KeyType: 118 StructureType struct {}
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 278
+      ID: 285
       Name: bucket<struct {},main.structWithCyclicMaps>
       ByteSize: 400
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 384 ArrayType []val<main.structWithCyclicMaps>
+          Type: 391 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 273 StructureType main.structWithCyclicMaps
+      ValueType: 280 StructureType main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 283
+      ID: 290
       Name: bucket<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 386 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 393 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+      ValueType: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 288
+      ID: 295
       Name: bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 388 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 395 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 293
+      ID: 300
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 390 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 397 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 298
+      ID: 305
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 392 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 399 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 303
+      ID: 310
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 394 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 401 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
       ID: 237
       Name: bucket<struct {},struct {}>
@@ -12086,13 +14846,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 355 ArrayType []val<struct {}>
+          Type: 362 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 236 PointerType *bucket<struct {},struct {}>
@@ -12105,18 +14865,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 345 ArrayType []key<uint8>
+          Type: 352 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 347 ArrayType []val<[4]int>
+          Type: 354 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 211 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 348 ArrayType [4]int
+      ValueType: 355 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 207
       Name: bucket<uint8,uint8>
@@ -12124,28 +14884,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 345 ArrayType []key<uint8>
+          Type: 352 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 206 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -12171,13 +14931,13 @@ Types:
       GoRuntimeType: 532224
       GoKind: 15
     - __kind: BaseType
-      ID: 431
+      ID: 438
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764704
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 432
+      ID: 439
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764800
@@ -12185,92 +14945,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 434 PointerType *compress/flate.InternalError.str
+          Type: 441 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 433 GoStringDataType compress/flate.InternalError.str
+      Data: 440 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 433
+      ID: 440
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296544e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 445
+      ID: 452
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767296
       GoKind: 2
     - __kind: BaseType
-      ID: 446
+      ID: 453
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767392
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 447
+      ID: 454
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 435
+      ID: 442
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 715
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1041
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 548
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.605504e+06
@@ -12281,34 +15041,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 833 ArrayType [5]uint8
+          Type: 840 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 663
+      ID: 670
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951744
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 613
+      ID: 620
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.608576e+06
@@ -12316,21 +15076,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 836 BaseType crypto/x509.InvalidReason
+          Type: 843 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 614
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.076032e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 609
+      ID: 616
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.40896e+06
@@ -12338,24 +15098,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 444
+      ID: 451
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 766912
       GoKind: 2
     - __kind: BaseType
-      ID: 836
+      ID: 843
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 2
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.372928e+06
@@ -12365,13 +15125,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 615
+      ID: 622
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.076288e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.608384e+06
@@ -12379,15 +15139,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 628
+      ID: 635
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.254016e+06
@@ -12397,7 +15157,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.254176e+06
@@ -12407,55 +15167,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 637
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 429
+      ID: 436
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764320
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 430
+      ID: 437
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764512
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 500
+      ID: 507
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 499
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 505
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 503
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 501
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1021
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238656e+06
@@ -12465,19 +15225,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 608
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 606
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 441
+      ID: 448
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766816
@@ -12485,22 +15245,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 443 PointerType *encoding/xml.UnmarshalError.str
+          Type: 450 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 442 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 449 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 442
+      ID: 449
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 611
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 999
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12517,11 +15277,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 470
+      ID: 477
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 673
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12537,15 +15297,15 @@ Types:
       GoRuntimeType: 532416
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 675
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 677
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12561,11 +15321,11 @@ Types:
       GoRuntimeType: 778048
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 530
+      ID: 537
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.603776e+06
@@ -12573,7 +15333,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 826 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 833 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -12581,25 +15341,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 520
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.072448e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 423
+      ID: 430
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763744
@@ -12607,18 +15367,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 425 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 432 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 424 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 424
+      ID: 431
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.074592e+06
@@ -12626,13 +15386,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 827 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 834 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -12641,7 +15401,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 828 GoSliceHeaderType []float64
+          Type: 835 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -12650,13 +15410,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 829 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 836 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 831 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 838 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -12667,13 +15427,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 827
+      ID: 834
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534272
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 420
+      ID: 427
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763648
@@ -12681,18 +15441,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 422 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 429 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 421 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 428 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 421
+      ID: 428
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 426
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763840
@@ -12700,60 +15460,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 428 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 427 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 427
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 629
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 784
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1017
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 557
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 564
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075264e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 440
+      ID: 447
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 765952
       GoKind: 2
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.075136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 560
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.40704e+06
@@ -12766,7 +15526,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 573
+      ID: 580
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.40784e+06
@@ -12779,7 +15539,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 577
+      ID: 584
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.607808e+06
@@ -12795,7 +15555,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 575
+      ID: 582
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.248416e+06
@@ -12805,7 +15565,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 571
+      ID: 578
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.248096e+06
@@ -12815,14 +15575,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 812
+      ID: 819
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135584e+06
       GoKind: 21
-      HeaderType: 814 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 821 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 835
+      ID: 842
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.009216e+06
@@ -12837,15 +15597,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 847 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 854 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 847
+      ID: 854
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 585
+      ID: 592
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.40816e+06
@@ -12853,12 +15613,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 812 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 819 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 812 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 819 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 579
+      ID: 586
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248576e+06
@@ -12868,7 +15628,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 590
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.608e+06
@@ -12879,12 +15639,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 581
+      ID: 588
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.408e+06
@@ -12897,7 +15657,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 587
+      ID: 594
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248736e+06
@@ -12905,9 +15665,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 804 StructureType time.Time
+          Type: 811 StructureType time.Time
     - __kind: StructureType
-      ID: 593
+      ID: 600
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.40848e+06
@@ -12920,7 +15680,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.249056e+06
@@ -12930,7 +15690,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 591
+      ID: 598
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.40832e+06
@@ -12943,7 +15703,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 589
+      ID: 596
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.248896e+06
@@ -12953,7 +15713,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 604
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.40864e+06
@@ -12966,7 +15726,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.240896e+06
@@ -12976,11 +15736,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.241056e+06
@@ -12988,21 +15748,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 881
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 532
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.241376e+06
@@ -13010,13 +15770,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 977
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 981
+      ID: 988
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.968864e+06
@@ -13024,12 +15784,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 969 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 976 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.992256e+06
@@ -13037,7 +15797,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 969 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 976 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -13045,11 +15805,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 523
+      ID: 530
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.241216e+06
@@ -13057,9 +15817,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241536e+06
@@ -13067,64 +15827,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 983
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 985
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 728
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 726
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 730
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 732
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 936
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 722
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 540
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242496e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1033
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 786
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.71248e+06
@@ -13140,11 +15900,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 753
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.509696e+06
@@ -13157,7 +15917,7 @@ Types:
           Offset: 1
           Type: 14 BaseType int8
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.712928e+06
@@ -13173,13 +15933,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 662
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 949152
       GoKind: 8
     - __kind: StructureType
-      ID: 750
+      ID: 757
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.712256e+06
@@ -13195,13 +15955,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 761920
       GoKind: 8
     - __kind: StructureType
-      ID: 748
+      ID: 755
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.712032e+06
@@ -13209,15 +15969,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 837 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 844 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 837 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 844 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.630624e+06
@@ -13230,7 +15990,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 754
+      ID: 761
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.712704e+06
@@ -13246,11 +16006,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1037
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.432608e+06
@@ -13260,19 +16020,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 689
+      ID: 696
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195424e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 687
+      ID: 694
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.195296e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.630816e+06
@@ -13285,7 +16045,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 452
+      ID: 459
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769312
@@ -13293,22 +16053,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 454 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 461 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 453 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 460 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 453
+      ID: 460
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.265856e+06
@@ -13318,7 +16078,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.48656e+06
@@ -13326,13 +16086,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 930 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 937 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 997
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 930
+      ID: 937
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.086144e+06
@@ -13345,7 +16105,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.381408e+06
@@ -13355,19 +16115,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 455
+      ID: 462
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769888
       GoKind: 10
     - __kind: BaseType
-      ID: 819
+      ID: 826
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962400
       GoKind: 10
     - __kind: StructureType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.751008e+06
@@ -13378,12 +16138,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 819 BaseType golang.org/x/net/http2.ErrCode
+          Type: 826 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.41584e+06
@@ -13391,12 +16151,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 819 BaseType golang.org/x/net/http2.ErrCode
+          Type: 826 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 459
+      ID: 466
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770080
@@ -13404,18 +16164,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 461 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 468 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 460 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 467 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 460
+      ID: 467
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 465
+      ID: 472
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770272
@@ -13423,18 +16183,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 467 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 474 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 466 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 473 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 466
+      ID: 473
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 462
+      ID: 469
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770176
@@ -13442,18 +16202,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 464 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 471 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 463 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 470 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 463
+      ID: 470
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 456
+      ID: 463
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 769984
@@ -13461,22 +16221,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 458 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 465 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 457 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 464 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 457
+      ID: 464
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 995
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 652
+      ID: 659
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266496e+06
@@ -13486,13 +16246,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 468
+      ID: 475
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770368
       GoKind: 2
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261536e+06
@@ -13502,11 +16262,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 792
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.776768e+06
@@ -13522,7 +16282,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 642
+      ID: 649
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.41536e+06
@@ -13535,7 +16295,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.83024e+06
@@ -13543,16 +16303,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 968 GoInterfaceType io.Reader
+          Type: 975 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 911
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.379008e+06
@@ -13562,29 +16322,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 627
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 724
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 790
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 788
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326144e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.254816e+06
@@ -13594,7 +16354,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 636
+      ID: 643
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.254976e+06
@@ -13604,11 +16364,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 572
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -13644,7 +16404,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 222 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 352 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 359 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 215
       Name: hash<[4]int,uint8>
@@ -13678,7 +16438,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 217 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 351 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 358 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 183
       Name: hash<[4]string,[2]int>
@@ -13712,7 +16472,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 185 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 335 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 342 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 195
       Name: hash<bool,main.node>
@@ -13746,7 +16506,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 197 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 342 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 349 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 139
       Name: hash<int,*main.deepMap2>
@@ -13780,9 +16540,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 141 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 323 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 330 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1066
+      ID: 1073
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -13803,20 +16563,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1072 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1079 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1094
+      ID: 1101
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -13837,20 +16597,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1100 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1107 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1103
+      ID: 1110
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -13871,18 +16631,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1109 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1116 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 163
       Name: hash<int,int>
@@ -13916,9 +16676,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<int,int>
-      BucketsType: 325 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 332 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1112
+      ID: 1119
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -13939,18 +16699,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1114 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1116 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1121 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1123 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 230
       Name: hash<int,struct {}>
@@ -13984,7 +16744,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 232 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 356 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 363 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 200
       Name: hash<int,uint8>
@@ -14018,7 +16778,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 202 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 344 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 351 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<string,[]main.structWithMap>
@@ -14052,7 +16812,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 339 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 346 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 178
       Name: hash<string,[]string>
@@ -14086,9 +16846,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 180 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 331 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 338 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 814
+      ID: 821
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -14109,18 +16869,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 844 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 851 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 173
       Name: hash<string,int>
@@ -14154,7 +16914,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 175 GoHMapBucketType bucket<string,int>
-      BucketsType: 329 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 336 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 168
       Name: hash<string,main.nestedStruct>
@@ -14188,7 +16948,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 170 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 328 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 335 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 225
       Name: hash<struct {},int>
@@ -14222,9 +16982,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 227 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 354 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 361 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
-      ID: 276
+      ID: 283
       Name: hash<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14245,20 +17005,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 385 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketType: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      BucketsType: 392 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 281
+      ID: 288
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14279,20 +17039,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 387 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 394 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 286
+      ID: 293
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14313,20 +17073,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 389 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 396 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 291
+      ID: 298
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14347,20 +17107,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 391 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 398 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 296
+      ID: 303
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14381,20 +17141,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 393 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 400 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 301
+      ID: 308
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14415,18 +17175,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 395 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 402 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 235
       Name: hash<struct {},struct {}>
@@ -14460,7 +17220,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 237 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 357 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 364 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 210
       Name: hash<uint8,[4]int>
@@ -14494,7 +17254,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 212 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 349 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 356 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 205
       Name: hash<uint8,uint8>
@@ -14528,9 +17288,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 207 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 346 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 353 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 662
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -14577,7 +17337,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 542
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -14603,25 +17363,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 751
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293504e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 479
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -14702,11 +17462,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 937
+      ID: 944
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104096e+06
@@ -14719,7 +17479,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 968
+      ID: 975
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 981312
@@ -14732,7 +17492,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 925
+      ID: 932
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.068864e+06
@@ -14758,25 +17518,25 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: io.discard
       GoRuntimeType: 1.281344e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 304
+      ID: 311
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14832,7 +17592,7 @@ Types:
           Offset: 0
           Type: 137 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 322
+      ID: 329
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.100384e+06
@@ -14840,9 +17600,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1064 GoMapType map[int]*main.deepMap3
+          Type: 1071 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1078
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14854,9 +17614,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoMapType map[int]*main.deepMap8
+          Type: 1099 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1099
+      ID: 1106
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099616e+06
@@ -14864,9 +17624,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1101 GoMapType map[int]*main.deepMap9
+          Type: 1108 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1108
+      ID: 1115
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.099488e+06
@@ -14874,7 +17634,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1110 GoMapType map[int]interface {}
+          Type: 1117 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 125
       Name: main.deepPtr1
@@ -14894,9 +17654,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1035 PointerType *main.deepPtr3
+          Type: 1042 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14908,9 +17668,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1073 PointerType *main.deepPtr8
+          Type: 1080 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1074
+      ID: 1081
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.100768e+06
@@ -14918,9 +17678,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1075 PointerType *main.deepPtr9
+          Type: 1082 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1076
+      ID: 1083
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.10064e+06
@@ -14940,7 +17700,7 @@ Types:
           Offset: 0
           Type: 131 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 315
+      ID: 322
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.102688e+06
@@ -14948,9 +17708,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1058 GoSliceHeaderType []*main.deepSlice3
+          Type: 1065 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14962,9 +17722,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1077 GoSliceHeaderType []*main.deepSlice8
+          Type: 1084 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.10192e+06
@@ -14972,9 +17732,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1083 GoSliceHeaderType []*main.deepSlice9
+          Type: 1090 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101792e+06
@@ -14982,9 +17742,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1089 GoSliceHeaderType []interface {}
+          Type: 1096 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 305
+      ID: 312
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -15000,16 +17760,16 @@ Types:
           Type: 150 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1042 StructureType sync.Mutex
+          Type: 1049 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1043 StructureType sync.Once
+          Type: 1050 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1046 StructureType sync.WaitGroup
+          Type: 1053 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1050 StructureType sync/atomic.Int32
+          Type: 1057 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 150
       Name: main.esotericStack
@@ -15039,7 +17799,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1052
+      ID: 1059
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.231936e+06
@@ -15048,6 +17808,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 245
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 9 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 249
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 17 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
     - __kind: StructureType
       ID: 116
       Name: main.nestedStruct
@@ -15075,7 +17886,7 @@ Types:
           Offset: 8
           Type: 242 PointerType *main.node
     - __kind: StructureType
-      ID: 259
+      ID: 266
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -15084,7 +17895,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1054
+      ID: 1061
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.232096e+06
@@ -15104,7 +17915,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15115,18 +17926,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1038 PointerType *main.stringType1.str
+          Type: 1045 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1037 GoStringDataType main.stringType1.str
+      Data: 1044 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1037
+      ID: 1044
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1046
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -15140,53 +17951,65 @@ Types:
           Offset: 0
           Type: 152 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 273
+      ID: 251
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 106 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 280
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 281 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 260
+      ID: 267
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 261 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 268 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 271 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 278 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 160
       Name: main.structWithMap
@@ -15198,7 +18021,7 @@ Types:
           Offset: 0
           Type: 161 GoMapType map[int]int
     - __kind: StructureType
-      ID: 250
+      ID: 257
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -15229,22 +18052,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1055 PointerType **main.t
+          Type: 1062 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1056 GoSliceDataType main.t.array
+      Data: 1063 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1056
+      ID: 1063
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 243 PointerType *main.t
     - __kind: StructureType
-      ID: 256
+      ID: 263
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -15263,6 +18086,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 250
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 9 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 9 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 9 BaseType int
     - __kind: GoMapType
       ID: 218
       Name: map[[4]int][4]int
@@ -15299,26 +18161,26 @@ Types:
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1064
+      ID: 1071
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 879904
       GoKind: 21
-      HeaderType: 1066 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1073 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1092
+      ID: 1099
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879424
       GoKind: 21
-      HeaderType: 1094 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1101 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1101
+      ID: 1108
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879328
       GoKind: 21
-      HeaderType: 1103 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1110 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
@@ -15327,12 +18189,12 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1110
+      ID: 1117
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879232
       GoKind: 21
-      HeaderType: 1112 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1119 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
@@ -15383,41 +18245,41 @@ Types:
       GoKind: 21
       HeaderType: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: GoMapType
-      ID: 274
+      ID: 281
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 276 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+      HeaderType: 283 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 279
+      ID: 286
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 281 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 288 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 284
+      ID: 291
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 286 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 293 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 289
+      ID: 296
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 291 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 298 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 294
+      ID: 301
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 296 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 303 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 299
+      ID: 306
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 301 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 308 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]struct {}
@@ -15440,7 +18302,7 @@ Types:
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 569
+      ID: 576
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247776e+06
@@ -15450,7 +18312,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244576e+06
@@ -15460,11 +18322,11 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 834
+      ID: 841
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.40576e+06
@@ -15477,35 +18339,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 804
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1003
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 780
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1013
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1023
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 732
+      ID: 739
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.072064e+06
@@ -15513,28 +18375,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 734 PointerType *net.UnknownNetworkError.str
+          Type: 741 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 733 GoStringDataType net.UnknownNetworkError.str
+      Data: 740 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 733
+      ID: 740
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: net.canceledError
       GoRuntimeType: 1.19632e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.96816e+06
@@ -15542,7 +18404,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -15553,27 +18415,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1019
       Name: net.noReadFrom
       GoRuntimeType: 1.07232e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1011
+      ID: 1018
       Name: net.noWriteTo
       GoRuntimeType: 1.072192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 511
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.603584e+06
@@ -15581,7 +18443,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 822 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 829 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -15589,7 +18451,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 1000
+      ID: 1007
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.14448e+06
@@ -15597,12 +18459,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1012 StructureType net.noReadFrom
+          Type: 1019 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1005 PointerType *net.TCPConn
+          Type: 1012 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 998
+      ID: 1005
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.143936e+06
@@ -15610,24 +18472,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1011 StructureType net.noWriteTo
+          Type: 1018 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1005 PointerType *net.TCPConn
+          Type: 1012 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 782
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 698
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 859
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.236096e+06
@@ -15637,19 +18499,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 401
+      ID: 408
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762400
       GoKind: 10
     - __kind: BaseType
-      ID: 811
+      ID: 818
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 949248
       GoKind: 10
     - __kind: StructureType
-      ID: 482
+      ID: 489
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.601664e+06
@@ -15660,12 +18522,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.76704e+06
@@ -15676,12 +18538,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.40528e+06
@@ -15689,16 +18551,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 405
+      ID: 412
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762592
@@ -15706,18 +18568,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 407 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 414 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 406 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 413 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 406
+      ID: 413
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 418
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762784
@@ -15725,18 +18587,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *net/http.http2headerFieldNameError.str
+          Type: 420 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 412 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 419 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 419
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 408
+      ID: 415
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762688
@@ -15744,32 +18606,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 410 PointerType *net/http.http2headerFieldValueError.str
+          Type: 417 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 409 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 416 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 409
+      ID: 416
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 773
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.19568e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 402
+      ID: 409
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762496
@@ -15777,18 +18639,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 404 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 411 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 403 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 410 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 403
+      ID: 410
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.602432e+06
@@ -15796,22 +18658,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 933 BaseType time.Duration
+          Type: 940 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 934
+      ID: 941
       Name: net/http.incomparable
       GoRuntimeType: 831040
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.367168e+06
@@ -15821,11 +18683,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.367008e+06
@@ -15833,9 +18695,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 915 PointerType *net/http.persistConn
+          Type: 922 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.673728e+06
@@ -15843,15 +18705,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 934 ArrayType net/http.incomparable
+          Type: 941 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 935 PointerType *bufio.Reader
+          Type: 942 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 937 GoInterfaceType io.ReadWriteCloser
+          Type: 944 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 490
+      ID: 497
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.237056e+06
@@ -15861,17 +18723,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.296224e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.367328e+06
@@ -15881,11 +18743,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 479
+      ID: 486
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 974
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
@@ -15893,13 +18755,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 960 PointerType *bufio.Writer
+          Type: 967 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 889
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 561
+      ID: 568
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.607424e+06
@@ -15915,7 +18777,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 559
+      ID: 566
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.4072e+06
@@ -15928,11 +18790,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.40912e+06
@@ -15940,16 +18802,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 923 PointerType *net/smtp.Client
+          Type: 930 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 925 GoInterfaceType io.WriteCloser
+          Type: 932 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 552
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 443
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765376
@@ -15957,26 +18819,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *net/textproto.ProtocolError.str
+          Type: 445 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 437 GoStringDataType net/textproto.ProtocolError.str
+      Data: 444 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 444
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 414
+      ID: 421
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763360
@@ -15984,18 +18846,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 416 PointerType *net/url.EscapeError.str
+          Type: 423 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 415 GoStringDataType net/url.EscapeError.str
+      Data: 422 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 415
+      ID: 422
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 417
+      ID: 424
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763456
@@ -16003,30 +18865,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 419 PointerType *net/url.InvalidHostError.str
+          Type: 426 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 418 GoStringDataType net/url.InvalidHostError.str
+      Data: 425 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 418
+      ID: 425
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1031
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 679
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 743
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.212672e+06
@@ -16034,12 +18896,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1028 StructureType os.noReadFrom
+          Type: 1035 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1023 PointerType *os.File
+          Type: 1030 PointerType *os.File
     - __kind: StructureType
-      ID: 1020
+      ID: 1027
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.211872e+06
@@ -16047,36 +18909,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1027 StructureType os.noWriteTo
+          Type: 1034 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1023 PointerType *os.File
+          Type: 1030 PointerType *os.File
     - __kind: StructureType
-      ID: 1028
+      ID: 1035
       Name: os.noReadFrom
       GoRuntimeType: 1.06976e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: os.noWriteTo
       GoRuntimeType: 1.069632e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 710
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 849
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510272e+06
@@ -16089,7 +18951,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 449
+      ID: 456
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768544
@@ -16097,36 +18959,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 451 PointerType *os/user.UnknownGroupIdError.str
+          Type: 458 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 450 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 457 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 450
+      ID: 457
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 448
+      ID: 455
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 474
+      ID: 481
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 574
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 682
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 687
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -16138,7 +19000,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.756608e+06
@@ -16155,9 +19017,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 840 BaseType runtime.boundsErrorCode
+          Type: 847 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 840
+      ID: 847
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532608
@@ -16177,7 +19039,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.627552e+06
@@ -16190,7 +19052,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 656
+      ID: 663
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 948096
@@ -16198,13 +19060,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 658 PointerType *runtime.errorString.str
+          Type: 665 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 657 GoStringDataType runtime.errorString.str
+      Data: 664 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 657
+      ID: 664
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16830,7 +19692,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 659
+      ID: 666
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948672
@@ -16838,13 +19700,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 661 PointerType *runtime.plainError.str
+          Type: 668 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 660 GoStringDataType runtime.plainError.str
+      Data: 667 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 660
+      ID: 667
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16926,7 +19788,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 689
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -16938,26 +19800,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *string.str
+          Type: 315 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType string.str
+      Data: 314 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 314
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 877
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.273024e+06
@@ -16973,7 +19835,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1042
+      ID: 1049
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281664e+06
@@ -16986,7 +19848,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282784e+06
@@ -16994,12 +19856,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1044 StructureType sync/atomic.Uint32
+          Type: 1051 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1042 StructureType sync.Mutex
+          Type: 1049 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421472e+06
@@ -17007,21 +19869,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1047 StructureType sync.noCopy
+          Type: 1054 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1048 StructureType sync/atomic.Uint64
+          Type: 1055 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1047
+      ID: 1054
       Name: sync.noCopy
       GoRuntimeType: 947040
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1050
+      ID: 1057
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.283104e+06
@@ -17029,12 +19891,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1044
+      ID: 1051
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283264e+06
@@ -17042,12 +19904,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.421856e+06
@@ -17055,37 +19917,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1049 StructureType sync/atomic.align64
+          Type: 1056 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1049
+      ID: 1056
       Name: sync/atomic.align64
       GoRuntimeType: 947232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1045
+      ID: 1052
       Name: sync/atomic.noCopy
       GoRuntimeType: 947136
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 788
+      ID: 795
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1001
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.514688e+06
@@ -17098,21 +19960,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 933
+      ID: 940
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.78288e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 484
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 804
+      ID: 811
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.224896e+06
@@ -17126,9 +19988,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 805 PointerType *time.Location
+          Type: 812 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 398
+      ID: 405
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761536
@@ -17136,13 +19998,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 400 PointerType *time.fileSizeError.str
+          Type: 407 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 399 GoStringDataType time.fileSizeError.str
+      Data: 406 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 399
+      ID: 406
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -17189,11 +20051,11 @@ Types:
       GoRuntimeType: 532544
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.927008e+06
@@ -17204,10 +20066,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 823 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 830 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 824 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 831 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -17222,18 +20084,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 825 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 832 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 825
+      ID: 832
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953376
       GoKind: 9
     - __kind: StructureType
-      ID: 823
+      ID: 830
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.793376e+06
@@ -17258,21 +20120,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 570
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 824
+      ID: 831
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536192
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.244896e+06
@@ -17282,13 +20144,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 439
+      ID: 446
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765472
       GoKind: 2
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510464e+06
@@ -17301,14 +20163,14 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 664
+      ID: 671
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1286
+MaxTypeID: 1341
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x1759760", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x175c760", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -3128,7 +3128,11 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04ac0..0xd04ac6, Pieces: []}]
+          Locations:
+            - Range: 0xd04ac0..0xd04ac5
+              Pieces: []
+            - Range: 0xd04ac5..0xd04ac6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3145,7 +3149,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd04ae0..0xd04b23, Pieces: []}]
+          Locations:
+            - Range: 0xd04ae0..0xd04b1d
+              Pieces: []
+            - Range: 0xd04b1d..0xd04b1e
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd04b1e..0xd04b23
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3188,7 +3198,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04de0..0xd04e46, Pieces: []}]
+          Locations:
+            - Range: 0xd04de0..0xd04e25
+              Pieces: []
+            - Range: 0xd04e25..0xd04e26
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04e26..0xd04e46
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3221,7 +3241,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd04e80..0xd04ed4, Pieces: []}]
+          Locations:
+            - Range: 0xd04e80..0xd04ebd
+              Pieces: []
+            - Range: 0xd04ebd..0xd04ebe
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04ebe..0xd04ed4
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3721,7 +3751,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07be0..0xd07c4c, Pieces: []}]
+          Locations:
+            - Range: 0xd07be0..0xd07c34
+              Pieces: []
+            - Range: 0xd07c34..0xd07c35
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07c35..0xd07c4c
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3738,7 +3774,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 93 PointerType *int
-          Locations: [{Range: 0xd07c60..0xd07cef, Pieces: []}]
+          Locations:
+            - Range: 0xd07c60..0xd07cd3
+              Pieces: []
+            - Range: 0xd07cd3..0xd07cd4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07cd4..0xd07cef
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3766,7 +3808,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd07d00..0xd07dcf, Pieces: []}]
+          Locations:
+            - Range: 0xd07d00..0xd07db1
+              Pieces: []
+            - Range: 0xd07db1..0xd07db2
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd07db2..0xd07dcf
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3797,7 +3845,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0xd07de0..0xd07e3b, Pieces: []}]
+          Locations:
+            - Range: 0xd07de0..0xd07e1a
+              Pieces: []
+            - Range: 0xd07e1a..0xd07e1b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07e1b..0xd07e25
+              Pieces: []
+            - Range: 0xd07e25..0xd07e26
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07e26..0xd07e3b
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3831,12 +3897,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xd07e40..0xd07ebc, Pieces: []}]
+          Locations:
+            - Range: 0xd07e40..0xd07e88
+              Pieces: []
+            - Range: 0xd07e88..0xd07e89
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07e89..0xd07e92
+              Pieces: []
+            - Range: 0xd07e92..0xd07e93
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07e93..0xd07ebc
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0xd07e40..0xd07ebc, Pieces: []}]
+          Locations:
+            - Range: 0xd07e40..0xd07e88
+              Pieces: []
+            - Range: 0xd07e88..0xd07e89
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07e89..0xd07e92
+              Pieces: []
+            - Range: 0xd07e92..0xd07e93
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xd07e93..0xd07ebc
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3869,7 +3971,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xd07ec0..0xd07f4b, Pieces: []}]
+          Locations:
+            - Range: 0xd07ec0..0xd07f27
+              Pieces: []
+            - Range: 0xd07f27..0xd07f28
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd07f28..0xd07f4b
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3908,7 +4020,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
-          Locations: [{Range: 0xd07f60..0xd08077, Pieces: []}]
+          Locations:
+            - Range: 0xd07f60..0xd08008
+              Pieces: []
+            - Range: 0xd08008..0xd08009
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd08009..0xd08012
+              Pieces: []
+            - Range: 0xd08012..0xd08013
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd08013..0xd08077
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3966,7 +4096,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0xd08080..0xd0810f, Pieces: []}]
+          Locations:
+            - Range: 0xd08080..0xd080f2
+              Pieces: []
+            - Range: 0xd080f2..0xd080f3
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd080f3..0xd0810f
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3985,12 +4121,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0xd08120..0xd081d8, Pieces: []}]
+          Locations:
+            - Range: 0xd08120..0xd081be
+              Pieces: []
+            - Range: 0xd081be..0xd081bf
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd081bf..0xd081d8
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd08120..0xd081d8, Pieces: []}]
+          Locations:
+            - Range: 0xd08120..0xd081be
+              Pieces: []
+            - Range: 0xd081be..0xd081bf
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd081bf..0xd081d8
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4009,17 +4157,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0xd081e0..0xd08299, Pieces: []}]
+          Locations:
+            - Range: 0xd081e0..0xd0827f
+              Pieces: []
+            - Range: 0xd0827f..0xd08280
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xd08280..0xd08299
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd081e0..0xd08299, Pieces: []}]
+          Locations:
+            - Range: 0xd081e0..0xd0827f
+              Pieces: []
+            - Range: 0xd0827f..0xd08280
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xd08280..0xd08299
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
-          Locations: [{Range: 0xd081e0..0xd08299, Pieces: []}]
+          Locations:
+            - Range: 0xd081e0..0xd0827f
+              Pieces: []
+            - Range: 0xd0827f..0xd08280
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xd08280..0xd08299
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4262,7 +4428,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0xd08a00..0xd08a52, Pieces: []}]
+          Locations:
+            - Range: 0xd08a00..0xd08a45
+              Pieces: []
+            - Range: 0xd08a45..0xd08a46
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd08a46..0xd08a52
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1432 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd9e4a", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdb8aa", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1433 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcd9e85", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcdb8e5", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1359 EventRootType Probe[main.testAny]
+          Type: 1366 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd610a", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1360 EventRootType Probe[main.testAny]Return
+          Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcd6145", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testAnyPtr]
+          Type: 1369 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcd61aa", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcd61dd", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda422", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd6920", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testBigStruct]
+          Type: 1335 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd4a60", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1329 EventRootType Probe[main.testBigStruct]Return
+          Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd4a7e", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1295 EventRootType Probe[main.testBoolArray]
+          Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd4180", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testByteArray]
+          Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd4120", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testChannel]
+          Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testCombinedByte]
+          Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testCycle]
+          Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testDeepMap1]
+          Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd4e40", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testDeepMap7]
+          Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd4e60", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testDeepPtr1]
+          Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd4b20", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testDeepPtr7]
+          Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd4b40", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testDeepSlice1]
+          Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd4cc0", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testDeepSlice7]
+          Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd4ce0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd99e0", Frameless: true}]
+          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1424 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd9a40", Frameless: true}]
+          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd9f80", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcda3c0", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcdbe20", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcda3e0", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcdbe40", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1361 EventRootType Probe[main.testError]
+          Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd6180", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testEsotericHeap]
+          Type: 1350 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd568a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1344 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd56cc", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testEsotericStack]
+          Type: 1348 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd556e", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1342 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd55fb", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testFrameless]
+          Type: 1360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd5de0", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1354 EventRootType Probe[main.testFrameless]Return
+          Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcd5de5", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testFramelessArray]
+          Type: 1362 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd5e04", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1356 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcd5e3d", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1357 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcd5e08", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testInlinedBA]
+          Type: 1352 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd5aca", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1346 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcd5b2e", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testInlinedBB]
+          Type: 1354 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd5b6e", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1348 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcd5bfe", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testInlinedBBA]
+          Type: 1356 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd5c4a", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1350 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcd5c8b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testInlinedBBB]
+          Type: 1509 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testInlinedBC]
+          Type: 1358 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd5cce", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1352 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcd5dbe", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testInlinedBCA]
+          Type: 1510 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1456 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testInlinedBCB]
+          Type: 1512 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1458 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testInlinedPrint]
+          Type: 1506 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0xcd5c4f"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1453 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testInlinedSq]
+          Type: 1514 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1460 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testInt16Array]
+          Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd41e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1299 EventRootType Probe[main.testInt32Array]
+          Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd4200", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testInt64Array]
+          Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1297 EventRootType Probe[main.testInt8Array]
+          Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd41c0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testIntArray]
+          Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd41a0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testInterface]
+          Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd60e0", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda333", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testLinkedList]
+          Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4eda", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1339 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd4f8d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd5054", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcda693", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd68e0", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1376 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd69a0", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcd6ae0", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcd6b20", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcd6b00", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testMapIntToInt]
+          Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd6960", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6ac0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd6aa0", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testMapMassive]
+          Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testMapMassive]
+          Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd6980", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd6a80", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1382 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd6a60", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testMapStringToInt]
+          Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd68a0", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd68c0", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd6880", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd69c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd6a20", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd6a40", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd69e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd6a00", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9f40", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1496 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcda933", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd9f40", Frameless: true}]
+          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd956e", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1417 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd95fe", Frameless: false}]
+          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd94ca", Frameless: false}]
+          Type: 1421 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1415 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd9532", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testNilPointer]
+          Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd9ac0", Frameless: true}]
+          Type: 1483 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd9a60", Frameless: true}]
+          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd9aa0", Frameless: true}]
+          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd9f20", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testPointerLoop]
+          Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testPointerToMap]
+          Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd6940", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd89c0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1410 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcd930a", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcd93ee", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1411 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xcd9364", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0xcd94a4"
+              Frameless: false
+            - PC: "0xcd94df"
+              Frameless: false
+            - PC: "0xcd95a2"
+              Frameless: false
+            - PC: "0xcd95ac"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcd928a", Frameless: false}]
+          Type: 1415 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcd928e", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1409 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1416 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcd92c8"
+            - PC: "0xcd92e4"
               Frameless: false
-            - PC: "0xcd92d2"
+            - PC: "0xcd9333"
               Frameless: false
+            - PC: "0xcd9367"
+              Frameless: false
+            - PC: "0xcd9399"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,12 +1754,12 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testReturnsError]
+          Type: 1413 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd922a", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1407 EventRootType Probe[main.testReturnsError]Return
+          Type: 1414 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd925a"
               Frameless: false
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testReturnsInt]
+          Type: 1407 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1401 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcd9074", Frameless: false}]
+          Type: 1408 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcd907b", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1411 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcd91f1", Frameless: false}]
+          Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcd9204", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1409 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1403 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcd9110", Frameless: false}]
+          Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcd9114", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1412 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcd93ae", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcd95ee", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1413 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1420 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcd9442"
+            - PC: "0xcd96cf"
               Frameless: false
-            - PC: "0xcd944c"
+            - PC: "0xcd96d9"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcda136", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1293 EventRootType Probe[main.testRuneArray]
+          Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd4140", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleBool]
+          Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd4760", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testSingleByte]
+          Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4720", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testSingleFloat32]
+          Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd48c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSingleFloat64]
+          Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd48e0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testSingleInt]
+          Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd4780", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testSingleInt16]
+          Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd47c0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testSingleInt32]
+          Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd47e0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSingleInt64]
+          Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4800", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testSingleInt8]
+          Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd47a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testSingleRune]
+          Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd4740", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1434 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd9ea0", Frameless: true}]
+          Type: 1489 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdb900", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testSingleUint]
+          Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4820", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testSingleUint16]
+          Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd4860", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testSingleUint32]
+          Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd4880", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testSingleUint64]
+          Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd48a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSingleUint8]
+          Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd4840", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcd9b00", Frameless: true}]
+          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1422 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd9a00", Frameless: true}]
+          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testSmallMap]
+          Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd6900", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcd962e", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1419 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd96bb", Frameless: false}]
+          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testStringArray]
+          Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd4160", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1397 EventRootType Probe[main.testStringPointer]
+          Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1426 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd9a80", Frameless: true}]
+          Type: 1481 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testStringType1]
+          Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd4e80", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testStringType2]
+          Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd4ea0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcda240", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdbca0", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcda262", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcdbcc2", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd9a20", Frameless: true}]
+          Type: 1478 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testStructWithAny]
+          Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcd6200", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcda100", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcdbb60", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcda11e", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xcdbb7e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcda0e0", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcdbb40", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1365 EventRootType Probe[main.testStructWithMap]
+          Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd6860", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd9ec0", Frameless: true}]
+          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdb920", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1436 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd9ee0", Frameless: true}]
+          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdb940", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1437 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcd9efe", Frameless: true}]
+          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcdb95e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1438 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd9f00", Frameless: true}]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdb960", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testTypeAlias]
+          Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4900", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testUint16Array]
+          Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testUint32Array]
+          Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testUint64Array]
+          Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testUint8Array]
+          Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testUintArray]
+          Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testUintPointer]
+          Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1420 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd99c0", Frameless: true}]
+          Type: 1475 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd9f60", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testUnsafePointer]
+          Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd9ae0", Frameless: true}]
+          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1430 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd9ae0", Frameless: true}]
+          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3737,29 +4205,36 @@ Subprograms:
           IsReturn: false
     - ID: 94
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcd9020..0xcd908c]
+      OutOfLinePCRanges: [0xcd9020..0xcd9092]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9020..0xcd903e
+            - Range: 0xcd9020..0xcd9032
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd903e..0xcd908c
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9020..0xcd9074
+            - Range: 0xcd9020..0xcd907b
               Pieces: []
-            - Range: 0xcd9074..0xcd9075
+            - Range: 0xcd907b..0xcd907c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9075..0xcd908c
+            - Range: 0xcd907c..0xcd9092
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9032..0xcd9045
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9045..0xcd9092
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcd90a0..0xcd912f]
@@ -3770,64 +4245,73 @@ Subprograms:
           Locations:
             - Range: 0xcd90a0..0xcd90ba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd90ba..0xcd912f
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90a0..0xcd9110
+            - Range: 0xcd90a0..0xcd9114
               Pieces: []
-            - Range: 0xcd9110..0xcd9111
+            - Range: 0xcd9114..0xcd9115
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9111..0xcd912f
+            - Range: 0xcd9115..0xcd912f
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90bf..0xcd90d5
+            - Range: 0xcd90bf..0xcd90d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90d5..0xcd912f
+            - Range: 0xcd90d9..0xcd912f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcd9140..0xcd920f]
+      OutOfLinePCRanges: [0xcd9140..0xcd921e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9140..0xcd9194
+            - Range: 0xcd9140..0xcd91a2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9194..0xcd920f
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9140..0xcd91f1
+            - Range: 0xcd9140..0xcd9204
               Pieces: []
-            - Range: 0xcd91f1..0xcd91f2
+            - Range: 0xcd9204..0xcd9205
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd91f2..0xcd920f
+            - Range: 0xcd9205..0xcd921e
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9140..0xcd920f, Pieces: []}]
+          Locations: [{Range: 0xcd9140..0xcd921e, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9156..0xcd91a7
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd91a7..0xcd921e
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd915f..0xcd9194
+            - Range: 0xcd916f..0xcd91a7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcd9194..0xcd920f
+            - Range: 0xcd91a7..0xcd921e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
@@ -3868,19 +4352,37 @@ Subprograms:
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcd9280..0xcd92fc]
+      OutOfLinePCRanges: [0xcd9280..0xcd93c6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9280..0xcd92a3
+            - Range: 0xcd9280..0xcd92cb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92a3..0xcd92a8
+            - Range: 0xcd92cb..0xcd92d6
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9307..0xcd930a
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9340..0xcd9345
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9374..0xcd9379
               Pieces:
                 - Size: 8
                   Op: null
@@ -3891,77 +4393,116 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd9280..0xcd92a8
+            - Range: 0xcd9280..0xcd92c3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9280..0xcd92c8
+            - Range: 0xcd9280..0xcd92e4
               Pieces: []
-            - Range: 0xcd92c8..0xcd92c9
+            - Range: 0xcd92e4..0xcd92e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92c9..0xcd92d2
+            - Range: 0xcd92e5..0xcd9333
               Pieces: []
-            - Range: 0xcd92d2..0xcd92d3
+            - Range: 0xcd9333..0xcd9334
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92d3..0xcd92fc
+            - Range: 0xcd9334..0xcd9367
+              Pieces: []
+            - Range: 0xcd9367..0xcd9368
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9368..0xcd9399
+              Pieces: []
+            - Range: 0xcd9399..0xcd939a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd939a..0xcd93c6
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd9280..0xcd92c8
+            - Range: 0xcd9280..0xcd92e4
               Pieces: []
-            - Range: 0xcd92c8..0xcd92c9
+            - Range: 0xcd92e4..0xcd92e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd92c9..0xcd92d2
+            - Range: 0xcd92e5..0xcd9333
               Pieces: []
-            - Range: 0xcd92d2..0xcd92d3
+            - Range: 0xcd9333..0xcd9334
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd92d3..0xcd92fc
+            - Range: 0xcd9334..0xcd9367
+              Pieces: []
+            - Range: 0xcd9367..0xcd9368
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcd9368..0xcd9399
+              Pieces: []
+            - Range: 0xcd9399..0xcd939a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcd939a..0xcd93c6
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd92cb..0xcd92d1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 99
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcd9300..0xcd9388]
+      OutOfLinePCRanges: [0xcd93e0..0xcd95d4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9300..0xcd9341
+            - Range: 0xcd93e0..0xcd942b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9341..0xcd9348
+            - Range: 0xcd942b..0xcd9432
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9348..0xcd9388
+            - Range: 0xcd9432..0xcd95d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -3972,267 +4513,1233 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9300..0xcd9364
+            - Range: 0xcd93e0..0xcd94a4
               Pieces: []
-            - Range: 0xcd9364..0xcd9365
+            - Range: 0xcd94a4..0xcd94a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9365..0xcd9388
+            - Range: 0xcd94a5..0xcd94df
+              Pieces: []
+            - Range: 0xcd94df..0xcd94e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd94e0..0xcd95a2
+              Pieces: []
+            - Range: 0xcd95a2..0xcd95a3
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd95a3..0xcd95ac
+              Pieces: []
+            - Range: 0xcd95ac..0xcd95ad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd95ad..0xcd95d4
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd94ca..0xcd94d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 98 PointerType *int
+          Locations:
+            - Range: 0xcd9485..0xcd94a4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 100
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcd93a0..0xcd94b4]
+      OutOfLinePCRanges: [0xcd95e0..0xcd973d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd93a0..0xcd93d5
+            - Range: 0xcd95e0..0xcd9620
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd93d5..0xcd941f
+            - Range: 0xcd9620..0xcd966e
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd941f..0xcd9452
+            - Range: 0xcd966e..0xcd96df
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd9452..0xcd9472
+            - Range: 0xcd96df..0xcd96ff
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9472..0xcd9479
+            - Range: 0xcd96ff..0xcd9706
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9479..0xcd94b4
+            - Range: 0xcd9706..0xcd973d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd93a0..0xcd9442
+            - Range: 0xcd95e0..0xcd96cf
               Pieces: []
-            - Range: 0xcd9442..0xcd9443
+            - Range: 0xcd96cf..0xcd96d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9443..0xcd944c
+            - Range: 0xcd96d0..0xcd96d9
               Pieces: []
-            - Range: 0xcd944c..0xcd944d
+            - Range: 0xcd96d9..0xcd96da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd944d..0xcd94b4
+            - Range: 0xcd96da..0xcd973d
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd93a0..0xcd93d5
+            - Range: 0xcd95e0..0xcd9620
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd93d5..0xcd941f
+            - Range: 0xcd9620..0xcd966e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd941f..0xcd9426
+            - Range: 0xcd966e..0xcd9675
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -56}
+                  Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9426..0xcd9448
+            - Range: 0xcd9675..0xcd96d5
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -56}
+                  Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9448..0xcd944a
+            - Range: 0xcd96d5..0xcd96d7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd944a..0xcd944c
+            - Range: 0xcd96d7..0xcd96d9
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd944c..0xcd94b4
+            - Range: 0xcd96d9..0xcd973d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcd94c0..0xcd954f]
+      OutOfLinePCRanges: [0xcd9740..0xcd97cf]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd94c0..0xcd94fc
+            - Range: 0xcd9740..0xcd9751
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd94fc..0xcd954f
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd94c0..0xcd9532
+            - Range: 0xcd9740..0xcd97b5
               Pieces: []
-            - Range: 0xcd9532..0xcd9533
+            - Range: 0xcd97b5..0xcd97b6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9533..0xcd954f
+            - Range: 0xcd97b6..0xcd97cf
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcd9560..0xcd9618]
+      OutOfLinePCRanges: [0xcd97e0..0xcd98a9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9560..0xcd95a6
+            - Range: 0xcd97e0..0xcd9833
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd95a6..0xcd9618
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9560..0xcd95fe
+            - Range: 0xcd97e0..0xcd988f
               Pieces: []
-            - Range: 0xcd95fe..0xcd95ff
+            - Range: 0xcd988f..0xcd9890
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd95ff..0xcd9618
+            - Range: 0xcd9890..0xcd98a9
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9560..0xcd95fe
+            - Range: 0xcd97e0..0xcd988f
               Pieces: []
-            - Range: 0xcd95fe..0xcd95ff
+            - Range: 0xcd988f..0xcd9890
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd95ff..0xcd9618
+            - Range: 0xcd9890..0xcd98a9
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcd9620..0xcd96d5]
+      OutOfLinePCRanges: [0xcd98c0..0xcd9985]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9620..0xcd9665
+            - Range: 0xcd98c0..0xcd9905
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9665..0xcd96d5
+            - Range: 0xcd9905..0xcd9985
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9620..0xcd96bb
+            - Range: 0xcd98c0..0xcd996b
               Pieces: []
-            - Range: 0xcd96bb..0xcd96bc
+            - Range: 0xcd996b..0xcd996c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd96bc..0xcd96d5
+            - Range: 0xcd996c..0xcd9985
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9620..0xcd96bb
+            - Range: 0xcd98c0..0xcd996b
               Pieces: []
-            - Range: 0xcd96bb..0xcd96bc
+            - Range: 0xcd996b..0xcd996c
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd96bc..0xcd96d5
+            - Range: 0xcd996c..0xcd9985
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9620..0xcd96bb
+            - Range: 0xcd98c0..0xcd996b
               Pieces: []
-            - Range: 0xcd96bb..0xcd96bc
+            - Range: 0xcd996b..0xcd996c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd96bc..0xcd96d5
+            - Range: 0xcd996c..0xcd9985
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd99c0..0xcd99c1]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0xcd99a0..0xcd9a1e]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 248 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd99c0..0xcd99c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 102 BaseType int16
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcd99a0..0xcd9a11
+              Pieces: []
+            - Range: 0xcd9a11..0xcd9a12
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcd9a12..0xcd9a1e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd99e0..0xcd99e1]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0xcd9a20..0xcd9b17]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 248 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd99e0..0xcd99e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0xcd9a20..0xcd9b07
+              Pieces: []
+            - Range: 0xcd9b07..0xcd9b08
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xcd9b08..0xcd9b17
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0xcd9a20..0xcd9b07
+              Pieces: []
+            - Range: 0xcd9b07..0xcd9b08
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcd9b08..0xcd9b17
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd9a00..0xcd9a01]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xcd9b20..0xcd9b93]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 94 BaseType complex64
+          Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 95 BaseType complex128
+          Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0xcd9ba0..0xcd9c45]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcd9ba0..0xcd9c33
+              Pieces: []
+            - Range: 0xcd9c33..0xcd9c34
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+            - Range: 0xcd9c34..0xcd9c45
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xcd9c60..0xcd9cda]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0xcd9c60..0xcd9ccd
+              Pieces: []
+            - Range: 0xcd9ccd..0xcd9cce
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcd9cce..0xcd9cda
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xcd9ce0..0xcd9d38]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 ArrayType [1]int
+          Locations:
+            - Range: 0xcd9ce0..0xcd9d2b
+              Pieces: []
+            - Range: 0xcd9d2b..0xcd9d2c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9d2c..0xcd9d38
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xcd9d40..0xcd9d93]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0xcd9d40..0xcd9d86
+              Pieces: []
+            - Range: 0xcd9d86..0xcd9d87
+              Pieces: []
+            - Range: 0xcd9d87..0xcd9d93
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xcd9da0..0xcd9e07]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 StructureType main.mixedStruct
+          Locations: [{Range: 0xcd9da0..0xcd9e07, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0xcd9e20..0xcd9eba]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd9e20..0xcd9eaa
+              Pieces: []
+            - Range: 0xcd9eaa..0xcd9eab
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xcd9eab..0xcd9eba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xcd9ec0..0xcd9f65]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 253 StructureType main.wideStruct
+          Locations:
+            - Range: 0xcd9ec0..0xcd9f54
+              Pieces: []
+            - Range: 0xcd9f54..0xcd9f55
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xcd9f55..0xcd9f65
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xcd9f80..0xcd9ff9]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9f80..0xcd9fec
+              Pieces: []
+            - Range: 0xcd9fec..0xcd9fed
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9fed..0xcd9ff9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcd9f80..0xcd9fec
+              Pieces: []
+            - Range: 0xcd9fec..0xcd9fed
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd9fed..0xcd9ff9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd9f80..0xcd9fec
+              Pieces: []
+            - Range: 0xcd9fec..0xcd9fed
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcd9fed..0xcd9ff9
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xcda000..0xcda07a]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcda000..0xcda06d
+              Pieces: []
+            - Range: 0xcda06d..0xcda06e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcda06e..0xcda07a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xcda080..0xcda0db]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcda080..0xcda0db, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xcda0e0..0xcda147]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0xcda160..0xcda1bd]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcda160..0xcda1b0
+              Pieces: []
+            - Range: 0xcda1b0..0xcda1b1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda1b1..0xcda1bd
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0xcda160..0xcda1b0
+              Pieces: []
+            - Range: 0xcda1b0..0xcda1b1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcda1b1..0xcda1bd
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0xcda1c0..0xcda345]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda1c0..0xcda345
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda1c0..0xcda333
+              Pieces: []
+            - Range: 0xcda333..0xcda334
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+            - Range: 0xcda334..0xcda345
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0xcda360..0xcda432]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0xcda360..0xcda432
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0xcda360..0xcda422
+              Pieces: []
+            - Range: 0xcda422..0xcda423
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xcda423..0xcda432
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0xcda440..0xcda67a]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda440..0xcda67a
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda440..0xcda67a
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda440..0xcda66a
+              Pieces: []
+            - Range: 0xcda66a..0xcda66b
+              Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
+            - Range: 0xcda66b..0xcda67a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0xcda680..0xcda90f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda71a
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcda71a..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda6f0
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcda6f0..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda680..0xcda730
+              Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
+            - Range: 0xcda730..0xcda90f
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0xcda680..0xcda8a2
+              Pieces: []
+            - Range: 0xcda8a2..0xcda8a3
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xcda8a3..0xcda90f
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0xcda920..0xcdabec]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9b5
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcda9b5..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda982
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcda982..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcda920..0xcda9cb
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcda9cb..0xcdabec
+              Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcda920..0xcdabec
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcda920..0xcdab6b
+              Pieces: []
+            - Range: 0xcdab6b..0xcdab6c
+              Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
+            - Range: 0xcdab6c..0xcdabec
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0xcdac00..0xcdac8c]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 159 ArrayType [5]int
+          Locations:
+            - Range: 0xcdac00..0xcdac8c
+              Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdac00..0xcdac7c
+              Pieces: []
+            - Range: 0xcdac7c..0xcdac7d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdac7d..0xcdac8c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdac00..0xcdac7c
+              Pieces: []
+            - Range: 0xcdac7c..0xcdac7d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdac7d..0xcdac8c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdac00..0xcdac7c
+              Pieces: []
+            - Range: 0xcdac7c..0xcdac7d
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcdac7d..0xcdac8c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0xcdaca0..0xcdad8e]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0xcdaca0..0xcdad8e
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0xcdaca0..0xcdad8e
+              Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdaca0..0xcdad7e
+              Pieces: []
+            - Range: 0xcdad7e..0xcdad7f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdad7f..0xcdad8e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0xcdaca0..0xcdad7e
+              Pieces: []
+            - Range: 0xcdad7e..0xcdad7f
+              Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
+            - Range: 0xcdad7f..0xcdad8e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0xcdada0..0xcdae6b]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcdada0..0xcdae6b
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdada0..0xcdae5a
+              Pieces: []
+            - Range: 0xcdae5a..0xcdae5b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdae5b..0xcdae6b
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcdada0..0xcdae5a
+              Pieces: []
+            - Range: 0xcdae5a..0xcdae5b
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xcdae5b..0xcdae6b
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdae26..0xcdae6b
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0xcdae80..0xcdaf26]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 251 ArrayType [0]int
+          Locations: [{Range: 0xcdae80..0xcdaf26, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdae80..0xcdaec5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdaec5..0xcdaee7
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xcdaee7..0xcdaefa
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcdaefa..0xcdaf26
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdae80..0xcdaf0c
+              Pieces: []
+            - Range: 0xcdaf0c..0xcdaf0d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdaf0d..0xcdaf26
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0xcdae80..0xcdaf0c
+              Pieces: []
+            - Range: 0xcdaf0c..0xcdaf0d
+              Pieces: []
+            - Range: 0xcdaf0d..0xcdaf26
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcdb420..0xcdb421]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 249 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd9a00..0xcd9a01
+            - Range: 0xcdb420..0xcdb421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4242,15 +5749,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcdb440..0xcdb441]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdb440..0xcdb441
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdb460..0xcdb461]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdb460..0xcdb461
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd9a20..0xcd9a21]
+      OutOfLinePCRanges: [0xcdb480..0xcdb481]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd9a20..0xcd9a21
+            - Range: 0xcdb480..0xcdb481
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4263,19 +5806,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9a20..0xcd9a21
+            - Range: 0xcdb480..0xcdb481
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd9a40..0xcd9a41]
+      OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd9a40..0xcd9a41
+            - Range: 0xcdb4a0..0xcdb4a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4288,19 +5831,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9a40..0xcd9a41
+            - Range: 0xcdb4a0..0xcdb4a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcd9a60..0xcd9a61]
+      OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcd9a60..0xcd9a61
+            - Range: 0xcdb4c0..0xcdb4c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4313,19 +5856,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9a60..0xcd9a61
+            - Range: 0xcdb4c0..0xcdb4c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcd9a80..0xcd9a81]
+      OutOfLinePCRanges: [0xcdb4e0..0xcdb4e1]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcd9a80..0xcd9a81
+            - Range: 0xcdb4e0..0xcdb4e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4335,22 +5878,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcd9aa0..0xcd9aa1]
+      OutOfLinePCRanges: [0xcdb500..0xcdb501]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd9aa0..0xcd9aa1
+            - Range: 0xcdb500..0xcdb501
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 255 GoSliceHeaderType []bool
+          Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd9aa0..0xcd9aa1
+            - Range: 0xcdb500..0xcdb501
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -4363,19 +5906,19 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd9aa0..0xcd9aa1
+            - Range: 0xcdb500..0xcdb501
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd9ac0..0xcd9ac1]
+      OutOfLinePCRanges: [0xcdb520..0xcdb521]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 256 GoSliceHeaderType []uint16
+          Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd9ac0..0xcd9ac1
+            - Range: 0xcdb520..0xcdb521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4385,15 +5928,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd9ae0..0xcd9ae1]
+      OutOfLinePCRanges: [0xcdb540..0xcdb541]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd9ae0..0xcd9ae1
+            - Range: 0xcdb540..0xcdb541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4403,15 +5946,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcd9b00..0xcd9b01]
+      OutOfLinePCRanges: [0xcdb560..0xcdb561]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 257 GoSliceHeaderType []struct {}
+          Type: 264 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcd9b00..0xcd9b01
+            - Range: 0xcdb560..0xcdb561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4421,35 +5964,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd9e40..0xcd9e92]
+      OutOfLinePCRanges: [0xcdb8a0..0xcdb8f2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9e40..0xcd9e85
+            - Range: 0xcdb8a0..0xcdb8e5
               Pieces: []
-            - Range: 0xcd9e85..0xcd9e86
+            - Range: 0xcdb8e5..0xcdb8e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9e86..0xcd9e92
+            - Range: 0xcdb8e6..0xcdb8f2
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd9ea0..0xcd9ea1]
+      OutOfLinePCRanges: [0xcdb900..0xcdb901]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9ea0..0xcd9ea1
+            - Range: 0xcdb900..0xcdb901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4457,15 +6000,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd9ec0..0xcd9ec1]
+      OutOfLinePCRanges: [0xcdb920..0xcdb921]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9ec0..0xcd9ec1
+            - Range: 0xcdb920..0xcdb921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4476,7 +6019,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9ec0..0xcd9ec1
+            - Range: 0xcdb920..0xcdb921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4487,7 +6030,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9ec0..0xcd9ec1
+            - Range: 0xcdb920..0xcdb921
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4495,15 +6038,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd9ee0..0xcd9eff]
+      OutOfLinePCRanges: [0xcdb940..0xcdb95f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 259 StructureType main.threeStringStruct
+          Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd9ee0..0xcd9eff
+            - Range: 0xcdb940..0xcdb95f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4519,39 +6062,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd9f00..0xcd9f01]
+      OutOfLinePCRanges: [0xcdb960..0xcdb961]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 260 PointerType *main.threeStringStruct
+          Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd9f00..0xcd9f01
+            - Range: 0xcdb960..0xcdb961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd9f20..0xcd9f21]
+      OutOfLinePCRanges: [0xcdb980..0xcdb981]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 261 PointerType *main.oneStringStruct
+          Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd9f20..0xcd9f21
+            - Range: 0xcdb980..0xcdb981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd9f40..0xcd9f41]
+      OutOfLinePCRanges: [0xcdb9a0..0xcdb9a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9f40..0xcd9f41
+            - Range: 0xcdb9a0..0xcdb9a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4559,15 +6102,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd9f60..0xcd9f61]
+      OutOfLinePCRanges: [0xcdb9c0..0xcdb9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9f60..0xcd9f61
+            - Range: 0xcdb9c0..0xcdb9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4575,15 +6118,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd9f80..0xcd9f81]
+      OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9f80..0xcd9f81
+            - Range: 0xcdb9e0..0xcdb9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4591,27 +6134,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcda0e0..0xcda0e1]
+      OutOfLinePCRanges: [0xcdbb40..0xcdbb41]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 263 StructureType main.structWithCyclicSlices
+          Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcda0e0..0xcda0e1
+            - Range: 0xcdbb40..0xcdbb41
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcda100..0xcda11f]
+      OutOfLinePCRanges: [0xcdbb60..0xcdbb7f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 276 StructureType main.structWithCyclicMaps
+          Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcda100..0xcda11f
+            - Range: 0xcdbb60..0xcdbb7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4627,15 +6170,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcda240..0xcda263]
+      OutOfLinePCRanges: [0xcdbca0..0xcdbcc3]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 307 StructureType main.aStruct
+          Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0xcda240..0xcda263
+            - Range: 0xcdbca0..0xcdbcc3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4653,29 +6196,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcda3c0..0xcda3c1]
+      OutOfLinePCRanges: [0xcdbe20..0xcdbe21]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 308 StructureType main.emptyStruct
-          Locations: [{Range: 0xcda3c0..0xcda3c1, Pieces: []}]
+          Type: 315 StructureType main.emptyStruct
+          Locations: [{Range: 0xcdbe20..0xcdbe21, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcda3e0..0xcda3e1]
+      OutOfLinePCRanges: [0xcdbe40..0xcdbe41]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 309 PointerType *main.emptyStruct
+          Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcda3e0..0xcda3e1
+            - Range: 0xcdbe40..0xcdbe41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5920..0xcd5982]
       InlinePCRanges:
@@ -4705,28 +6248,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5bc6..0xcd5bfe]
           RootRanges: [0xcd5b60..0xcd5c25]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5cd3..0xcd5d11]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5d86..0xcd5dbe]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4740,7 +6283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4765,20 +6308,20 @@ Types:
       ByteSize: 8
       Pointee: 138 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1211 PointerType *main.deepSlice3
+      Pointee: 1218 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1236 PointerType *main.deepSlice8
+      Pointee: 1243 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1242 PointerType *main.deepSlice9
+      Pointee: 1249 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 151
       Name: '**main.stringType2'
@@ -4786,7 +6329,7 @@ Types:
       GoKind: 22
       Pointee: 152 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '**main.t'
       ByteSize: 8
       Pointee: 246 PointerType *main.t
@@ -4823,30 +6366,30 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1219 PointerType *table<int,*main.deepMap3>
+      Pointee: 1226 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1253 PointerType *table<int,*main.deepMap8>
+      Pointee: 1260 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1268 PointerType *table<int,*main.deepMap9>
+      Pointee: 1275 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 168 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1282
+      ID: 1289
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1283 PointerType *table<int,interface {}>
+      Pointee: 1290 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '**table<int,struct {}>'
@@ -4868,10 +6411,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 953 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 960 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,int>'
@@ -4888,35 +6431,35 @@ Types:
       ByteSize: 8
       Pointee: 230 PointerType *table<struct {},int>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '**table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 PointerType *table<struct {},main.structWithCyclicMaps>
+      Pointee: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 305
+      ID: 312
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 306 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 239
       Name: '**table<struct {},struct {}>'
@@ -4933,115 +6476,115 @@ Types:
       ByteSize: 8
       Pointee: 210 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 320
+      ID: 327
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 326 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1213 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1220 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1246
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1238 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1245 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1252
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1244 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1251 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []*string.array
+      Pointee: 323 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 486 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 484 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 273
+      ID: 280
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 482 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 271
+      ID: 278
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 474
+      ID: 481
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 480 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 269
+      ID: 276
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 472
+      ID: 479
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 478 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 458
+      ID: 465
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 457 GoSliceDataType [][]uint.array
+      Pointee: 464 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 464
+      ID: 471
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 463 GoSliceDataType []bool.array
+      Pointee: 470 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 988 GoSliceDataType []float64.array
+      Pointee: 995 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []interface {}.array
+      Pointee: 1254 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 267
+      ID: 274
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 264 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 470
+      ID: 477
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 476 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 530
+      ID: 537
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 529 GoSliceDataType []main.structWithMap.array
+      Pointee: 536 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 460
+      ID: 467
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 459 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 466 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -5050,101 +6593,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 462
+      ID: 469
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 461 GoSliceDataType []string.array
+      Pointee: 468 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType []struct {}.array
+      Pointee: 474 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 250
+      ID: 257
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 248 GoSliceHeaderType []uint
+      Pointee: 255 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 456
+      ID: 463
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 455 GoSliceDataType []uint.array
+      Pointee: 462 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 466
+      ID: 473
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 465 GoSliceDataType []uint16.array
+      Pointee: 472 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 313
+      ID: 320
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 312 GoSliceDataType []uint8.array
+      Pointee: 319 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 315
+      ID: 322
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []uintptr.array
+      Pointee: 321 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.97904e+06
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1127 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 761 GoSliceHeaderType archive/tar.headerError
+      Pointee: 768 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 762 GoSliceDataType archive/tar.headerError.array
+      Pointee: 769 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.432864e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1062 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 927808
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1010 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 927904
       GoKind: 22
-      Pointee: 1005 StructureType archive/zip.dirWriter
+      Pointee: 1012 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.89872e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1110 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.05424e+06
       GoKind: 22
-      Pointee: 1031 StructureType archive/zip.nopCloser
+      Pointee: 1038 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.054496e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1040 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -5153,421 +6696,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.167168e+06
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType bufio.Reader
+      Pointee: 1085 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.943232e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType bufio.Writer
+      Pointee: 1114 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1157
+      ID: 1164
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.264448e+06
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1165 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 910144
       GoKind: 22
-      Pointee: 564 BaseType compress/flate.CorruptInputError
+      Pointee: 571 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 910240
       GoKind: 22
-      Pointee: 565 GoStringHeaderType compress/flate.InternalError
+      Pointee: 572 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType compress/flate.InternalError.str
+      Pointee: 573 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.422304e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1060 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 910336
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1006 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.72048e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1082 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.200832e+06
       GoKind: 22
-      Pointee: 905 StructureType context.deadlineExceededError
+      Pointee: 912 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922240
       GoKind: 22
-      Pointee: 578 BaseType crypto/aes.KeySizeError
+      Pointee: 585 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922432
       GoKind: 22
-      Pointee: 579 BaseType crypto/des.KeySizeError
+      Pointee: 586 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922720
       GoKind: 22
-      Pointee: 580 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 587 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.562784e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1072 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857152e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1106 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.114496e+06
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1138 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.899232e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1112 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1100
+      ID: 1107
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857824e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1108 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1096
+      ID: 1103
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.849984e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1104 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 923008
       GoKind: 22
-      Pointee: 581 BaseType crypto/rc4.KeySizeError
+      Pointee: 588 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.948608e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1122 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1086
+      ID: 1093
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.803968e+06
       GoKind: 22
-      Pointee: 1087 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1094 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 568 BaseType crypto/tls.AlertError
+      Pointee: 575 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.042848e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 852 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.37632e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1191 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 684 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 911584
       GoKind: 22
-      Pointee: 675 StructureType crypto/tls.RecordHeaderError
+      Pointee: 682 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.041184e+06
       GoKind: 22
-      Pointee: 800 BaseType crypto/tls.alert
+      Pointee: 807 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.555744e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1070 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.638176e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1077 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.422624e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 947 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.037088e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 962 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 921280
       GoKind: 22
-      Pointee: 749 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 756 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 920800
       GoKind: 22
-      Pointee: 743 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 750 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 920896
       GoKind: 22
-      Pointee: 745 StructureType crypto/x509.HostnameError
+      Pointee: 752 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 577 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 584 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.048608e+06
       GoKind: 22
-      Pointee: 850 StructureType crypto/x509.SystemRootsError
+      Pointee: 857 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 921376
       GoKind: 22
-      Pointee: 751 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 758 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 921184
       GoKind: 22
-      Pointee: 747 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 754 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 928096
       GoKind: 22
-      Pointee: 765 StructureType encoding/asn1.StructuralError
+      Pointee: 772 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 928288
       GoKind: 22
-      Pointee: 769 StructureType encoding/asn1.SyntaxError
+      Pointee: 776 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 928192
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 774 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 908224
       GoKind: 22
-      Pointee: 562 BaseType encoding/base64.CorruptInputError
+      Pointee: 569 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.038368e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1028 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 665
+      ID: 672
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 909088
       GoKind: 22
-      Pointee: 563 BaseType encoding/hex.InvalidByteError
+      Pointee: 570 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 902944
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 641 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.034656e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 843 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 625
+      ID: 632
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 902560
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 633 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 902848
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 639 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 902752
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 637 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 902656
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 635 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1163
+      ID: 1170
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.289472e+06
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1171 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 903328
       GoKind: 22
-      Pointee: 636 StructureType encoding/json.jsonError
+      Pointee: 643 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.051168e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1036 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 919744
       GoKind: 22
-      Pointee: 737 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 744 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 919648
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 742 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 919840
       GoKind: 22
-      Pointee: 574 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 581 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 582 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 919936
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 747 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1141
+      ID: 1148
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.152928e+06
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1149 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -5576,19 +7119,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 893248
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType errors.errorString
+      Pointee: 611 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.019552e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType errors.joinError
+      Pointee: 810 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -5604,813 +7147,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1151
+      ID: 1158
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.256768e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType fmt.pp
+      Pointee: 1159 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.01968e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType fmt.wrapError
+      Pointee: 812 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019808e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 814 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 663
+      ID: 670
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908608
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 671 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 905728
       GoKind: 22
-      Pointee: 645 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 652 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 646
+      ID: 653
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 905824
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 654 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 905536
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 974 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 906112
       GoKind: 22
-      Pointee: 651 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 658 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 905632
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 976 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 648
+      ID: 655
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 905920
       GoKind: 22
-      Pointee: 556 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 905440
       GoKind: 22
-      Pointee: 553 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 560 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 555
+      ID: 562
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 906016
       GoKind: 22
-      Pointee: 559 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 566 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 561
+      ID: 568
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.206336e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1050 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.052096e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1135 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 926560
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 766 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.20992e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 921 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.266496e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1167 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 915232
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 693 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 916288
       GoKind: 22
-      Pointee: 693 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 700 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 573 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 580 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 916192
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 698 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 916096
       GoKind: 22
-      Pointee: 689 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 696 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 709 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 716 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 713 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 720 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 711 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 718 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 707 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 714 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 997 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 728 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 715 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 722 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918688
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 726 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 724 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918880
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 730 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 736 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 738 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 734 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 732 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 919456
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 907264
       GoKind: 22
-      Pointee: 653 StructureType github.com/cihub/seelog.baseError
+      Pointee: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.796576e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 907360
       GoKind: 22
-      Pointee: 655 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 662 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.554624e+06
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.037344e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1024 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.420384e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1058 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 907552
       GoKind: 22
-      Pointee: 659 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 666 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1117
+      ID: 1124
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.96896e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1125 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.12608e+06
       GoKind: 22
-      Pointee: 1129 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1136 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.125696e+06
       GoKind: 22
-      Pointee: 1132 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1139 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1026 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 907456
       GoKind: 22
-      Pointee: 657 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 664 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 907648
       GoKind: 22
-      Pointee: 661 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 668 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1082
+      ID: 1089
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.798368e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.005696e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.036768e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1133 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.435264e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 952 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.062688e+06
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 865 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.06256e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 863 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.066656e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 867 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.066784e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 869 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.665248e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1079 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.049248e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 859 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 667 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 674 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1175
+      ID: 1182
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.352544e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1183 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.218368e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 923 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.19712e+06
       GoKind: 22
-      Pointee: 889 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.196736e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.02864e+06
       GoKind: 22
-      Pointee: 822 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 829 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.197504e+06
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.028512e+06
       GoKind: 22
-      Pointee: 799 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 806 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.196992e+06
       GoKind: 22
-      Pointee: 887 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.196864e+06
       GoKind: 22
-      Pointee: 885 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.197376e+06
       GoKind: 22
-      Pointee: 893 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.197248e+06
       GoKind: 22
-      Pointee: 891 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1179
+      ID: 1186
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.364352e+06
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1187 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.197888e+06
       GoKind: 22
-      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.028896e+06
       GoKind: 22
-      Pointee: 826 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.028768e+06
       GoKind: 22
-      Pointee: 824 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 831 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.19776e+06
       GoKind: 22
-      Pointee: 897 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 941056
       GoKind: 22
-      Pointee: 586 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 593 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 594 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.663712e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 965 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.081504e+06
       GoKind: 22
-      Pointee: 866 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 873 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.25792e+06
       GoKind: 22
-      Pointee: 1049 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1056 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1139
+      ID: 1146
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.141056e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1147 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.083808e+06
       GoKind: 22
-      Pointee: 1035 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1042 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 942304
       GoKind: 22
-      Pointee: 589 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 596 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.259584e+06
       GoKind: 22
-      Pointee: 924 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 931 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 942592
       GoKind: 22
-      Pointee: 785 StructureType golang.org/x/net/http2.connError
+      Pointee: 792 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 942496
       GoKind: 22
-      Pointee: 593 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 600 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 595
+      ID: 602
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 601 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 942784
       GoKind: 22
-      Pointee: 599 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 606 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 601
+      ID: 608
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 600 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 607 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 942688
       GoKind: 22
-      Pointee: 596 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 603 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 604 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 942400
       GoKind: 22
-      Pointee: 590 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 597 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 591 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 598 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1137
+      ID: 1144
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.139136e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1145 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 942880
       GoKind: 22
-      Pointee: 789 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 796 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 942976
       GoKind: 22
-      Pointee: 602 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 609 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 936256
       GoKind: 22
-      Pointee: 777 StructureType google.golang.org/grpc.dropError
+      Pointee: 784 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.25664e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.442624e+06
       GoKind: 22
-      Pointee: 947 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 954 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 939328
       GoKind: 22
-      Pointee: 779 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 786 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.804416e+06
       GoKind: 22
-      Pointee: 1089 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1096 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.253184e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1054 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.075744e+06
       GoKind: 22
-      Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 871 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 939424
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1014 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 924448
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 764 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.052576e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 861 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.22464e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 927 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.224384e+06
       GoKind: 22
-      Pointee: 918 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 925 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 929152
       GoKind: 22
-      Pointee: 771 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 778 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 929248
       GoKind: 22
-      Pointee: 773 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 780 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 916672
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 708 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1094
+      ID: 1101
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.845056e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1102 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 943744
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType html/template.Error
+      Pointee: 799 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 98
       Name: '*int'
@@ -6454,103 +7997,103 @@ Types:
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909856
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 678 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 676 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 992
+      ID: 999
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 897760
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1000 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.195968e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 888 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1181
+      ID: 1188
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.369984e+06
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1189 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.19584e+06
       GoKind: 22
-      Pointee: 879 StructureType internal/poll.errNetClosing
+      Pointee: 886 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896992
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 613 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.187648e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1046 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.187264e+06
       GoKind: 22
-      Pointee: 1037 StructureType io.discard
+      Pointee: 1044 StructureType io.discard
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.020576e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType io.multiWriter
+      Pointee: 1018 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.195584e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType io/fs.PathError
+      Pointee: 884 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1084
+      ID: 1091
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.798592e+06
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1092 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 327
+      ID: 334
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383744
       GoKind: 22
-      Pointee: 328 StructureType main.deepMap2
+      Pointee: 335 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType main.deepMap3
+      Pointee: 1234 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
@@ -6559,19 +8102,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 383360
       GoKind: 22
-      Pointee: 1261 StructureType main.deepMap8
+      Pointee: 1268 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 383296
       GoKind: 22
-      Pointee: 1276 StructureType main.deepMap9
+      Pointee: 1283 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
@@ -6580,12 +8123,12 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 384256
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1193 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
@@ -6594,33 +8137,33 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383936
       GoKind: 22
-      Pointee: 1231 StructureType main.deepPtr8
+      Pointee: 1238 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383872
       GoKind: 22
-      Pointee: 1233 StructureType main.deepPtr9
+      Pointee: 1240 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384896
       GoKind: 22
-      Pointee: 318 StructureType main.deepSlice2
+      Pointee: 325 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384832
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1219 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
@@ -6629,25 +8172,25 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384512
       GoKind: 22
-      Pointee: 1237 StructureType main.deepSlice8
+      Pointee: 1244 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 384448
       GoKind: 22
-      Pointee: 1243 StructureType main.deepSlice9
+      Pointee: 1250 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 309
+      ID: 316
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 StructureType main.emptyStruct
+      Pointee: 315 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 157
       Name: '*main.esotericHeap'
@@ -6656,12 +8199,12 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 892960
       GoKind: 22
-      Pointee: 1203 StructureType main.firstBehavior
+      Pointee: 1210 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 245
       Name: '*main.node'
@@ -6670,25 +8213,25 @@ Types:
       GoKind: 22
       Pointee: 244 StructureType main.node
     - __kind: PointerType
-      ID: 261
+      ID: 268
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 262 StructureType main.oneStringStruct
+      Pointee: 269 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 893056
       GoKind: 22
-      Pointee: 1205 StructureType main.secondBehavior
+      Pointee: 1212 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 893152
       GoKind: 22
-      Pointee: 1191 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1198 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType1'
@@ -6696,33 +8239,33 @@ Types:
       GoKind: 22
       Pointee: 150 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1187 GoStringDataType main.stringType1.str
+      Pointee: 1194 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 152
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType main.stringType2
+      Pointee: 1196 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 265
+      ID: 272
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 263 StructureType main.structWithCyclicSlices
+      Pointee: 270 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 383232
       GoKind: 22
       Pointee: 163 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 252
+      ID: 259
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 253 StructureType main.structWithNoStrings
+      Pointee: 260 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithTwoValues'
@@ -6736,16 +8279,16 @@ Types:
       GoKind: 22
       Pointee: 247 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1207 GoSliceDataType main.t.array
+      Pointee: 1214 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 260
+      ID: 267
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 259 StructureType main.threeStringStruct
+      Pointee: 266 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 222
       Name: '*map<[4]int,[4]int>'
@@ -6772,30 +8315,30 @@ Types:
       ByteSize: 8
       Pointee: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1217 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1224 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1251 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1258 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1266 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1273 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 166 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1281 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1288 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 232
       Name: '*map<int,struct {}>'
@@ -6817,10 +8360,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 951 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 958 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,int>'
@@ -6837,35 +8380,35 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: PointerType
-      ID: 278
+      ID: 285
       Name: '*map<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 279 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      Pointee: 286 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 283
+      ID: 290
       Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 284 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 291 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 288
+      ID: 295
       Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 289 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 293
+      ID: 300
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 294 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 298
+      ID: 305
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 299 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 303
+      ID: 310
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 304 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 311 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 237
       Name: '*map<struct {},struct {}>'
@@ -6888,696 +8431,696 @@ Types:
       GoKind: 22
       Pointee: 174 GoMapType map[string]int
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 705 StructureType math/big.ErrNaN
+      Pointee: 712 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 912352
       GoKind: 22
-      Pointee: 1001 StructureType mime/multipart.writerOnly·1
+      Pointee: 1008 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.20416e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net.AddrError
+      Pointee: 915 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.418624e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.DNSError
+      Pointee: 941 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1145
+      ID: 1152
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.227584e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType net.IPConn
+      Pointee: 1153 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.418304e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net.OpError
+      Pointee: 939 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.204288e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net.ParseError
+      Pointee: 917 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.257792e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType net.TCPConn
+      Pointee: 1163 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1165
+      ID: 1172
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.302784e+06
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType net.UDPConn
+      Pointee: 1173 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.25728e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType net.UnixConn
+      Pointee: 1161 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.203392e+06
       GoKind: 22
-      Pointee: 869 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 876 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 870 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 877 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.035552e+06
       GoKind: 22
-      Pointee: 838 StructureType net.canceledError
+      Pointee: 845 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.002816e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType net.conn
+      Pointee: 1129 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.840352e+06
       GoKind: 22
-      Pointee: 976 StructureType net.dialResult·1
+      Pointee: 983 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1167
+      ID: 1174
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.30704e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType net.netFD
+      Pointee: 1175 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 904288
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType net.notFoundError
+      Pointee: 645 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 904960
       GoKind: 22
-      Pointee: 640 StructureType net.result·2
+      Pointee: 647 StructureType net.result·2
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.243808e+06
       GoKind: 22
-      Pointee: 1150 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1157 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1147
+      ID: 1154
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.243328e+06
       GoKind: 22
-      Pointee: 1148 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1155 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.204928e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType net.temporaryError
+      Pointee: 919 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.418784e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType net.timeoutError
+      Pointee: 943 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.031328e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 835 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 900064
       GoKind: 22
-      Pointee: 995 StructureType net/http.bufioFlushWriter
+      Pointee: 1002 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 614
+      ID: 621
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 534 BaseType net/http.http2ConnectionError
+      Pointee: 541 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 616 StructureType net/http.http2GoAwayError
+      Pointee: 623 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.414464e+06
       GoKind: 22
-      Pointee: 928 StructureType net/http.http2StreamError
+      Pointee: 935 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 901408
       GoKind: 22
-      Pointee: 620 StructureType net/http.http2connError
+      Pointee: 627 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.551104e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1064 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 618
+      ID: 625
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 901312
       GoKind: 22
-      Pointee: 538 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 545 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 540
+      ID: 547
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 546 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901600
       GoKind: 22
-      Pointee: 544 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 551 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 546
+      ID: 553
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 552 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 901504
       GoKind: 22
-      Pointee: 541 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 548 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 542 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 549 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.199936e+06
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.031968e+06
       GoKind: 22
-      Pointee: 834 StructureType net/http.http2noCachedConnError
+      Pointee: 841 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.94528e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1118 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 901216
       GoKind: 22
-      Pointee: 535 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 542 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 543 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 901696
       GoKind: 22
-      Pointee: 997 StructureType net/http.http2stickyErrWriter
+      Pointee: 1004 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.031584e+06
       GoKind: 22
-      Pointee: 830 StructureType net/http.nothingWrittenError
+      Pointee: 837 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.168416e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1066 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.031456e+06
       GoKind: 22
-      Pointee: 1015 StructureType net/http.persistConnWriter
+      Pointee: 1022 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.19904e+06
       GoKind: 22
-      Pointee: 1041 StructureType net/http.readWriteCloserBody
+      Pointee: 1048 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901792
       GoKind: 22
-      Pointee: 624 StructureType net/http.requestBodyReadError
+      Pointee: 631 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.415584e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 937 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.199808e+06
       GoKind: 22
-      Pointee: 901 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.031712e+06
       GoKind: 22
-      Pointee: 832 StructureType net/http.transportReadFromServerError
+      Pointee: 839 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1092
+      ID: 1099
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.836992e+06
       GoKind: 22
-      Pointee: 1093 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1100 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899968
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 620 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.946816e+06
       GoKind: 22
-      Pointee: 1113 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1120 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1032 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 697 StructureType net/netip.parseAddrError
+      Pointee: 704 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 916384
       GoKind: 22
-      Pointee: 695 StructureType net/netip.parsePrefixError
+      Pointee: 702 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.113088e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1074 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.048864e+06
       GoKind: 22
-      Pointee: 1027 StructureType net/smtp.dataCloser
+      Pointee: 1034 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 680
+      ID: 687
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 912544
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/textproto.Error
+      Pointee: 688 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 912448
       GoKind: 22
-      Pointee: 569 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 576 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 577 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.043232e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1030 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.419104e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType net/url.Error
+      Pointee: 945 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 905056
       GoKind: 22
-      Pointee: 547 GoStringHeaderType net/url.EscapeError
+      Pointee: 554 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType net/url.EscapeError.str
+      Pointee: 555 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 905152
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 557 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 558 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 425
+      ID: 432
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 426 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 417
+      ID: 424
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 418 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 365
+      ID: 372
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 366 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 384
+      ID: 391
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 385 StructureType noalg.map.group[bool]main.node
+      Pointee: 392 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 323
+      ID: 330
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 333
+      ID: 340
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 334 StructureType noalg.map.group[int]int
+      Pointee: 341 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1287 StructureType noalg.map.group[int]interface {}
+      Pointee: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 442 StructureType noalg.map.group[int]struct {}
+      Pointee: 449 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 392
+      ID: 399
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 393 StructureType noalg.map.group[int]uint8
+      Pointee: 400 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 374
+      ID: 381
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 375 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 357
+      ID: 364
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[string][]string
+      Pointee: 365 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 349
+      ID: 356
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 350 StructureType noalg.map.group[string]int
+      Pointee: 357 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 341
+      ID: 348
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 342 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 433
+      ID: 440
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 434 StructureType noalg.map.group[struct {}]int
+      Pointee: 441 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 499
+      ID: 506
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 515
+      ID: 522
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 523
+      ID: 530
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 449
+      ID: 456
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 450 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 408
+      ID: 415
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 409 StructureType noalg.map.group[uint8][4]int
+      Pointee: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 400
+      ID: 407
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 401 StructureType noalg.map.group[uint8]uint8
+      Pointee: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1173
+      ID: 1180
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.345696e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType os.File
+      Pointee: 1181 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.022624e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType os.LinkError
+      Pointee: 816 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.188928e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType os.SyscallError
+      Pointee: 880 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.342016e+06
       GoKind: 22
-      Pointee: 1172 StructureType os.fileWithoutReadFrom
+      Pointee: 1179 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1169
+      ID: 1176
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.34128e+06
       GoKind: 22
-      Pointee: 1170 StructureType os.fileWithoutWriteTo
+      Pointee: 1177 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.039904e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType os/exec.Error
+      Pointee: 847 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.082944e+06
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 986 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1052 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.040032e+06
       GoKind: 22
-      Pointee: 842 StructureType os/exec.wrappedError
+      Pointee: 849 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 934336
       GoKind: 22
-      Pointee: 583 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 590 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 585
+      ID: 592
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 591 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 934240
       GoKind: 22
-      Pointee: 582 BaseType os/user.UnknownUserIdError
+      Pointee: 589 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 607
+      ID: 614
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897664
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType reflect.ValueError
+      Pointee: 615 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 917152
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 710 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.02416e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 820 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.025952e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 824 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7593,12 +9136,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.024288e+06
       GoKind: 22
-      Pointee: 815 StructureType runtime.boundsError
+      Pointee: 822 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -7614,24 +9157,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.194304e+06
       GoKind: 22
-      Pointee: 875 StructureType runtime.errorAddressString
+      Pointee: 882 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.023776e+06
       GoKind: 22
-      Pointee: 793 GoStringHeaderType runtime.errorString
+      Pointee: 800 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 794 GoStringDataType runtime.errorString.str
+      Pointee: 801 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -7647,17 +9190,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.023904e+06
       GoKind: 22
-      Pointee: 796 GoStringHeaderType runtime.plainError
+      Pointee: 803 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 797 GoStringDataType runtime.plainError.str
+      Pointee: 804 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7687,12 +9230,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.026208e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType strconv.NumError
+      Pointee: 826 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -7701,218 +9244,218 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 311
+      ID: 318
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType string.str
+      Pointee: 317 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.944e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType strings.Builder
+      Pointee: 1116 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.026336e+06
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1020 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 967136
       GoKind: 22
-      Pointee: 1009 StructureType struct { io.Writer }
+      Pointee: 1016 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 258
+      ID: 265
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 123 StructureType struct {}
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.413824e+06
       GoKind: 22
-      Pointee: 925 BaseType syscall.Errno
+      Pointee: 932 BaseType syscall.Errno
     - __kind: PointerType
       ID: 225
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 423 StructureType table<[4]int,[4]int>
+      Pointee: 430 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 220
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 415 StructureType table<[4]int,uint8>
+      Pointee: 422 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 188
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 363 StructureType table<[4]string,[2]int>
+      Pointee: 370 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 200
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 382 StructureType table<bool,main.node>
+      Pointee: 389 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 146
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap2>
+      Pointee: 328 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1219
+      ID: 1226
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1220 StructureType table<int,*main.deepMap3>
+      Pointee: 1227 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1253
+      ID: 1260
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1254 StructureType table<int,*main.deepMap8>
+      Pointee: 1261 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1268
+      ID: 1275
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1269 StructureType table<int,*main.deepMap9>
+      Pointee: 1276 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 168
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 331 StructureType table<int,int>
+      Pointee: 338 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1284 StructureType table<int,interface {}>
+      Pointee: 1291 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 235
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 439 StructureType table<int,struct {}>
+      Pointee: 446 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 205
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 390 StructureType table<int,uint8>
+      Pointee: 397 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 372 StructureType table<string,[]main.structWithMap>
+      Pointee: 379 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 183
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 355 StructureType table<string,[]string>
+      Pointee: 362 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 980 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 987 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 347 StructureType table<string,int>
+      Pointee: 354 StructureType table<string,int>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 339 StructureType table<string,main.nestedStruct>
+      Pointee: 346 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 230
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 431 StructureType table<struct {},int>
+      Pointee: 438 StructureType table<struct {},int>
     - __kind: PointerType
-      ID: 281
+      ID: 288
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 481 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 488 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 286
+      ID: 293
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 489 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 496 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 291
+      ID: 298
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 497 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 504 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 296
+      ID: 303
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 505 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 512 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 301
+      ID: 308
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 513 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 520 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 306
+      ID: 313
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 521 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 240
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 447 StructureType table<struct {},struct {}>
+      Pointee: 454 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 215
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 406 StructureType table<uint8,[4]int>
+      Pointee: 413 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 210
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 398 StructureType table<uint8,uint8>
+      Pointee: 405 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1143
+      ID: 1150
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.153312e+06
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1151 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.085344e+06
       GoKind: 22
-      Pointee: 868 StructureType text/template.ExecError
+      Pointee: 875 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.619168e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType time.Location
+      Pointee: 950 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 610
+      ID: 617
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 898528
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType time.ParseError
+      Pointee: 618 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 898432
       GoKind: 22
-      Pointee: 531 GoStringHeaderType time.fileSizeError
+      Pointee: 538 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 533
+      ID: 540
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 532 GoStringDataType time.fileSizeError.str
+      Pointee: 539 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -7956,52 +9499,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 916576
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 706 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.128768e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1143 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 682
+      ID: 689
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 912736
       GoKind: 22
-      Pointee: 683 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 690 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 912832
       GoKind: 22
-      Pointee: 572 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 579 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.043744e+06
       GoKind: 22
-      Pointee: 847 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 854 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.043872e+06
       GoKind: 22
-      Pointee: 801 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1432
+      ID: 1487
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1433
+      ID: 1488
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8013,11 +9556,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1369
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8033,7 +9576,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1370
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8049,7 +9592,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1366
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8065,7 +9608,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1367
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8081,7 +9624,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1459
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1317
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8097,7 +9672,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1308
+      ID: 1315
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8113,7 +9688,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1306
+      ID: 1313
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8129,7 +9704,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1371
+      ID: 1378
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8145,7 +9720,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1314
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8161,7 +9736,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1309
+      ID: 1316
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8177,7 +9752,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1328
+      ID: 1335
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8193,10 +9768,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1329
+      ID: 1336
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1295
+      ID: 1302
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8212,7 +9787,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1292
+      ID: 1299
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8228,7 +9803,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1391
+      ID: 1398
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8244,7 +9819,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1389
+      ID: 1396
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -8280,7 +9855,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1399
+      ID: 1406
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8296,7 +9871,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1334
+      ID: 1341
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8312,7 +9887,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
+      ID: 1342
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8328,7 +9903,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1337
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8344,7 +9919,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1338
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8360,7 +9935,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1339
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8376,7 +9951,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1333
+      ID: 1340
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8392,7 +9967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1479
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8401,10 +9976,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8414,11 +9989,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1476
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8427,14 +10002,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1498
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8446,11 +10021,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1450
+      ID: 1505
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8459,14 +10034,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 309 PointerType *main.emptyStruct
+            Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1504
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8475,14 +10050,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 308 StructureType main.emptyStruct
+            Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1361
+      ID: 1368
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8498,7 +10073,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1343
+      ID: 1350
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8514,10 +10089,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1351
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1341
+      ID: 1348
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8533,10 +10108,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1342
+      ID: 1349
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1355
+      ID: 1362
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8552,7 +10127,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1357
+      ID: 1364
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8578,7 +10153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1363
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8594,7 +10169,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1360
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8610,7 +10185,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1361
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8626,7 +10201,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1352
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8642,10 +10217,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1353
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1349
+      ID: 1356
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8661,13 +10236,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1509
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1347
+      ID: 1354
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8693,28 +10268,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1455
+      ID: 1510
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1511
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1457
+      ID: 1512
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1458
+      ID: 1513
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1351
+      ID: 1358
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1451
+      ID: 1506
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8726,11 +10301,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1508
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8742,14 +10317,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1507
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1459
+      ID: 1514
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8761,11 +10336,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1515
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8777,11 +10352,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1516
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8793,11 +10368,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1298
+      ID: 1305
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8813,7 +10388,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1299
+      ID: 1306
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8829,7 +10404,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1307
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8845,7 +10420,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1304
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8861,7 +10436,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1296
+      ID: 1303
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8877,7 +10452,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1365
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8893,7 +10468,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1457
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1400
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8909,36 +10516,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1345
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1339
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1340
+      ID: 1346
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8964,7 +10545,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1347
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1376
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8980,7 +10699,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1383
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8996,7 +10715,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1395
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9012,7 +10731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1393
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9028,7 +10747,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1394
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9044,7 +10763,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1380
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9060,7 +10779,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1392
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9076,7 +10795,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1391
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9092,7 +10811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1374
+      ID: 1381
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9108,7 +10827,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1382
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9124,7 +10843,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1390
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9140,7 +10859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
+      ID: 1389
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9156,7 +10875,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1374
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9172,7 +10891,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1375
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9188,7 +10907,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1373
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9204,7 +10923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1384
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9220,7 +10939,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1388
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9236,7 +10955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1380
+      ID: 1387
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9252,7 +10971,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1386
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9268,7 +10987,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1378
+      ID: 1385
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9284,7 +11003,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1495
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9296,11 +11015,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1496
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9312,11 +11031,217 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1416
+      ID: 1465
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1466
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9332,7 +11257,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1424
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9358,7 +11283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1397
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9414,7 +11339,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1421
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9430,7 +11355,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1422
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9446,7 +11371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1405
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9472,7 +11397,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1480
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9481,10 +11406,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9494,11 +11419,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1482
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9510,17 +11435,17 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 255 GoSliceHeaderType []bool
+            Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9530,11 +11455,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1483
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9543,14 +11468,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 GoSliceHeaderType []uint16
+            Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1439
+      ID: 1494
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9559,14 +11484,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 261 PointerType *main.oneStringStruct
+            Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1401
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9582,7 +11507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1379
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9598,7 +11523,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1399
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9614,7 +11539,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1415
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9640,7 +11565,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1409
+      ID: 1416
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9666,7 +11591,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1410
+      ID: 1417
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9682,7 +11607,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1418
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9698,7 +11623,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1406
+      ID: 1437
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1443
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1444
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1432
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1413
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9714,7 +11853,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1414
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9730,7 +11869,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1404
+      ID: 1411
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9746,7 +11885,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1412
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9772,7 +11911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9788,7 +11927,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1410
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9804,7 +11943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1407
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9820,7 +11959,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1401
+      ID: 1408
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9836,7 +11975,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1419
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9852,7 +11991,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1413
+      ID: 1420
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9868,7 +12007,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1433
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1430
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1427
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 102 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 12 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1446
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1300
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9884,7 +12474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1314
+      ID: 1321
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9900,7 +12490,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1312
+      ID: 1319
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9916,7 +12506,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1325
+      ID: 1332
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9932,7 +12522,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1326
+      ID: 1333
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9948,7 +12538,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1324
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9964,7 +12554,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1318
+      ID: 1325
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9980,7 +12570,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1319
+      ID: 1326
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9996,7 +12586,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1323
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10012,7 +12602,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1315
+      ID: 1322
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10028,7 +12618,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1320
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10044,7 +12634,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1434
+      ID: 1489
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10056,11 +12646,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1322
+      ID: 1329
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10076,7 +12666,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1323
+      ID: 1330
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10092,7 +12682,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1324
+      ID: 1331
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10108,7 +12698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1328
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10124,7 +12714,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1320
+      ID: 1327
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10140,7 +12730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1486
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10149,14 +12739,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 257 GoSliceHeaderType []struct {}
+            Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1422
+      ID: 1477
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10165,14 +12755,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 249 GoSliceHeaderType [][]uint
+            Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1370
+      ID: 1377
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10188,7 +12778,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1425
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10204,7 +12794,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1426
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10240,7 +12830,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1294
+      ID: 1467
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1301
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10256,7 +12898,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1397
+      ID: 1404
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10272,7 +12914,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1481
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10281,14 +12923,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 254 GoSliceHeaderType []string
+            Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1336
+      ID: 1343
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10304,7 +12946,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1344
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10320,7 +12962,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1478
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10329,10 +12971,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10342,11 +12984,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1371
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10362,7 +13004,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1471
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1500
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10371,17 +13055,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 276 StructureType main.structWithCyclicMaps
+            Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1446
+      ID: 1501
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1444
+      ID: 1499
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10390,14 +13074,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 263 StructureType main.structWithCyclicSlices
+            Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1365
+      ID: 1372
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10413,7 +13097,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1502
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10422,17 +13106,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 307 StructureType main.aStruct
+            Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1448
+      ID: 1503
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1438
+      ID: 1493
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10441,14 +13125,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 260 PointerType *main.threeStringStruct
+            Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1491
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10457,17 +13141,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 259 StructureType main.threeStringStruct
+            Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1437
+      ID: 1492
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1435
+      ID: 1490
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10479,7 +13163,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10489,7 +13173,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10499,11 +13183,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1327
+      ID: 1334
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10519,7 +13203,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1303
+      ID: 1310
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10535,7 +13219,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1304
+      ID: 1311
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10551,7 +13235,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1312
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10567,7 +13251,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1302
+      ID: 1309
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10583,7 +13267,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1301
+      ID: 1308
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10599,7 +13283,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1396
+      ID: 1403
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10615,7 +13299,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1475
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10624,14 +13308,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1442
+      ID: 1497
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10643,11 +13327,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1395
+      ID: 1402
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10663,7 +13347,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1318
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10679,7 +13363,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1429
+      ID: 1484
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10688,14 +13372,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1430
+      ID: 1485
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10704,16 +13388,74 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 251
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 7 BaseType int
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 683008
+      GoRuntimeType: 683104
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -10729,16 +13471,25 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 698048
+      GoRuntimeType: 698144
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 250
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 683200
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 697664
+      GoRuntimeType: 697760
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10747,7 +13498,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 697760
+      GoRuntimeType: 697856
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10772,7 +13523,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 697952
+      GoRuntimeType: 698048
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10914,22 +13665,31 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 697472
+      GoRuntimeType: 697568
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 249
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 682144
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 697184
+      GoRuntimeType: 697280
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 412
+      ID: 419
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 679840
@@ -10938,7 +13698,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 369
+      ID: 376
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 680128
@@ -10950,7 +13710,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 688576
+      GoRuntimeType: 688672
       GoKind: 17
       Count: 4
       HasCount: true
@@ -10964,7 +13724,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 970
+      ID: 977
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 681664
@@ -10976,7 +13736,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 694304
+      GoRuntimeType: 694400
       GoKind: 17
       Count: 6
       HasCount: true
@@ -10985,7 +13745,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 697856
+      GoRuntimeType: 697952
       GoKind: 17
       Count: 8
       HasCount: true
@@ -11006,15 +13766,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 319 GoSliceDataType []*main.deepSlice2.array
+      Data: 326 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 326
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 138 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1209
+      ID: 1216
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 475456
@@ -11022,22 +13782,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1210 PointerType **main.deepSlice3
+          Type: 1217 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1213 GoSliceDataType []*main.deepSlice3.array
+      Data: 1220 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1213
+      ID: 1220
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1211 PointerType *main.deepSlice3
+      Element: 1218 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1234
+      ID: 1241
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 475136
@@ -11045,22 +13805,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.deepSlice8
+          Type: 1242 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1238 GoSliceDataType []*main.deepSlice8.array
+      Data: 1245 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1245
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1236 PointerType *main.deepSlice8
+      Element: 1243 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1240
+      ID: 1247
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 475072
@@ -11068,20 +13828,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1241 PointerType **main.deepSlice9
+          Type: 1248 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1244 GoSliceDataType []*main.deepSlice9.array
+      Data: 1251 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1251
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1242 PointerType *main.deepSlice9
+      Element: 1249 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 127
       Name: '[]*string'
@@ -11098,309 +13858,309 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 316 GoSliceDataType []*string.array
+      Data: 323 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 93 PointerType *string
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 436
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 225 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 421
+      ID: 428
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 377
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 388
+      ID: 395
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 200 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 336
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 146 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1228
+      ID: 1235
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1219 PointerType *table<int,*main.deepMap3>
+      Element: 1226 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1262
+      ID: 1269
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1253 PointerType *table<int,*main.deepMap8>
+      Element: 1260 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1277
+      ID: 1284
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1268 PointerType *table<int,*main.deepMap9>
+      Element: 1275 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 337
+      ID: 344
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1290
+      ID: 1297
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1283 PointerType *table<int,interface {}>
+      Element: 1290 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 452
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 403
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 205 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 387
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 368
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 986
+      ID: 993
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 953 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 960 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 353
+      ID: 360
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 352
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 444
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 281 PointerType *table<struct {},main.structWithCyclicMaps>
+      Element: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 502
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 286 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 510
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 291 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 518
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 296 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 526
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 301 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 534
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 413
+      ID: 420
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 411
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 274
+      ID: 281
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 275 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 282 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 479 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 486 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 272
+      ID: 279
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 273 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 280 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 477 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 484 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 277
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType *[][][]main.structWithCyclicSlices
+          Type: 278 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 475 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 482 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 482
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 275
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 269 PointerType *[][]main.structWithCyclicSlices
+          Type: 276 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 473 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 480 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 266
+      ID: 273
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 267 PointerType *[]main.structWithCyclicSlices
+          Type: 274 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 471 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 478 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 264 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 256
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType *[]uint
+          Type: 257 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 457 GoSliceDataType [][]uint.array
+      Data: 464 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 464
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 248 GoSliceHeaderType []uint
+      Element: 255 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 255
+      ID: 262
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 484608
@@ -11415,15 +14175,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 463 GoSliceDataType []bool.array
+      Data: 470 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 965
+      ID: 972
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -11438,15 +14198,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 988 GoSliceDataType []float64.array
+      Data: 995 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1246
+      ID: 1253
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484928
@@ -11461,37 +14221,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1247 GoSliceDataType []interface {}.array
+      Data: 1254 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1254
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 155 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 264
+      ID: 271
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 265 PointerType *main.structWithCyclicSlices
+          Type: 272 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 469 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 476 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 263 StructureType main.structWithCyclicSlices
+      Element: 270 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 378
+      ID: 385
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475776
@@ -11499,210 +14259,210 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 379 PointerType *main.structWithMap
+          Type: 386 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 529 GoSliceDataType []main.structWithMap.array
+      Data: 536 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 163 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *main.structWithNoStrings
+          Type: 259 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 459 GoSliceDataType []main.structWithNoStrings.array
+      Data: 466 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 466
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 253 StructureType main.structWithNoStrings
+      Element: 260 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 426 StructureType noalg.map.group[[4]int][4]int
+      Element: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 429
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 418 StructureType noalg.map.group[[4]int]uint8
+      Element: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 371
+      ID: 378
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 366 StructureType noalg.map.group[[4]string][2]int
+      Element: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 389
+      ID: 396
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 385 StructureType noalg.map.group[bool]main.node
+      Element: 392 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 337
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1229
+      ID: 1236
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1270
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1278
+      ID: 1285
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 345
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 334 StructureType noalg.map.group[int]int
+      Element: 341 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1298
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1287 StructureType noalg.map.group[int]interface {}
+      Element: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 446
+      ID: 453
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 442 StructureType noalg.map.group[int]struct {}
+      Element: 449 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 397
+      ID: 404
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 393 StructureType noalg.map.group[int]uint8
+      Element: 400 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 381
+      ID: 388
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 375 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 369
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 358 StructureType noalg.map.group[string][]string
+      Element: 365 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 987
+      ID: 994
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 361
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 350 StructureType noalg.map.group[string]int
+      Element: 357 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 346
+      ID: 353
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 342 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 434 StructureType noalg.map.group[struct {}]int
+      Element: 441 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 495
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 527
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 528
+      ID: 535
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 450 StructureType noalg.map.group[struct {}]struct {}
+      Element: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 414
+      ID: 421
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 409 StructureType noalg.map.group[uint8][4]int
+      Element: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 405
+      ID: 412
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 401 StructureType noalg.map.group[uint8]uint8
+      Element: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 254
+      ID: 261
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 484736
@@ -11717,36 +14477,36 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 461 GoSliceDataType []string.array
+      Data: 468 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 257
+      ID: 264
       Name: '[]struct {}'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 258 PointerType *struct {}
+          Type: 265 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 467 GoSliceDataType []struct {}.array
+      Data: 474 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 474
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 123 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 255
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 484224
@@ -11761,15 +14521,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 455 GoSliceDataType []uint.array
+      Data: 462 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 263
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 483584
@@ -11784,9 +14544,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 465 GoSliceDataType []uint16.array
+      Data: 472 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11807,9 +14567,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 312 GoSliceDataType []uint8.array
+      Data: 319 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 312
+      ID: 319
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11830,19 +14590,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []uintptr.array
+      Data: 321 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 321
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 761
+      ID: 768
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 927712
@@ -11857,33 +14617,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 762 GoSliceDataType archive/tar.headerError.array
+      Data: 769 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 769
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1010
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1012
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.11648e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1110
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.561664e+06
@@ -11893,7 +14653,7 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1040
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11903,15 +14663,15 @@ Types:
       GoRuntimeType: 582112
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1165
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -11937,13 +14697,13 @@ Types:
       GoRuntimeType: 581856
       GoKind: 15
     - __kind: BaseType
-      ID: 564
+      ID: 571
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 832128
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 572
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 832224
@@ -11951,110 +14711,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *compress/flate.InternalError.str
+          Type: 574 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 566 GoStringDataType compress/flate.InternalError.str
+      Data: 573 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 573
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1082
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: context.deadlineExceededError
       GoRuntimeType: 1.476064e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 578
+      ID: 585
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834720
       GoKind: 2
     - __kind: BaseType
-      ID: 579
+      ID: 586
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834816
       GoKind: 2
     - __kind: BaseType
-      ID: 580
+      ID: 587
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834912
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1106
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1138
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1108
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1104
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 581
+      ID: 588
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 835008
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1087
+      ID: 1094
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 568
+      ID: 575
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 832704
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 852
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1191
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 684
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.725088e+06
@@ -12065,34 +14825,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 970 ArrayType [5]uint8
+          Type: 977 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 800
+      ID: 807
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 989952
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1077
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 947
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.727968e+06
@@ -12100,21 +14860,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 973 BaseType crypto/x509.InvalidReason
+          Type: 980 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.114048e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.596384e+06
@@ -12122,24 +14882,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 577
+      ID: 584
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 2
     - __kind: BaseType
-      ID: 973
+      ID: 980
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 587296
       GoKind: 2
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.557664e+06
@@ -12149,13 +14909,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.114304e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.727776e+06
@@ -12163,15 +14923,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.433504e+06
@@ -12181,7 +14941,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.433664e+06
@@ -12191,55 +14951,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 774
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 562
+      ID: 569
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831744
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 563
+      ID: 570
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831936
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 641
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 633
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 639
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 637
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 635
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1171
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 643
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.417344e+06
@@ -12249,19 +15009,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1036
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 737
+      ID: 744
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 742
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 581
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 834240
@@ -12269,22 +15029,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *encoding/xml.UnmarshalError.str
+          Type: 583 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 575 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 582 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 582
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1149
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12301,11 +15061,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 611
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12321,15 +15081,15 @@ Types:
       GoRuntimeType: 582048
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1159
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12345,11 +15105,11 @@ Types:
       GoRuntimeType: 845856
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 671
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.723936e+06
@@ -12357,7 +15117,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 963 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 970 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -12365,25 +15125,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 654
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 651
+      ID: 658
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.110336e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 976
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 563
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 831168
@@ -12391,18 +15151,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 557 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 564
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 963
+      ID: 970
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.21312e+06
@@ -12410,13 +15170,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 964 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 971 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 9 GoStringHeaderType string
@@ -12425,7 +15185,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 965 GoSliceHeaderType []float64
+          Type: 972 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -12434,13 +15194,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 966 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 973 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 968 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 975 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 9 GoStringHeaderType string
@@ -12451,13 +15211,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 964
+      ID: 971
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583904
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 560
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 831072
@@ -12465,18 +15225,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 562 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 554 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 561
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 566
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 831264
@@ -12484,60 +15244,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 568 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 560 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 567
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1050
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 766
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1167
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 693
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.11328e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 573
+      ID: 580
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 833376
       GoKind: 2
     - __kind: StructureType
-      ID: 691
+      ID: 698
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.113152e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 689
+      ID: 696
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.594464e+06
@@ -12550,7 +15310,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.595264e+06
@@ -12563,7 +15323,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.7272e+06
@@ -12579,7 +15339,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.427104e+06
@@ -12589,7 +15349,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.426784e+06
@@ -12599,14 +15359,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 949
+      ID: 956
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.497024e+06
       GoKind: 21
-      HeaderType: 951 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 958 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 972
+      ID: 979
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.047328e+06
@@ -12621,15 +15381,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 990 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 997 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.595584e+06
@@ -12637,12 +15397,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 949 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 956 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 949 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 956 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.427264e+06
@@ -12652,7 +15412,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.727392e+06
@@ -12663,12 +15423,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.595424e+06
@@ -12681,7 +15441,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.427424e+06
@@ -12689,9 +15449,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 941 StructureType time.Time
+          Type: 948 StructureType time.Time
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.595904e+06
@@ -12704,7 +15464,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.427744e+06
@@ -12714,7 +15474,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.595744e+06
@@ -12727,7 +15487,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.427584e+06
@@ -12737,7 +15497,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.596064e+06
@@ -12750,7 +15510,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 653
+      ID: 660
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.419584e+06
@@ -12760,11 +15520,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1088
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.419744e+06
@@ -12772,21 +15532,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1024
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1058
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.420064e+06
@@ -12794,13 +15554,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1125
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1129
+      ID: 1136
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.101504e+06
@@ -12808,12 +15568,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1117 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1124 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1132
+      ID: 1139
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.125312e+06
@@ -12821,7 +15581,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1117 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1124 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -12829,11 +15589,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1026
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 664
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.419904e+06
@@ -12841,9 +15601,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 661
+      ID: 668
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.420224e+06
@@ -12851,64 +15611,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1090
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1131
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 865
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 869
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.421184e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1183
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.8352e+06
@@ -12924,11 +15684,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.697984e+06
@@ -12941,7 +15701,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.835648e+06
@@ -12957,13 +15717,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 799
+      ID: 806
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 987264
       GoKind: 8
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.834976e+06
@@ -12979,13 +15739,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 974
+      ID: 981
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 829344
       GoKind: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.834752e+06
@@ -12993,15 +15753,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 974 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 981 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 974 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 981 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.74944e+06
@@ -13014,7 +15774,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.835424e+06
@@ -13030,11 +15790,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1187
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.620128e+06
@@ -13044,19 +15804,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.280128e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.28e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.749632e+06
@@ -13069,7 +15829,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 593
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 836832
@@ -13077,22 +15837,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 595 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 587 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 594 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 594
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 965
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.445344e+06
@@ -13102,7 +15862,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1049
+      ID: 1056
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.67408e+06
@@ -13110,13 +15870,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1073 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1080 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1147
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1073
+      ID: 1080
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.124032e+06
@@ -13129,7 +15889,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1035
+      ID: 1042
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.566624e+06
@@ -13139,19 +15899,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 589
+      ID: 596
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 837408
       GoKind: 10
     - __kind: BaseType
-      ID: 956
+      ID: 963
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.000416e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.8744e+06
@@ -13162,12 +15922,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 956 BaseType golang.org/x/net/http2.ErrCode
+          Type: 963 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.603104e+06
@@ -13175,12 +15935,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 956 BaseType golang.org/x/net/http2.ErrCode
+          Type: 963 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 600
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837600
@@ -13188,18 +15948,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 602 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 594 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 601 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 601
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 599
+      ID: 606
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 837792
@@ -13207,18 +15967,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 601 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 608 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 600 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 607 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 600
+      ID: 607
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 603
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 837696
@@ -13226,18 +15986,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 605 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 597 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 604 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 604
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 590
+      ID: 597
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837504
@@ -13245,22 +16005,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 592 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 599 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 591 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 598 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 591
+      ID: 598
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1145
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 796
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.445984e+06
@@ -13270,13 +16030,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 602
+      ID: 609
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 837888
       GoKind: 2
     - __kind: StructureType
-      ID: 777
+      ID: 784
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.441024e+06
@@ -13286,11 +16046,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.902304e+06
@@ -13306,7 +16066,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 779
+      ID: 786
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.602624e+06
@@ -13319,7 +16079,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1089
+      ID: 1096
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.959872e+06
@@ -13327,16 +16087,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1116 GoInterfaceType io.Reader
+          Type: 1123 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.564224e+06
@@ -13346,29 +16106,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1014
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 764
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.507584e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.434304e+06
@@ -13378,7 +16138,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.434464e+06
@@ -13388,393 +16148,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 708
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 424
+      ID: 431
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 425 PointerType *noalg.map.group[[4]int][4]int
+          Type: 432 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 426 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 430 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 433 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 437 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 416
+      ID: 423
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 417 PointerType *noalg.map.group[[4]int]uint8
+          Type: 424 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 418 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 422 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 425 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 429 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 364
+      ID: 371
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 365 PointerType *noalg.map.group[[4]string][2]int
+          Type: 372 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 366 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 371 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 373 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 383
+      ID: 390
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 384 PointerType *noalg.map.group[bool]main.node
+          Type: 391 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 385 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 389 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 392 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 396 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 329
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 330 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 331 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1221
+      ID: 1228
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1222 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1229 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1223 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1229 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1230 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1236 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1255
+      ID: 1262
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1256 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1263 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1257 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1263 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1264 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1270 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1270
+      ID: 1277
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1271 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1278 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1272 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1278 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1279 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1285 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 332
+      ID: 339
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 333 PointerType *noalg.map.group[int]int
+          Type: 340 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 334 StructureType noalg.map.group[int]int
-      GroupSliceType: 338 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 341 StructureType noalg.map.group[int]int
+      GroupSliceType: 345 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1285
+      ID: 1292
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1286 PointerType *noalg.map.group[int]interface {}
+          Type: 1293 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1287 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1291 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1294 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1298 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 440
+      ID: 447
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 441 PointerType *noalg.map.group[int]struct {}
+          Type: 448 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 442 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 446 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 449 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 391
+      ID: 398
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 392 PointerType *noalg.map.group[int]uint8
+          Type: 399 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 393 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 397 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 400 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 404 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 373
+      ID: 380
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 374 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 381 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 375 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 381 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 382 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 388 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 363
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[string][]string
+          Type: 364 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[string][]string
-      GroupSliceType: 362 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 365 StructureType noalg.map.group[string][]string
+      GroupSliceType: 369 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 981
+      ID: 988
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 982 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 989 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 987 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 994 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 348
+      ID: 355
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 349 PointerType *noalg.map.group[string]int
+          Type: 356 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 350 StructureType noalg.map.group[string]int
-      GroupSliceType: 354 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 357 StructureType noalg.map.group[string]int
+      GroupSliceType: 361 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 340
+      ID: 347
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 341 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 348 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 342 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 346 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 349 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 353 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 432
+      ID: 439
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 433 PointerType *noalg.map.group[struct {}]int
+          Type: 440 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 434 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 438 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 441 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 445 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 482
+      ID: 489
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 483 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 490 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 488 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 495 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 490
+      ID: 497
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 491 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 498 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 503 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 505
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 506 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 504 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 511 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 506
+      ID: 513
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 507 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 514 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 512 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 514
+      ID: 521
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 515 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 520 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 522
+      ID: 529
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 523 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 528 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 448
+      ID: 455
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 449 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 456 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 450 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 457 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 407
+      ID: 414
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 408 PointerType *noalg.map.group[uint8][4]int
+          Type: 415 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 409 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 414 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 416 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 421 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 399
+      ID: 406
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 400 PointerType *noalg.map.group[uint8]uint8
+          Type: 407 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 401 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 405 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 408 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 412 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1102
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -13821,7 +16581,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 678
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -13847,29 +16607,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 676
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1000
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1189
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.472864e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 613
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -13950,7 +16710,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1194
+      ID: 1201
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.470304e+06
@@ -13963,11 +16723,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1046
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1079
+      ID: 1086
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.187392e+06
@@ -13980,7 +16740,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1116
+      ID: 1123
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.020704e+06
@@ -13993,7 +16753,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1068
+      ID: 1075
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.106624e+06
@@ -14019,25 +16779,25 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: io.discard
       GoRuntimeType: 1.460704e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1018
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1092
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 307
+      ID: 314
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14093,7 +16853,7 @@ Types:
           Offset: 0
           Type: 142 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 328
+      ID: 335
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18368e+06
@@ -14101,9 +16861,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1215 GoMapType map[int]*main.deepMap3
+          Type: 1222 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1234
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14115,9 +16875,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoMapType map[int]*main.deepMap8
+          Type: 1256 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1261
+      ID: 1268
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.182912e+06
@@ -14125,9 +16885,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1264 GoMapType map[int]*main.deepMap9
+          Type: 1271 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1276
+      ID: 1283
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.182784e+06
@@ -14135,7 +16895,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1279 GoMapType map[int]interface {}
+          Type: 1286 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 130
       Name: main.deepPtr1
@@ -14155,9 +16915,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1185 PointerType *main.deepPtr3
+          Type: 1192 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1193
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14169,9 +16929,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1230 PointerType *main.deepPtr8
+          Type: 1237 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1231
+      ID: 1238
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.184064e+06
@@ -14179,9 +16939,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 PointerType *main.deepPtr9
+          Type: 1239 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.183936e+06
@@ -14201,7 +16961,7 @@ Types:
           Offset: 0
           Type: 136 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 318
+      ID: 325
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.185984e+06
@@ -14209,9 +16969,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1209 GoSliceHeaderType []*main.deepSlice3
+          Type: 1216 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1219
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14223,9 +16983,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoSliceHeaderType []*main.deepSlice8
+          Type: 1241 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1237
+      ID: 1244
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.185216e+06
@@ -14233,9 +16993,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1240 GoSliceHeaderType []*main.deepSlice9
+          Type: 1247 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1243
+      ID: 1250
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.185088e+06
@@ -14243,9 +17003,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1246 GoSliceHeaderType []interface {}
+          Type: 1253 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 308
+      ID: 315
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -14261,16 +17021,16 @@ Types:
           Type: 153 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1192 StructureType sync.Mutex
+          Type: 1199 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1195 StructureType sync.Once
+          Type: 1202 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1198 StructureType sync.WaitGroup
+          Type: 1205 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1201 StructureType sync/atomic.Int32
+          Type: 1208 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 153
       Name: main.esotericStack
@@ -14300,7 +17060,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1203
+      ID: 1210
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.410464e+06
@@ -14309,6 +17069,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 248
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 252
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 18 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
     - __kind: StructureType
       ID: 121
       Name: main.nestedStruct
@@ -14336,7 +17147,7 @@ Types:
           Offset: 8
           Type: 245 PointerType *main.node
     - __kind: StructureType
-      ID: 262
+      ID: 269
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -14345,7 +17156,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1205
+      ID: 1212
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.410624e+06
@@ -14365,7 +17176,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1191
+      ID: 1198
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14376,18 +17187,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1188 PointerType *main.stringType1.str
+          Type: 1195 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1187 GoStringDataType main.stringType1.str
+      Data: 1194 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1187
+      ID: 1194
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1196
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -14401,53 +17212,65 @@ Types:
           Offset: 0
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 276
+      ID: 254
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 111 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 283
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 277 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 282 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 287 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 292 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 309 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 263
+      ID: 270
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 264 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 271 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 274 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 281 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 163
       Name: main.structWithMap
@@ -14459,7 +17282,7 @@ Types:
           Offset: 0
           Type: 164 GoMapType map[int]int
     - __kind: StructureType
-      ID: 253
+      ID: 260
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -14490,22 +17313,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1206 PointerType **main.t
+          Type: 1213 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1207 GoSliceDataType main.t.array
+      Data: 1214 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1207
+      ID: 1214
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 246 PointerType *main.t
     - __kind: StructureType
-      ID: 259
+      ID: 266
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -14524,6 +17347,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 253
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 7 BaseType int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<[4]int,[4]int>
@@ -14554,8 +17416,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 429 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 426 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 436 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<[4]int,uint8>
@@ -14586,8 +17448,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 421 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 418 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 428 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<[4]string,[2]int>
@@ -14618,8 +17480,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 370 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 366 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 377 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 198
       Name: map<bool,main.node>
@@ -14650,8 +17512,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 388 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 385 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 395 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 392 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 144
       Name: map<int,*main.deepMap2>
@@ -14682,10 +17544,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 336 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1217
+      ID: 1224
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -14698,7 +17560,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1218 PointerType **table<int,*main.deepMap3>
+          Type: 1225 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14714,10 +17576,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1228 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1235 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1251
+      ID: 1258
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -14730,7 +17592,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1252 PointerType **table<int,*main.deepMap8>
+          Type: 1259 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14746,10 +17608,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1262 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1269 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1266
+      ID: 1273
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -14762,7 +17624,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1267 PointerType **table<int,*main.deepMap9>
+          Type: 1274 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14778,8 +17640,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1277 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1284 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<int,int>
@@ -14810,10 +17672,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 337 GoSliceDataType []*table<int,int>.array
-      GroupType: 334 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 344 GoSliceDataType []*table<int,int>.array
+      GroupType: 341 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1281
+      ID: 1288
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -14826,7 +17688,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1282 PointerType **table<int,interface {}>
+          Type: 1289 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14842,8 +17704,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1290 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1287 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1297 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<int,struct {}>
@@ -14874,8 +17736,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 445 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 442 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 452 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 449 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 203
       Name: map<int,uint8>
@@ -14906,8 +17768,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 396 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 393 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 403 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 400 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<string,[]main.structWithMap>
@@ -14938,8 +17800,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 380 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 375 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 387 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<string,[]string>
@@ -14970,10 +17832,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 361 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 358 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 368 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 365 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 951
+      ID: 958
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -14986,7 +17848,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 952 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 959 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15002,8 +17864,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 986 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 993 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,int>
@@ -15034,8 +17896,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 353 GoSliceDataType []*table<string,int>.array
-      GroupType: 350 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 360 GoSliceDataType []*table<string,int>.array
+      GroupType: 357 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,main.nestedStruct>
@@ -15066,8 +17928,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 345 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 342 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 352 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<struct {},int>
@@ -15098,10 +17960,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 437 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 434 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 444 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 441 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
-      ID: 279
+      ID: 286
       Name: map<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15114,7 +17976,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 280 PointerType **table<struct {},main.structWithCyclicMaps>
+          Type: 287 PointerType **table<struct {},main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15130,10 +17992,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 487 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 494 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 284
+      ID: 291
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15146,7 +18008,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 285 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 292 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15162,10 +18024,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 502 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 289
+      ID: 296
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15178,7 +18040,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 290 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 297 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15194,10 +18056,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 503 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 510 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 294
+      ID: 301
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15210,7 +18072,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 295 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 302 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15226,10 +18088,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 511 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 299
+      ID: 306
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15242,7 +18104,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 300 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 307 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15258,10 +18120,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 519 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 304
+      ID: 311
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15274,7 +18136,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 305 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 312 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15290,8 +18152,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 527 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 238
       Name: map<struct {},struct {}>
@@ -15322,8 +18184,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 450 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 460 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<uint8,[4]int>
@@ -15354,8 +18216,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 413 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 409 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 420 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<uint8,uint8>
@@ -15386,8 +18248,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 404 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 401 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 411 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 221
       Name: map[[4]int][4]int
@@ -15424,26 +18286,26 @@ Types:
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1215
+      ID: 1222
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.125696e+06
       GoKind: 21
-      HeaderType: 1217 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1224 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1249
+      ID: 1256
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.125056e+06
       GoKind: 21
-      HeaderType: 1251 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1258 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1264
+      ID: 1271
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.124928e+06
       GoKind: 21
-      HeaderType: 1266 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1273 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
@@ -15452,12 +18314,12 @@ Types:
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1279
+      ID: 1286
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.1248e+06
       GoKind: 21
-      HeaderType: 1281 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1288 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
@@ -15508,41 +18370,41 @@ Types:
       GoKind: 21
       HeaderType: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
-      ID: 277
+      ID: 284
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 279 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      HeaderType: 286 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 282
+      ID: 289
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 284 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 291 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 287
+      ID: 294
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 289 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 292
+      ID: 299
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 294 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 297
+      ID: 304
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 299 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 302
+      ID: 309
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 304 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 311 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 236
       Name: map[struct {}]struct {}
@@ -15565,7 +18427,7 @@ Types:
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.426464e+06
@@ -15575,7 +18437,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1001
+      ID: 1008
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.423264e+06
@@ -15585,11 +18447,11 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 971
+      ID: 978
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.593184e+06
@@ -15602,35 +18464,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1153
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1163
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1173
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1161
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 869
+      ID: 876
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.109952e+06
@@ -15638,28 +18500,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 871 PointerType *net.UnknownNetworkError.str
+          Type: 878 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 870 GoStringDataType net.UnknownNetworkError.str
+      Data: 877 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 870
+      ID: 877
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: net.canceledError
       GoRuntimeType: 1.281152e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.1008e+06
@@ -15667,7 +18529,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -15678,27 +18540,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1175
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: net.noReadFrom
       GoRuntimeType: 1.110208e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1161
+      ID: 1168
       Name: net.noWriteTo
       GoRuntimeType: 1.11008e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 645
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.723744e+06
@@ -15706,7 +18568,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 959 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 966 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -15714,7 +18576,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1150
+      ID: 1157
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.285536e+06
@@ -15722,12 +18584,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1162 StructureType net.noReadFrom
+          Type: 1169 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1155 PointerType *net.TCPConn
+          Type: 1162 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1148
+      ID: 1155
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.284992e+06
@@ -15735,24 +18597,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1161 StructureType net.noWriteTo
+          Type: 1168 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1155 PointerType *net.TCPConn
+          Type: 1162 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.414784e+06
@@ -15762,19 +18624,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 534
+      ID: 541
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 829824
       GoKind: 10
     - __kind: BaseType
-      ID: 948
+      ID: 955
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 987360
       GoKind: 10
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.722016e+06
@@ -15785,12 +18647,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 928
+      ID: 935
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.8936e+06
@@ -15801,12 +18663,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 620
+      ID: 627
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.592704e+06
@@ -15814,16 +18676,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 545
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 830016
@@ -15831,18 +18693,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 547 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 539 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 546 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 546
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 551
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 830208
@@ -15850,18 +18712,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *net/http.http2headerFieldNameError.str
+          Type: 553 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 545 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 552 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 552
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 541
+      ID: 548
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 830112
@@ -15869,32 +18731,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 543 PointerType *net/http.http2headerFieldValueError.str
+          Type: 550 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 542 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 549 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 542
+      ID: 549
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 841
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.280384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 542
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829920
@@ -15902,18 +18764,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 544 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 536 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 543 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 543
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.817888e+06
@@ -15921,18 +18783,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1090 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1097 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1091 BaseType time.Duration
+          Type: 1098 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1090
+      ID: 1097
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.414144e+06
@@ -15945,14 +18807,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1076
+      ID: 1083
       Name: net/http.incomparable
       GoRuntimeType: 899776
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.551744e+06
@@ -15962,11 +18824,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1022
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.551584e+06
@@ -15974,9 +18836,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1058 PointerType *net/http.persistConn
+          Type: 1065 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1041
+      ID: 1048
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.793888e+06
@@ -15984,15 +18846,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 ArrayType net/http.incomparable
+          Type: 1083 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1077 PointerType *bufio.Reader
+          Type: 1084 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1079 GoInterfaceType io.ReadWriteCloser
+          Type: 1086 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.415744e+06
@@ -16002,17 +18864,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.475744e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.551904e+06
@@ -16022,7 +18884,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1093
+      ID: 1100
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.019776e+06
@@ -16030,16 +18892,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 620
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1113
+      ID: 1120
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.035808e+06
@@ -16047,13 +18909,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1106 PointerType *bufio.Writer
+          Type: 1113 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.726816e+06
@@ -16069,7 +18931,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.594624e+06
@@ -16082,11 +18944,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1074
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.596544e+06
@@ -16094,16 +18956,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1066 PointerType *net/smtp.Client
+          Type: 1073 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1068 GoInterfaceType io.WriteCloser
+          Type: 1075 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 688
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 576
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 832800
@@ -16111,26 +18973,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *net/textproto.ProtocolError.str
+          Type: 578 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType net/textproto.ProtocolError.str
+      Data: 577 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 577
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1030
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 945
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 554
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830784
@@ -16138,18 +19000,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *net/url.EscapeError.str
+          Type: 556 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 548 GoStringDataType net/url.EscapeError.str
+      Data: 555 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 555
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 557
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830880
@@ -16157,254 +19019,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/url.InvalidHostError.str
+          Type: 559 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 551 GoStringDataType net/url.InvalidHostError.str
+      Data: 558 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 558
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 427
+      ID: 434
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 428 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 435 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 419
+      ID: 426
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 680032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 420 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 427 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 367
+      ID: 374
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 680320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 368 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 375 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 386
+      ID: 393
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 680416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 387 StructureType noalg.struct { key bool; elem main.node }
+      Element: 394 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 325
+      ID: 332
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 679264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 333 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1224
+      ID: 1231
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 679168
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1225 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1232 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1258
+      ID: 1265
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 678688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1259 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1266 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1273
+      ID: 1280
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 678592
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1274 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1281 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 335
+      ID: 342
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 677440
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 336 StructureType noalg.struct { key int; elem int }
+      Element: 343 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1288
+      ID: 1295
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 678496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1289 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1296 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 443
+      ID: 450
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 680512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 444 StructureType noalg.struct { key int; elem struct {} }
+      Element: 451 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 394
+      ID: 401
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 680608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 395 StructureType noalg.struct { key int; elem uint8 }
+      Element: 402 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 376
+      ID: 383
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 680704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 377 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 384 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 359
+      ID: 366
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 680800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key string; elem []string }
+      Element: 367 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 984
+      ID: 991
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 756096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 985 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 992 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 351
+      ID: 358
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 680896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 352 StructureType noalg.struct { key string; elem int }
+      Element: 359 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 343
+      ID: 350
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 344 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 351 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 435
+      ID: 442
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 681088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 436 StructureType noalg.struct { key struct {}; elem int }
+      Element: 443 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 486 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 493 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 494 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 501 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 501
+      ID: 508
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 509 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 509
+      ID: 516
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 510 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 517 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 517
+      ID: 524
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 518 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 525
+      ID: 532
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 526 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 451
+      ID: 458
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 452 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 459 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 410
+      ID: 417
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 681280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 411 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 418 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 402
+      ID: 409
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 681376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 403 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 410 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 426
+      ID: 433
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.29216e+06
@@ -16415,9 +19277,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 427 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 434 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 418
+      ID: 425
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.292416e+06
@@ -16428,9 +19290,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 419 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 426 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 366
+      ID: 373
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.292672e+06
@@ -16441,9 +19303,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 367 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 374 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 385
+      ID: 392
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.292928e+06
@@ -16454,9 +19316,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 386 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 393 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 324
+      ID: 331
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.291904e+06
@@ -16467,9 +19329,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 332 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1223
+      ID: 1230
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.291648e+06
@@ -16480,9 +19342,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1224 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1231 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1257
+      ID: 1264
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.290368e+06
@@ -16493,9 +19355,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1258 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1265 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1272
+      ID: 1279
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.290112e+06
@@ -16506,9 +19368,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1273 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1280 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 334
+      ID: 341
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.289088e+06
@@ -16519,9 +19381,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 335 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 342 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1287
+      ID: 1294
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.289856e+06
@@ -16532,9 +19394,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1288 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1295 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.293184e+06
@@ -16545,9 +19407,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 443 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 450 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 393
+      ID: 400
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.29344e+06
@@ -16558,9 +19420,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 394 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 401 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 375
+      ID: 382
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.293696e+06
@@ -16571,9 +19433,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 376 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 383 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 358
+      ID: 365
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.293952e+06
@@ -16584,9 +19446,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 366 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 983
+      ID: 990
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.355648e+06
@@ -16597,9 +19459,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 984 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 991 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 350
+      ID: 357
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.294208e+06
@@ -16610,9 +19472,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 351 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 358 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 342
+      ID: 349
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.294464e+06
@@ -16623,9 +19485,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 343 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 350 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 434
+      ID: 441
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.29472e+06
@@ -16636,9 +19498,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 435 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 442 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -16648,9 +19510,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 485 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 492 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 492
+      ID: 499
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16660,9 +19522,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 493 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 500 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 500
+      ID: 507
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16672,9 +19534,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 508 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16684,9 +19546,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 509 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 516
+      ID: 523
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16696,9 +19558,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 517 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 524
+      ID: 531
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16708,9 +19570,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 525 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.294976e+06
@@ -16721,9 +19583,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 451 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 458 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 409
+      ID: 416
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.295232e+06
@@ -16734,9 +19596,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 410 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 417 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 401
+      ID: 408
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.295488e+06
@@ -16747,9 +19609,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 402 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 409 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 428
+      ID: 435
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.292032e+06
@@ -16757,12 +19619,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
     - __kind: StructureType
-      ID: 420
+      ID: 427
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.292288e+06
@@ -16770,12 +19632,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 368
+      ID: 375
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.292544e+06
@@ -16783,12 +19645,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 369 ArrayType [4]string
+          Type: 376 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 111 ArrayType [2]int
     - __kind: StructureType
-      ID: 387
+      ID: 394
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.2928e+06
@@ -16801,7 +19663,7 @@ Types:
           Offset: 8
           Type: 244 StructureType main.node
     - __kind: StructureType
-      ID: 326
+      ID: 333
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.291776e+06
@@ -16812,9 +19674,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap2
+          Type: 334 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1225
+      ID: 1232
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.29152e+06
@@ -16825,9 +19687,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1226 PointerType *main.deepMap3
+          Type: 1233 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1259
+      ID: 1266
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.29024e+06
@@ -16838,9 +19700,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1260 PointerType *main.deepMap8
+          Type: 1267 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1274
+      ID: 1281
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.289984e+06
@@ -16851,9 +19713,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1275 PointerType *main.deepMap9
+          Type: 1282 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 336
+      ID: 343
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.28896e+06
@@ -16866,7 +19728,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1289
+      ID: 1296
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.289728e+06
@@ -16879,7 +19741,7 @@ Types:
           Offset: 8
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 444
+      ID: 451
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.293056e+06
@@ -16892,7 +19754,7 @@ Types:
           Offset: 8
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 395
+      ID: 402
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.293312e+06
@@ -16905,7 +19767,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 377
+      ID: 384
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.293568e+06
@@ -16916,9 +19778,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 378 GoSliceHeaderType []main.structWithMap
+          Type: 385 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 360
+      ID: 367
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.293824e+06
@@ -16929,9 +19791,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 985
+      ID: 992
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.35552e+06
@@ -16942,9 +19804,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 352
+      ID: 359
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.29408e+06
@@ -16957,7 +19819,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 344
+      ID: 351
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.294336e+06
@@ -16970,7 +19832,7 @@ Types:
           Offset: 16
           Type: 121 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 436
+      ID: 443
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.294592e+06
@@ -16983,7 +19845,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -16993,9 +19855,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 276 StructureType main.structWithCyclicMaps
+          Type: 283 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17005,9 +19867,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 277 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17017,9 +19879,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 282 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 510
+      ID: 517
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17029,9 +19891,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 287 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 518
+      ID: 525
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17041,9 +19903,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 292 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17053,9 +19915,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.294848e+06
       GoKind: 25
@@ -17067,7 +19929,7 @@ Types:
           Offset: 0
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 411
+      ID: 418
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.295104e+06
@@ -17078,9 +19940,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
     - __kind: StructureType
-      ID: 403
+      ID: 410
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.29536e+06
@@ -17093,19 +19955,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1181
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.354144e+06
@@ -17113,12 +19975,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1178 StructureType os.noReadFrom
+          Type: 1185 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1173 PointerType *os.File
+          Type: 1180 PointerType *os.File
     - __kind: StructureType
-      ID: 1170
+      ID: 1177
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.353344e+06
@@ -17126,36 +19988,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1177 StructureType os.noWriteTo
+          Type: 1184 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1173 PointerType *os.File
+          Type: 1180 PointerType *os.File
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: os.noReadFrom
       GoRuntimeType: 1.10752e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1177
+      ID: 1184
       Name: os.noWriteTo
       GoRuntimeType: 1.107392e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 986
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1052
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.69856e+06
@@ -17168,7 +20030,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 590
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 836064
@@ -17176,36 +20038,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *os/user.UnknownGroupIdError.str
+          Type: 592 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 584 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 591 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 591
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 582
+      ID: 589
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 835968
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 615
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 710
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 824
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -17217,7 +20079,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 822
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.882016e+06
@@ -17234,9 +20096,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 977 BaseType runtime.boundsErrorCode
+          Type: 984 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 977
+      ID: 984
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 582240
@@ -17256,7 +20118,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.746368e+06
@@ -17269,7 +20131,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 793
+      ID: 800
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 986016
@@ -17277,13 +20139,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 795 PointerType *runtime.errorString.str
+          Type: 802 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 794 GoStringDataType runtime.errorString.str
+      Data: 801 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 794
+      ID: 801
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -17939,7 +20801,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 796
+      ID: 803
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 986112
@@ -17947,13 +20809,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 798 PointerType *runtime.plainError.str
+          Type: 805 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 797 GoStringDataType runtime.plainError.str
+      Data: 804 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 797
+      ID: 804
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18039,7 +20901,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 826
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -18051,26 +20913,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *string.str
+          Type: 318 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 310 GoStringDataType string.str
+      Data: 317 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 317
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1020
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1009
+      ID: 1016
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.452544e+06
@@ -18086,7 +20948,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.461024e+06
@@ -18094,12 +20956,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1194 StructureType internal/sync.Mutex
+          Type: 1201 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1195
+      ID: 1202
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.609376e+06
@@ -18107,15 +20969,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1196 StructureType sync/atomic.Uint32
+          Type: 1203 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1192 StructureType sync.Mutex
+          Type: 1199 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1198
+      ID: 1205
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.609568e+06
@@ -18123,21 +20985,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1199 StructureType sync/atomic.Uint64
+          Type: 1206 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1193
+      ID: 1200
       Name: sync.noCopy
       GoRuntimeType: 984960
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1201
+      ID: 1208
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.462304e+06
@@ -18145,12 +21007,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.462464e+06
@@ -18158,12 +21020,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1199
+      ID: 1206
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.609952e+06
@@ -18171,33 +21033,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1200 StructureType sync/atomic.align64
+          Type: 1207 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1200
+      ID: 1207
       Name: sync/atomic.align64
       GoRuntimeType: 985152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: sync/atomic.noCopy
       GoRuntimeType: 985056
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 925
+      ID: 932
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.279744e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 423
+      ID: 430
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18219,9 +21081,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 424 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 431 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 415
+      ID: 422
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18243,9 +21105,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 416 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 423 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 363
+      ID: 370
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -18267,9 +21129,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 364 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 371 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 382
+      ID: 389
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -18291,9 +21153,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 383 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 390 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 321
+      ID: 328
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -18315,9 +21177,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 329 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1220
+      ID: 1227
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -18339,9 +21201,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1221 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1228 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1254
+      ID: 1261
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -18363,9 +21225,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1255 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1262 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1269
+      ID: 1276
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -18387,9 +21249,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1270 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1277 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 331
+      ID: 338
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -18411,9 +21273,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 332 GoSwissMapGroupsType groupReference<int,int>
+          Type: 339 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1284
+      ID: 1291
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -18435,9 +21297,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1285 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1292 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 439
+      ID: 446
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18459,9 +21321,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 440 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 447 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 390
+      ID: 397
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18483,9 +21345,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 391 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 398 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 372
+      ID: 379
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -18507,9 +21369,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 373 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 380 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 355
+      ID: 362
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -18531,9 +21393,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 363 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 980
+      ID: 987
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -18555,9 +21417,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 981 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 988 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 347
+      ID: 354
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -18579,9 +21441,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 348 GoSwissMapGroupsType groupReference<string,int>
+          Type: 355 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 339
+      ID: 346
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -18603,9 +21465,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 340 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 347 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 431
+      ID: 438
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -18627,9 +21489,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 432 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 439 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 481
+      ID: 488
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18651,9 +21513,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 482 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 489 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18675,9 +21537,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 490 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 497 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 497
+      ID: 504
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18699,9 +21561,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 505 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18723,9 +21585,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 506 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 513 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18747,9 +21609,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 514 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18771,9 +21633,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 522 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18795,9 +21657,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 448 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 455 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 406
+      ID: 413
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18819,9 +21681,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 407 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 414 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 398
+      ID: 405
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18843,13 +21705,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 399 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 406 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1151
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 875
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.702976e+06
@@ -18862,21 +21724,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1091
+      ID: 1098
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.90816e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 618
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.369024e+06
@@ -18890,9 +21752,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 942 PointerType *time.Location
+          Type: 949 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 531
+      ID: 538
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828960
@@ -18900,13 +21762,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 533 PointerType *time.fileSizeError.str
+          Type: 540 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 532 GoStringDataType time.fileSizeError.str
+      Data: 539 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 532
+      ID: 539
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18953,7 +21815,7 @@ Types:
       GoRuntimeType: 582176
       GoKind: 26
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.057216e+06
@@ -18964,10 +21826,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 960 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 961 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 968 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -18982,18 +21844,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 962 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 962
+      ID: 969
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 991584
       GoKind: 9
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.918912e+06
@@ -19018,21 +21880,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 961
+      ID: 968
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585824
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1143
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 683
+      ID: 690
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.423584e+06
@@ -19042,13 +21904,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 572
+      ID: 579
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 832896
       GoKind: 2
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.698752e+06
@@ -19061,14 +21923,14 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 801
+      ID: 808
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1461
+MaxTypeID: 1516
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x17fe3a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x18003a0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -3128,7 +3128,11 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5de0..0xcd5de6, Pieces: []}]
+          Locations:
+            - Range: 0xcd5de0..0xcd5de5
+              Pieces: []
+            - Range: 0xcd5de5..0xcd5de6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3145,7 +3149,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd5e00..0xcd5e43, Pieces: []}]
+          Locations:
+            - Range: 0xcd5e00..0xcd5e3d
+              Pieces: []
+            - Range: 0xcd5e3d..0xcd5e3e
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd5e3e..0xcd5e43
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3188,7 +3198,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd6100..0xcd6166, Pieces: []}]
+          Locations:
+            - Range: 0xcd6100..0xcd6145
+              Pieces: []
+            - Range: 0xcd6145..0xcd6146
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd6146..0xcd6166
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3221,7 +3241,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd61a0..0xcd61f4, Pieces: []}]
+          Locations:
+            - Range: 0xcd61a0..0xcd61dd
+              Pieces: []
+            - Range: 0xcd61dd..0xcd61de
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd61de..0xcd61f4
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3721,7 +3751,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9020..0xcd908c, Pieces: []}]
+          Locations:
+            - Range: 0xcd9020..0xcd9074
+              Pieces: []
+            - Range: 0xcd9074..0xcd9075
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9075..0xcd908c
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3738,7 +3774,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 98 PointerType *int
-          Locations: [{Range: 0xcd90a0..0xcd912f, Pieces: []}]
+          Locations:
+            - Range: 0xcd90a0..0xcd9110
+              Pieces: []
+            - Range: 0xcd9110..0xcd9111
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9111..0xcd912f
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3766,7 +3808,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9140..0xcd920f, Pieces: []}]
+          Locations:
+            - Range: 0xcd9140..0xcd91f1
+              Pieces: []
+            - Range: 0xcd91f1..0xcd91f2
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd91f2..0xcd920f
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3797,7 +3845,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcd9220..0xcd927b, Pieces: []}]
+          Locations:
+            - Range: 0xcd9220..0xcd925a
+              Pieces: []
+            - Range: 0xcd925a..0xcd925b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd925b..0xcd9265
+              Pieces: []
+            - Range: 0xcd9265..0xcd9266
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9266..0xcd927b
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3831,12 +3897,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcd9280..0xcd92fc, Pieces: []}]
+          Locations:
+            - Range: 0xcd9280..0xcd92c8
+              Pieces: []
+            - Range: 0xcd92c8..0xcd92c9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd92c9..0xcd92d2
+              Pieces: []
+            - Range: 0xcd92d2..0xcd92d3
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd92d3..0xcd92fc
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcd9280..0xcd92fc, Pieces: []}]
+          Locations:
+            - Range: 0xcd9280..0xcd92c8
+              Pieces: []
+            - Range: 0xcd92c8..0xcd92c9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcd92c9..0xcd92d2
+              Pieces: []
+            - Range: 0xcd92d2..0xcd92d3
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcd92d3..0xcd92fc
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3869,7 +3971,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcd9300..0xcd9388, Pieces: []}]
+          Locations:
+            - Range: 0xcd9300..0xcd9364
+              Pieces: []
+            - Range: 0xcd9364..0xcd9365
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9365..0xcd9388
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3908,7 +4020,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
-          Locations: [{Range: 0xcd93a0..0xcd94b4, Pieces: []}]
+          Locations:
+            - Range: 0xcd93a0..0xcd9442
+              Pieces: []
+            - Range: 0xcd9442..0xcd9443
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9443..0xcd944c
+              Pieces: []
+            - Range: 0xcd944c..0xcd944d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd944d..0xcd94b4
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3966,7 +4096,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd94c0..0xcd954f, Pieces: []}]
+          Locations:
+            - Range: 0xcd94c0..0xcd9532
+              Pieces: []
+            - Range: 0xcd9532..0xcd9533
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd9533..0xcd954f
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3985,12 +4121,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9560..0xcd9618, Pieces: []}]
+          Locations:
+            - Range: 0xcd9560..0xcd95fe
+              Pieces: []
+            - Range: 0xcd95fe..0xcd95ff
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd95ff..0xcd9618
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9560..0xcd9618, Pieces: []}]
+          Locations:
+            - Range: 0xcd9560..0xcd95fe
+              Pieces: []
+            - Range: 0xcd95fe..0xcd95ff
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd95ff..0xcd9618
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4009,17 +4157,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9620..0xcd96d5, Pieces: []}]
+          Locations:
+            - Range: 0xcd9620..0xcd96bb
+              Pieces: []
+            - Range: 0xcd96bb..0xcd96bc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcd96bc..0xcd96d5
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9620..0xcd96d5, Pieces: []}]
+          Locations:
+            - Range: 0xcd9620..0xcd96bb
+              Pieces: []
+            - Range: 0xcd96bb..0xcd96bc
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcd96bc..0xcd96d5
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcd9620..0xcd96d5, Pieces: []}]
+          Locations:
+            - Range: 0xcd9620..0xcd96bb
+              Pieces: []
+            - Range: 0xcd96bb..0xcd96bc
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcd96bc..0xcd96d5
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4262,7 +4428,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcd9e40..0xcd9e92, Pieces: []}]
+          Locations:
+            - Range: 0xcd9e40..0xcd9e85
+              Pieces: []
+            - Range: 0xcd9e85..0xcd9e86
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd9e86..0xcd9e92
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcde68a", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xce00ca", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1452 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcde6c5", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xce0105", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1378 EventRootType Probe[main.testAny]
+          Type: 1385 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcda9ea", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1379 EventRootType Probe[main.testAny]Return
+          Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0xcdaa25", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testAnyPtr]
+          Type: 1388 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0xcdaa8a", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0xcdaabd", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0xcd8c60", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd8be0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd8c20", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcdb1a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0xcd8c40", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testBigStruct]
+          Type: 1354 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd9360", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1348 EventRootType Probe[main.testBigStruct]Return
+          Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0xcd937e", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testBoolArray]
+          Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd8a80", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testByteArray]
+          Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1410 EventRootType Probe[main.testChannel]
+          Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testCombinedByte]
+          Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcdcca0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testCycle]
+          Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testDeepMap1]
+          Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0xcd9740", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testDeepMap7]
+          Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0xcd9760", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testDeepPtr1]
+          Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0xcd9420", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testDeepPtr7]
+          Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0xcd9440", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testDeepSlice1]
+          Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0xcd95c0", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testDeepSlice7]
+          Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0xcd95e0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1440 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcde220", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcde280", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcde7c0", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdec00", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xce0640", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcdec20", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xce0660", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testError]
+          Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcdaa60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testEsotericHeap]
+          Type: 1369 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd9f6a", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0xcd9fac", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEsotericStack]
+          Type: 1367 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd9e4e", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1361 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0xcd9edb", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testFrameless]
+          Type: 1379 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcda6c0", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1373 EventRootType Probe[main.testFrameless]Return
+          Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0xcda6c5", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testFramelessArray]
+          Type: 1381 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcda6e4", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1375 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0xcda71d", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1376 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0xcda6e8", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testInlinedBA]
+          Type: 1371 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcda3aa", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1365 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0xcda40e", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBB]
+          Type: 1373 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1367 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0xcda4de", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testInlinedBBA]
+          Type: 1375 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcda52a", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1369 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0xcda56b", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testInlinedBBB]
+          Type: 1528 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInlinedBC]
+          Type: 1377 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcda5ae", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1371 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0xcda693", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testInlinedBCA]
+          Type: 1529 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1475 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testInlinedBCB]
+          Type: 1531 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1477 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testInlinedPrint]
+          Type: 1525 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0xcda52f"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1472 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testInlinedSq]
+          Type: 1533 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1479 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testInt16Array]
+          Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd8ae0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testInt32Array]
+          Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd8b00", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testInt64Array]
+          Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd8b20", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testInt8Array]
+          Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd8ac0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testIntArray]
+          Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testInterface]
+          Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcda9c0", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1412 EventRootType Probe[main.testLinkedList]
+          Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1357 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd97da", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1358 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd988d", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1359 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0xcd9954", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcdb160", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcdb220", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0xcdb360", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0xcdb3a0", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0xcdb380", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapIntToInt]
+          Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcdb1e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb340", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1403 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcdb320", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapMassive]
+          Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapMassive]
+          Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcdb200", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcdb300", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1401 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcdb2e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapStringToInt]
+          Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcdb120", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcdb140", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcdb100", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcdb240", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcdb2a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcdb2c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcdb260", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcdb280", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcde780", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1515 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcde780", Frameless: true}]
+          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcdddae", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcdde3e", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcddd0a", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcddd72", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1417 EventRootType Probe[main.testNilPointer]
+          Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcde300", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcde2a0", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcde2e0", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcde760", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1413 EventRootType Probe[main.testPointerLoop]
+          Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testPointerToMap]
+          Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcdb1c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1411 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcddb4a", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcddc2e", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0xcddba4", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0xcddcd5"
+              Frameless: false
+            - PC: "0xcddd24"
+              Frameless: false
+            - PC: "0xcddde0"
+              Frameless: false
+            - PC: "0xcdddea"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcddaca", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcddace", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1435 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcddb08"
+            - PC: "0xcddb24"
               Frameless: false
-            - PC: "0xcddb12"
+            - PC: "0xcddb73"
               Frameless: false
+            - PC: "0xcddba7"
+              Frameless: false
+            - PC: "0xcddbd9"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,12 +1754,12 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testReturnsError]
+          Type: 1432 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcdda6a", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testReturnsError]Return
+          Type: 1433 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcdda9a"
               Frameless: false
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1419 EventRootType Probe[main.testReturnsInt]
+          Type: 1426 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1420 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcdd8b4", Frameless: false}]
+          Type: 1427 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcdd8bb", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1430 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcdda31", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcdda44", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1428 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1422 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcdd950", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcdd954", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcddbee", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcdde2e", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1439 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcddc82"
+            - PC: "0xcddeff"
               Frameless: false
-            - PC: "0xcddc8c"
+            - PC: "0xcddf09"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcde473", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcde347", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcde638", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcde976", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcde251", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcde794", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testRuneArray]
+          Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testSingleBool]
+          Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd9060", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSingleByte]
+          Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd9020", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleFloat32]
+          Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd91c0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleFloat64]
+          Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd91e0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleInt]
+          Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd9080", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testSingleInt16]
+          Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd90c0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testSingleInt32]
+          Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd90e0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSingleInt64]
+          Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd9100", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testSingleInt8]
+          Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd90a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleRune]
+          Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd9040", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcde6e0", Frameless: true}]
+          Type: 1508 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xce0120", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testSingleUint]
+          Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd9120", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testSingleUint16]
+          Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd9160", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testSingleUint32]
+          Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd9180", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSingleUint64]
+          Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd91a0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testSingleUint8]
+          Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd9140", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcde340", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcde240", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testSmallMap]
+          Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcdb180", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcddefb", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStringArray]
+          Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1416 EventRootType Probe[main.testStringPointer]
+          Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcde2c0", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testStringType1]
+          Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0xcd9780", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testStringType2]
+          Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0xcd97a0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdea80", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xce04c0", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcdeaa2", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xce04e2", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcde260", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testStructWithAny]
+          Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0xcdaae0", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcde940", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xce0380", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcde95e", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xce039e", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcde920", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xce0360", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testStructWithMap]
+          Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcdb0e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcde700", Frameless: true}]
+          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xce0140", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcde720", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xce0160", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcde73e", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xce017e", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcde740", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xce0180", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testTypeAlias]
+          Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd9200", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUint16Array]
+          Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testUint32Array]
+          Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd8ba0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testUint64Array]
+          Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testUint8Array]
+          Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd8b60", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testUintArray]
+          Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1415 EventRootType Probe[main.testUintPointer]
+          Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcde200", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcde7a0", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testUnsafePointer]
+          Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd8ca0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcde320", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3737,29 +4205,36 @@ Subprograms:
           IsReturn: false
     - ID: 94
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdd860..0xcdd8cc]
+      OutOfLinePCRanges: [0xcdd860..0xcdd8d2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd860..0xcdd87e
+            - Range: 0xcdd860..0xcdd872
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd87e..0xcdd8cc
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd860..0xcdd8b4
+            - Range: 0xcdd860..0xcdd8bb
               Pieces: []
-            - Range: 0xcdd8b4..0xcdd8b5
+            - Range: 0xcdd8bb..0xcdd8bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8b5..0xcdd8cc
+            - Range: 0xcdd8bc..0xcdd8d2
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd872..0xcdd885
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdd885..0xcdd8d2
+              Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcdd8e0..0xcdd96f]
@@ -3770,64 +4245,73 @@ Subprograms:
           Locations:
             - Range: 0xcdd8e0..0xcdd8fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdd8fa..0xcdd96f
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd8e0..0xcdd950
+            - Range: 0xcdd8e0..0xcdd954
               Pieces: []
-            - Range: 0xcdd950..0xcdd951
+            - Range: 0xcdd954..0xcdd955
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd951..0xcdd96f
+            - Range: 0xcdd955..0xcdd96f
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd8ff..0xcdd915
+            - Range: 0xcdd8ff..0xcdd919
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd915..0xcdd96f
+            - Range: 0xcdd919..0xcdd96f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdd980..0xcdda4f]
+      OutOfLinePCRanges: [0xcdd980..0xcdda5e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd980..0xcdd9d4
+            - Range: 0xcdd980..0xcdd9e2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd9d4..0xcdda4f
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd980..0xcdda31
+            - Range: 0xcdd980..0xcdda44
               Pieces: []
-            - Range: 0xcdda31..0xcdda32
+            - Range: 0xcdda44..0xcdda45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdda32..0xcdda4f
+            - Range: 0xcdda45..0xcdda5e
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcdd980..0xcdda4f, Pieces: []}]
+          Locations: [{Range: 0xcdd980..0xcdda5e, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdd996..0xcdd9e7
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcdd9e7..0xcdda5e
+              Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcdd99f..0xcdd9d4
+            - Range: 0xcdd9af..0xcdd9e7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdd9d4..0xcdda4f
+            - Range: 0xcdd9e7..0xcdda5e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           IsParameter: false
           IsReturn: false
@@ -3868,19 +4352,37 @@ Subprograms:
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcddac0..0xcddb3c]
+      OutOfLinePCRanges: [0xcddac0..0xcddc06]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddac0..0xcddae3
+            - Range: 0xcddac0..0xcddb0b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddae3..0xcddae8
+            - Range: 0xcddb0b..0xcddb16
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddb47..0xcddb4a
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddb80..0xcddb85
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddbb4..0xcddbb9
               Pieces:
                 - Size: 8
                   Op: null
@@ -3891,77 +4393,116 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcddac0..0xcddae8
+            - Range: 0xcddac0..0xcddb03
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddac0..0xcddb08
+            - Range: 0xcddac0..0xcddb24
               Pieces: []
-            - Range: 0xcddb08..0xcddb09
+            - Range: 0xcddb24..0xcddb25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb09..0xcddb12
+            - Range: 0xcddb25..0xcddb73
               Pieces: []
-            - Range: 0xcddb12..0xcddb13
+            - Range: 0xcddb73..0xcddb74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb13..0xcddb3c
+            - Range: 0xcddb74..0xcddba7
+              Pieces: []
+            - Range: 0xcddba7..0xcddba8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddba8..0xcddbd9
+              Pieces: []
+            - Range: 0xcddbd9..0xcddbda
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddbda..0xcddc06
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcddac0..0xcddb08
+            - Range: 0xcddac0..0xcddb24
               Pieces: []
-            - Range: 0xcddb08..0xcddb09
+            - Range: 0xcddb24..0xcddb25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddb09..0xcddb12
+            - Range: 0xcddb25..0xcddb73
               Pieces: []
-            - Range: 0xcddb12..0xcddb13
+            - Range: 0xcddb73..0xcddb74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddb13..0xcddb3c
+            - Range: 0xcddb74..0xcddba7
+              Pieces: []
+            - Range: 0xcddba7..0xcddba8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcddba8..0xcddbd9
+              Pieces: []
+            - Range: 0xcddbd9..0xcddbda
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcddbda..0xcddc06
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcddb0b..0xcddb11
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 99
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcddb40..0xcddbc8]
+      OutOfLinePCRanges: [0xcddc20..0xcdde0e]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddb40..0xcddb81
+            - Range: 0xcddc20..0xcddc6b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb81..0xcddb88
+            - Range: 0xcddc6b..0xcddc72
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddb88..0xcddbc8
+            - Range: 0xcddc72..0xcdde0e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -3972,267 +4513,1233 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddb40..0xcddba4
+            - Range: 0xcddc20..0xcddcd5
               Pieces: []
-            - Range: 0xcddba4..0xcddba5
+            - Range: 0xcddcd5..0xcddcd6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddba5..0xcddbc8
+            - Range: 0xcddcd6..0xcddd24
+              Pieces: []
+            - Range: 0xcddd24..0xcddd25
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddd25..0xcddde0
+              Pieces: []
+            - Range: 0xcddde0..0xcddde1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddde1..0xcdddea
+              Pieces: []
+            - Range: 0xcdddea..0xcdddeb
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdddeb..0xcdde0e
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcddcc0..0xcddcc6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 99 PointerType *int
+          Locations:
+            - Range: 0xcddd05..0xcddd24
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 100
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcddbe0..0xcddcf4]
+      OutOfLinePCRanges: [0xcdde20..0xcddf74]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddbe0..0xcddc15
+            - Range: 0xcdde20..0xcdde60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc15..0xcddc5f
+            - Range: 0xcdde60..0xcddeae
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddc5f..0xcddc92
+            - Range: 0xcddeae..0xcddf0f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddc92..0xcddcb2
+            - Range: 0xcddf0f..0xcddf31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddcb2..0xcddcb9
+            - Range: 0xcddf31..0xcddf38
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddcb9..0xcddcf4
+            - Range: 0xcddf38..0xcddf74
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcddbe0..0xcddc82
+            - Range: 0xcdde20..0xcddeff
               Pieces: []
-            - Range: 0xcddc82..0xcddc83
+            - Range: 0xcddeff..0xcddf00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc83..0xcddc8c
+            - Range: 0xcddf00..0xcddf09
               Pieces: []
-            - Range: 0xcddc8c..0xcddc8d
+            - Range: 0xcddf09..0xcddf0a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc8d..0xcddcf4
+            - Range: 0xcddf0a..0xcddf74
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcddbe0..0xcddc15
+            - Range: 0xcdde20..0xcdde60
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc15..0xcddc5f
+            - Range: 0xcdde60..0xcddeae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddc5f..0xcddc66
+            - Range: 0xcddeae..0xcddeb5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddc66..0xcddc88
+            - Range: 0xcddeb5..0xcddf05
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddc88..0xcddc8a
+            - Range: 0xcddf05..0xcddf07
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddc8a..0xcddc8c
+            - Range: 0xcddf07..0xcddf09
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddc8c..0xcddcf4
+            - Range: 0xcddf09..0xcddf74
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcddd00..0xcddd8f]
+      OutOfLinePCRanges: [0xcddf80..0xcde00f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddd00..0xcddd3c
+            - Range: 0xcddf80..0xcddf91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddd3c..0xcddd8f
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddd00..0xcddd72
+            - Range: 0xcddf80..0xcddff5
               Pieces: []
-            - Range: 0xcddd72..0xcddd73
+            - Range: 0xcddff5..0xcddff6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddd73..0xcddd8f
+            - Range: 0xcddff6..0xcde00f
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcddda0..0xcdde58]
+      OutOfLinePCRanges: [0xcde020..0xcde0e9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddda0..0xcddde6
+            - Range: 0xcde020..0xcde071
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddde6..0xcdde58
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddda0..0xcdde3e
+            - Range: 0xcde020..0xcde0cf
               Pieces: []
-            - Range: 0xcdde3e..0xcdde3f
+            - Range: 0xcde0cf..0xcde0d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdde3f..0xcdde58
+            - Range: 0xcde0d0..0xcde0e9
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddda0..0xcdde3e
+            - Range: 0xcde020..0xcde0cf
               Pieces: []
-            - Range: 0xcdde3e..0xcdde3f
+            - Range: 0xcde0cf..0xcde0d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdde3f..0xcdde58
+            - Range: 0xcde0d0..0xcde0e9
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcdde60..0xcddf15]
+      OutOfLinePCRanges: [0xcde100..0xcde1c7]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdde60..0xcddea5
+            - Range: 0xcde100..0xcde145
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddea5..0xcddf15
+            - Range: 0xcde145..0xcde1c7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdde60..0xcddefb
+            - Range: 0xcde100..0xcde1ad
               Pieces: []
-            - Range: 0xcddefb..0xcddefc
+            - Range: 0xcde1ad..0xcde1ae
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddefc..0xcddf15
+            - Range: 0xcde1ae..0xcde1c7
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdde60..0xcddefb
+            - Range: 0xcde100..0xcde1ad
               Pieces: []
-            - Range: 0xcddefb..0xcddefc
+            - Range: 0xcde1ad..0xcde1ae
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcddefc..0xcddf15
+            - Range: 0xcde1ae..0xcde1c7
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdde60..0xcddefb
+            - Range: 0xcde100..0xcde1ad
               Pieces: []
-            - Range: 0xcddefb..0xcddefc
+            - Range: 0xcde1ad..0xcde1ae
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcddefc..0xcddf15
+            - Range: 0xcde1ae..0xcde1c7
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcde200..0xcde201]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0xcde1e0..0xcde25e]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 250 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 16 BaseType int8
           Locations:
-            - Range: 0xcde200..0xcde201
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 104 BaseType int16
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcde1e0..0xcde251
+              Pieces: []
+            - Range: 0xcde251..0xcde252
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcde252..0xcde25e
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcde220..0xcde221]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0xcde260..0xcde357]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 250 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcde220..0xcde221
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 15 BaseType float64
+          Locations:
+            - Range: 0xcde260..0xcde347
+              Pieces: []
+            - Range: 0xcde347..0xcde348
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xcde348..0xcde357
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 15 BaseType float64
+          Locations:
+            - Range: 0xcde260..0xcde347
+              Pieces: []
+            - Range: 0xcde347..0xcde348
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcde348..0xcde357
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcde240..0xcde241]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xcde360..0xcde3d3]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 96 BaseType complex64
+          Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 97 BaseType complex128
+          Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0xcde3e0..0xcde485]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcde3e0..0xcde473
+              Pieces: []
+            - Range: 0xcde473..0xcde474
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+            - Range: 0xcde474..0xcde485
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xcde4a0..0xcde51a]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0xcde4a0..0xcde50d
+              Pieces: []
+            - Range: 0xcde50d..0xcde50e
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcde50e..0xcde51a
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xcde520..0xcde578]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 ArrayType [1]int
+          Locations:
+            - Range: 0xcde520..0xcde56b
+              Pieces: []
+            - Range: 0xcde56b..0xcde56c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcde56c..0xcde578
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xcde580..0xcde5d3]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0xcde580..0xcde5c6
+              Pieces: []
+            - Range: 0xcde5c6..0xcde5c7
+              Pieces: []
+            - Range: 0xcde5c7..0xcde5d3
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xcde5e0..0xcde647]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.mixedStruct
+          Locations: [{Range: 0xcde5e0..0xcde647, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0xcde660..0xcde6fa]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcde660..0xcde6ea
+              Pieces: []
+            - Range: 0xcde6ea..0xcde6eb
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xcde6eb..0xcde6fa
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xcde700..0xcde7a5]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 255 StructureType main.wideStruct
+          Locations:
+            - Range: 0xcde700..0xcde794
+              Pieces: []
+            - Range: 0xcde794..0xcde795
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xcde795..0xcde7a5
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xcde7c0..0xcde839]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde7c0..0xcde82c
+              Pieces: []
+            - Range: 0xcde82c..0xcde82d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcde82d..0xcde839
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcde7c0..0xcde82c
+              Pieces: []
+            - Range: 0xcde82c..0xcde82d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcde82d..0xcde839
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcde7c0..0xcde82c
+              Pieces: []
+            - Range: 0xcde82c..0xcde82d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcde82d..0xcde839
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0xcde840..0xcde8ba]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcde840..0xcde8ad
+              Pieces: []
+            - Range: 0xcde8ad..0xcde8ae
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcde8ae..0xcde8ba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0xcde8c0..0xcde91b]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde8c0..0xcde91b, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0xcde920..0xcde987]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float32
+          Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 15 BaseType float64
+          Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0xcde9a0..0xcde9fd]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xcde9a0..0xcde9f0
+              Pieces: []
+            - Range: 0xcde9f0..0xcde9f1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcde9f1..0xcde9fd
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0xcde9a0..0xcde9f0
+              Pieces: []
+            - Range: 0xcde9f0..0xcde9f1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcde9f1..0xcde9fd
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0xcdea00..0xcdeb85]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdea00..0xcdeb85
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdea00..0xcdeb73
+              Pieces: []
+            - Range: 0xcdeb73..0xcdeb74
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+            - Range: 0xcdeb74..0xcdeb85
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0xcdeba0..0xcdec72]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0xcdeba0..0xcdec72
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0xcdeba0..0xcdec62
+              Pieces: []
+            - Range: 0xcdec62..0xcdec63
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xcdec63..0xcdec72
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0xcdec80..0xcdeeba]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdec80..0xcdeeba
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdec80..0xcdeeba
+              Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdec80..0xcdeeaa
+              Pieces: []
+            - Range: 0xcdeeaa..0xcdeeab
+              Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
+            - Range: 0xcdeeab..0xcdeeba
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0xcdeec0..0xcdf14f]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef5a
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcdef5a..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef30
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcdef30..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdeec0..0xcdef70
+              Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
+            - Range: 0xcdef70..0xcdf14f
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0xcdeec0..0xcdf0e2
+              Pieces: []
+            - Range: 0xcdf0e2..0xcdf0e3
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xcdf0e3..0xcdf14f
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0xcdf160..0xcdf42c]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf1f5
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcdf1f5..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf1c2
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcdf1c2..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf160..0xcdf20b
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcdf20b..0xcdf42c
+              Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdf160..0xcdf42c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcdf160..0xcdf3ab
+              Pieces: []
+            - Range: 0xcdf3ab..0xcdf3ac
+              Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
+            - Range: 0xcdf3ac..0xcdf42c
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0xcdf440..0xcdf4cc]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 161 ArrayType [5]int
+          Locations:
+            - Range: 0xcdf440..0xcdf4cc
+              Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf440..0xcdf4bc
+              Pieces: []
+            - Range: 0xcdf4bc..0xcdf4bd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf4bd..0xcdf4cc
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf440..0xcdf4bc
+              Pieces: []
+            - Range: 0xcdf4bc..0xcdf4bd
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdf4bd..0xcdf4cc
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf440..0xcdf4bc
+              Pieces: []
+            - Range: 0xcdf4bc..0xcdf4bd
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcdf4bd..0xcdf4cc
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0xcdf4e0..0xcdf5cf]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0xcdf4e0..0xcdf5cf
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0xcdf4e0..0xcdf5cf
+              Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf4e0..0xcdf5bf
+              Pieces: []
+            - Range: 0xcdf5bf..0xcdf5c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf5c0..0xcdf5cf
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0xcdf4e0..0xcdf5bf
+              Pieces: []
+            - Range: 0xcdf5bf..0xcdf5c0
+              Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
+            - Range: 0xcdf5c0..0xcdf5cf
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0xcdf5e0..0xcdf6ac]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcdf5e0..0xcdf6ac
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf5e0..0xcdf69c
+              Pieces: []
+            - Range: 0xcdf69c..0xcdf69d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf69d..0xcdf6ac
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0xcdf5e0..0xcdf69c
+              Pieces: []
+            - Range: 0xcdf69c..0xcdf69d
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+            - Range: 0xcdf69d..0xcdf6ac
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf666..0xcdf6ac
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0xcdf6c0..0xcdf766]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 253 ArrayType [0]int
+          Locations: [{Range: 0xcdf6c0..0xcdf766, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf6c0..0xcdf705
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf705..0xcdf727
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xcdf727..0xcdf73a
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+            - Range: 0xcdf73a..0xcdf766
+              Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdf6c0..0xcdf74c
+              Pieces: []
+            - Range: 0xcdf74c..0xcdf74d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdf74d..0xcdf766
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0xcdf6c0..0xcdf74c
+              Pieces: []
+            - Range: 0xcdf74c..0xcdf74d
+              Pieces: []
+            - Range: 0xcdf74d..0xcdf766
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcdfc40..0xcdfc41]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 251 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcde240..0xcde241
+            - Range: 0xcdfc40..0xcdfc41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4242,15 +5749,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcdfc60..0xcdfc61]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdfc60..0xcdfc61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0xcdfc80..0xcdfc81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcde260..0xcde261]
+      OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcde260..0xcde261
+            - Range: 0xcdfca0..0xcdfca1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4263,19 +5806,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde260..0xcde261
+            - Range: 0xcdfca0..0xcdfca1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcde280..0xcde281]
+      OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcde280..0xcde281
+            - Range: 0xcdfcc0..0xcdfcc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4288,19 +5831,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde280..0xcde281
+            - Range: 0xcdfcc0..0xcdfcc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0xcde2a0..0xcde2a1]
+      OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0xcde2a0..0xcde2a1
+            - Range: 0xcdfce0..0xcdfce1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4313,19 +5856,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde2a0..0xcde2a1
+            - Range: 0xcdfce0..0xcdfce1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0xcde2c0..0xcde2c1]
+      OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0xcde2c0..0xcde2c1
+            - Range: 0xcdfd00..0xcdfd01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4335,22 +5878,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0xcde2e0..0xcde2e1]
+      OutOfLinePCRanges: [0xcdfd20..0xcdfd21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcde2e0..0xcde2e1
+            - Range: 0xcdfd20..0xcdfd21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 257 GoSliceHeaderType []bool
+          Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcde2e0..0xcde2e1
+            - Range: 0xcdfd20..0xcdfd21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -4363,19 +5906,19 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcde2e0..0xcde2e1
+            - Range: 0xcdfd20..0xcdfd21
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcde300..0xcde301]
+      OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 258 GoSliceHeaderType []uint16
+          Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcde300..0xcde301
+            - Range: 0xcdfd40..0xcdfd41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4385,15 +5928,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcde320..0xcde321]
+      OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 250 GoSliceHeaderType []uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcde320..0xcde321
+            - Range: 0xcdfd60..0xcdfd61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4403,15 +5946,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0xcde340..0xcde341]
+      OutOfLinePCRanges: [0xcdfd80..0xcdfd81]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 259 GoSliceHeaderType []struct {}
+          Type: 266 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0xcde340..0xcde341
+            - Range: 0xcdfd80..0xcdfd81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4421,35 +5964,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0xcde680..0xcde6d2]
+      OutOfLinePCRanges: [0xce00c0..0xce0112]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde680..0xcde6c5
+            - Range: 0xce00c0..0xce0105
               Pieces: []
-            - Range: 0xcde6c5..0xcde6c6
+            - Range: 0xce0105..0xce0106
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcde6c6..0xcde6d2
+            - Range: 0xce0106..0xce0112
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcde6e0..0xcde6e1]
+      OutOfLinePCRanges: [0xce0120..0xce0121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde6e0..0xcde6e1
+            - Range: 0xce0120..0xce0121
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4457,15 +6000,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcde700..0xcde701]
+      OutOfLinePCRanges: [0xce0140..0xce0141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde700..0xcde701
+            - Range: 0xce0140..0xce0141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4476,7 +6019,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde700..0xcde701
+            - Range: 0xce0140..0xce0141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4487,7 +6030,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde700..0xcde701
+            - Range: 0xce0140..0xce0141
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4495,15 +6038,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcde720..0xcde73f]
+      OutOfLinePCRanges: [0xce0160..0xce017f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 261 StructureType main.threeStringStruct
+          Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcde720..0xcde73f
+            - Range: 0xce0160..0xce017f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4519,39 +6062,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcde740..0xcde741]
+      OutOfLinePCRanges: [0xce0180..0xce0181]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 262 PointerType *main.threeStringStruct
+          Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcde740..0xcde741
+            - Range: 0xce0180..0xce0181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcde760..0xcde761]
+      OutOfLinePCRanges: [0xce01a0..0xce01a1]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 263 PointerType *main.oneStringStruct
+          Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcde760..0xcde761
+            - Range: 0xce01a0..0xce01a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcde780..0xcde781]
+      OutOfLinePCRanges: [0xce01c0..0xce01c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde780..0xcde781
+            - Range: 0xce01c0..0xce01c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4559,15 +6102,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcde7a0..0xcde7a1]
+      OutOfLinePCRanges: [0xce01e0..0xce01e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde7a0..0xcde7a1
+            - Range: 0xce01e0..0xce01e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4575,15 +6118,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcde7c0..0xcde7c1]
+      OutOfLinePCRanges: [0xce0200..0xce0201]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde7c0..0xcde7c1
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4591,27 +6134,27 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcde920..0xcde921]
+      OutOfLinePCRanges: [0xce0360..0xce0361]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 265 StructureType main.structWithCyclicSlices
+          Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcde920..0xcde921
+            - Range: 0xce0360..0xce0361
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcde940..0xcde95f]
+      OutOfLinePCRanges: [0xce0380..0xce039f]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 278 StructureType main.structWithCyclicMaps
+          Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcde940..0xcde95f
+            - Range: 0xce0380..0xce039f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4627,15 +6170,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcdea80..0xcdeaa3]
+      OutOfLinePCRanges: [0xce04c0..0xce04e3]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 309 StructureType main.aStruct
+          Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0xcdea80..0xcdeaa3
+            - Range: 0xce04c0..0xce04e3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4653,29 +6196,29 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdec00..0xcdec01]
+      OutOfLinePCRanges: [0xce0640..0xce0641]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 310 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdec00..0xcdec01, Pieces: []}]
+          Type: 317 StructureType main.emptyStruct
+          Locations: [{Range: 0xce0640..0xce0641, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcdec20..0xcdec21]
+      OutOfLinePCRanges: [0xce0660..0xce0661]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 311 PointerType *main.emptyStruct
+          Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcdec20..0xcdec21
+            - Range: 0xce0660..0xce0661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda200..0xcda262]
       InlinePCRanges:
@@ -4705,28 +6248,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda4a6..0xcda4de]
           RootRanges: [0xcda440..0xcda505]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda5b3..0xcda5f1]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda65b..0xcda693]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4740,7 +6283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4765,20 +6308,20 @@ Types:
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1229
+      ID: 1236
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1230 PointerType *main.deepSlice3
+      Pointee: 1237 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1255 PointerType *main.deepSlice8
+      Pointee: 1262 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1261 PointerType *main.deepSlice9
+      Pointee: 1268 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -4786,7 +6329,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1225
+      ID: 1232
       Name: '**main.t'
       ByteSize: 8
       Pointee: 248 PointerType *main.t
@@ -4829,30 +6372,30 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1237
+      ID: 1244
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1238 PointerType *table<int,*main.deepMap3>
+      Pointee: 1245 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1272 PointerType *table<int,*main.deepMap8>
+      Pointee: 1279 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1287 PointerType *table<int,*main.deepMap9>
+      Pointee: 1294 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 170 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1301
+      ID: 1308
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1302 PointerType *table<int,interface {}>
+      Pointee: 1309 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '**table<int,struct {}>'
@@ -4874,10 +6417,10 @@ Types:
       ByteSize: 8
       Pointee: 185 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 972 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,int>'
@@ -4894,35 +6437,35 @@ Types:
       ByteSize: 8
       Pointee: 232 PointerType *table<struct {},int>
     - __kind: PointerType
-      ID: 282
+      ID: 289
       Name: '**table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 283 PointerType *table<struct {},main.structWithCyclicMaps>
+      Pointee: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 287
+      ID: 294
       Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 288 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 292
+      ID: 299
       Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 293 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 297
+      ID: 304
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 298 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 302
+      ID: 309
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 307
+      ID: 314
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 241
       Name: '**table<struct {},struct {}>'
@@ -4939,120 +6482,120 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 325
+      ID: 332
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 331 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1233
+      ID: 1240
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1232 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1239 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1257 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1264 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1264
+      ID: 1271
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1263 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1270 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 320
+      ID: 327
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []*runtime.p.array
+      Pointee: 326 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 322
+      ID: 329
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType []*string.array
+      Pointee: 328 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 491 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 277
+      ID: 284
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 489 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 487 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 273
+      ID: 280
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 479
+      ID: 486
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 485 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 271
+      ID: 278
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 477
+      ID: 484
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 483 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 463
+      ID: 470
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 462 GoSliceDataType [][]uint.array
+      Pointee: 469 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 469
+      ID: 476
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 468 GoSliceDataType []bool.array
+      Pointee: 475 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1007 GoSliceDataType []float64.array
+      Pointee: 1014 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1266 GoSliceDataType []interface {}.array
+      Pointee: 1273 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 269
+      ID: 276
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 266 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 481 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 535
+      ID: 542
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 534 GoSliceDataType []main.structWithMap.array
+      Pointee: 541 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 465
+      ID: 472
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 464 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -5061,101 +6604,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 466 GoSliceDataType []string.array
+      Pointee: 473 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType []struct {}.array
+      Pointee: 479 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 252
+      ID: 259
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 250 GoSliceHeaderType []uint
+      Pointee: 257 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 461
+      ID: 468
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 460 GoSliceDataType []uint.array
+      Pointee: 467 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 471
+      ID: 478
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []uint16.array
+      Pointee: 477 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 315
+      ID: 322
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []uint8.array
+      Pointee: 321 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []uintptr.array
+      Pointee: 323 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.988096e+06
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1146 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 932384
       GoKind: 22
-      Pointee: 774 GoSliceHeaderType archive/tar.headerError
+      Pointee: 781 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 775 GoSliceDataType archive/tar.headerError.array
+      Pointee: 782 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.437216e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1081 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 932576
       GoKind: 22
-      Pointee: 1022 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1029 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 932672
       GoKind: 22
-      Pointee: 1024 StructureType archive/zip.dirWriter
+      Pointee: 1031 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1117
+      ID: 1124
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1125 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1049
+      ID: 1056
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.058784e+06
       GoKind: 22
-      Pointee: 1050 StructureType archive/zip.nopCloser
+      Pointee: 1057 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.05904e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1059 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -5164,435 +6707,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1096
+      ID: 1103
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.176192e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType bufio.Reader
+      Pointee: 1104 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.950976e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType bufio.Writer
+      Pointee: 1133 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1176
+      ID: 1183
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.269056e+06
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1184 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914816
       GoKind: 22
-      Pointee: 572 BaseType compress/flate.CorruptInputError
+      Pointee: 579 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 914912
       GoKind: 22
-      Pointee: 573 GoStringHeaderType compress/flate.InternalError
+      Pointee: 580 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 574 GoStringDataType compress/flate.InternalError.str
+      Pointee: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.426816e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1079 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 915008
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1025 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.72752e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1101 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.204704e+06
       GoKind: 22
-      Pointee: 922 StructureType context.deadlineExceededError
+      Pointee: 929 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927008
       GoKind: 22
-      Pointee: 586 BaseType crypto/aes.KeySizeError
+      Pointee: 593 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927200
       GoKind: 22
-      Pointee: 587 BaseType crypto/des.KeySizeError
+      Pointee: 594 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927488
       GoKind: 22
-      Pointee: 588 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 595 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.668256e+06
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1096 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.066592e+06
       GoKind: 22
-      Pointee: 871 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 878 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.906752e+06
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1127 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.121344e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1157 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.907264e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.907008e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1129 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1115
+      ID: 1122
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.904448e+06
       GoKind: 22
-      Pointee: 1116 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1123 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927776
       GoKind: 22
-      Pointee: 589 BaseType crypto/rc4.KeySizeError
+      Pointee: 596 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.985216e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1144 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.873824e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1119 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 691
+      ID: 698
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 916640
       GoKind: 22
-      Pointee: 576 BaseType crypto/tls.AlertError
+      Pointee: 583 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.047392e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 867 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.380576e+06
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1210 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 916352
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 695 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 916256
       GoKind: 22
-      Pointee: 686 StructureType crypto/tls.RecordHeaderError
+      Pointee: 693 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.045728e+06
       GoKind: 22
-      Pointee: 813 BaseType crypto/tls.alert
+      Pointee: 820 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.56112e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1089 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 916448
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 697 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1086
+      ID: 1093
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.643296e+06
       GoKind: 22
-      Pointee: 1087 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1094 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.427296e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 964 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.044384e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 981 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 926048
       GoKind: 22
-      Pointee: 762 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 769 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 925568
       GoKind: 22
-      Pointee: 756 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 763 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 925664
       GoKind: 22
-      Pointee: 758 StructureType crypto/x509.HostnameError
+      Pointee: 765 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 925472
       GoKind: 22
-      Pointee: 585 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.053152e+06
       GoKind: 22
-      Pointee: 865 StructureType crypto/x509.SystemRootsError
+      Pointee: 872 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 926144
       GoKind: 22
-      Pointee: 764 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 771 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 925952
       GoKind: 22
-      Pointee: 760 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 767 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 932864
       GoKind: 22
-      Pointee: 778 StructureType encoding/asn1.StructuralError
+      Pointee: 785 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 933056
       GoKind: 22
-      Pointee: 782 StructureType encoding/asn1.SyntaxError
+      Pointee: 789 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932960
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 787 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912800
       GoKind: 22
-      Pointee: 567 BaseType encoding/base64.CorruptInputError
+      Pointee: 574 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.042784e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1047 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 675
+      ID: 682
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 913664
       GoKind: 22
-      Pointee: 568 BaseType encoding/hex.InvalidByteError
+      Pointee: 575 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 907616
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 651 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.038944e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 856 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 907232
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 643 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 907520
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 649 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 907424
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 647 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 907328
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 645 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1182
+      ID: 1189
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.294592e+06
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1190 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 908000
       GoKind: 22
-      Pointee: 646 StructureType encoding/json.jsonError
+      Pointee: 653 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.055712e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1055 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 924512
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 757 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 924416
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 755 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 924608
       GoKind: 22
-      Pointee: 582 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 583 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 924704
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 760 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1160
+      ID: 1167
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.161184e+06
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1168 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -5601,19 +7144,19 @@ Types:
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
-      ID: 611
+      ID: 618
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897632
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType errors.errorString
+      Pointee: 619 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.02384e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType errors.joinError
+      Pointee: 823 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -5629,813 +7172,813 @@ Types:
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.261376e+06
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType fmt.pp
+      Pointee: 1178 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023968e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType fmt.wrapError
+      Pointee: 825 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.024096e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 827 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 913184
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 681 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 910400
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 910496
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 664 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 910208
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 993 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 910784
       GoKind: 22
-      Pointee: 661 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 668 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 910304
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 995 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 910592
       GoKind: 22
-      Pointee: 561 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 563
+      ID: 570
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 562 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 910112
       GoKind: 22
-      Pointee: 558 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 565 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 559 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 566 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 659
+      ID: 666
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 910688
       GoKind: 22
-      Pointee: 564 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 566
+      ID: 573
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 565 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1059
+      ID: 1066
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.210208e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1067 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.059392e+06
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 931328
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 779 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.213792e+06
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.271104e+06
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1186 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 920000
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 706 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 921056
       GoKind: 22
-      Pointee: 706 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 713 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 920768
       GoKind: 22
-      Pointee: 581 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 704 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 711 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 702 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 709 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 721
+      ID: 728
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 922976
       GoKind: 22
-      Pointee: 722 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 729 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 923168
       GoKind: 22
-      Pointee: 726 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 923072
       GoKind: 22
-      Pointee: 724 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 731 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 719
+      ID: 726
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 922880
       GoKind: 22
-      Pointee: 720 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 727 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1009 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 923552
       GoKind: 22
-      Pointee: 734 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 923264
       GoKind: 22
-      Pointee: 728 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 923456
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 923360
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 923648
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 923936
       GoKind: 22
-      Pointee: 742 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 749 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 924032
       GoKind: 22
-      Pointee: 744 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 751 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 923840
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 747 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 923744
       GoKind: 22
-      Pointee: 738 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 745 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 924224
       GoKind: 22
-      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 911936
       GoKind: 22
-      Pointee: 663 StructureType github.com/cihub/seelog.baseError
+      Pointee: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.804384e+06
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1107 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 912032
       GoKind: 22
-      Pointee: 665 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 672 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.55984e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.041632e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1043 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.424896e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 912224
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 676 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.97744e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1142 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.133984e+06
       GoKind: 22
-      Pointee: 1148 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1155 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.1336e+06
       GoKind: 22
-      Pointee: 1151 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1037
+      ID: 1044
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.04176e+06
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 912128
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 674 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 912320
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 678 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.806176e+06
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1109 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.013568e+06
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1150 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.044064e+06
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1152 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.439616e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 969 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.06736e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 882 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.067232e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 880 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.071328e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 884 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.071456e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 886 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1090
+      ID: 1097
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.67056e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.053792e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 874 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 913856
       GoKind: 22
-      Pointee: 677 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 684 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.357024e+06
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1202 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.222368e+06
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 940 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.201248e+06
       GoKind: 22
-      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.200864e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 907 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.032928e+06
       GoKind: 22
-      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.201632e+06
       GoKind: 22
-      Pointee: 912 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 919 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.0328e+06
       GoKind: 22
-      Pointee: 812 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 819 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.20112e+06
       GoKind: 22
-      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.200992e+06
       GoKind: 22
-      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.201504e+06
       GoKind: 22
-      Pointee: 910 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 917 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.201376e+06
       GoKind: 22
-      Pointee: 908 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 915 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.369632e+06
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1206 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.202016e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 923 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.033184e+06
       GoKind: 22
-      Pointee: 839 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.033056e+06
       GoKind: 22
-      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.201888e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 921 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945824
       GoKind: 22
-      Pointee: 594 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 601 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 595 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 602 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.669024e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 984 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.086176e+06
       GoKind: 22
-      Pointee: 883 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 890 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1065
+      ID: 1072
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.262176e+06
       GoKind: 22
-      Pointee: 1066 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1073 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1158
+      ID: 1165
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.149344e+06
       GoKind: 22
-      Pointee: 1159 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1166 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1053
+      ID: 1060
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.08848e+06
       GoKind: 22
-      Pointee: 1054 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1061 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 947072
       GoKind: 22
-      Pointee: 597 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 604 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.26384e+06
       GoKind: 22
-      Pointee: 941 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 948 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 947360
       GoKind: 22
-      Pointee: 798 StructureType golang.org/x/net/http2.connError
+      Pointee: 805 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947264
       GoKind: 22
-      Pointee: 601 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 608 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 602 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 609 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 947552
       GoKind: 22
-      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 608 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 615 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 947456
       GoKind: 22
-      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 612 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 947168
       GoKind: 22
-      Pointee: 598 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 605 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 606 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1156
+      ID: 1163
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.147424e+06
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1164 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 947648
       GoKind: 22
-      Pointee: 802 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 809 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947744
       GoKind: 22
-      Pointee: 610 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 617 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 941024
       GoKind: 22
-      Pointee: 790 StructureType google.golang.org/grpc.dropError
+      Pointee: 797 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.260896e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 946 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.446976e+06
       GoKind: 22
-      Pointee: 964 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 971 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 944096
       GoKind: 22
-      Pointee: 792 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 799 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1105
+      ID: 1112
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.811776e+06
       GoKind: 22
-      Pointee: 1106 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1113 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1063
+      ID: 1070
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.25744e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1071 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.080416e+06
       GoKind: 22
-      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 888 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 944192
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1033 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 929216
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 777 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.05712e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 876 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.228768e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 944 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.228512e+06
       GoKind: 22
-      Pointee: 935 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 942 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 933920
       GoKind: 22
-      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 791 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 934016
       GoKind: 22
-      Pointee: 786 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 793 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 921440
       GoKind: 22
-      Pointee: 714 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 721 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1113
+      ID: 1120
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.9024e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1121 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 948512
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType html/template.Error
+      Pointee: 812 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -6479,129 +8022,129 @@ Types:
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.213696e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType internal/abi.Type
+      Pointee: 973 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 914528
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 689 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 914432
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 687 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 902432
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1019 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.200096e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 905 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.375296e+06
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1208 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.199968e+06
       GoKind: 22
-      Pointee: 896 StructureType internal/poll.errNetClosing
+      Pointee: 903 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 901664
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 914240
       GoKind: 22
-      Pointee: 569 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 576 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 577 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.044064e+06
       GoKind: 22
-      Pointee: 853 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 860 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1057
+      ID: 1064
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.191648e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1065 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1062
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.191264e+06
       GoKind: 22
-      Pointee: 1056 StructureType io.discard
+      Pointee: 1063 StructureType io.discard
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.024864e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType io.multiWriter
+      Pointee: 1037 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.199456e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType io/fs.PathError
+      Pointee: 901 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.8064e+06
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1111 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 332
+      ID: 339
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 386560
       GoKind: 22
-      Pointee: 333 StructureType main.deepMap2
+      Pointee: 340 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1245
+      ID: 1252
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 386496
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType main.deepMap3
+      Pointee: 1253 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -6610,19 +8153,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1279
+      ID: 1286
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
-      Pointee: 1280 StructureType main.deepMap8
+      Pointee: 1287 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 386112
       GoKind: 22
-      Pointee: 1295 StructureType main.deepMap9
+      Pointee: 1302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -6631,12 +8174,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 387072
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1212 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -6645,33 +8188,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1249
+      ID: 1256
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386752
       GoKind: 22
-      Pointee: 1250 StructureType main.deepPtr8
+      Pointee: 1257 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1251
+      ID: 1258
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386688
       GoKind: 22
-      Pointee: 1252 StructureType main.deepPtr9
+      Pointee: 1259 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387712
       GoKind: 22
-      Pointee: 323 StructureType main.deepSlice2
+      Pointee: 330 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387648
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1238 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -6680,25 +8223,25 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1255
+      ID: 1262
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 387328
       GoKind: 22
-      Pointee: 1256 StructureType main.deepSlice8
+      Pointee: 1263 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1261
+      ID: 1268
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 387264
       GoKind: 22
-      Pointee: 1262 StructureType main.deepSlice9
+      Pointee: 1269 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 311
+      ID: 318
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 StructureType main.emptyStruct
+      Pointee: 317 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 159
       Name: '*main.esotericHeap'
@@ -6707,12 +8250,12 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1221
+      ID: 1228
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 897344
       GoKind: 22
-      Pointee: 1222 StructureType main.firstBehavior
+      Pointee: 1229 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 247
       Name: '*main.node'
@@ -6721,25 +8264,25 @@ Types:
       GoKind: 22
       Pointee: 246 StructureType main.node
     - __kind: PointerType
-      ID: 263
+      ID: 270
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 264 StructureType main.oneStringStruct
+      Pointee: 271 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1223
+      ID: 1230
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 897440
       GoKind: 22
-      Pointee: 1224 StructureType main.secondBehavior
+      Pointee: 1231 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1209
+      ID: 1216
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 897536
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1217 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -6747,33 +8290,33 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1206 GoStringDataType main.stringType1.str
+      Pointee: 1213 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType main.stringType2
+      Pointee: 1215 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 267
+      ID: 274
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 265 StructureType main.structWithCyclicSlices
+      Pointee: 272 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 384
+      ID: 391
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 386048
       GoKind: 22
       Pointee: 165 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 254
+      ID: 261
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 255 StructureType main.structWithNoStrings
+      Pointee: 262 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 244
       Name: '*main.structWithTwoValues'
@@ -6787,16 +8330,16 @@ Types:
       GoKind: 22
       Pointee: 249 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1227
+      ID: 1234
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1226 GoSliceDataType main.t.array
+      Pointee: 1233 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 262
+      ID: 269
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 261 StructureType main.threeStringStruct
+      Pointee: 268 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 224
       Name: '*map<[4]int,[4]int>'
@@ -6823,30 +8366,30 @@ Types:
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1236 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1243 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1270 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1277 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1284
+      ID: 1291
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1285 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1292 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1299
+      ID: 1306
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1300 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1307 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '*map<int,struct {}>'
@@ -6868,10 +8411,10 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 970 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,int>'
@@ -6888,35 +8431,35 @@ Types:
       ByteSize: 8
       Pointee: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '*map<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      Pointee: 288 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 305
+      ID: 312
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 313 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 239
       Name: '*map<struct {},struct {}>'
@@ -6939,696 +8482,696 @@ Types:
       GoKind: 22
       Pointee: 176 GoMapType map[string]int
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 922304
       GoKind: 22
-      Pointee: 718 StructureType math/big.ErrNaN
+      Pointee: 725 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 917120
       GoKind: 22
-      Pointee: 1020 StructureType mime/multipart.writerOnly·1
+      Pointee: 1027 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.208032e+06
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType net.AddrError
+      Pointee: 932 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.423136e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.DNSError
+      Pointee: 958 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.234048e+06
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType net.IPConn
+      Pointee: 1172 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.422816e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.OpError
+      Pointee: 956 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.20816e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType net.ParseError
+      Pointee: 934 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.2624e+06
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType net.TCPConn
+      Pointee: 1182 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1184
+      ID: 1191
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.307904e+06
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType net.UDPConn
+      Pointee: 1192 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1172
+      ID: 1179
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.261888e+06
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType net.UnixConn
+      Pointee: 1180 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.207264e+06
       GoKind: 22
-      Pointee: 886 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 893 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 887 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 894 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03984e+06
       GoKind: 22
-      Pointee: 851 StructureType net.canceledError
+      Pointee: 858 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.010976e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType net.conn
+      Pointee: 1148 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.849184e+06
       GoKind: 22
-      Pointee: 995 StructureType net.dialResult·1
+      Pointee: 1002 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1186
+      ID: 1193
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.31216e+06
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType net.netFD
+      Pointee: 1194 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908960
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.notFoundError
+      Pointee: 655 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 909632
       GoKind: 22
-      Pointee: 650 StructureType net.result·2
+      Pointee: 657 StructureType net.result·2
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.248416e+06
       GoKind: 22
-      Pointee: 1169 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1176 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.247936e+06
       GoKind: 22
-      Pointee: 1167 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1174 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.2088e+06
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType net.temporaryError
+      Pointee: 936 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.423296e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType net.timeoutError
+      Pointee: 960 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.035616e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 848 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 904736
       GoKind: 22
-      Pointee: 1014 StructureType net/http.bufioFlushWriter
+      Pointee: 1021 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 905408
       GoKind: 22
-      Pointee: 539 BaseType net/http.http2ConnectionError
+      Pointee: 546 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 625
+      ID: 632
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 905504
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2GoAwayError
+      Pointee: 633 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.418816e+06
       GoKind: 22
-      Pointee: 945 StructureType net/http.http2StreamError
+      Pointee: 952 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 906080
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2connError
+      Pointee: 637 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.55632e+06
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1083 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 628
+      ID: 635
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905984
       GoKind: 22
-      Pointee: 543 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 550 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 545
+      ID: 552
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 544 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 551 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 906272
       GoKind: 22
-      Pointee: 549 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 556 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 550 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 557 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 906176
       GoKind: 22
-      Pointee: 546 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 553 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 554 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.203936e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 927 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.036256e+06
       GoKind: 22
-      Pointee: 847 StructureType net/http.http2noCachedConnError
+      Pointee: 854 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.95328e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1137 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905888
       GoKind: 22
-      Pointee: 540 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 547 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 542
+      ID: 549
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 541 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 548 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 906368
       GoKind: 22
-      Pointee: 1016 StructureType net/http.http2stickyErrWriter
+      Pointee: 1023 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.035872e+06
       GoKind: 22
-      Pointee: 843 StructureType net/http.nothingWrittenError
+      Pointee: 850 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.17744e+06
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1085 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.035744e+06
       GoKind: 22
-      Pointee: 1034 StructureType net/http.persistConnWriter
+      Pointee: 1041 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1067
+      ID: 1074
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.418976e+06
       GoKind: 22
-      Pointee: 1068 StructureType net/http.readWriteCloserBody
+      Pointee: 1075 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 906464
       GoKind: 22
-      Pointee: 634 StructureType net/http.requestBodyReadError
+      Pointee: 641 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.420096e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 954 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.203808e+06
       GoKind: 22
-      Pointee: 918 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 925 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.036e+06
       GoKind: 22
-      Pointee: 845 StructureType net/http.transportReadFromServerError
+      Pointee: 852 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1109
+      ID: 1116
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.845824e+06
       GoKind: 22
-      Pointee: 1110 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1117 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 904640
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 630 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.955072e+06
       GoKind: 22
-      Pointee: 1132 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1139 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.048544e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1051 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 921248
       GoKind: 22
-      Pointee: 710 StructureType net/netip.parseAddrError
+      Pointee: 717 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 921152
       GoKind: 22
-      Pointee: 708 StructureType net/netip.parsePrefixError
+      Pointee: 715 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.119936e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1091 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.053408e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/smtp.dataCloser
+      Pointee: 1053 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 693
+      ID: 700
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 917312
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType net/textproto.Error
+      Pointee: 701 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 917216
       GoKind: 22
-      Pointee: 577 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 579
+      ID: 586
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 578 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.047776e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1049 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.423616e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType net/url.Error
+      Pointee: 962 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909728
       GoKind: 22
-      Pointee: 552 GoStringHeaderType net/url.EscapeError
+      Pointee: 559 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 554
+      ID: 561
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType net/url.EscapeError.str
+      Pointee: 560 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909824
       GoKind: 22
-      Pointee: 555 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 562 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 557
+      ID: 564
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 556 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 563 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 430
+      ID: 437
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 431 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 423 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 370
+      ID: 377
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 371 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 389
+      ID: 396
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 390 StructureType noalg.map.group[bool]main.node
+      Pointee: 397 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 328
+      ID: 335
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 329 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1290
+      ID: 1297
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 338
+      ID: 345
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 339 StructureType noalg.map.group[int]int
+      Pointee: 346 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1305
+      ID: 1312
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1306 StructureType noalg.map.group[int]interface {}
+      Pointee: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 446
+      ID: 453
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[int]struct {}
+      Pointee: 454 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 397
+      ID: 404
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 398 StructureType noalg.map.group[int]uint8
+      Pointee: 405 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 380 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 362
+      ID: 369
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 363 StructureType noalg.map.group[string][]string
+      Pointee: 370 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 354
+      ID: 361
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 355 StructureType noalg.map.group[string]int
+      Pointee: 362 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 346
+      ID: 353
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 347 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 438
+      ID: 445
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 439 StructureType noalg.map.group[struct {}]int
+      Pointee: 446 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 496
+      ID: 503
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 504
+      ID: 511
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 454
+      ID: 461
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 455 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 413
+      ID: 420
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 414 StructureType noalg.map.group[uint8][4]int
+      Pointee: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 405
+      ID: 412
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 406 StructureType noalg.map.group[uint8]uint8
+      Pointee: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1192
+      ID: 1199
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.351648e+06
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType os.File
+      Pointee: 1200 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.026912e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType os.LinkError
+      Pointee: 829 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.1928e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType os.SyscallError
+      Pointee: 897 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.350176e+06
       GoKind: 22
-      Pointee: 1191 StructureType os.fileWithoutReadFrom
+      Pointee: 1198 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.34944e+06
       GoKind: 22
-      Pointee: 1189 StructureType os.fileWithoutWriteTo
+      Pointee: 1196 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.044448e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType os/exec.Error
+      Pointee: 862 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.0912e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1005 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1061
+      ID: 1068
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.215072e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1069 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.044576e+06
       GoKind: 22
-      Pointee: 857 StructureType os/exec.wrappedError
+      Pointee: 864 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 939104
       GoKind: 22
-      Pointee: 591 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 598 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 593
+      ID: 600
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 592 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 599 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 939008
       GoKind: 22
-      Pointee: 590 BaseType os/user.UnknownUserIdError
+      Pointee: 597 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 902336
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType reflect.ValueError
+      Pointee: 625 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 715
+      ID: 722
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 921920
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 723 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.028448e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 833 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.03024e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 837 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7644,12 +9187,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.028576e+06
       GoKind: 22
-      Pointee: 828 StructureType runtime.boundsError
+      Pointee: 835 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -7665,24 +9208,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.198304e+06
       GoKind: 22
-      Pointee: 892 StructureType runtime.errorAddressString
+      Pointee: 899 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.028064e+06
       GoKind: 22
-      Pointee: 806 GoStringHeaderType runtime.errorString
+      Pointee: 813 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 807 GoStringDataType runtime.errorString.str
+      Pointee: 814 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -7703,19 +9246,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.0296e+06
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType runtime.p
+      Pointee: 325 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.028192e+06
       GoKind: 22
-      Pointee: 809 GoStringHeaderType runtime.plainError
+      Pointee: 816 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 810 GoStringDataType runtime.plainError.str
+      Pointee: 817 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7731,12 +9274,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 613
+      ID: 620
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 22
-      Pointee: 614 StructureType runtime.synctestDeadlockError
+      Pointee: 621 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -7752,12 +9295,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.030496e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType strconv.NumError
+      Pointee: 839 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -7766,220 +9309,220 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 313
+      ID: 320
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType string.str
+      Pointee: 319 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.952e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType strings.Builder
+      Pointee: 1135 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.030624e+06
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1039 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1034
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 972096
       GoKind: 22
-      Pointee: 1028 StructureType struct { io.Writer }
+      Pointee: 1035 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 260
+      ID: 267
       Name: '*struct {}'
       ByteSize: 8
       GoRuntimeType: 476864
       GoKind: 22
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.418176e+06
       GoKind: 22
-      Pointee: 942 BaseType syscall.Errno
+      Pointee: 949 BaseType syscall.Errno
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 428 StructureType table<[4]int,[4]int>
+      Pointee: 435 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 222
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 420 StructureType table<[4]int,uint8>
+      Pointee: 427 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 190
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 368 StructureType table<[4]string,[2]int>
+      Pointee: 375 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 202
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 387 StructureType table<bool,main.node>
+      Pointee: 394 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 326 StructureType table<int,*main.deepMap2>
+      Pointee: 333 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1239 StructureType table<int,*main.deepMap3>
+      Pointee: 1246 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1272
+      ID: 1279
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1273 StructureType table<int,*main.deepMap8>
+      Pointee: 1280 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1288 StructureType table<int,*main.deepMap9>
+      Pointee: 1295 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 170
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 336 StructureType table<int,int>
+      Pointee: 343 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1303 StructureType table<int,interface {}>
+      Pointee: 1310 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 237
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 444 StructureType table<int,struct {}>
+      Pointee: 451 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 207
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 395 StructureType table<int,uint8>
+      Pointee: 402 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 377 StructureType table<string,[]main.structWithMap>
+      Pointee: 384 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 360 StructureType table<string,[]string>
+      Pointee: 367 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 999 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1006 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 352 StructureType table<string,int>
+      Pointee: 359 StructureType table<string,int>
     - __kind: PointerType
       ID: 175
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 344 StructureType table<string,main.nestedStruct>
+      Pointee: 351 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 232
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 436 StructureType table<struct {},int>
+      Pointee: 443 StructureType table<struct {},int>
     - __kind: PointerType
-      ID: 283
+      ID: 290
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 486 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 493 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 288
+      ID: 295
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 494 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 501 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 293
+      ID: 300
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 502 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 509 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 298
+      ID: 305
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 510 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 517 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 303
+      ID: 310
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 518 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 525 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 308
+      ID: 315
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 526 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 533 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 242
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 452 StructureType table<struct {},struct {}>
+      Pointee: 459 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 411 StructureType table<uint8,[4]int>
+      Pointee: 418 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 212
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 403 StructureType table<uint8,uint8>
+      Pointee: 410 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.161568e+06
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1170 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.090016e+06
       GoKind: 22
-      Pointee: 885 StructureType text/template.ExecError
+      Pointee: 892 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.624288e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType time.Location
+      Pointee: 967 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 627
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 903200
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 628 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 903104
       GoKind: 22
-      Pointee: 536 GoStringHeaderType time.fileSizeError
+      Pointee: 543 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 538
+      ID: 545
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 537 GoStringDataType time.fileSizeError.str
+      Pointee: 544 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -8023,52 +9566,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 921344
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 719 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.137056e+06
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1162 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 917504
       GoKind: 22
-      Pointee: 696 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 703 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 917600
       GoKind: 22
-      Pointee: 580 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.048288e+06
       GoKind: 22
-      Pointee: 862 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 869 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.048416e+06
       GoKind: 22
-      Pointee: 814 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1451
+      ID: 1506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1507
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8080,11 +9623,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1388
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8100,7 +9643,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
+      ID: 1389
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8116,7 +9659,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1378
+      ID: 1385
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8132,7 +9675,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1379
+      ID: 1386
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8148,7 +9691,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1329
+      ID: 1478
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1336
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8164,7 +9739,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1327
+      ID: 1334
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8180,7 +9755,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1325
+      ID: 1332
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8196,7 +9771,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1390
+      ID: 1397
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8212,7 +9787,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1326
+      ID: 1333
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8228,7 +9803,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1328
+      ID: 1335
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8244,7 +9819,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1347
+      ID: 1354
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8260,10 +9835,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1348
+      ID: 1355
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1314
+      ID: 1321
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8279,7 +9854,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1311
+      ID: 1318
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8295,7 +9870,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1410
+      ID: 1417
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8311,7 +9886,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1408
+      ID: 1415
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -8347,7 +9922,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1418
+      ID: 1425
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8363,7 +9938,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1360
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8379,7 +9954,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1361
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8395,7 +9970,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1356
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8411,7 +9986,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1357
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8427,7 +10002,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1358
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8443,7 +10018,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1352
+      ID: 1359
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8459,7 +10034,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8468,10 +10043,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8481,11 +10056,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8494,14 +10069,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1517
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8513,11 +10088,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1524
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8526,14 +10101,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 311 PointerType *main.emptyStruct
+            Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1523
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8542,14 +10117,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 310 StructureType main.emptyStruct
+            Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1380
+      ID: 1387
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8565,7 +10140,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1369
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8581,10 +10156,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1370
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1360
+      ID: 1367
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8600,10 +10175,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1361
+      ID: 1368
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1374
+      ID: 1381
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8619,7 +10194,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1376
+      ID: 1383
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8645,7 +10220,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1382
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8661,7 +10236,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1379
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8677,7 +10252,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1380
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8693,7 +10268,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1371
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8709,10 +10284,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1372
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1368
+      ID: 1375
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8728,13 +10303,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1473
+      ID: 1528
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1366
+      ID: 1373
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8760,28 +10335,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1474
+      ID: 1529
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1530
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1476
+      ID: 1531
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1477
+      ID: 1532
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1370
+      ID: 1377
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1371
+      ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1470
+      ID: 1525
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8793,11 +10368,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1472
+      ID: 1527
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8809,14 +10384,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1471
+      ID: 1526
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1478
+      ID: 1533
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8828,11 +10403,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1534
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8844,11 +10419,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1535
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8860,11 +10435,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1317
+      ID: 1324
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8880,7 +10455,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1318
+      ID: 1325
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8896,7 +10471,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1326
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8912,7 +10487,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1316
+      ID: 1323
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8928,7 +10503,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1315
+      ID: 1322
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8944,7 +10519,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1377
+      ID: 1384
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8960,7 +10535,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1476
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1419
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8976,36 +10583,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1364
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1358
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1359
+      ID: 1365
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9031,7 +10612,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1366
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1483
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1395
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9047,7 +10766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1402
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9063,7 +10782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1414
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9079,7 +10798,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1412
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9095,7 +10814,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1413
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9111,7 +10830,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1399
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9127,7 +10846,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1411
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9143,7 +10862,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1410
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9159,7 +10878,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1400
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9175,7 +10894,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1401
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9191,7 +10910,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9207,7 +10926,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1401
+      ID: 1408
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9223,7 +10942,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1393
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9239,7 +10958,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1394
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9255,7 +10974,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1392
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9271,7 +10990,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1403
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9287,7 +11006,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1407
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9303,7 +11022,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1406
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9319,7 +11038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1405
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9335,7 +11054,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1404
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9351,7 +11070,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1514
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9363,11 +11082,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1460
+      ID: 1515
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9379,11 +11098,217 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1435
+      ID: 1484
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1485
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1488
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1489
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1442
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9399,7 +11324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1443
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9425,7 +11350,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1416
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9481,7 +11406,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1440
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9497,7 +11422,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1434
+      ID: 1441
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9513,7 +11438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1424
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9539,7 +11464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9548,10 +11473,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9561,11 +11486,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9577,17 +11502,17 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 257 GoSliceHeaderType []bool
+            Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9597,11 +11522,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9610,14 +11535,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 258 GoSliceHeaderType []uint16
+            Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1458
+      ID: 1513
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9626,14 +11551,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 263 PointerType *main.oneStringStruct
+            Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1420
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9649,7 +11574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1398
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9665,7 +11590,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1418
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9681,7 +11606,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1434
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9707,7 +11632,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1428
+      ID: 1435
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9733,7 +11658,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1436
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9749,7 +11674,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1437
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9765,7 +11690,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1425
+      ID: 1456
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1459
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1432
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9781,7 +11920,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1426
+      ID: 1433
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9797,7 +11936,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1423
+      ID: 1430
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9813,7 +11952,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1431
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9839,7 +11978,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1428
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9855,7 +11994,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1422
+      ID: 1429
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9871,7 +12010,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1426
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9887,7 +12026,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1427
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9903,7 +12042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1438
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9919,7 +12058,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1432
+      ID: 1439
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9935,7 +12074,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1312
+      ID: 1452
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1466
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1446
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 104 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 12 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1465
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 255 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1319
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9951,7 +12541,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1340
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9967,7 +12557,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1331
+      ID: 1338
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9983,7 +12573,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1351
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9999,7 +12589,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1345
+      ID: 1352
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10015,7 +12605,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
+      ID: 1343
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10031,7 +12621,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1337
+      ID: 1344
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10047,7 +12637,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1338
+      ID: 1345
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10063,7 +12653,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
+      ID: 1342
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10079,7 +12669,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1334
+      ID: 1341
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10095,7 +12685,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1339
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10111,7 +12701,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1453
+      ID: 1508
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10123,11 +12713,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1341
+      ID: 1348
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10143,7 +12733,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1342
+      ID: 1349
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10159,7 +12749,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1343
+      ID: 1350
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10175,7 +12765,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1347
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10191,7 +12781,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1339
+      ID: 1346
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10207,7 +12797,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1505
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10216,14 +12806,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 259 GoSliceHeaderType []struct {}
+            Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1441
+      ID: 1496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10232,14 +12822,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType [][]uint
+            Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1389
+      ID: 1396
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10255,7 +12845,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10271,7 +12861,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10307,7 +12897,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1486
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1487
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1320
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10323,7 +12965,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1416
+      ID: 1423
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10339,7 +12981,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10348,14 +12990,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 GoSliceHeaderType []string
+            Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1355
+      ID: 1362
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10371,7 +13013,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1363
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10387,7 +13029,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10396,10 +13038,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10409,11 +13051,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1390
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10429,7 +13071,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1464
+      ID: 1490
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1519
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10438,17 +13122,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 278 StructureType main.structWithCyclicMaps
+            Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1465
+      ID: 1520
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1463
+      ID: 1518
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10457,14 +13141,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 265 StructureType main.structWithCyclicSlices
+            Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1384
+      ID: 1391
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10480,7 +13164,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1521
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10489,17 +13173,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 309 StructureType main.aStruct
+            Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1467
+      ID: 1522
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1457
+      ID: 1512
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10508,14 +13192,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 262 PointerType *main.threeStringStruct
+            Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1510
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10524,17 +13208,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 261 StructureType main.threeStringStruct
+            Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1456
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1509
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10546,7 +13230,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10556,7 +13240,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10566,11 +13250,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1346
+      ID: 1353
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10586,7 +13270,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1322
+      ID: 1329
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10602,7 +13286,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1323
+      ID: 1330
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10618,7 +13302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1331
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10634,7 +13318,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1328
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10650,7 +13334,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1320
+      ID: 1327
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10666,7 +13350,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1415
+      ID: 1422
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10682,7 +13366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10691,14 +13375,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1461
+      ID: 1516
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10710,11 +13394,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1421
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10730,7 +13414,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1337
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10746,7 +13430,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1448
+      ID: 1503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10755,14 +13439,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1449
+      ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10771,12 +13455,70 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 253
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 7 BaseType int
     - __kind: ArrayType
       ID: 126
       Name: '[100]uint'
@@ -10789,16 +13531,25 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701888
+      GoRuntimeType: 701984
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 252
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 687040
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 701504
+      GoRuntimeType: 701600
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10807,7 +13558,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701600
+      GoRuntimeType: 701696
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10832,7 +13583,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701792
+      GoRuntimeType: 701888
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10974,22 +13725,31 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 701312
+      GoRuntimeType: 701408
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 251
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 685888
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700736
+      GoRuntimeType: 700832
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 417
+      ID: 424
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683584
@@ -10998,7 +13758,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 374
+      ID: 381
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683872
@@ -11010,7 +13770,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 692320
+      GoRuntimeType: 692416
       GoKind: 17
       Count: 4
       HasCount: true
@@ -11024,7 +13784,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 989
+      ID: 996
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 685408
@@ -11036,7 +13796,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 697952
+      GoRuntimeType: 698048
       GoKind: 17
       Count: 6
       HasCount: true
@@ -11045,7 +13805,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701696
+      GoRuntimeType: 701792
       GoKind: 17
       Count: 8
       HasCount: true
@@ -11066,15 +13826,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []*main.deepSlice2.array
+      Data: 331 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 331
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1228
+      ID: 1235
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 478336
@@ -11082,22 +13842,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1229 PointerType **main.deepSlice3
+          Type: 1236 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1232 GoSliceDataType []*main.deepSlice3.array
+      Data: 1239 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1232
+      ID: 1239
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1230 PointerType *main.deepSlice3
+      Element: 1237 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1253
+      ID: 1260
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 478016
@@ -11105,22 +13865,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1254 PointerType **main.deepSlice8
+          Type: 1261 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1257 GoSliceDataType []*main.deepSlice8.array
+      Data: 1264 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1264
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1255 PointerType *main.deepSlice8
+      Element: 1262 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1259
+      ID: 1266
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477952
@@ -11128,20 +13888,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1260 PointerType **main.deepSlice9
+          Type: 1267 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1263 GoSliceDataType []*main.deepSlice9.array
+      Data: 1270 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1270
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1261 PointerType *main.deepSlice9
+      Element: 1268 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -11158,9 +13918,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 319 GoSliceDataType []*runtime.p.array
+      Data: 326 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 326
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -11181,309 +13941,309 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType []*string.array
+      Data: 328 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 328
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 441
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 426
+      ID: 433
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 375
+      ID: 382
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 400
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 334
+      ID: 341
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1254
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1238 PointerType *table<int,*main.deepMap3>
+      Element: 1245 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1281
+      ID: 1288
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1272 PointerType *table<int,*main.deepMap8>
+      Element: 1279 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1296
+      ID: 1303
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1287 PointerType *table<int,*main.deepMap9>
+      Element: 1294 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 349
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1309
+      ID: 1316
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1302 PointerType *table<int,interface {}>
+      Element: 1309 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 457
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 408
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 392
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 373
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1005
+      ID: 1012
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 972 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 365
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 350
+      ID: 357
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 449
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 283 PointerType *table<struct {},main.structWithCyclicMaps>
+      Element: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 288 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 293 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 531
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 539
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 465
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 425
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 217 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 409
+      ID: 416
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 276
+      ID: 283
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 284 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 491 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 491
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 274
+      ID: 281
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 275 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 282 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 489 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 489
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 272
+      ID: 279
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 273 PointerType *[][][]main.structWithCyclicSlices
+          Type: 280 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 487 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 487
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 277
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType *[][]main.structWithCyclicSlices
+          Type: 278 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 485 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 485
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 275
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 269 PointerType *[]main.structWithCyclicSlices
+          Type: 276 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 483 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 483
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 266 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *[]uint
+          Type: 259 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 462 GoSliceDataType [][]uint.array
+      Data: 469 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 469
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 250 GoSliceHeaderType []uint
+      Element: 257 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 257
+      ID: 264
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 487936
@@ -11498,15 +14258,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 468 GoSliceDataType []bool.array
+      Data: 475 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 475
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 984
+      ID: 991
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487808
@@ -11521,15 +14281,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1007 GoSliceDataType []float64.array
+      Data: 1014 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1014
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 15 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1265
+      ID: 1272
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 488256
@@ -11544,37 +14304,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1266 GoSliceDataType []interface {}.array
+      Data: 1273 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1273
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 157 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 266
+      ID: 273
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 267 PointerType *main.structWithCyclicSlices
+          Type: 274 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 474 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 481 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 481
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 265 StructureType main.structWithCyclicSlices
+      Element: 272 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 383
+      ID: 390
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 478656
@@ -11582,210 +14342,210 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 384 PointerType *main.structWithMap
+          Type: 391 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 534 GoSliceDataType []main.structWithMap.array
+      Data: 541 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 541
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 165 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 253
+      ID: 260
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 254 PointerType *main.structWithNoStrings
+          Type: 261 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 464 GoSliceDataType []main.structWithNoStrings.array
+      Data: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 255 StructureType main.structWithNoStrings
+      Element: 262 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 442
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 431 StructureType noalg.map.group[[4]int][4]int
+      Element: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 434
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 423 StructureType noalg.map.group[[4]int]uint8
+      Element: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 383
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 371 StructureType noalg.map.group[[4]string][2]int
+      Element: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 401
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 390 StructureType noalg.map.group[bool]main.node
+      Element: 397 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 342
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 329 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1248
+      ID: 1255
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1282
+      ID: 1289
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1297
+      ID: 1304
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 350
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 339 StructureType noalg.map.group[int]int
+      Element: 346 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1310
+      ID: 1317
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1306 StructureType noalg.map.group[int]interface {}
+      Element: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 458
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 447 StructureType noalg.map.group[int]struct {}
+      Element: 454 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 402
+      ID: 409
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 398 StructureType noalg.map.group[int]uint8
+      Element: 405 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 393
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 380 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 374
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 363 StructureType noalg.map.group[string][]string
+      Element: 370 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1006
+      ID: 1013
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 366
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 355 StructureType noalg.map.group[string]int
+      Element: 362 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 358
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 347 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 439 StructureType noalg.map.group[struct {}]int
+      Element: 446 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 493
+      ID: 500
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 501
+      ID: 508
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 509
+      ID: 516
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 517
+      ID: 524
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 532
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 540
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 466
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 455 StructureType noalg.map.group[struct {}]struct {}
+      Element: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 426
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 414 StructureType noalg.map.group[uint8][4]int
+      Element: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 410
+      ID: 417
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 406 StructureType noalg.map.group[uint8]uint8
+      Element: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 263
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 488064
@@ -11800,36 +14560,36 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 466 GoSliceDataType []string.array
+      Data: 473 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 473
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 259
+      ID: 266
       Name: '[]struct {}'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 260 PointerType *struct {}
+          Type: 267 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 472 GoSliceDataType []struct {}.array
+      Data: 479 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 257
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 487552
@@ -11844,15 +14604,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 460 GoSliceDataType []uint.array
+      Data: 467 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 467
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 258
+      ID: 265
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -11867,9 +14627,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 470 GoSliceDataType []uint16.array
+      Data: 477 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 477
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11890,9 +14650,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []uint8.array
+      Data: 321 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 321
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11913,19 +14673,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 316 GoSliceDataType []uintptr.array
+      Data: 323 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 774
+      ID: 781
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 932480
@@ -11940,33 +14700,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 775 GoSliceDataType archive/tar.headerError.array
+      Data: 782 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 775
+      ID: 782
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1081
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1022
+      ID: 1029
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1024
+      ID: 1031
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.121312e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1125
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1057
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.56704e+06
@@ -11976,7 +14736,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1059
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11986,15 +14746,15 @@ Types:
       GoRuntimeType: 585888
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1104
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1184
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -12020,13 +14780,13 @@ Types:
       GoRuntimeType: 585632
       GoKind: 15
     - __kind: BaseType
-      ID: 572
+      ID: 579
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835648
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 573
+      ID: 580
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835744
@@ -12034,116 +14794,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 575 PointerType *compress/flate.InternalError.str
+          Type: 582 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 574 GoStringDataType compress/flate.InternalError.str
+      Data: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 574
+      ID: 581
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 922
+      ID: 929
       Name: context.deadlineExceededError
       GoRuntimeType: 1.48144e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 586
+      ID: 593
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838240
       GoKind: 2
     - __kind: BaseType
-      ID: 587
+      ID: 594
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838336
       GoKind: 2
     - __kind: BaseType
-      ID: 588
+      ID: 595
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1096
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.290656e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1157
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1131
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1116
+      ID: 1123
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 589
+      ID: 596
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1119
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 576
+      ID: 583
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 836224
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1210
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 695
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 693
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.732128e+06
@@ -12154,38 +14914,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 989 ArrayType [5]uint8
+          Type: 996 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 813
+      ID: 820
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 994464
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 697
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1087
+      ID: 1094
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.735008e+06
@@ -12193,21 +14953,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 992 BaseType crypto/x509.InvalidReason
+          Type: 999 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.11888e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.601152e+06
@@ -12215,24 +14975,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 585
+      ID: 592
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837856
       GoKind: 2
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 591072
       GoKind: 2
     - __kind: StructureType
-      ID: 865
+      ID: 872
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.56304e+06
@@ -12242,13 +15002,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.119136e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.734816e+06
@@ -12256,15 +15016,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 13 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.437856e+06
@@ -12274,7 +15034,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.438016e+06
@@ -12284,55 +15044,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 787
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 567
+      ID: 574
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835168
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 568
+      ID: 575
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 835360
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 651
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 643
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 649
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 647
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 645
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1190
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 653
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.421856e+06
@@ -12342,19 +15102,19 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1055
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 755
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 582
+      ID: 589
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837760
@@ -12362,22 +15122,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 584 PointerType *encoding/xml.UnmarshalError.str
+          Type: 591 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 583 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 583
+      ID: 590
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 760
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1168
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12394,11 +15154,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 619
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12414,15 +15174,15 @@ Types:
       GoRuntimeType: 585824
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12438,11 +15198,11 @@ Types:
       GoRuntimeType: 849376
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 681
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.730976e+06
@@ -12450,7 +15210,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 982 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 989 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -12458,25 +15218,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 664
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 661
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.115168e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 995
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 561
+      ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 834592
@@ -12484,18 +15244,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 563 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 562 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 562
+      ID: 569
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.220864e+06
@@ -12503,13 +15263,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 983 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 990 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 9 GoStringHeaderType string
@@ -12518,7 +15278,7 @@ Types:
           Type: 15 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 984 GoSliceHeaderType []float64
+          Type: 991 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 12 BaseType int64
@@ -12527,13 +15287,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 985 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 992 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 987 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 994 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 9 GoStringHeaderType string
@@ -12544,13 +15304,13 @@ Types:
           Offset: 184
           Type: 12 BaseType int64
     - __kind: BaseType
-      ID: 983
+      ID: 990
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587680
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 558
+      ID: 565
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 834496
@@ -12558,18 +15318,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 560 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 567 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 559 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 566 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 559
+      ID: 566
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 564
+      ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834688
@@ -12577,60 +15337,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 566 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 565 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 565
+      ID: 572
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1067
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1154
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 779
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1186
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.118112e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 581
+      ID: 588
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 2
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.117984e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 702
+      ID: 709
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.599232e+06
@@ -12643,7 +15403,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 722
+      ID: 729
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.600032e+06
@@ -12656,7 +15416,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 726
+      ID: 733
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.73424e+06
@@ -12672,7 +15432,7 @@ Types:
           Offset: 24
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 724
+      ID: 731
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.431776e+06
@@ -12682,7 +15442,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 720
+      ID: 727
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.431456e+06
@@ -12692,14 +15452,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 968
+      ID: 975
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.50224e+06
       GoKind: 21
-      HeaderType: 970 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 991
+      ID: 998
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.051872e+06
@@ -12714,15 +15474,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1009 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1009
+      ID: 1016
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 734
+      ID: 741
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.600352e+06
@@ -12730,12 +15490,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 968 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 968 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.431936e+06
@@ -12745,7 +15505,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 739
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.734432e+06
@@ -12756,12 +15516,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.600192e+06
@@ -12774,7 +15534,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.432096e+06
@@ -12782,9 +15542,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 958 StructureType time.Time
+          Type: 965 StructureType time.Time
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.600672e+06
@@ -12797,7 +15557,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 744
+      ID: 751
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.432416e+06
@@ -12807,7 +15567,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.600512e+06
@@ -12820,7 +15580,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.432256e+06
@@ -12830,7 +15590,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 746
+      ID: 753
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.600832e+06
@@ -12843,7 +15603,7 @@ Types:
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 663
+      ID: 670
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.424096e+06
@@ -12853,11 +15613,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.424256e+06
@@ -12865,21 +15625,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1087
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1077
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.424576e+06
@@ -12887,13 +15647,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1148
+      ID: 1155
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.108352e+06
@@ -12901,12 +15661,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1134 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1141 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 12 BaseType int64
     - __kind: StructureType
-      ID: 1151
+      ID: 1158
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.133216e+06
@@ -12914,7 +15674,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1134 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1141 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -12922,11 +15682,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1045
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.424416e+06
@@ -12934,9 +15694,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 671
+      ID: 678
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.424736e+06
@@ -12944,64 +15704,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1152
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1098
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.425696e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1202
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.844032e+06
@@ -13017,11 +15777,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.70368e+06
@@ -13034,7 +15794,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.84448e+06
@@ -13050,13 +15810,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 812
+      ID: 819
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991776
       GoKind: 8
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.843808e+06
@@ -13072,13 +15832,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832768
       GoKind: 8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.843584e+06
@@ -13086,15 +15846,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 993 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 993 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.757632e+06
@@ -13107,7 +15867,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.844256e+06
@@ -13123,11 +15883,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.625248e+06
@@ -13137,19 +15897,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.28464e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.284512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.757824e+06
@@ -13162,7 +15922,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 594
+      ID: 601
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 840352
@@ -13170,22 +15930,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 596 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 603 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 595 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 602 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 595
+      ID: 602
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.449696e+06
@@ -13195,7 +15955,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1066
+      ID: 1073
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.679392e+06
@@ -13203,13 +15963,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1092 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1099 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1159
+      ID: 1166
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1092
+      ID: 1099
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.128864e+06
@@ -13222,7 +15982,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1054
+      ID: 1061
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.57184e+06
@@ -13232,19 +15992,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 597
+      ID: 604
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840928
       GoKind: 10
     - __kind: BaseType
-      ID: 975
+      ID: 982
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.004928e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.88256e+06
@@ -13255,12 +16015,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 975 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.607872e+06
@@ -13268,12 +16028,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 975 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 601
+      ID: 608
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841120
@@ -13281,18 +16041,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 603 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 610 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 602 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 609 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 602
+      ID: 609
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 607
+      ID: 614
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 841312
@@ -13300,18 +16060,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 609 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 616 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 608 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 615 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 608
+      ID: 615
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 611
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 841216
@@ -13319,18 +16079,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 613 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 605 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 612 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 612
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 605
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 841024
@@ -13338,22 +16098,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 607 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 599 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 606 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 606
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1164
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 802
+      ID: 809
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.450336e+06
@@ -13363,13 +16123,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 610
+      ID: 617
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 2
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.445376e+06
@@ -13379,11 +16139,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.910336e+06
@@ -13399,7 +16159,7 @@ Types:
           Offset: 24
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.607392e+06
@@ -13412,7 +16172,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1106
+      ID: 1113
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.968384e+06
@@ -13420,16 +16180,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1133 GoInterfaceType io.Reader
+          Type: 1140 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1071
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.56944e+06
@@ -13439,29 +16199,29 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1033
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 777
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.51296e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.438656e+06
@@ -13471,7 +16231,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 786
+      ID: 793
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.438816e+06
@@ -13481,393 +16241,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 714
+      ID: 721
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 429
+      ID: 436
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 430 PointerType *noalg.map.group[[4]int][4]int
+          Type: 437 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 431 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 435 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 438 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 442 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 421
+      ID: 428
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 422 PointerType *noalg.map.group[[4]int]uint8
+          Type: 429 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 423 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 427 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 430 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 434 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 369
+      ID: 376
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 370 PointerType *noalg.map.group[[4]string][2]int
+          Type: 377 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 371 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 376 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 378 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 383 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 388
+      ID: 395
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 389 PointerType *noalg.map.group[bool]main.node
+          Type: 396 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 390 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 397 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 401 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 327
+      ID: 334
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 328 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 335 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 329 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 335 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 336 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 342 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1240
+      ID: 1247
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1241 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1248 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1242 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1248 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1249 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1255 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1274
+      ID: 1281
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1275 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1282 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1276 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1282 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1283 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1289 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1289
+      ID: 1296
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1290 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1297 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1291 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1297 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1298 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1304 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 337
+      ID: 344
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 338 PointerType *noalg.map.group[int]int
+          Type: 345 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 339 StructureType noalg.map.group[int]int
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 346 StructureType noalg.map.group[int]int
+      GroupSliceType: 350 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1304
+      ID: 1311
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1305 PointerType *noalg.map.group[int]interface {}
+          Type: 1312 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1306 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1310 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1313 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1317 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 452
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[int]struct {}
+          Type: 453 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 451 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 454 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 458 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 396
+      ID: 403
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 397 PointerType *noalg.map.group[int]uint8
+          Type: 404 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 398 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 402 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 405 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 409 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 378
+      ID: 385
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 379 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 386 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 380 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 386 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 387 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 393 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 361
+      ID: 368
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 362 PointerType *noalg.map.group[string][]string
+          Type: 369 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 363 StructureType noalg.map.group[string][]string
-      GroupSliceType: 367 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 370 StructureType noalg.map.group[string][]string
+      GroupSliceType: 374 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1000
+      ID: 1007
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1001 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1008 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1006 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1013 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 353
+      ID: 360
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 354 PointerType *noalg.map.group[string]int
+          Type: 361 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 355 StructureType noalg.map.group[string]int
-      GroupSliceType: 359 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 362 StructureType noalg.map.group[string]int
+      GroupSliceType: 366 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 345
+      ID: 352
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 346 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 353 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 347 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 351 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 354 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 358 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 437
+      ID: 444
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 438 PointerType *noalg.map.group[struct {}]int
+          Type: 445 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 439 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 446 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 450 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 487
+      ID: 494
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 488 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 495 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 493 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 500 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 495
+      ID: 502
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 496 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 503 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 501 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 508 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 503
+      ID: 510
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 504 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 511 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 509 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 516 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 511
+      ID: 518
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 512 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 519 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 517 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 524 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 519
+      ID: 526
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 520 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 527 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 532 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 534
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 535 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 453
+      ID: 460
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 454 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 461 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 455 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 459 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 462 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 466 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 412
+      ID: 419
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 413 PointerType *noalg.map.group[uint8][4]int
+          Type: 420 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 414 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 419 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 421 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 426 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 404
+      ID: 411
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 405 PointerType *noalg.map.group[uint8]uint8
+          Type: 412 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 406 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 410 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 413 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 417 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1121
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -13914,11 +16674,11 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 689
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -13944,29 +16704,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 687
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1208
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.47824e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 623
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -14047,7 +16807,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 576
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 835552
@@ -14055,18 +16815,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 578 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 577 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 577
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.5608e+06
@@ -14074,9 +16834,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 965 PointerType *internal/abi.Type
+          Type: 972 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1213
+      ID: 1220
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.47568e+06
@@ -14089,11 +16849,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1065
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1098
+      ID: 1105
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.191392e+06
@@ -14106,7 +16866,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1133
+      ID: 1140
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.024992e+06
@@ -14119,7 +16879,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1085
+      ID: 1092
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.111456e+06
@@ -14145,25 +16905,25 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1056
+      ID: 1063
       Name: io.discard
       GoRuntimeType: 1.46528e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1037
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1111
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 309
+      ID: 316
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14219,7 +16979,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 333
+      ID: 340
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.18768e+06
@@ -14227,9 +16987,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoMapType map[int]*main.deepMap3
+          Type: 1241 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1253
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14241,9 +17001,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1268 GoMapType map[int]*main.deepMap8
+          Type: 1275 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1280
+      ID: 1287
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.186912e+06
@@ -14251,9 +17011,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1283 GoMapType map[int]*main.deepMap9
+          Type: 1290 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1295
+      ID: 1302
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.186784e+06
@@ -14261,7 +17021,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1298 GoMapType map[int]interface {}
+          Type: 1305 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -14281,9 +17041,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1204 PointerType *main.deepPtr3
+          Type: 1211 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1212
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14295,9 +17055,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 PointerType *main.deepPtr8
+          Type: 1256 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1250
+      ID: 1257
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.188064e+06
@@ -14305,9 +17065,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1251 PointerType *main.deepPtr9
+          Type: 1258 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1252
+      ID: 1259
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.187936e+06
@@ -14327,7 +17087,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 323
+      ID: 330
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.189984e+06
@@ -14335,9 +17095,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1228 GoSliceHeaderType []*main.deepSlice3
+          Type: 1235 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1238
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14349,9 +17109,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1253 GoSliceHeaderType []*main.deepSlice8
+          Type: 1260 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1256
+      ID: 1263
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.189216e+06
@@ -14359,9 +17119,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1259 GoSliceHeaderType []*main.deepSlice9
+          Type: 1266 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1262
+      ID: 1269
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.189088e+06
@@ -14369,9 +17129,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1265 GoSliceHeaderType []interface {}
+          Type: 1272 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 310
+      ID: 317
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -14387,16 +17147,16 @@ Types:
           Type: 155 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1211 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1214 StructureType sync.Once
+          Type: 1221 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1217 StructureType sync.WaitGroup
+          Type: 1224 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1220 StructureType sync/atomic.Int32
+          Type: 1227 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 155
       Name: main.esotericStack
@@ -14426,7 +17186,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1222
+      ID: 1229
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.414336e+06
@@ -14435,6 +17195,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 250
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 254
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 15 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
     - __kind: StructureType
       ID: 123
       Name: main.nestedStruct
@@ -14462,7 +17273,7 @@ Types:
           Offset: 8
           Type: 247 PointerType *main.node
     - __kind: StructureType
-      ID: 264
+      ID: 271
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -14471,7 +17282,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1224
+      ID: 1231
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.414496e+06
@@ -14491,7 +17302,7 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1217
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14502,18 +17313,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1207 PointerType *main.stringType1.str
+          Type: 1214 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1206 GoStringDataType main.stringType1.str
+      Data: 1213 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1206
+      ID: 1213
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1215
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -14527,53 +17338,65 @@ Types:
           Offset: 0
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 278
+      ID: 256
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 113 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 285
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 279 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 284 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 311 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 265
+      ID: 272
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 266 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 273 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 276 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 283 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 165
       Name: main.structWithMap
@@ -14585,7 +17408,7 @@ Types:
           Offset: 0
           Type: 166 GoMapType map[int]int
     - __kind: StructureType
-      ID: 255
+      ID: 262
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -14616,22 +17439,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1225 PointerType **main.t
+          Type: 1232 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1226 GoSliceDataType main.t.array
+      Data: 1233 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1226
+      ID: 1233
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 248 PointerType *main.t
     - __kind: StructureType
-      ID: 261
+      ID: 268
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -14650,6 +17473,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 255
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 7 BaseType int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,[4]int>
@@ -14683,8 +17545,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 434 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 431 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 441 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<[4]int,uint8>
@@ -14718,8 +17580,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 426 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 423 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 433 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<[4]string,[2]int>
@@ -14753,8 +17615,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 375 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 371 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 382 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<bool,main.node>
@@ -14788,8 +17650,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 390 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 400 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 397 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -14823,10 +17685,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 334 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 329 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 341 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1236
+      ID: 1243
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -14839,7 +17701,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1237 PointerType **table<int,*main.deepMap3>
+          Type: 1244 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14858,10 +17720,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1247 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1254 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1270
+      ID: 1277
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -14874,7 +17736,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1271 PointerType **table<int,*main.deepMap8>
+          Type: 1278 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14893,10 +17755,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1281 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1288 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1285
+      ID: 1292
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -14909,7 +17771,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1286 PointerType **table<int,*main.deepMap9>
+          Type: 1293 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14928,8 +17790,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1296 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1303 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 168
       Name: map<int,int>
@@ -14963,10 +17825,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,int>.array
-      GroupType: 339 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 349 GoSliceDataType []*table<int,int>.array
+      GroupType: 346 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1300
+      ID: 1307
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -14979,7 +17841,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1301 PointerType **table<int,interface {}>
+          Type: 1308 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14998,8 +17860,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1309 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1306 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1316 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<int,struct {}>
@@ -15033,8 +17895,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 450 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 447 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 457 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 454 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<int,uint8>
@@ -15068,8 +17930,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 401 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 398 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 408 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 405 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<string,[]main.structWithMap>
@@ -15103,8 +17965,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 385 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 380 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 392 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,[]string>
@@ -15138,10 +18000,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 366 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 363 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 373 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 370 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 970
+      ID: 977
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -15154,7 +18016,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 971 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 978 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15173,8 +18035,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1005 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1012 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,int>
@@ -15208,8 +18070,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 358 GoSliceDataType []*table<string,int>.array
-      GroupType: 355 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 365 GoSliceDataType []*table<string,int>.array
+      GroupType: 362 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<string,main.nestedStruct>
@@ -15243,8 +18105,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 350 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 347 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 357 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 230
       Name: map<struct {},int>
@@ -15278,10 +18140,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 439 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 449 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 446 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
-      ID: 281
+      ID: 288
       Name: map<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15294,7 +18156,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 282 PointerType **table<struct {},main.structWithCyclicMaps>
+          Type: 289 PointerType **table<struct {},main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15313,10 +18175,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 492 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 499 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 286
+      ID: 293
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15329,7 +18191,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 287 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15348,10 +18210,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 500 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 507 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 291
+      ID: 298
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15364,7 +18226,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 292 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15383,10 +18245,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 508 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 515 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 296
+      ID: 303
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15399,7 +18261,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 297 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15418,10 +18280,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 516 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 523 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 301
+      ID: 308
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15434,7 +18296,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 302 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15453,10 +18315,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 531 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 306
+      ID: 313
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15469,7 +18331,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 307 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 314 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15488,8 +18350,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 539 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<struct {},struct {}>
@@ -15523,8 +18385,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 458 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 455 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 465 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,[4]int>
@@ -15558,8 +18420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 418 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 414 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 425 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<uint8,uint8>
@@ -15593,8 +18455,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 409 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 406 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 416 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 223
       Name: map[[4]int][4]int
@@ -15631,26 +18493,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1234
+      ID: 1241
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.130528e+06
       GoKind: 21
-      HeaderType: 1236 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1243 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1268
+      ID: 1275
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.129888e+06
       GoKind: 21
-      HeaderType: 1270 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1277 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1283
+      ID: 1290
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.12976e+06
       GoKind: 21
-      HeaderType: 1285 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1292 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
@@ -15659,12 +18521,12 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1298
+      ID: 1305
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.129632e+06
       GoKind: 21
-      HeaderType: 1300 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1307 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
@@ -15715,41 +18577,41 @@ Types:
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
-      ID: 279
+      ID: 286
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 281 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      HeaderType: 288 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 284
+      ID: 291
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 286 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 293 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 289
+      ID: 296
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 291 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 298 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 294
+      ID: 301
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 303 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 299
+      ID: 306
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 308 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 304
+      ID: 311
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 313 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 238
       Name: map[struct {}]struct {}
@@ -15772,7 +18634,7 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 718
+      ID: 725
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.430976e+06
@@ -15782,7 +18644,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1020
+      ID: 1027
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.427776e+06
@@ -15792,11 +18654,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 990
+      ID: 997
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.597952e+06
@@ -15809,35 +18671,35 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1172
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1192
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1180
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 886
+      ID: 893
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.114784e+06
@@ -15845,28 +18707,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 888 PointerType *net.UnknownNetworkError.str
+          Type: 895 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 887 GoStringDataType net.UnknownNetworkError.str
+      Data: 894 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 887
+      ID: 894
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: net.canceledError
       GoRuntimeType: 1.285664e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1148
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.107648e+06
@@ -15874,7 +18736,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 13 GoInterfaceType error
@@ -15885,27 +18747,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1194
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1181
+      ID: 1188
       Name: net.noReadFrom
       GoRuntimeType: 1.11504e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1180
+      ID: 1187
       Name: net.noWriteTo
       GoRuntimeType: 1.114912e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 655
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.730784e+06
@@ -15913,7 +18775,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 978 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 985 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -15921,7 +18783,7 @@ Types:
           Offset: 96
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1169
+      ID: 1176
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.290656e+06
@@ -15929,12 +18791,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1181 StructureType net.noReadFrom
+          Type: 1188 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1174 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1167
+      ID: 1174
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.290112e+06
@@ -15942,24 +18804,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1180 StructureType net.noWriteTo
+          Type: 1187 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1174 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 936
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 848
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1014
+      ID: 1021
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.419296e+06
@@ -15969,19 +18831,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 539
+      ID: 546
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 833248
       GoKind: 10
     - __kind: BaseType
-      ID: 967
+      ID: 974
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991872
       GoKind: 10
     - __kind: StructureType
-      ID: 626
+      ID: 633
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.729056e+06
@@ -15992,12 +18854,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.900864e+06
@@ -16008,12 +18870,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.597472e+06
@@ -16021,16 +18883,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1083
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 543
+      ID: 550
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833440
@@ -16038,18 +18900,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 545 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 552 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 544 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 551 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 544
+      ID: 551
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 549
+      ID: 556
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833632
@@ -16057,18 +18919,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 551 PointerType *net/http.http2headerFieldNameError.str
+          Type: 558 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 550 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 557 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 550
+      ID: 557
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 553
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 833536
@@ -16076,32 +18938,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *net/http.http2headerFieldValueError.str
+          Type: 555 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 554 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 554
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.284896e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1137
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 540
+      ID: 547
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 833344
@@ -16109,18 +18971,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 542 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 549 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 541 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 548 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 541
+      ID: 548
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1016
+      ID: 1023
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.82672e+06
@@ -16128,18 +18990,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1107 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1114 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1108 BaseType time.Duration
+          Type: 1115 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1107
+      ID: 1114
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.418496e+06
@@ -16152,14 +19014,14 @@ Types:
           Offset: 8
           Type: 14 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1095
+      ID: 1102
       Name: net/http.incomparable
       GoRuntimeType: 904448
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.55696e+06
@@ -16169,11 +19031,11 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1034
+      ID: 1041
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.5568e+06
@@ -16181,9 +19043,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1077 PointerType *net/http.persistConn
+          Type: 1084 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1068
+      ID: 1075
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.801696e+06
@@ -16191,15 +19053,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1095 ArrayType net/http.incomparable
+          Type: 1102 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1096 PointerType *bufio.Reader
+          Type: 1103 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1098 GoInterfaceType io.ReadWriteCloser
+          Type: 1105 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.420256e+06
@@ -16209,17 +19071,17 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.48112e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.55712e+06
@@ -16229,7 +19091,7 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: StructureType
-      ID: 1110
+      ID: 1117
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.02736e+06
@@ -16237,16 +19099,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 630
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1132
+      ID: 1139
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.043104e+06
@@ -16254,13 +19116,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1125 PointerType *bufio.Writer
+          Type: 1132 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1051
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.733856e+06
@@ -16276,7 +19138,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.599392e+06
@@ -16289,11 +19151,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.601312e+06
@@ -16301,16 +19163,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1083 PointerType *net/smtp.Client
+          Type: 1090 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1085 GoInterfaceType io.WriteCloser
+          Type: 1092 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 701
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 577
+      ID: 584
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 836320
@@ -16318,26 +19180,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 579 PointerType *net/textproto.ProtocolError.str
+          Type: 586 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 578 GoStringDataType net/textproto.ProtocolError.str
+      Data: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 578
+      ID: 585
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1049
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 559
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 834208
@@ -16345,18 +19207,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *net/url.EscapeError.str
+          Type: 561 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType net/url.EscapeError.str
+      Data: 560 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 560
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 555
+      ID: 562
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 834304
@@ -16364,254 +19226,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 557 PointerType *net/url.InvalidHostError.str
+          Type: 564 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 556 GoStringDataType net/url.InvalidHostError.str
+      Data: 563 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 556
+      ID: 563
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 432
+      ID: 439
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683680
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 433 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 440 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 424
+      ID: 431
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683776
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 425 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 432 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 372
+      ID: 379
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 684064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 373 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 380 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 391
+      ID: 398
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 684160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 392 StructureType noalg.struct { key bool; elem main.node }
+      Element: 399 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 330
+      ID: 337
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 683008
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 331 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 338 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1243
+      ID: 1250
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682912
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1244 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1251 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1277
+      ID: 1284
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 682432
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1278 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1285 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1292
+      ID: 1299
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 682336
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1293 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1300 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 340
+      ID: 347
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 341 StructureType noalg.struct { key int; elem int }
+      Element: 348 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1307
+      ID: 1314
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 682240
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1308 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1315 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 448
+      ID: 455
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 684256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key int; elem struct {} }
+      Element: 456 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 399
+      ID: 406
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 684352
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 400 StructureType noalg.struct { key int; elem uint8 }
+      Element: 407 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 381
+      ID: 388
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 684448
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 382 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 389 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 364
+      ID: 371
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684544
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 365 StructureType noalg.struct { key string; elem []string }
+      Element: 372 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1003
+      ID: 1010
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 760480
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1004 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1011 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 356
+      ID: 363
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684640
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 357 StructureType noalg.struct { key string; elem int }
+      Element: 364 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 348
+      ID: 355
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684736
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 349 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 356 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 440
+      ID: 447
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 441 StructureType noalg.struct { key struct {}; elem int }
+      Element: 448 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 490
+      ID: 497
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 491 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 498 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 498
+      ID: 505
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 499 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 506 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 506
+      ID: 513
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 507 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 514 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 514
+      ID: 521
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 515 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 522 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 522
+      ID: 529
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 523 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 530 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 530
+      ID: 537
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 538 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 456
+      ID: 463
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 457 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 464 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 415
+      ID: 422
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 685024
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 416 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 423 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 407
+      ID: 414
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 685120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 408 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 415 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 431
+      ID: 438
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.296672e+06
@@ -16622,9 +19484,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 432 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 439 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 423
+      ID: 430
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.296928e+06
@@ -16635,9 +19497,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 424 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 431 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 371
+      ID: 378
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.297184e+06
@@ -16648,9 +19510,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 372 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 379 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 390
+      ID: 397
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.29744e+06
@@ -16661,9 +19523,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 391 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 398 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 329
+      ID: 336
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.296416e+06
@@ -16674,9 +19536,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 330 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 337 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1242
+      ID: 1249
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.29616e+06
@@ -16687,9 +19549,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1243 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1250 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1276
+      ID: 1283
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.29488e+06
@@ -16700,9 +19562,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1277 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1284 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1291
+      ID: 1298
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.294624e+06
@@ -16713,9 +19575,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1292 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1299 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 339
+      ID: 346
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.2936e+06
@@ -16726,9 +19588,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 340 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 347 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1306
+      ID: 1313
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.294368e+06
@@ -16739,9 +19601,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1307 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1314 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.297696e+06
@@ -16752,9 +19614,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 455 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 398
+      ID: 405
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.297952e+06
@@ -16765,9 +19627,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 399 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 406 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 380
+      ID: 387
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.298208e+06
@@ -16778,9 +19640,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 381 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 388 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 363
+      ID: 370
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.298464e+06
@@ -16791,9 +19653,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 364 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 371 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.359904e+06
@@ -16804,9 +19666,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1003 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1010 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 355
+      ID: 362
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.29872e+06
@@ -16817,9 +19679,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 356 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 363 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 347
+      ID: 354
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.298976e+06
@@ -16830,9 +19692,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 348 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 355 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 439
+      ID: 446
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.299232e+06
@@ -16843,9 +19705,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 440 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 447 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -16855,9 +19717,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 490 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 497 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 497
+      ID: 504
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16867,9 +19729,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 498 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 505 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16879,9 +19741,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 506 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 513 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16891,9 +19753,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 514 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 521 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16903,9 +19765,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 529 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16915,9 +19777,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 537 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.299488e+06
@@ -16928,9 +19790,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 456 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 463 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 414
+      ID: 421
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.299744e+06
@@ -16941,9 +19803,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 415 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 422 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 406
+      ID: 413
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.3e+06
@@ -16954,9 +19816,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 407 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 414 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 433
+      ID: 440
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.296544e+06
@@ -16964,12 +19826,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
     - __kind: StructureType
-      ID: 425
+      ID: 432
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.2968e+06
@@ -16977,12 +19839,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 373
+      ID: 380
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.297056e+06
@@ -16990,12 +19852,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 374 ArrayType [4]string
+          Type: 381 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 392
+      ID: 399
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.297312e+06
@@ -17008,7 +19870,7 @@ Types:
           Offset: 8
           Type: 246 StructureType main.node
     - __kind: StructureType
-      ID: 331
+      ID: 338
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.296288e+06
@@ -17019,9 +19881,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 332 PointerType *main.deepMap2
+          Type: 339 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1244
+      ID: 1251
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.296032e+06
@@ -17032,9 +19894,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1245 PointerType *main.deepMap3
+          Type: 1252 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1278
+      ID: 1285
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.294752e+06
@@ -17045,9 +19907,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1279 PointerType *main.deepMap8
+          Type: 1286 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1293
+      ID: 1300
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.294496e+06
@@ -17058,9 +19920,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1294 PointerType *main.deepMap9
+          Type: 1301 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 341
+      ID: 348
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.293472e+06
@@ -17073,7 +19935,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1308
+      ID: 1315
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.29424e+06
@@ -17086,7 +19948,7 @@ Types:
           Offset: 8
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 449
+      ID: 456
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.297568e+06
@@ -17099,7 +19961,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 400
+      ID: 407
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.297824e+06
@@ -17112,7 +19974,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 382
+      ID: 389
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.29808e+06
@@ -17123,9 +19985,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 383 GoSliceHeaderType []main.structWithMap
+          Type: 390 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 365
+      ID: 372
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.298336e+06
@@ -17136,9 +19998,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.359776e+06
@@ -17149,9 +20011,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 357
+      ID: 364
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.298592e+06
@@ -17164,7 +20026,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 349
+      ID: 356
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.298848e+06
@@ -17177,7 +20039,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 441
+      ID: 448
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.299104e+06
@@ -17190,7 +20052,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 491
+      ID: 498
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -17200,9 +20062,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 278 StructureType main.structWithCyclicMaps
+          Type: 285 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 499
+      ID: 506
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17212,9 +20074,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 279 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 507
+      ID: 514
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17224,9 +20086,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 284 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 515
+      ID: 522
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17236,9 +20098,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 523
+      ID: 530
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17248,9 +20110,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17260,9 +20122,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 457
+      ID: 464
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.29936e+06
       GoKind: 25
@@ -17274,7 +20136,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 416
+      ID: 423
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.299616e+06
@@ -17285,9 +20147,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
     - __kind: StructureType
-      ID: 408
+      ID: 415
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.299872e+06
@@ -17300,19 +20162,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1200
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.361024e+06
@@ -17320,12 +20182,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1197 StructureType os.noReadFrom
+          Type: 1204 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1192 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.360224e+06
@@ -17333,36 +20195,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1196 StructureType os.noWriteTo
+          Type: 1203 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1192 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: os.noReadFrom
       GoRuntimeType: 1.112352e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: os.noWriteTo
       GoRuntimeType: 1.112224e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1005
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1069
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.704256e+06
@@ -17375,7 +20237,7 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 591
+      ID: 598
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 839584
@@ -17383,36 +20245,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 593 PointerType *os/user.UnknownGroupIdError.str
+          Type: 600 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 592 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 599 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 592
+      ID: 599
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 590
+      ID: 597
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 625
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 723
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -17424,7 +20286,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 828
+      ID: 835
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.889728e+06
@@ -17441,9 +20303,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 996 BaseType runtime.boundsErrorCode
+          Type: 1003 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 996
+      ID: 1003
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 586016
@@ -17463,7 +20325,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.75456e+06
@@ -17476,7 +20338,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 806
+      ID: 813
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 990432
@@ -17484,13 +20346,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 808 PointerType *runtime.errorString.str
+          Type: 815 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 807 GoStringDataType runtime.errorString.str
+      Data: 814 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 807
+      ID: 814
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18117,7 +20979,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 325
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -18153,7 +21015,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 809
+      ID: 816
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 990528
@@ -18161,13 +21023,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 811 PointerType *runtime.plainError.str
+          Type: 818 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 810 GoStringDataType runtime.plainError.str
+      Data: 817 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 810
+      ID: 817
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18208,7 +21070,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.597152e+06
@@ -18266,7 +21128,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -18278,26 +21140,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *string.str
+          Type: 320 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 312 GoStringDataType string.str
+      Data: 319 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 319
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1028
+      ID: 1035
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.457056e+06
@@ -18313,7 +21175,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.4656e+06
@@ -18321,12 +21183,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1213 StructureType internal/sync.Mutex
+          Type: 1220 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1214
+      ID: 1221
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.614496e+06
@@ -18334,15 +21196,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1215 StructureType sync/atomic.Bool
+          Type: 1222 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1211 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1217
+      ID: 1224
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.614304e+06
@@ -18350,21 +21212,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1218 StructureType sync/atomic.Uint64
+          Type: 1225 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1212
+      ID: 1219
       Name: sync.noCopy
       GoRuntimeType: 989376
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1215
+      ID: 1222
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.46672e+06
@@ -18372,12 +21234,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1220
+      ID: 1227
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.46688e+06
@@ -18385,12 +21247,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 10 BaseType int32
     - __kind: StructureType
-      ID: 1218
+      ID: 1225
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.61488e+06
@@ -18398,33 +21260,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1219 StructureType sync/atomic.align64
+          Type: 1226 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1219
+      ID: 1226
       Name: sync/atomic.align64
       GoRuntimeType: 989568
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1216
+      ID: 1223
       Name: sync/atomic.noCopy
       GoRuntimeType: 989472
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 942
+      ID: 949
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.284256e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 428
+      ID: 435
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18446,9 +21308,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 429 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 436 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 420
+      ID: 427
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18470,9 +21332,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 421 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 428 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 368
+      ID: 375
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -18494,9 +21356,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 369 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 376 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 387
+      ID: 394
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -18518,9 +21380,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 388 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 395 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 326
+      ID: 333
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -18542,9 +21404,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 327 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 334 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1239
+      ID: 1246
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -18566,9 +21428,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1240 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1247 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1273
+      ID: 1280
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -18590,9 +21452,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1274 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1281 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1288
+      ID: 1295
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -18614,9 +21476,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1289 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1296 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 336
+      ID: 343
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -18638,9 +21500,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 337 GoSwissMapGroupsType groupReference<int,int>
+          Type: 344 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1303
+      ID: 1310
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -18662,9 +21524,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1304 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1311 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 444
+      ID: 451
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18686,9 +21548,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 452 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 395
+      ID: 402
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18710,9 +21572,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 396 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 403 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 377
+      ID: 384
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -18734,9 +21596,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 378 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 385 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 360
+      ID: 367
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -18758,9 +21620,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 361 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 368 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 999
+      ID: 1006
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -18782,9 +21644,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1000 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1007 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 352
+      ID: 359
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -18806,9 +21668,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 353 GoSwissMapGroupsType groupReference<string,int>
+          Type: 360 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 344
+      ID: 351
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -18830,9 +21692,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 345 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 352 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 436
+      ID: 443
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -18854,9 +21716,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 437 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 444 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18878,9 +21740,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 487 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 494 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18902,9 +21764,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 495 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 502 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18926,9 +21788,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 503 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 510 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 510
+      ID: 517
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18950,9 +21812,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 511 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 518 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 518
+      ID: 525
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18974,9 +21836,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 519 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 526 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18998,9 +21860,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 534 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -19022,9 +21884,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 453 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 460 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 411
+      ID: 418
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -19046,9 +21908,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 412 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 419 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 403
+      ID: 410
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -19070,13 +21932,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 404 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 411 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.708672e+06
@@ -19089,21 +21951,21 @@ Types:
           Offset: 16
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 1108
+      ID: 1115
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.917184e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 967
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 628
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.374336e+06
@@ -19117,9 +21979,9 @@ Types:
           Type: 12 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 959 PointerType *time.Location
+          Type: 966 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 536
+      ID: 543
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 832384
@@ -19127,13 +21989,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 538 PointerType *time.fileSizeError.str
+          Type: 545 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 537 GoStringDataType time.fileSizeError.str
+      Data: 544 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 537
+      ID: 544
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -19180,7 +22042,7 @@ Types:
       GoRuntimeType: 585952
       GoKind: 26
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.064832e+06
@@ -19191,10 +22053,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 979 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 986 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 980 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 987 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -19209,18 +22071,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 981 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 988 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 996096
       GoKind: 9
     - __kind: StructureType
-      ID: 979
+      ID: 986
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.928192e+06
@@ -19245,21 +22107,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 980
+      ID: 987
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 589600
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1162
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 703
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.428096e+06
@@ -19269,13 +22131,13 @@ Types:
           Offset: 0
           Type: 13 GoInterfaceType error
     - __kind: BaseType
-      ID: 580
+      ID: 587
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 2
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.704448e+06
@@ -19288,14 +22150,14 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 814
+      ID: 821
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1480
+MaxTypeID: 1535
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x1802520", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -3128,7 +3128,11 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda6c0..0xcda6c6, Pieces: []}]
+          Locations:
+            - Range: 0xcda6c0..0xcda6c5
+              Pieces: []
+            - Range: 0xcda6c5..0xcda6c6
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3145,7 +3149,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcda6e0..0xcda723, Pieces: []}]
+          Locations:
+            - Range: 0xcda6e0..0xcda71d
+              Pieces: []
+            - Range: 0xcda71d..0xcda71e
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcda71e..0xcda723
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3188,7 +3198,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcda9e0..0xcdaa46, Pieces: []}]
+          Locations:
+            - Range: 0xcda9e0..0xcdaa25
+              Pieces: []
+            - Range: 0xcdaa25..0xcdaa26
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdaa26..0xcdaa46
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3221,7 +3241,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcdaa80..0xcdaad4, Pieces: []}]
+          Locations:
+            - Range: 0xcdaa80..0xcdaabd
+              Pieces: []
+            - Range: 0xcdaabd..0xcdaabe
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdaabe..0xcdaad4
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3721,7 +3751,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd860..0xcdd8cc, Pieces: []}]
+          Locations:
+            - Range: 0xcdd860..0xcdd8b4
+              Pieces: []
+            - Range: 0xcdd8b4..0xcdd8b5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdd8b5..0xcdd8cc
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3738,7 +3774,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
-          Locations: [{Range: 0xcdd8e0..0xcdd96f, Pieces: []}]
+          Locations:
+            - Range: 0xcdd8e0..0xcdd950
+              Pieces: []
+            - Range: 0xcdd950..0xcdd951
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdd951..0xcdd96f
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3766,7 +3808,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdd980..0xcdda4f, Pieces: []}]
+          Locations:
+            - Range: 0xcdd980..0xcdda31
+              Pieces: []
+            - Range: 0xcdda31..0xcdda32
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdda32..0xcdda4f
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3797,7 +3845,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcdda60..0xcddabb, Pieces: []}]
+          Locations:
+            - Range: 0xcdda60..0xcdda9a
+              Pieces: []
+            - Range: 0xcdda9a..0xcdda9b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcdda9b..0xcddaa5
+              Pieces: []
+            - Range: 0xcddaa5..0xcddaa6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddaa6..0xcddabb
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3831,12 +3897,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcddac0..0xcddb3c, Pieces: []}]
+          Locations:
+            - Range: 0xcddac0..0xcddb08
+              Pieces: []
+            - Range: 0xcddb08..0xcddb09
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddb09..0xcddb12
+              Pieces: []
+            - Range: 0xcddb12..0xcddb13
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddb13..0xcddb3c
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 13 GoInterfaceType error
-          Locations: [{Range: 0xcddac0..0xcddb3c, Pieces: []}]
+          Locations:
+            - Range: 0xcddac0..0xcddb08
+              Pieces: []
+            - Range: 0xcddb08..0xcddb09
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcddb09..0xcddb12
+              Pieces: []
+            - Range: 0xcddb12..0xcddb13
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xcddb13..0xcddb3c
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3869,7 +3971,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0xcddb40..0xcddbc8, Pieces: []}]
+          Locations:
+            - Range: 0xcddb40..0xcddba4
+              Pieces: []
+            - Range: 0xcddba4..0xcddba5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddba5..0xcddbc8
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3908,7 +4020,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
-          Locations: [{Range: 0xcddbe0..0xcddcf4, Pieces: []}]
+          Locations:
+            - Range: 0xcddbe0..0xcddc82
+              Pieces: []
+            - Range: 0xcddc82..0xcddc83
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddc83..0xcddc8c
+              Pieces: []
+            - Range: 0xcddc8c..0xcddc8d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcddc8d..0xcddcf4
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3966,7 +4096,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcddd00..0xcddd8f, Pieces: []}]
+          Locations:
+            - Range: 0xcddd00..0xcddd72
+              Pieces: []
+            - Range: 0xcddd72..0xcddd73
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcddd73..0xcddd8f
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3985,12 +4121,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0xcddda0..0xcdde58, Pieces: []}]
+          Locations:
+            - Range: 0xcddda0..0xcdde3e
+              Pieces: []
+            - Range: 0xcdde3e..0xcdde3f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcdde3f..0xcdde58
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcddda0..0xcdde58, Pieces: []}]
+          Locations:
+            - Range: 0xcddda0..0xcdde3e
+              Pieces: []
+            - Range: 0xcdde3e..0xcdde3f
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcdde3f..0xcdde58
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4009,17 +4157,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdde60..0xcddf15, Pieces: []}]
+          Locations:
+            - Range: 0xcdde60..0xcddefb
+              Pieces: []
+            - Range: 0xcddefb..0xcddefc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcddefc..0xcddf15
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdde60..0xcddf15, Pieces: []}]
+          Locations:
+            - Range: 0xcdde60..0xcddefb
+              Pieces: []
+            - Range: 0xcddefb..0xcddefc
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcddefc..0xcddf15
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0xcdde60..0xcddf15, Pieces: []}]
+          Locations:
+            - Range: 0xcdde60..0xcddefb
+              Pieces: []
+            - Range: 0xcddefb..0xcddefc
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcddefc..0xcddf15
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4262,7 +4428,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0xcde680..0xcde6d2, Pieces: []}]
+          Locations:
+            - Range: 0xcde680..0xcde6c5
+              Pieces: []
+            - Range: 0xcde6c5..0xcde6c6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcde6c6..0xcde6d2
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1257 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x890f28", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x892858", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1258 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x890f5c", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x89288c", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1184 EventRootType Probe[main.testAny]
+          Type: 1191 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88dd58", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1185 EventRootType Probe[main.testAny]Return
+          Type: 1192 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x88dd84", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1187 EventRootType Probe[main.testAnyPtr]
+          Type: 1194 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x88ddd8", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1188 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1195 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x88de04", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1284 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x89160c", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1285 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1135 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1142 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1131 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1138 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1133 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1140 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1196 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1203 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1132 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1139 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1134 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1141 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1153 EventRootType Probe[main.testBigStruct]
+          Type: 1160 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c8b0", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1154 EventRootType Probe[main.testBigStruct]Return
+          Type: 1161 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x88c8c8", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1120 EventRootType Probe[main.testBoolArray]
+          Type: 1127 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1117 EventRootType Probe[main.testByteArray]
+          Type: 1124 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88c240", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1216 EventRootType Probe[main.testChannel]
+          Type: 1223 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1214 EventRootType Probe[main.testCombinedByte]
+          Type: 1221 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1224 EventRootType Probe[main.testCycle]
+          Type: 1231 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fdd0", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1159 EventRootType Probe[main.testDeepMap1]
+          Type: 1166 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1160 EventRootType Probe[main.testDeepMap7]
+          Type: 1167 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1155 EventRootType Probe[main.testDeepPtr1]
+          Type: 1162 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x88c980", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1156 EventRootType Probe[main.testDeepPtr7]
+          Type: 1163 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x88c990", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1157 EventRootType Probe[main.testDeepSlice1]
+          Type: 1164 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x88cb30", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1158 EventRootType Probe[main.testDeepSlice7]
+          Type: 1165 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1246 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x890ba0", Frameless: true}]
+          Type: 1301 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1249 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x890bd0", Frameless: true}]
+          Type: 1304 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x892500", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1268 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x891000", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x892930", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1274 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x891350", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x892c80", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1275 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x891360", Frameless: true}]
+          Type: 1330 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x892c90", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1186 EventRootType Probe[main.testError]
+          Type: 1193 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88ddb0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1168 EventRootType Probe[main.testEsotericHeap]
+          Type: 1175 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88d358", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1169 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1176 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x88d394", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1166 EventRootType Probe[main.testEsotericStack]
+          Type: 1173 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88d26c", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1167 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1174 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x88d2dc", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1178 EventRootType Probe[main.testFrameless]
+          Type: 1185 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88da80", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1179 EventRootType Probe[main.testFrameless]Return
+          Type: 1186 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x88da88", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1180 EventRootType Probe[main.testFramelessArray]
+          Type: 1187 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1181 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1188 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x88dad8", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1182 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1189 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1170 EventRootType Probe[main.testInlinedBA]
+          Type: 1177 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88d798", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1171 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1178 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x88d7f0", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1172 EventRootType Probe[main.testInlinedBB]
+          Type: 1179 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88d828", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1173 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1180 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x88d8b0", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1174 EventRootType Probe[main.testInlinedBBA]
+          Type: 1181 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88d8f8", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1175 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1182 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x88d934", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1279 EventRootType Probe[main.testInlinedBBB]
+          Type: 1334 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1176 EventRootType Probe[main.testInlinedBC]
+          Type: 1183 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88d978", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1177 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1184 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x88da68", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1280 EventRootType Probe[main.testInlinedBCA]
+          Type: 1335 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1281 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1336 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1282 EventRootType Probe[main.testInlinedBCB]
+          Type: 1337 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1283 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1338 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1276 EventRootType Probe[main.testInlinedPrint]
+          Type: 1331 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0x88d8fc"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1277 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1332 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1278 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1333 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1284 EventRootType Probe[main.testInlinedSq]
+          Type: 1339 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1285 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1340 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1286 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1341 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1123 EventRootType Probe[main.testInt16Array]
+          Type: 1130 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1124 EventRootType Probe[main.testInt32Array]
+          Type: 1131 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1125 EventRootType Probe[main.testInt64Array]
+          Type: 1132 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1122 EventRootType Probe[main.testInt8Array]
+          Type: 1129 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1121 EventRootType Probe[main.testIntArray]
+          Type: 1128 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1183 EventRootType Probe[main.testInterface]
+          Type: 1190 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88dd30", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1282 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x891430", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1283 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x891588", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1218 EventRootType Probe[main.testLinkedList]
+          Type: 1225 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1163 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1170 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ccec", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1164 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1171 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88cd80", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1165 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1172 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x88ce2c", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1288 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x89193c", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1289 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x891aac", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1194 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1201 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1201 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1208 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1211 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1218 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1213 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1220 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1212 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1219 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1198 EventRootType Probe[main.testMapIntToInt]
+          Type: 1205 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1210 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1217 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88e510", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1209 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1216 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88e500", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1199 EventRootType Probe[main.testMapMassive]
+          Type: 1206 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1200 EventRootType Probe[main.testMapMassive]
+          Type: 1207 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1208 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1215 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1207 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1214 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1192 EventRootType Probe[main.testMapStringToInt]
+          Type: 1199 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1193 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1200 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1191 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1198 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1202 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1209 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1205 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1212 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1206 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1213 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1203 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1210 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1204 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1211 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x892910", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1321 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x892910", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1290 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x891b30", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1291 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1294 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1295 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1266 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x890fe0", Frameless: true}]
+          Type: 1286 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1287 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1241 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890768", Frameless: false}]
+          Type: 1248 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1242 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x8907e4", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1215 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1222 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f990", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1239 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x8906c8", Frameless: false}]
+          Type: 1246 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x890958", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1240 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x890724", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1223 EventRootType Probe[main.testNilPointer]
+          Type: 1230 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fdb0", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x890c10", Frameless: true}]
+          Type: 1308 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1250 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x890be0", Frameless: true}]
+          Type: 1305 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1252 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x890c00", Frameless: true}]
+          Type: 1307 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1264 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x890fd0", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x892900", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1219 EventRootType Probe[main.testPointerLoop]
+          Type: 1226 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1197 EventRootType Probe[main.testPointerToMap]
+          Type: 1204 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1217 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1224 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1235 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x8904f8", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x8905e8", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1236 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x89054c", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0x890688"
+              Frameless: false
+            - PC: "0x8906d0"
+              Frameless: false
+            - PC: "0x890794"
+              Frameless: false
+            - PC: "0x8907a8"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1233 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x890458", Frameless: false}]
+          Type: 1240 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x890468", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1234 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1241 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x890498"
+            - PC: "0x8904d4"
               Frameless: false
-            - PC: "0x8904ac"
+            - PC: "0x890520"
               Frameless: false
+            - PC: "0x890560"
+              Frameless: false
+            - PC: "0x8905a0"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1260 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1261 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x890e90", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1262 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1263 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x890f04", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1264 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x890f38", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1265 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x890f70", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1268 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x891028", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1269 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x89108c", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1280 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1281 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1256 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1257 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x890d34", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,16 +1754,16 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1231 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x8903d8", Frameless: false}]
+          Type: 1238 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x8903e8", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1232 EventRootType Probe[main.testReturnsError]Return
+          Type: 1239 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x890408"
+            - PC: "0x890418"
               Frameless: false
-            - PC: "0x89041c"
+            - PC: "0x89042c"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1225 EventRootType Probe[main.testReturnsInt]
+          Type: 1232 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x8901f8", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1226 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x890238", Frameless: false}]
+          Type: 1233 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x89023c", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1229 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1236 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x890318", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1230 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x8903a0", Frameless: false}]
+          Type: 1237 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x8903b0", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1227 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x89027c", Frameless: false}]
+          Type: 1234 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x890278", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1228 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x8902d8", Frameless: false}]
+          Type: 1235 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x8902dc", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1237 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x890598", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x8907e8", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1238 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1245 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x890628"
+            - PC: "0x8908b8"
               Frameless: false
-            - PC: "0x89063c"
+            - PC: "0x8908cc"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1258 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x890d70", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1259 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x890e04", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1254 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x890c28", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1255 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x890cac", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1272 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1273 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x891200", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1266 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1267 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1278 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x891338", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1279 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x89137c", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1276 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1277 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x891308", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1252 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x890b98", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1253 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1274 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x89123c", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1275 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x891290", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1270 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1271 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x891174", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1118 EventRootType Probe[main.testRuneArray]
+          Type: 1125 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1139 EventRootType Probe[main.testSingleBool]
+          Type: 1146 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1137 EventRootType Probe[main.testSingleByte]
+          Type: 1144 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1150 EventRootType Probe[main.testSingleFloat32]
+          Type: 1157 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1151 EventRootType Probe[main.testSingleFloat64]
+          Type: 1158 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c790", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1140 EventRootType Probe[main.testSingleInt]
+          Type: 1147 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1142 EventRootType Probe[main.testSingleInt16]
+          Type: 1149 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1143 EventRootType Probe[main.testSingleInt32]
+          Type: 1150 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1144 EventRootType Probe[main.testSingleInt64]
+          Type: 1151 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1141 EventRootType Probe[main.testSingleInt8]
+          Type: 1148 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1138 EventRootType Probe[main.testSingleRune]
+          Type: 1145 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1259 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x890f80", Frameless: true}]
+          Type: 1314 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x8928b0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1145 EventRootType Probe[main.testSingleUint]
+          Type: 1152 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1147 EventRootType Probe[main.testSingleUint16]
+          Type: 1154 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1148 EventRootType Probe[main.testSingleUint32]
+          Type: 1155 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1149 EventRootType Probe[main.testSingleUint64]
+          Type: 1156 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1146 EventRootType Probe[main.testSingleUint8]
+          Type: 1153 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1256 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x890c30", Frameless: true}]
+          Type: 1311 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1247 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x890bb0", Frameless: true}]
+          Type: 1302 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1195 EventRootType Probe[main.testSmallMap]
+          Type: 1202 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1243 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x890828", Frameless: false}]
+          Type: 1250 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1244 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x8908a4", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x890b54", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1292 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x891d68", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1293 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1119 EventRootType Probe[main.testStringArray]
+          Type: 1126 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1222 EventRootType Probe[main.testStringPointer]
+          Type: 1229 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fd90", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1251 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x890bf0", Frameless: true}]
+          Type: 1306 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1161 EventRootType Probe[main.testStringType1]
+          Type: 1168 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1162 EventRootType Probe[main.testStringType2]
+          Type: 1169 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1272 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x891250", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x892b80", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1273 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x89126c", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x892b9c", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1248 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x890bc0", Frameless: true}]
+          Type: 1303 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1189 EventRootType Probe[main.testStructWithAny]
+          Type: 1196 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x88de30", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1296 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x891eec", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1297 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1270 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x891160", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x892a90", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1271 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x891178", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x892aa8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1269 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x891150", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x892a80", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1190 EventRootType Probe[main.testStructWithMap]
+          Type: 1197 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1260 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x890f90", Frameless: true}]
+          Type: 1315 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x8928c0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1261 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x890fa0", Frameless: true}]
+          Type: 1316 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x8928d0", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1262 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x890fb8", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x8928e8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1263 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x890fc0", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x8928f0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1152 EventRootType Probe[main.testTypeAlias]
+          Type: 1159 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1128 EventRootType Probe[main.testUint16Array]
+          Type: 1135 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1129 EventRootType Probe[main.testUint32Array]
+          Type: 1136 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1130 EventRootType Probe[main.testUint64Array]
+          Type: 1137 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1127 EventRootType Probe[main.testUint8Array]
+          Type: 1134 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1126 EventRootType Probe[main.testUintArray]
+          Type: 1133 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1221 EventRootType Probe[main.testUintPointer]
+          Type: 1228 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1245 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x890b90", Frameless: true}]
+          Type: 1300 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1267 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x890ff0", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x892920", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1220 EventRootType Probe[main.testUnsafePointer]
+          Type: 1227 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1136 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1143 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88c380", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1254 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x890c20", Frameless: true}]
+          Type: 1309 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1255 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x890c20", Frameless: true}]
+          Type: 1310 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x892550", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1298 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1299 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x892024", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3745,23 +4213,30 @@ Subprograms:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8901e0..0x890204
+            - Range: 0x8901e0..0x8901fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890204..0x890260
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8901e0..0x890238
+            - Range: 0x8901e0..0x89023c
               Pieces: []
-            - Range: 0x890238..0x890239
+            - Range: 0x89023c..0x89023d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890239..0x890260
+            - Range: 0x89023d..0x890260
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x8901fc..0x890208
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890208..0x890260
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x890260..0x890300]
@@ -3772,117 +4247,144 @@ Subprograms:
           Locations:
             - Range: 0x890260..0x890284
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890284..0x890300
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x890260..0x8902d8
+            - Range: 0x890260..0x8902dc
               Pieces: []
-            - Range: 0x8902d8..0x8902d9
+            - Range: 0x8902dc..0x8902dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902d9..0x890300
+            - Range: 0x8902dd..0x890300
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x890288..0x8902a0
+            - Range: 0x890288..0x8902a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902a0..0x890300
+            - Range: 0x8902a4..0x890300
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x890300..0x8903c0]
+      OutOfLinePCRanges: [0x890300..0x8903d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890300..0x89034c
+            - Range: 0x890300..0x890358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89034c..0x8903c0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890300..0x8903a0
+            - Range: 0x890300..0x8903b0
               Pieces: []
-            - Range: 0x8903a0..0x8903a1
+            - Range: 0x8903b0..0x8903b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8903a1..0x8903c0
+            - Range: 0x8903b1..0x8903d0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890300..0x8903c0, Pieces: []}]
+          Locations: [{Range: 0x890300..0x8903d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x89031c..0x89035c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x89035c..0x8903d0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x890320..0x89034c
+            - Range: 0x89032c..0x89035c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x89034c..0x8903c0
+            - Range: 0x89035c..0x8903d0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
     - ID: 97
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8903c0..0x890440]
+      OutOfLinePCRanges: [0x8903d0..0x890450]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8903c0..0x8903e4
+            - Range: 0x8903d0..0x8903f4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x8903c0..0x890408
+            - Range: 0x8903d0..0x890418
               Pieces: []
-            - Range: 0x890408..0x890409
+            - Range: 0x890418..0x890419
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890409..0x89041c
+            - Range: 0x890419..0x89042c
               Pieces: []
-            - Range: 0x89041c..0x89041d
+            - Range: 0x89042c..0x89042d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89041d..0x890440
+            - Range: 0x89042d..0x890450
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x890440..0x8904e0]
+      OutOfLinePCRanges: [0x890450..0x8905d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890440..0x89046c
+            - Range: 0x890450..0x8904a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89046c..0x890470
+            - Range: 0x8904a8..0x8904ac
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890504..0x890508
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x890534..0x890538
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890574..0x890578
               Pieces:
                 - Size: 8
                   Op: null
@@ -3893,77 +4395,116 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x890440..0x890470
+            - Range: 0x890450..0x8904a4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890440..0x890498
+            - Range: 0x890450..0x8904d4
               Pieces: []
-            - Range: 0x890498..0x890499
+            - Range: 0x8904d4..0x8904d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890499..0x8904ac
+            - Range: 0x8904d5..0x890520
               Pieces: []
-            - Range: 0x8904ac..0x8904ad
+            - Range: 0x890520..0x890521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8904ad..0x8904e0
+            - Range: 0x890521..0x890560
+              Pieces: []
+            - Range: 0x890560..0x890561
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890561..0x8905a0
+              Pieces: []
+            - Range: 0x8905a0..0x8905a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8905a1..0x8905d0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x890440..0x890498
+            - Range: 0x890450..0x8904d4
               Pieces: []
-            - Range: 0x890498..0x890499
+            - Range: 0x8904d4..0x8904d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890499..0x8904ac
+            - Range: 0x8904d5..0x890520
               Pieces: []
-            - Range: 0x8904ac..0x8904ad
+            - Range: 0x890520..0x890521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8904ad..0x8904e0
+            - Range: 0x890521..0x890560
+              Pieces: []
+            - Range: 0x890560..0x890561
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x890561..0x8905a0
+              Pieces: []
+            - Range: 0x8905a0..0x8905a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8905a1..0x8905d0
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x890504..0x89050c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 99
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8904e0..0x890580]
+      OutOfLinePCRanges: [0x8905d0..0x8907d0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904e0..0x89053c
+            - Range: 0x8905d0..0x89062c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89053c..0x890540
+            - Range: 0x89062c..0x890630
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890540..0x890580
+            - Range: 0x890630..0x8907d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3974,267 +4515,1467 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904e0..0x89054c
+            - Range: 0x8905d0..0x890688
               Pieces: []
-            - Range: 0x89054c..0x89054d
+            - Range: 0x890688..0x890689
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89054d..0x890580
+            - Range: 0x890689..0x8906d0
+              Pieces: []
+            - Range: 0x8906d0..0x8906d1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8906d1..0x890794
+              Pieces: []
+            - Range: 0x890794..0x890795
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890795..0x8907a8
+              Pieces: []
+            - Range: 0x8907a8..0x8907a9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8907a9..0x8907d0
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x8906bc..0x8906c4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 94 PointerType *int
+          Locations:
+            - Range: 0x89066c..0x890688
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 100
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x890580..0x8906b0]
+      OutOfLinePCRanges: [0x8907d0..0x890940]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890580..0x8905bc
+            - Range: 0x8907d0..0x89080c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905bc..0x89061c
+            - Range: 0x89080c..0x89086c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89061c..0x890648
+            - Range: 0x89086c..0x8908d8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x890648..0x890670
+            - Range: 0x8908d8..0x890900
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890670..0x890674
+            - Range: 0x890900..0x890904
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890674..0x8906b0
+            - Range: 0x890904..0x890940
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890580..0x890628
+            - Range: 0x8907d0..0x8908b8
               Pieces: []
-            - Range: 0x890628..0x890629
+            - Range: 0x8908b8..0x8908b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890629..0x89063c
+            - Range: 0x8908b9..0x8908cc
               Pieces: []
-            - Range: 0x89063c..0x89063d
+            - Range: 0x8908cc..0x8908cd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89063d..0x8906b0
+            - Range: 0x8908cd..0x890940
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890580..0x8905bc
+            - Range: 0x8907d0..0x89080c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905bc..0x89060c
+            - Range: 0x89080c..0x89085c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89060c..0x89061c
+            - Range: 0x89085c..0x89086c
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -48}
+                  Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89061c..0x890634
+            - Range: 0x89086c..0x8908c4
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -48}
+                  Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890634..0x890638
+            - Range: 0x8908c4..0x8908c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890638..0x89063c
+            - Range: 0x8908c8..0x8908cc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89063c..0x8906b0
+            - Range: 0x8908cc..0x890940
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x8906b0..0x890750]
+      OutOfLinePCRanges: [0x890940..0x8909e0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8906b0..0x8906f0
+            - Range: 0x890940..0x89095c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8906f0..0x890750
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8906b0..0x890724
+            - Range: 0x890940..0x8909b8
               Pieces: []
-            - Range: 0x890724..0x890725
+            - Range: 0x8909b8..0x8909b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890725..0x890750
+            - Range: 0x8909b9..0x8909e0
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x890750..0x890810]
+      OutOfLinePCRanges: [0x8909e0..0x890ab0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890750..0x890794
+            - Range: 0x8909e0..0x890a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890794..0x890810
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890750..0x8907e4
+            - Range: 0x8909e0..0x890a84
               Pieces: []
-            - Range: 0x8907e4..0x8907e5
+            - Range: 0x890a84..0x890a85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8907e5..0x890810
+            - Range: 0x890a85..0x890ab0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890750..0x8907e4
+            - Range: 0x8909e0..0x890a84
               Pieces: []
-            - Range: 0x8907e4..0x8907e5
+            - Range: 0x890a84..0x890a85
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8907e5..0x890810
+            - Range: 0x890a85..0x890ab0
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x890810..0x8908d0]
+      OutOfLinePCRanges: [0x890ab0..0x890b80]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890810..0x890850
+            - Range: 0x890ab0..0x890af0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890850..0x8908d0
+            - Range: 0x890af0..0x890b80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890810..0x8908a4
+            - Range: 0x890ab0..0x890b54
               Pieces: []
-            - Range: 0x8908a4..0x8908a5
+            - Range: 0x890b54..0x890b55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8908a5..0x8908d0
+            - Range: 0x890b55..0x890b80
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890810..0x8908a4
+            - Range: 0x890ab0..0x890b54
               Pieces: []
-            - Range: 0x8908a4..0x8908a5
+            - Range: 0x890b54..0x890b55
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8908a5..0x8908d0
+            - Range: 0x890b55..0x890b80
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890810..0x8908a4
+            - Range: 0x890ab0..0x890b54
               Pieces: []
-            - Range: 0x8908a4..0x8908a5
+            - Range: 0x890b54..0x890b55
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8908a5..0x8908d0
+            - Range: 0x890b55..0x890b80
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x890b90..0x890ba0]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0x890b80..0x890c10]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 245 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 15 BaseType int8
           Locations:
-            - Range: 0x890b90..0x890ba0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 89 BaseType int16
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 13 BaseType int32
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 14 BaseType int64
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType uint16
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0x890b80..0x890bf0
+              Pieces: []
+            - Range: 0x890bf0..0x890bf1
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x890bf1..0x890c10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x890ba0..0x890bb0]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x890c10..0x890cd0]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 245 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x890ba0..0x890bb0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 17 BaseType float64
+          Locations:
+            - Range: 0x890c10..0x890cac
+              Pieces: []
+            - Range: 0x890cac..0x890cad
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x890cad..0x890cd0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x890bb0..0x890bc0]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x890cd0..0x890d50]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 90 BaseType complex64
+          Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 91 BaseType complex128
+          Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0x890d50..0x890e20]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x890d50..0x890e04
+              Pieces: []
+            - Range: 0x890e04..0x890e05
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x890e05..0x890e20
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x890e20..0x890eb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0x890e20..0x890e90
+              Pieces: []
+            - Range: 0x890e90..0x890e91
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x890e91..0x890eb0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x890eb0..0x890f20]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 247 ArrayType [1]int
+          Locations:
+            - Range: 0x890eb0..0x890f04
+              Pieces: []
+            - Range: 0x890f04..0x890f05
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890f05..0x890f20
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x890f20..0x890f90]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0x890f20..0x890f70
+              Pieces: []
+            - Range: 0x890f70..0x890f71
+              Pieces: []
+            - Range: 0x890f71..0x890f90
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x890f90..0x891010]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 StructureType main.mixedStruct
+          Locations: [{Range: 0x890f90..0x891010, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0x891010..0x8910b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x891010..0x89108c
+              Pieces: []
+            - Range: 0x89108c..0x89108d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x89108d..0x8910b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0x8910b0..0x891190]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 StructureType main.wideStruct
+          Locations:
+            - Range: 0x8910b0..0x891174
+              Pieces: []
+            - Range: 0x891174..0x891175
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+            - Range: 0x891175..0x891190
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x891190..0x891220]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891190..0x891200
+              Pieces: []
+            - Range: 0x891200..0x891201
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891201..0x891220
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x891190..0x891220, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891190..0x891200
+              Pieces: []
+            - Range: 0x891200..0x891201
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x891201..0x891220
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x891190..0x891220, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x891190..0x891200
+              Pieces: []
+            - Range: 0x891200..0x891201
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x891201..0x891220
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x891220..0x8912b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0x891220..0x891290
+              Pieces: []
+            - Range: 0x891290..0x891291
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x891291..0x8912b0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x8912b0..0x891320]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x8912b0..0x891320, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x891320..0x8913a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 16 BaseType float32
+          Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 17 BaseType float64
+          Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0x8913a0..0x891410]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x8913a0..0x8913f8
+              Pieces: []
+            - Range: 0x8913f8..0x8913f9
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8913f9..0x891410
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0x8913a0..0x8913f8
+              Pieces: []
+            - Range: 0x8913f8..0x8913f9
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x8913f9..0x891410
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0x891410..0x8915f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x891410..0x89147c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x89147c..0x891490
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891490..0x891494
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x891410..0x891588
+              Pieces: []
+            - Range: 0x891588..0x891589
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891589..0x8915f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0x8915f0..0x8916c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0x8915f0..0x8916c0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0x8915f0..0x8916a4
+              Pieces: []
+            - Range: 0x8916a4..0x8916a5
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x8916a5..0x8916c0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0x8916c0..0x891920]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x8916c0..0x891730
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891730..0x891744
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891744..0x891748
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x8916c0..0x891920
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x8916c0..0x8918b0
+              Pieces: []
+            - Range: 0x8918b0..0x8918b1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x8918b1..0x891920
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0x891920..0x891b10]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891920..0x891998
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0x891998..0x891b10
+              Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0x891920..0x891aac
+              Pieces: []
+            - Range: 0x891aac..0x891aad
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+            - Range: 0x891aad..0x891b10
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0x891b10..0x891d50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x891b98..0x891d50
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x891b10..0x891b98
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891b98..0x891d50
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 245 StructureType main.largeStruct
+          Locations:
+            - Range: 0x891b10..0x891ce0
+              Pieces: []
+            - Range: 0x891ce0..0x891ce1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x891ce1..0x891d50
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0x891d50..0x891df0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 156 ArrayType [5]int
+          Locations:
+            - Range: 0x891d50..0x891df0
+              Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891d50..0x891dcc
+              Pieces: []
+            - Range: 0x891dcc..0x891dcd
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891dcd..0x891df0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891d50..0x891dcc
+              Pieces: []
+            - Range: 0x891dcc..0x891dcd
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x891dcd..0x891df0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891d50..0x891dcc
+              Pieces: []
+            - Range: 0x891dcc..0x891dcd
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x891dcd..0x891df0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0x891df0..0x891ed0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0x891df0..0x891ed0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 246 ArrayType [3]int
+          Locations:
+            - Range: 0x891df0..0x891ed0
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891df0..0x891eb0
+              Pieces: []
+            - Range: 0x891eb0..0x891eb1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891eb1..0x891ed0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 106 ArrayType [2]int
+          Locations:
+            - Range: 0x891df0..0x891eb0
+              Pieces: []
+            - Range: 0x891eb0..0x891eb1
+              Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
+            - Range: 0x891eb1..0x891ed0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0x891ed0..0x891fa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0x891ed0..0x891fa0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891ed0..0x891f7c
+              Pieces: []
+            - Range: 0x891f7c..0x891f7d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891f7d..0x891fa0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 251 StructureType main.structWithArray
+          Locations:
+            - Range: 0x891ed0..0x891f7c
+              Pieces: []
+            - Range: 0x891f7c..0x891f7d
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x891f7d..0x891fa0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891f50..0x891fa0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0x891fa0..0x892050]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 248 ArrayType [0]int
+          Locations: [{Range: 0x891fa0..0x892050, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891fa0..0x891fe0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x891fe0..0x891ffc
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x891ffc..0x892018
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x892018..0x892050
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x891fa0..0x892024
+              Pieces: []
+            - Range: 0x892024..0x892025
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x892025..0x892050
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 248 ArrayType [0]int
+          Locations:
+            - Range: 0x891fa0..0x892024
+              Pieces: []
+            - Range: 0x892024..0x892025
+              Pieces: []
+            - Range: 0x892025..0x892050
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x8924c0..0x8924d0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 246 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x890bb0..0x890bc0
+            - Range: 0x8924c0..0x8924d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4244,15 +5985,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x8924d0..0x8924e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x8924d0..0x8924e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x8924e0..0x8924f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x8924e0..0x8924f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x890bc0..0x890bd0]
+      OutOfLinePCRanges: [0x8924f0..0x892500]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x890bc0..0x890bd0
+            - Range: 0x8924f0..0x892500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4265,19 +6042,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890bc0..0x890bd0
+            - Range: 0x8924f0..0x892500
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x890bd0..0x890be0]
+      OutOfLinePCRanges: [0x892500..0x892510]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x890bd0..0x890be0
+            - Range: 0x892500..0x892510
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4290,19 +6067,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890bd0..0x890be0
+            - Range: 0x892500..0x892510
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x890be0..0x890bf0]
+      OutOfLinePCRanges: [0x892510..0x892520]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []main.structWithNoStrings
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x890be0..0x890bf0
+            - Range: 0x892510..0x892520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4315,19 +6092,19 @@ Subprograms:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890be0..0x890bf0
+            - Range: 0x892510..0x892520
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x890bf0..0x890c00]
+      OutOfLinePCRanges: [0x892520..0x892530]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
           Locations:
-            - Range: 0x890bf0..0x890c00
+            - Range: 0x892520..0x892530
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4337,22 +6114,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x890c00..0x890c10]
+      OutOfLinePCRanges: [0x892530..0x892540]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x890c00..0x890c10
+            - Range: 0x892530..0x892540
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 252 GoSliceHeaderType []bool
+          Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x890c00..0x890c10
+            - Range: 0x892530..0x892540
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -4365,19 +6142,19 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x890c00..0x890c10
+            - Range: 0x892530..0x892540
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x890c10..0x890c20]
+      OutOfLinePCRanges: [0x892540..0x892550]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []uint16
+          Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x890c10..0x890c20
+            - Range: 0x892540..0x892550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4387,15 +6164,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x890c20..0x890c30]
+      OutOfLinePCRanges: [0x892550..0x892560]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 245 GoSliceHeaderType []uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x890c20..0x890c30
+            - Range: 0x892550..0x892560
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4405,15 +6182,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x890c30..0x890c40]
+      OutOfLinePCRanges: [0x892560..0x892570]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 254 GoSliceHeaderType []struct {}
+          Type: 261 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x890c30..0x890c40
+            - Range: 0x892560..0x892570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4423,35 +6200,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0x890f10..0x890f80]
+      OutOfLinePCRanges: [0x892840..0x8928b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890f10..0x890f5c
+            - Range: 0x892840..0x89288c
               Pieces: []
-            - Range: 0x890f5c..0x890f5d
+            - Range: 0x89288c..0x89288d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890f5d..0x890f80
+            - Range: 0x89288d..0x8928b0
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x890f80..0x890f90]
+      OutOfLinePCRanges: [0x8928b0..0x8928c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890f80..0x890f90
+            - Range: 0x8928b0..0x8928c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4459,15 +6236,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x890f90..0x890fa0]
+      OutOfLinePCRanges: [0x8928c0..0x8928d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890f90..0x890fa0
+            - Range: 0x8928c0..0x8928d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4478,7 +6255,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890f90..0x890fa0
+            - Range: 0x8928c0..0x8928d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4489,7 +6266,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890f90..0x890fa0
+            - Range: 0x8928c0..0x8928d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4497,15 +6274,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x890fa0..0x890fc0]
+      OutOfLinePCRanges: [0x8928d0..0x8928f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 256 StructureType main.threeStringStruct
+          Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x890fa0..0x890fc0
+            - Range: 0x8928d0..0x8928f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4521,39 +6298,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x890fc0..0x890fd0]
+      OutOfLinePCRanges: [0x8928f0..0x892900]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 257 PointerType *main.threeStringStruct
+          Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x890fc0..0x890fd0
+            - Range: 0x8928f0..0x892900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x890fd0..0x890fe0]
+      OutOfLinePCRanges: [0x892900..0x892910]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 258 PointerType *main.oneStringStruct
+          Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x890fd0..0x890fe0
+            - Range: 0x892900..0x892910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x890fe0..0x890ff0]
+      OutOfLinePCRanges: [0x892910..0x892920]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890fe0..0x890ff0
+            - Range: 0x892910..0x892920
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4561,15 +6338,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x890ff0..0x891000]
+      OutOfLinePCRanges: [0x892920..0x892930]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x890ff0..0x891000
+            - Range: 0x892920..0x892930
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4577,15 +6354,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x891000..0x891010]
+      OutOfLinePCRanges: [0x892930..0x892940]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891000..0x891010
+            - Range: 0x892930..0x892940
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4593,27 +6370,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x891150..0x891160]
+      OutOfLinePCRanges: [0x892a80..0x892a90]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 260 StructureType main.structWithCyclicSlices
+          Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x891150..0x891160
+            - Range: 0x892a80..0x892a90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x891160..0x891180]
+      OutOfLinePCRanges: [0x892a90..0x892ab0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 273 StructureType main.structWithCyclicMaps
+          Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x891160..0x891180
+            - Range: 0x892a90..0x892ab0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4629,15 +6406,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0x891250..0x891270]
+      OutOfLinePCRanges: [0x892b80..0x892ba0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 304 StructureType main.aStruct
+          Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x891250..0x891270
+            - Range: 0x892b80..0x892ba0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4655,29 +6432,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x891350..0x891360]
+      OutOfLinePCRanges: [0x892c80..0x892c90]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 305 StructureType main.emptyStruct
-          Locations: [{Range: 0x891350..0x891360, Pieces: []}]
+          Type: 312 StructureType main.emptyStruct
+          Locations: [{Range: 0x892c80..0x892c90, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x891360..0x891370]
+      OutOfLinePCRanges: [0x892c90..0x892ca0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 306 PointerType *main.emptyStruct
+          Type: 313 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x891360..0x891370
+            - Range: 0x892c90..0x892ca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d5e0..0x88d650]
       InlinePCRanges:
@@ -4707,28 +6484,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d878..0x88d8b0]
           RootRanges: [0x88d810..0x88d8e0]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d97c..0x88d9c0]
           RootRanges: [0x88d960..0x88da80]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88da30..0x88da68]
           RootRanges: [0x88d960..0x88da80]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4742,7 +6519,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4767,20 +6544,20 @@ Types:
       ByteSize: 8
       Pointee: 133 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1059
+      ID: 1066
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1060 PointerType *main.deepSlice3
+      Pointee: 1067 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1078
+      ID: 1085
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1079 PointerType *main.deepSlice8
+      Pointee: 1086 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1084
+      ID: 1091
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1085 PointerType *main.deepSlice9
+      Pointee: 1092 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 148
       Name: '**main.stringType2'
@@ -4788,7 +6565,7 @@ Types:
       GoKind: 22
       Pointee: 149 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1055
+      ID: 1062
       Name: '**main.t'
       ByteSize: 8
       Pointee: 243 PointerType *main.t
@@ -4800,115 +6577,115 @@ Types:
       GoKind: 22
       Pointee: 88 PointerType *string
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 323 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1063
+      ID: 1070
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1062 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1069 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1082
+      ID: 1089
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1081 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1088 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1087 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1094 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 314
+      ID: 321
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 313 GoSliceDataType []*string.array
+      Pointee: 320 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 383
+      ID: 390
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 382 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 389 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 272
+      ID: 279
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 381
+      ID: 388
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 380 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 387 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 270
+      ID: 277
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 378 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 385 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 268
+      ID: 275
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 377
+      ID: 384
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 376 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 383 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 266
+      ID: 273
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 375
+      ID: 382
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 374 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 381 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 361
+      ID: 368
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 360 GoSliceDataType [][]uint.array
+      Pointee: 367 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 367
+      ID: 374
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 366 GoSliceDataType []bool.array
+      Pointee: 373 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 845 GoSliceDataType []float64.array
+      Pointee: 852 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1091
+      ID: 1098
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1090 GoSliceDataType []interface {}.array
+      Pointee: 1097 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 264
+      ID: 271
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 261 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 373
+      ID: 380
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 372 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 379 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 397
+      ID: 404
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 396 GoSliceDataType []main.structWithMap.array
+      Pointee: 403 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 363
+      ID: 370
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 362 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 369 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -4917,101 +6694,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 365
+      ID: 372
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 364 GoSliceDataType []string.array
+      Pointee: 371 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 371
+      ID: 378
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 370 GoSliceDataType []struct {}.array
+      Pointee: 377 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 247
+      ID: 254
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 245 GoSliceHeaderType []uint
+      Pointee: 252 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 359
+      ID: 366
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 358 GoSliceDataType []uint.array
+      Pointee: 365 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 369
+      ID: 376
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 368 GoSliceDataType []uint16.array
+      Pointee: 375 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 310
+      ID: 317
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 309 GoSliceDataType []uint8.array
+      Pointee: 316 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 312
+      ID: 319
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 311 GoSliceDataType []uintptr.array
+      Pointee: 318 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.849952e+06
       GoKind: 22
-      Pointee: 972 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 979 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 858592
       GoKind: 22
-      Pointee: 624 GoSliceHeaderType archive/tar.headerError
+      Pointee: 631 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 626
+      ID: 633
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 625 GoSliceDataType archive/tar.headerError.array
+      Pointee: 632 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.253568e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 919 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 858784
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 867 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 858880
       GoKind: 22
-      Pointee: 862 StructureType archive/zip.dirWriter
+      Pointee: 869 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 958
+      ID: 965
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.77424e+06
       GoKind: 22
-      Pointee: 959 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 966 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 887
+      ID: 894
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.017088e+06
       GoKind: 22
-      Pointee: 888 StructureType archive/zip.nopCloser
+      Pointee: 895 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.017344e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 897 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -5045,30 +6822,30 @@ Types:
       ByteSize: 8
       Pointee: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1067
+      ID: 1074
       Name: '*bucket<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
+      Pointee: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1095
+      ID: 1102
       Name: '*bucket<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
+      Pointee: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*bucket<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
+      Pointee: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: PointerType
       ID: 164
       Name: '*bucket<int,int>'
       ByteSize: 8
       Pointee: 165 GoHMapBucketType bucket<int,int>
     - __kind: PointerType
-      ID: 1113
+      ID: 1120
       Name: '*bucket<int,interface {}>'
       ByteSize: 8
-      Pointee: 1114 GoHMapBucketType bucket<int,interface {}>
+      Pointee: 1121 GoHMapBucketType bucket<int,interface {}>
     - __kind: PointerType
       ID: 231
       Name: '*bucket<int,struct {}>'
@@ -5090,10 +6867,10 @@ Types:
       ByteSize: 8
       Pointee: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*bucket<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 174
       Name: '*bucket<string,int>'
@@ -5110,35 +6887,35 @@ Types:
       ByteSize: 8
       Pointee: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: PointerType
-      ID: 277
+      ID: 284
       Name: '*bucket<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      Pointee: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 282
+      ID: 289
       Name: '*bucket<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 287
+      ID: 294
       Name: '*bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 292
+      ID: 299
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 297
+      ID: 304
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 302
+      ID: 309
       Name: '*bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 236
       Name: '*bucket<struct {},struct {}>'
@@ -5155,393 +6932,393 @@ Types:
       ByteSize: 8
       Pointee: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.030432e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType bufio.Reader
+      Pointee: 943 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 960
+      ID: 967
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.81568e+06
       GoKind: 22
-      Pointee: 961 UnresolvedPointeeType bufio.Writer
+      Pointee: 968 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1007
+      ID: 1014
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.123392e+06
       GoKind: 22
-      Pointee: 1008 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1015 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 536
+      ID: 543
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 841216
       GoKind: 22
-      Pointee: 431 BaseType compress/flate.CorruptInputError
+      Pointee: 438 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 841312
       GoKind: 22
-      Pointee: 432 GoStringHeaderType compress/flate.InternalError
+      Pointee: 439 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 434
+      ID: 441
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 433 GoStringDataType compress/flate.InternalError.str
+      Pointee: 440 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.243808e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 917 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 841408
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 863 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.600864e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 939 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.11824e+06
       GoKind: 22
-      Pointee: 768 StructureType context.deadlineExceededError
+      Pointee: 775 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 616
+      ID: 623
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853504
       GoKind: 22
-      Pointee: 445 BaseType crypto/aes.KeySizeError
+      Pointee: 452 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853696
       GoKind: 22
-      Pointee: 446 BaseType crypto/des.KeySizeError
+      Pointee: 453 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*crypto/hmac.hmac'
       ByteSize: 8
       GoRuntimeType: 1.37424e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType crypto/hmac.hmac
+      Pointee: 929 UnresolvedPointeeType crypto/hmac.hmac
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.679872e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 954 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 618
+      ID: 625
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 853984
       GoKind: 22
-      Pointee: 447 BaseType crypto/rc4.KeySizeError
+      Pointee: 454 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.771424e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 962 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*crypto/sha256.digest'
       ByteSize: 8
       GoRuntimeType: 1.68032e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType crypto/sha256.digest
+      Pointee: 956 UnresolvedPointeeType crypto/sha256.digest
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*crypto/sha512.digest'
       ByteSize: 8
       GoRuntimeType: 1.680768e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType crypto/sha512.digest
+      Pointee: 958 UnresolvedPointeeType crypto/sha512.digest
     - __kind: PointerType
-      ID: 542
+      ID: 549
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 842848
       GoKind: 22
-      Pointee: 435 BaseType crypto/tls.AlertError
+      Pointee: 442 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.004928e+06
       GoKind: 22
-      Pointee: 708 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 715 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.232512e+06
       GoKind: 22
-      Pointee: 1034 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1041 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 540
+      ID: 547
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 842656
       GoKind: 22
-      Pointee: 541 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 548 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 538
+      ID: 545
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 842560
       GoKind: 22
-      Pointee: 539 StructureType crypto/tls.RecordHeaderError
+      Pointee: 546 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.003264e+06
       GoKind: 22
-      Pointee: 663 BaseType crypto/tls.alert
+      Pointee: 670 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.37136e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 927 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.450432e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 934 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.244128e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 810 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.907104e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 825 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 852448
       GoKind: 22
-      Pointee: 613 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 620 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 851968
       GoKind: 22
-      Pointee: 607 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 614 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 608
+      ID: 615
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 852064
       GoKind: 22
-      Pointee: 609 StructureType crypto/x509.HostnameError
+      Pointee: 616 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 851872
       GoKind: 22
-      Pointee: 444 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 451 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.010816e+06
       GoKind: 22
-      Pointee: 713 StructureType crypto/x509.SystemRootsError
+      Pointee: 720 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 614
+      ID: 621
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 852544
       GoKind: 22
-      Pointee: 615 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 622 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 610
+      ID: 617
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 852352
       GoKind: 22
-      Pointee: 611 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 618 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 859072
       GoKind: 22
-      Pointee: 628 StructureType encoding/asn1.StructuralError
+      Pointee: 635 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 859264
       GoKind: 22
-      Pointee: 632 StructureType encoding/asn1.SyntaxError
+      Pointee: 639 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 859168
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 637 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 839488
       GoKind: 22
-      Pointee: 429 BaseType encoding/base64.CorruptInputError
+      Pointee: 436 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 877
+      ID: 884
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.000064e+06
       GoKind: 22
-      Pointee: 878 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 885 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 531
+      ID: 538
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 840352
       GoKind: 22
-      Pointee: 430 BaseType encoding/hex.InvalidByteError
+      Pointee: 437 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 499
+      ID: 506
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 834208
       GoKind: 22
-      Pointee: 500 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 507 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 995712
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 706 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 833824
       GoKind: 22
-      Pointee: 492 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 499 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 497
+      ID: 504
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 834112
       GoKind: 22
-      Pointee: 498 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 505 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 495
+      ID: 502
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 834016
       GoKind: 22
-      Pointee: 496 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 503 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 493
+      ID: 500
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 833920
       GoKind: 22
-      Pointee: 494 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 501 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.14896e+06
       GoKind: 22
-      Pointee: 1014 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1021 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 501
+      ID: 508
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 834592
       GoKind: 22
-      Pointee: 502 StructureType encoding/json.jsonError
+      Pointee: 509 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 885
+      ID: 892
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.013632e+06
       GoKind: 22
-      Pointee: 886 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 893 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 850912
       GoKind: 22
-      Pointee: 601 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 608 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 850816
       GoKind: 22
-      Pointee: 599 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 606 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 602
+      ID: 609
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 851008
       GoKind: 22
-      Pointee: 441 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 448 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 443
+      ID: 450
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 442 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 449 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 851104
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 611 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.018912e+06
       GoKind: 22
-      Pointee: 992 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 999 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 99
       Name: '*error'
@@ -5550,19 +7327,19 @@ Types:
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
-      ID: 469
+      ID: 476
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 824512
       GoKind: 22
-      Pointee: 470 UnresolvedPointeeType errors.errorString
+      Pointee: 477 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 665
+      ID: 672
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 980352
       GoKind: 22
-      Pointee: 666 UnresolvedPointeeType errors.joinError
+      Pointee: 673 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 101
       Name: '*float32'
@@ -5578,806 +7355,806 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.114688e+06
       GoKind: 22
-      Pointee: 1002 UnresolvedPointeeType fmt.pp
+      Pointee: 1009 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 667
+      ID: 674
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 980480
       GoKind: 22
-      Pointee: 668 UnresolvedPointeeType fmt.wrapError
+      Pointee: 675 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 669
+      ID: 676
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 980608
       GoKind: 22
-      Pointee: 670 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 677 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 529
+      ID: 536
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 839872
       GoKind: 22
-      Pointee: 530 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 537 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 510
+      ID: 517
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 836992
       GoKind: 22
-      Pointee: 511 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 518 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 837088
       GoKind: 22
-      Pointee: 513 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 520 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 836800
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 837 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 516
+      ID: 523
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 517 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 524 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 836896
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 839 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 514
+      ID: 521
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 837184
       GoKind: 22
-      Pointee: 423 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 430 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 425
+      ID: 432
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 424 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 509
+      ID: 516
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 836704
       GoKind: 22
-      Pointee: 420 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 427 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 421 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 428 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 515
+      ID: 522
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 837280
       GoKind: 22
-      Pointee: 426 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 433 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 428
+      ID: 435
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 427 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.124e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 907 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 979
+      ID: 986
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 1.922112e+06
       GoKind: 22
-      Pointee: 980 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 987 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 857536
       GoKind: 22
-      Pointee: 622 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 629 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.127328e+06
       GoKind: 22
-      Pointee: 777 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 784 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1009
+      ID: 1016
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.124928e+06
       GoKind: 22
-      Pointee: 1010 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1017 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 846400
       GoKind: 22
-      Pointee: 550 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 557 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 556
+      ID: 563
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 847456
       GoKind: 22
-      Pointee: 557 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 564 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 847168
       GoKind: 22
-      Pointee: 440 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 447 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 554
+      ID: 561
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 847360
       GoKind: 22
-      Pointee: 555 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 562 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 847264
       GoKind: 22
-      Pointee: 553 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 560 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 572
+      ID: 579
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 849376
       GoKind: 22
-      Pointee: 573 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 580 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 849568
       GoKind: 22
-      Pointee: 577 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 584 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 574
+      ID: 581
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 849472
       GoKind: 22
-      Pointee: 575 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 582 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 570
+      ID: 577
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 849280
       GoKind: 22
-      Pointee: 571 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 578 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 847 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 854 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 849952
       GoKind: 22
-      Pointee: 585 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 592 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 578
+      ID: 585
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 849664
       GoKind: 22
-      Pointee: 579 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 586 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 582
+      ID: 589
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 849856
       GoKind: 22
-      Pointee: 583 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 590 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 580
+      ID: 587
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 849760
       GoKind: 22
-      Pointee: 581 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 588 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 586
+      ID: 593
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 850048
       GoKind: 22
-      Pointee: 587 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 594 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 850336
       GoKind: 22
-      Pointee: 593 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 600 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 594
+      ID: 601
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 850432
       GoKind: 22
-      Pointee: 595 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 602 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 590
+      ID: 597
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 850240
       GoKind: 22
-      Pointee: 591 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 598 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 850144
       GoKind: 22
-      Pointee: 589 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 596 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 850624
       GoKind: 22
-      Pointee: 597 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 604 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 518
+      ID: 525
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 838528
       GoKind: 22
-      Pointee: 519 StructureType github.com/cihub/seelog.baseError
+      Pointee: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.67696e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 946 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 838624
       GoKind: 22
-      Pointee: 521 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 528 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.37024e+06
       GoKind: 22
-      Pointee: 918 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 925 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 873
+      ID: 880
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 999040
       GoKind: 22
-      Pointee: 874 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 881 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.241888e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 915 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 524
+      ID: 531
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 838816
       GoKind: 22
-      Pointee: 525 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 532 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.84016e+06
       GoKind: 22
-      Pointee: 970 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 977 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 984
+      ID: 991
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 1.993568e+06
       GoKind: 22
-      Pointee: 981 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 988 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 983
+      ID: 990
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 1.993184e+06
       GoKind: 22
-      Pointee: 982 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 989 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 875
+      ID: 882
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 999168
       GoKind: 22
-      Pointee: 876 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 883 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 522
+      ID: 529
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 838720
       GoKind: 22
-      Pointee: 523 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 530 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 526
+      ID: 533
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 838912
       GoKind: 22
-      Pointee: 527 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 534 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.678528e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 950 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.876032e+06
       GoKind: 22
-      Pointee: 976 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 983 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 977
+      ID: 984
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.906784e+06
       GoKind: 22
-      Pointee: 978 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 985 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 807
+      ID: 814
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.255968e+06
       GoKind: 22
-      Pointee: 808 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 815 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.025024e+06
       GoKind: 22
-      Pointee: 721 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 728 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.024896e+06
       GoKind: 22
-      Pointee: 719 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 726 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.028992e+06
       GoKind: 22
-      Pointee: 723 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 730 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.02912e+06
       GoKind: 22
-      Pointee: 725 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 732 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.47808e+06
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 936 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.011584e+06
       GoKind: 22
-      Pointee: 715 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 722 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 532
+      ID: 539
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 840544
       GoKind: 22
-      Pointee: 533 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 540 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.211616e+06
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1033 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.13552e+06
       GoKind: 22
-      Pointee: 779 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 786 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 752 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 759 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.114016e+06
       GoKind: 22
-      Pointee: 746 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 753 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 989568
       GoKind: 22
-      Pointee: 685 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 692 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114784e+06
       GoKind: 22
-      Pointee: 758 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 765 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 989440
       GoKind: 22
-      Pointee: 662 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 669 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.114272e+06
       GoKind: 22
-      Pointee: 750 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 757 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.114144e+06
       GoKind: 22
-      Pointee: 748 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 755 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.114656e+06
       GoKind: 22
-      Pointee: 756 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 763 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.114528e+06
       GoKind: 22
-      Pointee: 754 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 761 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.222656e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1037 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.115168e+06
       GoKind: 22
-      Pointee: 762 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 769 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 989824
       GoKind: 22
-      Pointee: 689 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 696 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 686
+      ID: 693
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 989696
       GoKind: 22
-      Pointee: 687 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 694 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.11504e+06
       GoKind: 22
-      Pointee: 760 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 767 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 871168
       GoKind: 22
-      Pointee: 452 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 459 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 454
+      ID: 461
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 453 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 460 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.476544e+06
       GoKind: 22
-      Pointee: 821 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 828 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.043968e+06
       GoKind: 22
-      Pointee: 729 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 736 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.174432e+06
       GoKind: 22
-      Pointee: 906 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 913 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.008544e+06
       GoKind: 22
-      Pointee: 990 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 997 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.046272e+06
       GoKind: 22
-      Pointee: 892 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 899 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 872416
       GoKind: 22
-      Pointee: 455 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 462 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.176096e+06
       GoKind: 22
-      Pointee: 787 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 794 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 872704
       GoKind: 22
-      Pointee: 648 StructureType golang.org/x/net/http2.connError
+      Pointee: 655 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 646
+      ID: 653
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872608
       GoKind: 22
-      Pointee: 459 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 466 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 461
+      ID: 468
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 460 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 467 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 22
-      Pointee: 465 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 472 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 466 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 473 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 872800
       GoKind: 22
-      Pointee: 462 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 469 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 464
+      ID: 471
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 463 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 470 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 872512
       GoKind: 22
-      Pointee: 456 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 463 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 458
+      ID: 465
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 457 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 464 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.006624e+06
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 995 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 22
-      Pointee: 652 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 659 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 873088
       GoKind: 22
-      Pointee: 468 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 475 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 866560
       GoKind: 22
-      Pointee: 640 StructureType google.golang.org/grpc.dropError
+      Pointee: 647 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.173024e+06
       GoKind: 22
-      Pointee: 785 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 792 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 809
+      ID: 816
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.263328e+06
       GoKind: 22
-      Pointee: 810 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 817 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 869440
       GoKind: 22
-      Pointee: 642 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 649 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.685248e+06
       GoKind: 22
-      Pointee: 953 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 960 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.169568e+06
       GoKind: 22
-      Pointee: 904 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 911 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.038208e+06
       GoKind: 22
-      Pointee: 727 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 734 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 869536
       GoKind: 22
-      Pointee: 864 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 871 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 855424
       GoKind: 22
-      Pointee: 620 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 627 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.01504e+06
       GoKind: 22
-      Pointee: 717 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 724 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.14128e+06
       GoKind: 22
-      Pointee: 783 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 790 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.141024e+06
       GoKind: 22
-      Pointee: 781 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 788 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 860128
       GoKind: 22
-      Pointee: 634 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 641 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 860224
       GoKind: 22
-      Pointee: 636 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 643 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 564
+      ID: 571
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 847840
       GoKind: 22
-      Pointee: 565 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 572 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.677632e+06
       GoKind: 22
-      Pointee: 941 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 948 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
       ID: 219
       Name: '*hash<[4]int,[4]int>'
@@ -6404,30 +8181,30 @@ Types:
       ByteSize: 8
       Pointee: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1065
+      ID: 1072
       Name: '*hash<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1066 GoHMapHeaderType hash<int,*main.deepMap3>
+      Pointee: 1073 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*hash<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1094 GoHMapHeaderType hash<int,*main.deepMap8>
+      Pointee: 1101 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*hash<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1103 GoHMapHeaderType hash<int,*main.deepMap9>
+      Pointee: 1110 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: PointerType
       ID: 162
       Name: '*hash<int,int>'
       ByteSize: 8
       Pointee: 163 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*hash<int,interface {}>'
       ByteSize: 8
-      Pointee: 1112 GoHMapHeaderType hash<int,interface {}>
+      Pointee: 1119 GoHMapHeaderType hash<int,interface {}>
     - __kind: PointerType
       ID: 229
       Name: '*hash<int,struct {}>'
@@ -6449,10 +8226,10 @@ Types:
       ByteSize: 8
       Pointee: 178 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 813
+      ID: 820
       Name: '*hash<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 814 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 821 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 172
       Name: '*hash<string,int>'
@@ -6469,35 +8246,35 @@ Types:
       ByteSize: 8
       Pointee: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*hash<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 276 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+      Pointee: 283 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '*hash<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 288 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '*hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '*hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 234
       Name: '*hash<struct {},struct {}>'
@@ -6514,12 +8291,12 @@ Types:
       ByteSize: 8
       Pointee: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 22
-      Pointee: 655 UnresolvedPointeeType html/template.Error
+      Pointee: 662 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -6563,96 +8340,96 @@ Types:
       GoKind: 22
       Pointee: 152 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 534
+      ID: 541
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 840928
       GoKind: 22
-      Pointee: 535 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 542 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 829120
       GoKind: 22
-      Pointee: 850 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 857 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.113248e+06
       GoKind: 22
-      Pointee: 744 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 751 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.227328e+06
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1039 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.11312e+06
       GoKind: 22
-      Pointee: 742 StructureType internal/poll.errNetClosing
+      Pointee: 749 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 471
+      ID: 478
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 828256
       GoKind: 22
-      Pointee: 472 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 479 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 22
-      Pointee: 896 UnresolvedPointeeType io.PipeWriter
+      Pointee: 903 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.10416e+06
       GoKind: 22
-      Pointee: 894 StructureType io.discard
+      Pointee: 901 StructureType io.discard
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 981376
       GoKind: 22
-      Pointee: 868 UnresolvedPointeeType io.multiWriter
+      Pointee: 875 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.112864e+06
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType io/fs.PathError
+      Pointee: 747 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.678752e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 952 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 321
+      ID: 328
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 356512
       GoKind: 22
-      Pointee: 322 StructureType main.deepMap2
+      Pointee: 329 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1070
+      ID: 1077
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 356448
       GoKind: 22
-      Pointee: 1071 UnresolvedPointeeType main.deepMap3
+      Pointee: 1078 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 144
       Name: '*main.deepMap7'
@@ -6661,19 +8438,19 @@ Types:
       GoKind: 22
       Pointee: 145 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 356128
       GoKind: 22
-      Pointee: 1099 StructureType main.deepMap8
+      Pointee: 1106 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1107
+      ID: 1114
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 356064
       GoKind: 22
-      Pointee: 1108 StructureType main.deepMap9
+      Pointee: 1115 StructureType main.deepMap9
     - __kind: PointerType
       ID: 126
       Name: '*main.deepPtr2'
@@ -6682,12 +8459,12 @@ Types:
       GoKind: 22
       Pointee: 127 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 357024
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1043 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 128
       Name: '*main.deepPtr7'
@@ -6696,33 +8473,33 @@ Types:
       GoKind: 22
       Pointee: 129 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 356704
       GoKind: 22
-      Pointee: 1074 StructureType main.deepPtr8
+      Pointee: 1081 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 356640
       GoKind: 22
-      Pointee: 1076 StructureType main.deepPtr9
+      Pointee: 1083 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 357664
       GoKind: 22
-      Pointee: 315 StructureType main.deepSlice2
+      Pointee: 322 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 357600
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1068 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 134
       Name: '*main.deepSlice7'
@@ -6731,25 +8508,25 @@ Types:
       GoKind: 22
       Pointee: 135 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 357280
       GoKind: 22
-      Pointee: 1080 StructureType main.deepSlice8
+      Pointee: 1087 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1085
+      ID: 1092
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 357216
       GoKind: 22
-      Pointee: 1086 StructureType main.deepSlice9
+      Pointee: 1093 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 306
+      ID: 313
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 305 StructureType main.emptyStruct
+      Pointee: 312 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 154
       Name: '*main.esotericHeap'
@@ -6758,12 +8535,12 @@ Types:
       GoKind: 22
       Pointee: 155 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 824224
       GoKind: 22
-      Pointee: 1052 StructureType main.firstBehavior
+      Pointee: 1059 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 242
       Name: '*main.node'
@@ -6772,25 +8549,25 @@ Types:
       GoKind: 22
       Pointee: 241 StructureType main.node
     - __kind: PointerType
-      ID: 258
+      ID: 265
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 259 StructureType main.oneStringStruct
+      Pointee: 266 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1053
+      ID: 1060
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 824320
       GoKind: 22
-      Pointee: 1054 StructureType main.secondBehavior
+      Pointee: 1061 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 824416
       GoKind: 22
-      Pointee: 1041 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1048 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 146
       Name: '*main.stringType1'
@@ -6798,33 +8575,33 @@ Types:
       GoKind: 22
       Pointee: 147 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1037 GoStringDataType main.stringType1.str
+      Pointee: 1044 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType main.stringType2
+      Pointee: 1046 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 262
+      ID: 269
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 260 StructureType main.structWithCyclicSlices
+      Pointee: 267 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 338
+      ID: 345
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 356000
       GoKind: 22
       Pointee: 160 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 249
+      ID: 256
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 250 StructureType main.structWithNoStrings
+      Pointee: 257 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 239
       Name: '*main.structWithTwoValues'
@@ -6838,16 +8615,16 @@ Types:
       GoKind: 22
       Pointee: 244 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1057
+      ID: 1064
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1056 GoSliceDataType main.t.array
+      Pointee: 1063 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 257
+      ID: 264
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 256 StructureType main.threeStringStruct
+      Pointee: 263 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 187
       Name: '*map[string]int'
@@ -6855,554 +8632,554 @@ Types:
       GoKind: 22
       Pointee: 171 GoMapType map[string]int
     - __kind: PointerType
-      ID: 568
+      ID: 575
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 848704
       GoKind: 22
-      Pointee: 569 StructureType math/big.ErrNaN
+      Pointee: 576 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 843328
       GoKind: 22
-      Pointee: 858 StructureType mime/multipart.writerOnly·1
+      Pointee: 865 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.121568e+06
       GoKind: 22
-      Pointee: 771 UnresolvedPointeeType net.AddrError
+      Pointee: 778 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.240128e+06
       GoKind: 22
-      Pointee: 797 UnresolvedPointeeType net.DNSError
+      Pointee: 804 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 995
+      ID: 1002
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.08688e+06
       GoKind: 22
-      Pointee: 996 UnresolvedPointeeType net.IPConn
+      Pointee: 1003 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.239808e+06
       GoKind: 22
-      Pointee: 795 UnresolvedPointeeType net.OpError
+      Pointee: 802 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.121696e+06
       GoKind: 22
-      Pointee: 773 UnresolvedPointeeType net.ParseError
+      Pointee: 780 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1005
+      ID: 1012
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.116736e+06
       GoKind: 22
-      Pointee: 1006 UnresolvedPointeeType net.TCPConn
+      Pointee: 1013 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.161696e+06
       GoKind: 22
-      Pointee: 1016 UnresolvedPointeeType net.UDPConn
+      Pointee: 1023 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1003
+      ID: 1010
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.116224e+06
       GoKind: 22
-      Pointee: 1004 UnresolvedPointeeType net.UnixConn
+      Pointee: 1011 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.1208e+06
       GoKind: 22
-      Pointee: 732 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 739 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 733 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 740 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 996480
       GoKind: 22
-      Pointee: 701 StructureType net.canceledError
+      Pointee: 708 StructureType net.canceledError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 1.873728e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType net.conn
+      Pointee: 981 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.717952e+06
       GoKind: 22
-      Pointee: 839 StructureType net.dialResult·1
+      Pointee: 846 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.165952e+06
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType net.netFD
+      Pointee: 1025 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 503
+      ID: 510
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 835552
       GoKind: 22
-      Pointee: 504 UnresolvedPointeeType net.notFoundError
+      Pointee: 511 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 505
+      ID: 512
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 836224
       GoKind: 22
-      Pointee: 506 StructureType net.result·2
+      Pointee: 513 StructureType net.result·2
     - __kind: PointerType
-      ID: 999
+      ID: 1006
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.100768e+06
       GoKind: 22
-      Pointee: 1000 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1007 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.100288e+06
       GoKind: 22
-      Pointee: 998 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1005 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.122336e+06
       GoKind: 22
-      Pointee: 775 UnresolvedPointeeType net.temporaryError
+      Pointee: 782 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.240288e+06
       GoKind: 22
-      Pointee: 799 UnresolvedPointeeType net.timeoutError
+      Pointee: 806 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 992256
       GoKind: 22
-      Pointee: 691 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 698 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 831424
       GoKind: 22
-      Pointee: 852 StructureType net/http.bufioFlushWriter
+      Pointee: 859 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 832096
       GoKind: 22
-      Pointee: 401 BaseType net/http.http2ConnectionError
+      Pointee: 408 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 832192
       GoKind: 22
-      Pointee: 482 StructureType net/http.http2GoAwayError
+      Pointee: 489 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.235968e+06
       GoKind: 22
-      Pointee: 791 StructureType net/http.http2StreamError
+      Pointee: 798 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 832672
       GoKind: 22
-      Pointee: 486 StructureType net/http.http2connError
+      Pointee: 493 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.36688e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 921 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 484
+      ID: 491
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832576
       GoKind: 22
-      Pointee: 405 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 412 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 407
+      ID: 414
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 406 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 413 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 832864
       GoKind: 22
-      Pointee: 411 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 418 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 413
+      ID: 420
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 412 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 419 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 487
+      ID: 494
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 832768
       GoKind: 22
-      Pointee: 408 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 415 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 410
+      ID: 417
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 409 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 416 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.117344e+06
       GoKind: 22
-      Pointee: 766 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 773 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 992896
       GoKind: 22
-      Pointee: 697 StructureType net/http.http2noCachedConnError
+      Pointee: 704 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 964
+      ID: 971
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.817728e+06
       GoKind: 22
-      Pointee: 965 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 972 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 832480
       GoKind: 22
-      Pointee: 402 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 409 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 404
+      ID: 411
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 403 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 410 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 832960
       GoKind: 22
-      Pointee: 854 StructureType net/http.http2stickyErrWriter
+      Pointee: 861 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 992512
       GoKind: 22
-      Pointee: 693 StructureType net/http.nothingWrittenError
+      Pointee: 700 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.03168e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType net/http.persistConn
+      Pointee: 923 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 992384
       GoKind: 22
-      Pointee: 872 StructureType net/http.persistConnWriter
+      Pointee: 879 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.11632e+06
       GoKind: 22
-      Pointee: 898 StructureType net/http.readWriteCloserBody
+      Pointee: 905 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 489
+      ID: 496
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 833056
       GoKind: 22
-      Pointee: 490 StructureType net/http.requestBodyReadError
+      Pointee: 497 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 792
+      ID: 799
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.237088e+06
       GoKind: 22
-      Pointee: 793 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 800 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.117216e+06
       GoKind: 22
-      Pointee: 764 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 771 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 992640
       GoKind: 22
-      Pointee: 695 StructureType net/http.transportReadFromServerError
+      Pointee: 702 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 831328
       GoKind: 22
-      Pointee: 479 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 486 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.819264e+06
       GoKind: 22
-      Pointee: 967 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 974 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 881
+      ID: 888
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.005952e+06
       GoKind: 22
-      Pointee: 882 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 889 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 847648
       GoKind: 22
-      Pointee: 561 StructureType net/netip.parseAddrError
+      Pointee: 568 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 847552
       GoKind: 22
-      Pointee: 559 StructureType net/netip.parsePrefixError
+      Pointee: 566 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 1.981344e+06
       GoKind: 22
-      Pointee: 924 UnresolvedPointeeType net/smtp.Client
+      Pointee: 931 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 883
+      ID: 890
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.011072e+06
       GoKind: 22
-      Pointee: 884 StructureType net/smtp.dataCloser
+      Pointee: 891 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 544
+      ID: 551
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 843520
       GoKind: 22
-      Pointee: 545 UnresolvedPointeeType net/textproto.Error
+      Pointee: 552 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 843424
       GoKind: 22
-      Pointee: 436 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 443 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 438
+      ID: 445
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 437 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 444 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 879
+      ID: 886
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.005312e+06
       GoKind: 22
-      Pointee: 880 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 887 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.240608e+06
       GoKind: 22
-      Pointee: 801 UnresolvedPointeeType net/url.Error
+      Pointee: 808 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 836320
       GoKind: 22
-      Pointee: 414 GoStringHeaderType net/url.EscapeError
+      Pointee: 421 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 416
+      ID: 423
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 415 GoStringDataType net/url.EscapeError.str
+      Pointee: 422 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 508
+      ID: 515
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 836416
       GoKind: 22
-      Pointee: 417 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 424 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 419
+      ID: 426
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 418 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 425 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.2032e+06
       GoKind: 22
-      Pointee: 1024 UnresolvedPointeeType os.File
+      Pointee: 1031 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 671
+      ID: 678
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 983424
       GoKind: 22
-      Pointee: 672 UnresolvedPointeeType os.LinkError
+      Pointee: 679 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.105824e+06
       GoKind: 22
-      Pointee: 736 UnresolvedPointeeType os.SyscallError
+      Pointee: 743 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.200256e+06
       GoKind: 22
-      Pointee: 1022 StructureType os.fileWithoutReadFrom
+      Pointee: 1029 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.19952e+06
       GoKind: 22
-      Pointee: 1020 StructureType os.fileWithoutWriteTo
+      Pointee: 1027 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.001984e+06
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType os/exec.Error
+      Pointee: 710 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 1.953312e+06
       GoKind: 22
-      Pointee: 842 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 849 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.128352e+06
       GoKind: 22
-      Pointee: 902 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 909 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.002112e+06
       GoKind: 22
-      Pointee: 705 StructureType os/exec.wrappedError
+      Pointee: 712 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 638
+      ID: 645
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 864640
       GoKind: 22
-      Pointee: 449 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 456 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 451
+      ID: 458
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 450 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 457 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 864544
       GoKind: 22
-      Pointee: 448 BaseType os/user.UnknownUserIdError
+      Pointee: 455 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 829024
       GoKind: 22
-      Pointee: 474 UnresolvedPointeeType reflect.ValueError
+      Pointee: 481 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 566
+      ID: 573
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 848320
       GoKind: 22
-      Pointee: 567 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 574 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 984960
       GoKind: 22
-      Pointee: 675 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 682 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 986880
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 687 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7418,12 +9195,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 985088
       GoKind: 22
-      Pointee: 677 StructureType runtime.boundsError
+      Pointee: 684 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
@@ -7439,24 +9216,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.1112e+06
       GoKind: 22
-      Pointee: 738 StructureType runtime.errorAddressString
+      Pointee: 745 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 984704
       GoKind: 22
-      Pointee: 656 GoStringHeaderType runtime.errorString
+      Pointee: 663 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 657 GoStringDataType runtime.errorString.str
+      Pointee: 664 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
@@ -7479,17 +9256,17 @@ Types:
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 986624
       GoKind: 22
-      Pointee: 659 GoStringHeaderType runtime.plainError
+      Pointee: 666 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 661
+      ID: 668
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 660 GoStringDataType runtime.plainError.str
+      Pointee: 667 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7512,12 +9289,12 @@ Types:
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 987136
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType strconv.NumError
+      Pointee: 689 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 88
       Name: '*string'
@@ -7526,83 +9303,83 @@ Types:
       GoKind: 22
       Pointee: 11 GoStringHeaderType string
     - __kind: PointerType
-      ID: 308
+      ID: 315
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 307 GoStringDataType string.str
+      Pointee: 314 GoStringDataType string.str
     - __kind: PointerType
-      ID: 962
+      ID: 969
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.816448e+06
       GoKind: 22
-      Pointee: 963 UnresolvedPointeeType strings.Builder
+      Pointee: 970 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 869
+      ID: 876
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 987264
       GoKind: 22
-      Pointee: 870 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 877 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 866 StructureType struct { io.Writer }
+      Pointee: 873 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 255
+      ID: 262
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 118 StructureType struct {}
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.235328e+06
       GoKind: 22
-      Pointee: 788 BaseType syscall.Errno
+      Pointee: 795 BaseType syscall.Errno
     - __kind: PointerType
-      ID: 993
+      ID: 1000
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.019296e+06
       GoKind: 22
-      Pointee: 994 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1001 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.047808e+06
       GoKind: 22
-      Pointee: 731 StructureType text/template.ExecError
+      Pointee: 738 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 805
+      ID: 812
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.432e+06
       GoKind: 22
-      Pointee: 806 UnresolvedPointeeType time.Location
+      Pointee: 813 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 829888
       GoKind: 22
-      Pointee: 477 UnresolvedPointeeType time.ParseError
+      Pointee: 484 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 829792
       GoKind: 22
-      Pointee: 398 GoStringHeaderType time.fileSizeError
+      Pointee: 405 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 400
+      ID: 407
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 399 GoStringDataType time.fileSizeError.str
+      Pointee: 406 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 100
       Name: '*uint'
@@ -7646,59 +9423,59 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*vendor/golang.org/x/crypto/sha3.state'
       ByteSize: 8
       GoRuntimeType: 1.772704e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
+      Pointee: 964 UnresolvedPointeeType vendor/golang.org/x/crypto/sha3.state
     - __kind: PointerType
-      ID: 562
+      ID: 569
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 847744
       GoKind: 22
-      Pointee: 563 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 570 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 1.995872e+06
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 993 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 546
+      ID: 553
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 843904
       GoKind: 22
-      Pointee: 547 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 554 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 844000
       GoKind: 22
-      Pointee: 439 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 446 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.005696e+06
       GoKind: 22
-      Pointee: 710 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 717 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.005824e+06
       GoKind: 22
-      Pointee: 664 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 671 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1257
+      ID: 1312
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1258
+      ID: 1313
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7710,11 +9487,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1187
+      ID: 1194
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7730,7 +9507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1188
+      ID: 1195
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7746,7 +9523,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1184
+      ID: 1191
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7762,7 +9539,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1185
+      ID: 1192
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7778,7 +9555,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1135
+      ID: 1284
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1285
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1142
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7794,7 +9603,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1133
+      ID: 1140
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -7810,7 +9619,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1131
+      ID: 1138
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7826,7 +9635,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1196
+      ID: 1203
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7842,7 +9651,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1132
+      ID: 1139
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7858,7 +9667,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1134
+      ID: 1141
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7874,7 +9683,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1153
+      ID: 1160
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7890,10 +9699,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1154
+      ID: 1161
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1120
+      ID: 1127
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7909,7 +9718,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1117
+      ID: 1124
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -7925,7 +9734,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1216
+      ID: 1223
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7941,7 +9750,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1214
+      ID: 1221
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7977,7 +9786,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1224
+      ID: 1231
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7993,7 +9802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1159
+      ID: 1166
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8009,7 +9818,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1160
+      ID: 1167
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8025,7 +9834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1155
+      ID: 1162
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8041,7 +9850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1156
+      ID: 1163
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8057,7 +9866,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1157
+      ID: 1164
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8073,7 +9882,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1158
+      ID: 1165
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8089,7 +9898,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1249
+      ID: 1304
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8098,10 +9907,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8111,11 +9920,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1246
+      ID: 1301
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8124,14 +9933,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1268
+      ID: 1323
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8143,11 +9952,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1275
+      ID: 1330
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8156,14 +9965,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 306 PointerType *main.emptyStruct
+            Type: 313 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1274
+      ID: 1329
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8172,14 +9981,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 305 StructureType main.emptyStruct
+            Type: 312 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1186
+      ID: 1193
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8195,7 +10004,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1168
+      ID: 1175
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8211,10 +10020,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1169
+      ID: 1176
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1166
+      ID: 1173
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8230,10 +10039,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1167
+      ID: 1174
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1180
+      ID: 1187
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8249,7 +10058,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1182
+      ID: 1189
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8275,7 +10084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1181
+      ID: 1188
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8291,7 +10100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1178
+      ID: 1185
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8307,7 +10116,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1179
+      ID: 1186
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8323,7 +10132,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1170
+      ID: 1177
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8339,10 +10148,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1171
+      ID: 1178
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1174
+      ID: 1181
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8358,13 +10167,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1175
+      ID: 1182
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1279
+      ID: 1334
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1172
+      ID: 1179
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8390,28 +10199,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1173
+      ID: 1180
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1280
+      ID: 1335
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1281
+      ID: 1336
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1282
+      ID: 1337
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1283
+      ID: 1338
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1176
+      ID: 1183
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1177
+      ID: 1184
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1276
+      ID: 1331
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8423,11 +10232,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1278
+      ID: 1333
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8439,14 +10248,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1277
+      ID: 1332
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1284
+      ID: 1339
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8458,11 +10267,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1285
+      ID: 1340
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8474,11 +10283,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1286
+      ID: 1341
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8490,11 +10299,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1123
+      ID: 1130
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8510,7 +10319,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1124
+      ID: 1131
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8526,7 +10335,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1125
+      ID: 1132
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8542,7 +10351,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1122
+      ID: 1129
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8558,7 +10367,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1121
+      ID: 1128
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8574,7 +10383,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1183
+      ID: 1190
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8590,7 +10399,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1218
+      ID: 1282
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1225
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8606,36 +10447,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1163
+      ID: 1170
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1164
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1165
+      ID: 1171
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8661,7 +10476,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1194
+      ID: 1172
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1288
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1289
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1201
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8677,7 +10630,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1201
+      ID: 1208
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8693,7 +10646,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1213
+      ID: 1220
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8709,7 +10662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1211
+      ID: 1218
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8725,7 +10678,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1212
+      ID: 1219
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8741,7 +10694,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1198
+      ID: 1205
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8757,7 +10710,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1210
+      ID: 1217
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8773,7 +10726,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1209
+      ID: 1216
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8789,7 +10742,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1199
+      ID: 1206
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8805,7 +10758,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1200
+      ID: 1207
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8821,7 +10774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1208
+      ID: 1215
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8837,7 +10790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1207
+      ID: 1214
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8853,7 +10806,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1192
+      ID: 1199
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8869,7 +10822,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1193
+      ID: 1200
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8885,7 +10838,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1191
+      ID: 1198
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8901,7 +10854,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1202
+      ID: 1209
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8917,7 +10870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1206
+      ID: 1213
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8933,7 +10886,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1205
+      ID: 1212
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8949,7 +10902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1204
+      ID: 1211
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8965,7 +10918,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1203
+      ID: 1210
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8981,7 +10934,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1320
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8993,11 +10946,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1266
+      ID: 1321
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9009,11 +10962,217 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1241
+      ID: 1290
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1291
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1294
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1295
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1286
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1287
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1248
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9029,7 +11188,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1242
+      ID: 1249
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9055,7 +11214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1215
+      ID: 1222
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9111,7 +11270,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1239
+      ID: 1246
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9127,7 +11286,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1240
+      ID: 1247
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9143,7 +11302,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1223
+      ID: 1230
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9169,7 +11328,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1250
+      ID: 1305
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9178,10 +11337,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9191,11 +11350,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1307
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9207,17 +11366,17 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 252 GoSliceHeaderType []bool
+            Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9227,11 +11386,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1253
+      ID: 1308
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9240,14 +11399,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []uint16
+            Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1264
+      ID: 1319
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9256,14 +11415,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 258 PointerType *main.oneStringStruct
+            Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1219
+      ID: 1226
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9279,7 +11438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1197
+      ID: 1204
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9295,7 +11454,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1217
+      ID: 1224
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9311,7 +11470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1240
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9337,7 +11496,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1234
+      ID: 1241
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9363,7 +11522,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1242
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9379,7 +11538,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1236
+      ID: 1243
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9395,7 +11554,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1231
+      ID: 1262
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1263
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1264
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1265
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1260
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1261
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1268
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1269
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1257
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 91 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1238
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9411,7 +11784,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1232
+      ID: 1239
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9427,7 +11800,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1229
+      ID: 1236
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9443,7 +11816,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1230
+      ID: 1237
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9469,7 +11842,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1227
+      ID: 1234
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9485,7 +11858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1228
+      ID: 1235
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9501,7 +11874,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1225
+      ID: 1232
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9517,7 +11890,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1226
+      ID: 1233
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9533,7 +11906,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1237
+      ID: 1244
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9549,7 +11922,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1238
+      ID: 1245
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9565,7 +11938,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1118
+      ID: 1258
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1259
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1254
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1255
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1266
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1267
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1272
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1273
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1278
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 16 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1276
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1277
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1252
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 89 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 14 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1274
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1275
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1270
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1271
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1125
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9581,7 +12405,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1139
+      ID: 1146
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9597,7 +12421,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1137
+      ID: 1144
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9613,7 +12437,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1150
+      ID: 1157
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9629,7 +12453,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1151
+      ID: 1158
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9645,7 +12469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1142
+      ID: 1149
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9661,7 +12485,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1143
+      ID: 1150
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9677,7 +12501,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1144
+      ID: 1151
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9693,7 +12517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1141
+      ID: 1148
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9709,7 +12533,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1140
+      ID: 1147
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9725,7 +12549,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1138
+      ID: 1145
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9741,7 +12565,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1259
+      ID: 1314
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9753,11 +12577,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1147
+      ID: 1154
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9773,7 +12597,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1148
+      ID: 1155
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9789,7 +12613,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1149
+      ID: 1156
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9805,7 +12629,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1146
+      ID: 1153
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9821,7 +12645,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1145
+      ID: 1152
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9837,7 +12661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1311
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9846,14 +12670,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 254 GoSliceHeaderType []struct {}
+            Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1247
+      ID: 1302
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9862,14 +12686,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 246 GoSliceHeaderType [][]uint
+            Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1195
+      ID: 1202
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9885,7 +12709,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1243
+      ID: 1250
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9901,7 +12725,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1244
+      ID: 1251
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9937,7 +12761,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1119
+      ID: 1292
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 156 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1293
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1126
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9953,7 +12829,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1222
+      ID: 1229
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9969,7 +12845,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1251
+      ID: 1306
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9978,14 +12854,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []string
+            Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1161
+      ID: 1168
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10001,7 +12877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1162
+      ID: 1169
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10017,7 +12893,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1248
+      ID: 1303
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10026,10 +12902,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []main.structWithNoStrings
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10039,11 +12915,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1189
+      ID: 1196
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10059,7 +12935,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1270
+      ID: 1296
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1297
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 251 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1325
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10068,17 +12986,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 273 StructureType main.structWithCyclicMaps
+            Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1271
+      ID: 1326
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1269
+      ID: 1324
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10087,14 +13005,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 260 StructureType main.structWithCyclicSlices
+            Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1190
+      ID: 1197
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10110,7 +13028,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1272
+      ID: 1327
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10119,17 +13037,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 304 StructureType main.aStruct
+            Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1273
+      ID: 1328
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1263
+      ID: 1318
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10138,14 +13056,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 257 PointerType *main.threeStringStruct
+            Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1261
+      ID: 1316
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10154,17 +13072,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 StructureType main.threeStringStruct
+            Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1262
+      ID: 1317
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1260
+      ID: 1315
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10176,7 +13094,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10186,7 +13104,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10196,11 +13114,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1152
+      ID: 1159
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10216,7 +13134,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1128
+      ID: 1135
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10232,7 +13150,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1129
+      ID: 1136
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10248,7 +13166,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1130
+      ID: 1137
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10264,7 +13182,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1127
+      ID: 1134
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10280,7 +13198,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1126
+      ID: 1133
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10296,7 +13214,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1221
+      ID: 1228
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10312,7 +13230,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1245
+      ID: 1300
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10321,14 +13239,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1267
+      ID: 1322
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10340,11 +13258,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1220
+      ID: 1227
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10360,7 +13278,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1136
+      ID: 1143
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10376,7 +13294,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1254
+      ID: 1309
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10385,14 +13303,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1255
+      ID: 1310
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10401,12 +13319,70 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 245 GoSliceHeaderType []uint
+            Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1298
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 248
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 9 BaseType int
     - __kind: ArrayType
       ID: 119
       Name: '[100]uint'
@@ -10419,16 +13395,25 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 639200
+      GoRuntimeType: 639296
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 247
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 625984
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 638912
+      GoRuntimeType: 639008
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10453,7 +13438,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 639104
+      GoRuntimeType: 639200
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10595,22 +13580,31 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 638720
+      GoRuntimeType: 638816
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 246
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 624832
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 9 BaseType int
+    - __kind: ArrayType
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 638432
+      GoRuntimeType: 638528
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 348
+      ID: 355
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 622912
@@ -10619,7 +13613,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 333
+      ID: 340
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 623200
@@ -10631,7 +13625,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 630496
+      GoRuntimeType: 630592
       GoKind: 17
       Count: 4
       HasCount: true
@@ -10645,7 +13639,7 @@ Types:
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 833
+      ID: 840
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 624352
@@ -10657,7 +13651,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 635936
+      GoRuntimeType: 636032
       GoKind: 17
       Count: 6
       HasCount: true
@@ -10666,13 +13660,13 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 639008
+      GoRuntimeType: 639104
       GoKind: 17
       Count: 8
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 318
+      ID: 325
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 620320
@@ -10696,15 +13690,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 316 GoSliceDataType []*main.deepSlice2.array
+      Data: 323 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 133 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1058
+      ID: 1065
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 447136
@@ -10712,22 +13706,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1059 PointerType **main.deepSlice3
+          Type: 1066 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1062 GoSliceDataType []*main.deepSlice3.array
+      Data: 1069 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1062
+      ID: 1069
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1060 PointerType *main.deepSlice3
+      Element: 1067 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1077
+      ID: 1084
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 446816
@@ -10735,22 +13729,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1078 PointerType **main.deepSlice8
+          Type: 1085 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1081 GoSliceDataType []*main.deepSlice8.array
+      Data: 1088 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1081
+      ID: 1088
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1079 PointerType *main.deepSlice8
+      Element: 1086 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1083
+      ID: 1090
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 446752
@@ -10758,20 +13752,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1084 PointerType **main.deepSlice9
+          Type: 1091 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1087 GoSliceDataType []*main.deepSlice9.array
+      Data: 1094 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1087
+      ID: 1094
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1085 PointerType *main.deepSlice9
+      Element: 1092 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 122
       Name: '[]*string'
@@ -10788,147 +13782,147 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 313 GoSliceDataType []*string.array
+      Data: 320 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 313
+      ID: 320
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 88 PointerType *string
     - __kind: GoSliceHeaderType
-      ID: 271
+      ID: 278
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 272 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 279 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 382 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 389 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 382
+      ID: 389
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 269
+      ID: 276
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 270 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 277 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 380 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 387 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 387
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 267
+      ID: 274
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 268 PointerType *[][][]main.structWithCyclicSlices
+          Type: 275 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 378 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 385 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 378
+      ID: 385
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 265
+      ID: 272
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 266 PointerType *[][]main.structWithCyclicSlices
+          Type: 273 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 376 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 383 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 383
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 263
+      ID: 270
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 264 PointerType *[]main.structWithCyclicSlices
+          Type: 271 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 374 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 381 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 374
+      ID: 381
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 261 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 268 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 246
+      ID: 253
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 247 PointerType *[]uint
+          Type: 254 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 360 GoSliceDataType [][]uint.array
+      Data: 367 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 360
+      ID: 367
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 245 GoSliceHeaderType []uint
+      Element: 252 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 252
+      ID: 259
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 454496
@@ -10943,177 +13937,177 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 366 GoSliceDataType []bool.array
+      Data: 373 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 373
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceDataType
-      ID: 352
+      ID: 359
       Name: '[]bucket<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 528
       Element: 222 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 358
       Name: '[]bucket<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 217 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 342
       Name: '[]bucket<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 656
       Element: 185 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 349
       Name: '[]bucket<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 152
       Element: 197 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 323
+      ID: 330
       Name: '[]bucket<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 141 GoHMapBucketType bucket<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1072
+      ID: 1079
       Name: '[]bucket<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
+      Element: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1100
+      ID: 1107
       Name: '[]bucket<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
+      Element: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1109
+      ID: 1116
       Name: '[]bucket<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
+      Element: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 325
+      ID: 332
       Name: '[]bucket<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
       Element: 165 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 1116
+      ID: 1123
       Name: '[]bucket<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 1114 GoHMapBucketType bucket<int,interface {}>
+      Element: 1121 GoHMapBucketType bucket<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 356
+      ID: 363
       Name: '[]bucket<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 232 GoHMapBucketType bucket<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 344
+      ID: 351
       Name: '[]bucket<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
       Element: 202 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 339
+      ID: 346
       Name: '[]bucket<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 331
+      ID: 338
       Name: '[]bucket<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 180 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 844
+      ID: 851
       Name: '[]bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
-      Element: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 336
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 175 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 328
+      ID: 335
       Name: '[]bucket<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 336
       Element: 170 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 361
       Name: '[]bucket<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
       Element: 227 GoHMapBucketType bucket<struct {},int>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 392
       Name: '[]bucket<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 400
-      Element: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      Element: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 387
+      ID: 394
       Name: '[]bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 389
+      ID: 396
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 391
+      ID: 398
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 400
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 395
+      ID: 402
       Name: '[]bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 80
-      Element: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 357
+      ID: 364
       Name: '[]bucket<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
       Element: 237 GoHMapBucketType bucket<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 349
+      ID: 356
       Name: '[]bucket<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 280
       Element: 212 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 346
+      ID: 353
       Name: '[]bucket<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 32
       Element: 207 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 828
+      ID: 835
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 454368
@@ -11128,15 +14122,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 845 GoSliceDataType []float64.array
+      Data: 852 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 845
+      ID: 852
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 17 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1089
+      ID: 1096
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -11151,85 +14145,85 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1090 GoSliceDataType []interface {}.array
+      Data: 1097 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1090
+      ID: 1097
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 350
+      ID: 357
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 348 ArrayType [4]int
+      Element: 355 ArrayType [4]int
     - __kind: ArrayType
-      ID: 332
+      ID: 339
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 333 ArrayType [4]string
+      Element: 340 ArrayType [4]string
     - __kind: ArrayType
-      ID: 340
+      ID: 347
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType bool
     - __kind: ArrayType
-      ID: 319
+      ID: 326
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 326
+      ID: 333
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 11 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 353
+      ID: 360
       Name: '[]key<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 345
+      ID: 352
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceHeaderType
-      ID: 261
+      ID: 268
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 262 PointerType *main.structWithCyclicSlices
+          Type: 269 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 372 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 379 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 372
+      ID: 379
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 260 StructureType main.structWithCyclicSlices
+      Element: 267 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 337
+      ID: 344
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 447456
@@ -11237,48 +14231,48 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 338 PointerType *main.structWithMap
+          Type: 345 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 396 GoSliceDataType []main.structWithMap.array
+      Data: 403 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 403
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 160 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 255
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 249 PointerType *main.structWithNoStrings
+          Type: 256 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 362 GoSliceDataType []main.structWithNoStrings.array
+      Data: 369 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 369
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 250 StructureType main.structWithNoStrings
+      Element: 257 StructureType main.structWithNoStrings
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 454624
@@ -11293,15 +14287,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 364 GoSliceDataType []string.array
+      Data: 371 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 364
+      ID: 371
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 254
+      ID: 261
       Name: '[]struct {}'
       ByteSize: 24
       GoRuntimeType: 447776
@@ -11309,21 +14303,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 255 PointerType *struct {}
+          Type: 262 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 370 GoSliceDataType []struct {}.array
+      Data: 377 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 377
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 118 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 245
+      ID: 252
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 454112
@@ -11338,15 +14332,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 358 GoSliceDataType []uint.array
+      Data: 365 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 365
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 12 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 253
+      ID: 260
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 453472
@@ -11361,9 +14355,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 368 GoSliceDataType []uint16.array
+      Data: 375 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 368
+      ID: 375
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11384,9 +14378,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 309 GoSliceDataType []uint8.array
+      Data: 316 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 309
+      ID: 316
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11407,165 +14401,165 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 311 GoSliceDataType []uintptr.array
+      Data: 318 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 311
+      ID: 318
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 320
+      ID: 327
       Name: '[]val<*main.deepMap2>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 321 PointerType *main.deepMap2
+      Element: 328 PointerType *main.deepMap2
     - __kind: ArrayType
-      ID: 1069
+      ID: 1076
       Name: '[]val<*main.deepMap3>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1070 PointerType *main.deepMap3
+      Element: 1077 PointerType *main.deepMap3
     - __kind: ArrayType
-      ID: 1097
+      ID: 1104
       Name: '[]val<*main.deepMap8>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1098 PointerType *main.deepMap8
+      Element: 1105 PointerType *main.deepMap8
     - __kind: ArrayType
-      ID: 1106
+      ID: 1113
       Name: '[]val<*main.deepMap9>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 1107 PointerType *main.deepMap9
+      Element: 1114 PointerType *main.deepMap9
     - __kind: ArrayType
-      ID: 334
+      ID: 341
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 106 ArrayType [2]int
     - __kind: ArrayType
-      ID: 347
+      ID: 354
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 348 ArrayType [4]int
+      Element: 355 ArrayType [4]int
     - __kind: ArrayType
-      ID: 336
+      ID: 343
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 337 GoSliceHeaderType []main.structWithMap
+      Element: 344 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 330
+      ID: 337
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 251 GoSliceHeaderType []string
+      Element: 258 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 843
+      ID: 850
       Name: '[]val<github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      Element: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: ArrayType
-      ID: 324
+      ID: 331
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 1115
+      ID: 1122
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 152 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 327
+      ID: 334
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
       Element: 116 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 341
+      ID: 348
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 241 StructureType main.node
     - __kind: ArrayType
-      ID: 384
+      ID: 391
       Name: '[]val<main.structWithCyclicMaps>'
       ByteSize: 384
       Count: 8
       HasCount: true
-      Element: 273 StructureType main.structWithCyclicMaps
+      Element: 280 StructureType main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 386
+      ID: 393
       Name: '[]val<map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+      Element: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 388
+      ID: 395
       Name: '[]val<map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 390
+      ID: 397
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 392
+      ID: 399
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 394
+      ID: 401
       Name: '[]val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: ArrayType
-      ID: 355
+      ID: 362
       Name: '[]val<struct {}>'
       Count: 8
       HasCount: true
       Element: 118 StructureType struct {}
     - __kind: ArrayType
-      ID: 343
+      ID: 350
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 972
+      ID: 979
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 624
+      ID: 631
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 858688
@@ -11580,33 +14574,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 625 GoSliceDataType archive/tar.headerError.array
+      Data: 632 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 625
+      ID: 632
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.078912e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 959
+      ID: 966
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 888
+      ID: 895
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.37696e+06
@@ -11616,7 +14610,7 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11632,18 +14626,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<[4]int>
+          Type: 357 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 347 ArrayType []val<[4]int>
+          Type: 354 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
           Type: 221 PointerType *bucket<[4]int,[4]int>
-      KeyType: 348 ArrayType [4]int
-      ValueType: 348 ArrayType [4]int
+      KeyType: 355 ArrayType [4]int
+      ValueType: 355 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 217
       Name: bucket<[4]int,uint8>
@@ -11651,17 +14645,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 350 ArrayType []key<[4]int>
+          Type: 357 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
           Type: 216 PointerType *bucket<[4]int,uint8>
-      KeyType: 348 ArrayType [4]int
+      KeyType: 355 ArrayType [4]int
       ValueType: 3 BaseType uint8
     - __kind: GoHMapBucketType
       ID: 185
@@ -11670,17 +14664,17 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 332 ArrayType []key<[4]string>
+          Type: 339 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 334 ArrayType []val<[2]int>
+          Type: 341 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
           Type: 184 PointerType *bucket<[4]string,[2]int>
-      KeyType: 333 ArrayType [4]string
+      KeyType: 340 ArrayType [4]string
       ValueType: 106 ArrayType [2]int
     - __kind: GoHMapBucketType
       ID: 197
@@ -11689,13 +14683,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 340 ArrayType []key<bool>
+          Type: 347 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 341 ArrayType []val<main.node>
+          Type: 348 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
           Type: 196 PointerType *bucket<bool,main.node>
@@ -11708,75 +14702,75 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 320 ArrayType []val<*main.deepMap2>
+          Type: 327 ArrayType []val<*main.deepMap2>
         - Name: overflow
           Offset: 136
           Type: 140 PointerType *bucket<int,*main.deepMap2>
       KeyType: 9 BaseType int
-      ValueType: 321 PointerType *main.deepMap2
+      ValueType: 328 PointerType *main.deepMap2
     - __kind: GoHMapBucketType
-      ID: 1068
+      ID: 1075
       Name: bucket<int,*main.deepMap3>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1069 ArrayType []val<*main.deepMap3>
+          Type: 1076 ArrayType []val<*main.deepMap3>
         - Name: overflow
           Offset: 136
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
       KeyType: 9 BaseType int
-      ValueType: 1070 PointerType *main.deepMap3
+      ValueType: 1077 PointerType *main.deepMap3
     - __kind: GoHMapBucketType
-      ID: 1096
+      ID: 1103
       Name: bucket<int,*main.deepMap8>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1097 ArrayType []val<*main.deepMap8>
+          Type: 1104 ArrayType []val<*main.deepMap8>
         - Name: overflow
           Offset: 136
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
       KeyType: 9 BaseType int
-      ValueType: 1098 PointerType *main.deepMap8
+      ValueType: 1105 PointerType *main.deepMap8
     - __kind: GoHMapBucketType
-      ID: 1105
+      ID: 1112
       Name: bucket<int,*main.deepMap9>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1106 ArrayType []val<*main.deepMap9>
+          Type: 1113 ArrayType []val<*main.deepMap9>
         - Name: overflow
           Offset: 136
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
       KeyType: 9 BaseType int
-      ValueType: 1107 PointerType *main.deepMap9
+      ValueType: 1114 PointerType *main.deepMap9
     - __kind: GoHMapBucketType
       ID: 165
       Name: bucket<int,int>
@@ -11784,35 +14778,35 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 136
           Type: 164 PointerType *bucket<int,int>
       KeyType: 9 BaseType int
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 1114
+      ID: 1121
       Name: bucket<int,interface {}>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 1115 ArrayType []val<interface {}>
+          Type: 1122 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 200
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
       KeyType: 9 BaseType int
       ValueType: 152 GoEmptyInterfaceType interface {}
     - __kind: GoHMapBucketType
@@ -11822,13 +14816,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 355 ArrayType []val<struct {}>
+          Type: 362 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 72
           Type: 231 PointerType *bucket<int,struct {}>
@@ -11841,13 +14835,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 319 ArrayType []key<int>
+          Type: 326 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
           Type: 201 PointerType *bucket<int,uint8>
@@ -11860,18 +14854,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 336 ArrayType []val<[]main.structWithMap>
+          Type: 343 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
           Type: 191 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 337 GoSliceHeaderType []main.structWithMap
+      ValueType: 344 GoSliceHeaderType []main.structWithMap
     - __kind: GoHMapBucketType
       ID: 180
       Name: bucket<string,[]string>
@@ -11879,37 +14873,37 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 330 ArrayType []val<[]string>
+          Type: 337 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
           Type: 179 PointerType *bucket<string,[]string>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 251 GoSliceHeaderType []string
+      ValueType: 258 GoSliceHeaderType []string
     - __kind: GoHMapBucketType
-      ID: 816
+      ID: 823
       Name: bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 843 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 850 ArrayType []val<github.com/DataDog/go-tuf/data.HexBytes>
         - Name: overflow
           Offset: 328
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
       KeyType: 11 GoStringHeaderType string
-      ValueType: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+      ValueType: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoHMapBucketType
       ID: 175
       Name: bucket<string,int>
@@ -11917,13 +14911,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 174 PointerType *bucket<string,int>
@@ -11936,13 +14930,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 326 ArrayType []key<string>
+          Type: 333 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 327 ArrayType []val<main.nestedStruct>
+          Type: 334 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
           Type: 169 PointerType *bucket<string,main.nestedStruct>
@@ -11955,132 +14949,132 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 324 ArrayType []val<int>
+          Type: 331 ArrayType []val<int>
         - Name: overflow
           Offset: 72
           Type: 226 PointerType *bucket<struct {},int>
       KeyType: 118 StructureType struct {}
       ValueType: 9 BaseType int
     - __kind: GoHMapBucketType
-      ID: 278
+      ID: 285
       Name: bucket<struct {},main.structWithCyclicMaps>
       ByteSize: 400
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 384 ArrayType []val<main.structWithCyclicMaps>
+          Type: 391 ArrayType []val<main.structWithCyclicMaps>
         - Name: overflow
           Offset: 392
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 273 StructureType main.structWithCyclicMaps
+      ValueType: 280 StructureType main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 283
+      ID: 290
       Name: bucket<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 386 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
+          Type: 393 ArrayType []val<map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+      ValueType: 281 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 288
+      ID: 295
       Name: bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 388 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 395 ArrayType []val<map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 293
+      ID: 300
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 390 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 397 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 298
+      ID: 305
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 392 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 399 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
-      ID: 303
+      ID: 310
       Name: bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 80
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 394 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 401 ArrayType []val<map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: overflow
           Offset: 72
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       KeyType: 118 StructureType struct {}
-      ValueType: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      ValueType: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoHMapBucketType
       ID: 237
       Name: bucket<struct {},struct {}>
@@ -12088,13 +15082,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 353 ArrayType []key<struct {}>
+          Type: 360 ArrayType []key<struct {}>
         - Name: values
           Offset: 8
-          Type: 355 ArrayType []val<struct {}>
+          Type: 362 ArrayType []val<struct {}>
         - Name: overflow
           Offset: 8
           Type: 236 PointerType *bucket<struct {},struct {}>
@@ -12107,18 +15101,18 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 345 ArrayType []key<uint8>
+          Type: 352 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 347 ArrayType []val<[4]int>
+          Type: 354 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
           Type: 211 PointerType *bucket<uint8,[4]int>
       KeyType: 3 BaseType uint8
-      ValueType: 348 ArrayType [4]int
+      ValueType: 355 ArrayType [4]int
     - __kind: GoHMapBucketType
       ID: 207
       Name: bucket<uint8,uint8>
@@ -12126,28 +15120,28 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 318 ArrayType [8]uint8
+          Type: 325 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 345 ArrayType []key<uint8>
+          Type: 352 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 343 ArrayType []val<uint8>
+          Type: 350 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
           Type: 206 PointerType *bucket<uint8,uint8>
       KeyType: 3 BaseType uint8
       ValueType: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 961
+      ID: 968
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1008
+      ID: 1015
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -12173,13 +15167,13 @@ Types:
       GoRuntimeType: 532416
       GoKind: 15
     - __kind: BaseType
-      ID: 431
+      ID: 438
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764800
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 432
+      ID: 439
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 764896
@@ -12187,92 +15181,92 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 434 PointerType *compress/flate.InternalError.str
+          Type: 441 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 433 GoStringDataType compress/flate.InternalError.str
+      Data: 440 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 433
+      ID: 440
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 768
+      ID: 775
       Name: context.deadlineExceededError
       GoRuntimeType: 1.296736e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 445
+      ID: 452
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767392
       GoKind: 2
     - __kind: BaseType
-      ID: 446
+      ID: 453
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767488
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: crypto/hmac.hmac
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 447
+      ID: 454
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 767584
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: crypto/sha256.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: crypto/sha512.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 435
+      ID: 442
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 765376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 708
+      ID: 715
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1034
+      ID: 1041
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 541
+      ID: 548
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 539
+      ID: 546
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.606048e+06
@@ -12283,34 +15277,34 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 833 ArrayType [5]uint8
+          Type: 840 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 663
+      ID: 670
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 951936
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 613
+      ID: 620
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.60912e+06
@@ -12318,21 +15312,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 836 BaseType crypto/x509.InvalidReason
+          Type: 843 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 607
+      ID: 614
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.076224e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 609
+      ID: 616
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.409312e+06
@@ -12340,24 +15334,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 444
+      ID: 451
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 767008
       GoKind: 2
     - __kind: BaseType
-      ID: 836
+      ID: 843
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 537920
       GoKind: 2
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.37328e+06
@@ -12367,13 +15361,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 615
+      ID: 622
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.07648e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 611
+      ID: 618
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.608928e+06
@@ -12381,15 +15375,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 18 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 817 PointerType *crypto/x509.Certificate
+          Type: 824 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 628
+      ID: 635
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.254208e+06
@@ -12399,7 +15393,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 632
+      ID: 639
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.254368e+06
@@ -12409,55 +15403,55 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 637
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 429
+      ID: 436
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 764416
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 878
+      ID: 885
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 430
+      ID: 437
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 764608
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 500
+      ID: 507
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 492
+      ID: 499
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 498
+      ID: 505
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 496
+      ID: 503
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 494
+      ID: 501
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1014
+      ID: 1021
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.238848e+06
@@ -12467,19 +15461,19 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 886
+      ID: 893
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 601
+      ID: 608
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 599
+      ID: 606
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 441
+      ID: 448
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 766912
@@ -12487,22 +15481,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 443 PointerType *encoding/xml.UnmarshalError.str
+          Type: 450 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 442 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 449 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 442
+      ID: 449
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 611
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 992
+      ID: 999
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12519,11 +15513,11 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 470
+      ID: 477
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 666
+      ID: 673
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12539,15 +15533,15 @@ Types:
       GoRuntimeType: 532608
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1002
+      ID: 1009
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 668
+      ID: 675
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 670
+      ID: 677
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12563,11 +15557,11 @@ Types:
       GoRuntimeType: 778144
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 530
+      ID: 537
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 511
+      ID: 518
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.60432e+06
@@ -12575,7 +15569,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 826 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 833 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 9 BaseType int
@@ -12583,25 +15577,25 @@ Types:
           Offset: 200
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 513
+      ID: 520
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 517
+      ID: 524
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.07264e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 423
+      ID: 430
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 763840
@@ -12609,18 +15603,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 425 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 432 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 424 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 431 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 424
+      ID: 431
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.075136e+06
@@ -12628,13 +15622,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 827 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 834 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 11 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 11 GoStringHeaderType string
@@ -12643,7 +15637,7 @@ Types:
           Type: 17 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 828 GoSliceHeaderType []float64
+          Type: 835 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 14 BaseType int64
@@ -12652,13 +15646,13 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 829 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 836 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 831 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 838 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 251 GoSliceHeaderType []string
+          Type: 258 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 11 GoStringHeaderType string
@@ -12669,13 +15663,13 @@ Types:
           Offset: 184
           Type: 14 BaseType int64
     - __kind: BaseType
-      ID: 827
+      ID: 834
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 534464
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 420
+      ID: 427
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 763744
@@ -12683,18 +15677,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 422 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 429 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 421 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 428 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 421
+      ID: 428
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 426
+      ID: 433
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 763936
@@ -12702,60 +15696,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 428 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 435 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 427 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 434 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 427
+      ID: 434
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 980
+      ID: 987
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 622
+      ID: 629
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 777
+      ID: 784
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1010
+      ID: 1017
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 550
+      ID: 557
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 557
+      ID: 564
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.075456e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 440
+      ID: 447
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 766048
       GoKind: 2
     - __kind: StructureType
-      ID: 555
+      ID: 562
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.075328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 553
+      ID: 560
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.407392e+06
@@ -12768,7 +15762,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 573
+      ID: 580
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.408192e+06
@@ -12781,7 +15775,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 577
+      ID: 584
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.608352e+06
@@ -12797,7 +15791,7 @@ Types:
           Offset: 24
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 575
+      ID: 582
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.248608e+06
@@ -12807,7 +15801,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 571
+      ID: 578
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.248288e+06
@@ -12817,14 +15811,14 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 812
+      ID: 819
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.135776e+06
       GoKind: 21
-      HeaderType: 814 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 821 GoHMapHeaderType hash<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 835
+      ID: 842
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.009408e+06
@@ -12839,15 +15833,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 847 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 854 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 847
+      ID: 854
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 585
+      ID: 592
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.408512e+06
@@ -12855,12 +15849,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 812 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 819 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 812 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 819 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 579
+      ID: 586
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.248768e+06
@@ -12870,7 +15864,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 583
+      ID: 590
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.608544e+06
@@ -12881,12 +15875,12 @@ Types:
           Type: 11 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 835 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 842 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 581
+      ID: 588
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.408352e+06
@@ -12899,7 +15893,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 587
+      ID: 594
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.248928e+06
@@ -12907,9 +15901,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 804 StructureType time.Time
+          Type: 811 StructureType time.Time
     - __kind: StructureType
-      ID: 593
+      ID: 600
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.408832e+06
@@ -12922,7 +15916,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 595
+      ID: 602
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.249248e+06
@@ -12932,7 +15926,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 591
+      ID: 598
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.408672e+06
@@ -12945,7 +15939,7 @@ Types:
           Offset: 8
           Type: 9 BaseType int
     - __kind: StructureType
-      ID: 589
+      ID: 596
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.249088e+06
@@ -12955,7 +15949,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 597
+      ID: 604
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.408992e+06
@@ -12968,7 +15962,7 @@ Types:
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 519
+      ID: 526
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.241088e+06
@@ -12978,11 +15972,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.241248e+06
@@ -12990,21 +15984,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 918
+      ID: 925
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 874
+      ID: 881
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 525
+      ID: 532
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.241568e+06
@@ -13012,13 +16006,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 970
+      ID: 977
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 981
+      ID: 988
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 1.969408e+06
@@ -13026,12 +16020,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 969 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 976 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 14 BaseType int64
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 1.9928e+06
@@ -13039,7 +16033,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 969 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 976 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 11 GoStringHeaderType string
@@ -13047,11 +16041,11 @@ Types:
           Offset: 24
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 876
+      ID: 883
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 523
+      ID: 530
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.241408e+06
@@ -13059,9 +16053,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 527
+      ID: 534
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.241728e+06
@@ -13069,64 +16063,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 519 StructureType github.com/cihub/seelog.baseError
+          Type: 526 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 976
+      ID: 983
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 978
+      ID: 985
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 808
+      ID: 815
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 721
+      ID: 728
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 719
+      ID: 726
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 723
+      ID: 730
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 725
+      ID: 732
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 936
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 715
+      ID: 722
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 533
+      ID: 540
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.242688e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 9 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1033
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 779
+      ID: 786
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 752
+      ID: 759
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.713024e+06
@@ -13142,11 +16136,11 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 746
+      ID: 753
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 685
+      ID: 692
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.510048e+06
@@ -13159,7 +16153,7 @@ Types:
           Offset: 1
           Type: 15 BaseType int8
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.713472e+06
@@ -13175,13 +16169,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 662
+      ID: 669
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 949344
       GoKind: 8
     - __kind: StructureType
-      ID: 750
+      ID: 757
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.7128e+06
@@ -13197,13 +16191,13 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 762016
       GoKind: 8
     - __kind: StructureType
-      ID: 748
+      ID: 755
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.712576e+06
@@ -13211,15 +16205,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 837 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 844 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 837 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 844 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.631168e+06
@@ -13232,7 +16226,7 @@ Types:
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 754
+      ID: 761
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.713248e+06
@@ -13248,11 +16242,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1037
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.43296e+06
@@ -13262,19 +16256,19 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 689
+      ID: 696
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.195616e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 687
+      ID: 694
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.195488e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.63136e+06
@@ -13287,7 +16281,7 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 452
+      ID: 459
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 769408
@@ -13295,22 +16289,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 454 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 461 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 453 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 460 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 453
+      ID: 460
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 821
+      ID: 828
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.266048e+06
@@ -13320,7 +16314,7 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.486912e+06
@@ -13328,13 +16322,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 930 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 937 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 990
+      ID: 997
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 930
+      ID: 937
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.086336e+06
@@ -13347,7 +16341,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.38176e+06
@@ -13357,19 +16351,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 455
+      ID: 462
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 769984
       GoKind: 10
     - __kind: BaseType
-      ID: 819
+      ID: 826
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 962592
       GoKind: 10
     - __kind: StructureType
-      ID: 787
+      ID: 794
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.751552e+06
@@ -13380,12 +16374,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 819 BaseType golang.org/x/net/http2.ErrCode
+          Type: 826 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 648
+      ID: 655
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.416192e+06
@@ -13393,12 +16387,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 819 BaseType golang.org/x/net/http2.ErrCode
+          Type: 826 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 459
+      ID: 466
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770176
@@ -13406,18 +16400,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 461 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 468 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 460 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 467 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 460
+      ID: 467
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 465
+      ID: 472
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 770368
@@ -13425,18 +16419,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 467 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 474 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 466 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 473 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 466
+      ID: 473
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 462
+      ID: 469
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 770272
@@ -13444,18 +16438,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 464 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 471 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 463 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 470 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 463
+      ID: 470
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 456
+      ID: 463
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 770080
@@ -13463,22 +16457,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 458 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 465 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 457 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 464 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 457
+      ID: 464
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 995
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 652
+      ID: 659
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.266688e+06
@@ -13488,13 +16482,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 468
+      ID: 475
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 770464
       GoKind: 2
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.261728e+06
@@ -13504,11 +16498,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 785
+      ID: 792
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 810
+      ID: 817
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.777312e+06
@@ -13524,7 +16518,7 @@ Types:
           Offset: 24
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 642
+      ID: 649
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.415712e+06
@@ -13537,7 +16531,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 953
+      ID: 960
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.830784e+06
@@ -13545,16 +16539,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 968 GoInterfaceType io.Reader
+          Type: 975 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 904
+      ID: 911
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.37936e+06
@@ -13564,29 +16558,29 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 864
+      ID: 871
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 620
+      ID: 627
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 717
+      ID: 724
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 783
+      ID: 790
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 781
+      ID: 788
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.326496e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.255008e+06
@@ -13596,7 +16590,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 636
+      ID: 643
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.255168e+06
@@ -13606,11 +16600,11 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 565
+      ID: 572
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 941
+      ID: 948
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: GoHMapHeaderType
@@ -13646,7 +16640,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 222 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 352 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 359 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 215
       Name: hash<[4]int,uint8>
@@ -13680,7 +16674,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 217 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 351 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 358 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 183
       Name: hash<[4]string,[2]int>
@@ -13714,7 +16708,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 185 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 335 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 342 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: GoHMapHeaderType
       ID: 195
       Name: hash<bool,main.node>
@@ -13748,7 +16742,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 197 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 342 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 349 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: GoHMapHeaderType
       ID: 139
       Name: hash<int,*main.deepMap2>
@@ -13782,9 +16776,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 141 GoHMapBucketType bucket<int,*main.deepMap2>
-      BucketsType: 323 GoSliceDataType []bucket<int,*main.deepMap2>.array
+      BucketsType: 330 GoSliceDataType []bucket<int,*main.deepMap2>.array
     - __kind: GoHMapHeaderType
-      ID: 1066
+      ID: 1073
       Name: hash<int,*main.deepMap3>
       ByteSize: 48
       RawFields:
@@ -13805,20 +16799,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
         - Name: oldbuckets
           Offset: 24
-          Type: 1067 PointerType *bucket<int,*main.deepMap3>
+          Type: 1074 PointerType *bucket<int,*main.deepMap3>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1068 GoHMapBucketType bucket<int,*main.deepMap3>
-      BucketsType: 1072 GoSliceDataType []bucket<int,*main.deepMap3>.array
+      BucketType: 1075 GoHMapBucketType bucket<int,*main.deepMap3>
+      BucketsType: 1079 GoSliceDataType []bucket<int,*main.deepMap3>.array
     - __kind: GoHMapHeaderType
-      ID: 1094
+      ID: 1101
       Name: hash<int,*main.deepMap8>
       ByteSize: 48
       RawFields:
@@ -13839,20 +16833,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
         - Name: oldbuckets
           Offset: 24
-          Type: 1095 PointerType *bucket<int,*main.deepMap8>
+          Type: 1102 PointerType *bucket<int,*main.deepMap8>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1096 GoHMapBucketType bucket<int,*main.deepMap8>
-      BucketsType: 1100 GoSliceDataType []bucket<int,*main.deepMap8>.array
+      BucketType: 1103 GoHMapBucketType bucket<int,*main.deepMap8>
+      BucketsType: 1107 GoSliceDataType []bucket<int,*main.deepMap8>.array
     - __kind: GoHMapHeaderType
-      ID: 1103
+      ID: 1110
       Name: hash<int,*main.deepMap9>
       ByteSize: 48
       RawFields:
@@ -13873,18 +16867,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
         - Name: oldbuckets
           Offset: 24
-          Type: 1104 PointerType *bucket<int,*main.deepMap9>
+          Type: 1111 PointerType *bucket<int,*main.deepMap9>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1105 GoHMapBucketType bucket<int,*main.deepMap9>
-      BucketsType: 1109 GoSliceDataType []bucket<int,*main.deepMap9>.array
+      BucketType: 1112 GoHMapBucketType bucket<int,*main.deepMap9>
+      BucketsType: 1116 GoSliceDataType []bucket<int,*main.deepMap9>.array
     - __kind: GoHMapHeaderType
       ID: 163
       Name: hash<int,int>
@@ -13918,9 +16912,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 165 GoHMapBucketType bucket<int,int>
-      BucketsType: 325 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 332 GoSliceDataType []bucket<int,int>.array
     - __kind: GoHMapHeaderType
-      ID: 1112
+      ID: 1119
       Name: hash<int,interface {}>
       ByteSize: 48
       RawFields:
@@ -13941,18 +16935,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 1113 PointerType *bucket<int,interface {}>
+          Type: 1120 PointerType *bucket<int,interface {}>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 1114 GoHMapBucketType bucket<int,interface {}>
-      BucketsType: 1116 GoSliceDataType []bucket<int,interface {}>.array
+      BucketType: 1121 GoHMapBucketType bucket<int,interface {}>
+      BucketsType: 1123 GoSliceDataType []bucket<int,interface {}>.array
     - __kind: GoHMapHeaderType
       ID: 230
       Name: hash<int,struct {}>
@@ -13986,7 +16980,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 232 GoHMapBucketType bucket<int,struct {}>
-      BucketsType: 356 GoSliceDataType []bucket<int,struct {}>.array
+      BucketsType: 363 GoSliceDataType []bucket<int,struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 200
       Name: hash<int,uint8>
@@ -14020,7 +17014,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 202 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 344 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 351 GoSliceDataType []bucket<int,uint8>.array
     - __kind: GoHMapHeaderType
       ID: 190
       Name: hash<string,[]main.structWithMap>
@@ -14054,7 +17048,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 192 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 339 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 346 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: GoHMapHeaderType
       ID: 178
       Name: hash<string,[]string>
@@ -14088,9 +17082,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 180 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 331 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 338 GoSliceDataType []bucket<string,[]string>.array
     - __kind: GoHMapHeaderType
-      ID: 814
+      ID: 821
       Name: hash<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       RawFields:
@@ -14111,18 +17105,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: oldbuckets
           Offset: 24
-          Type: 815 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 822 PointerType *bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 816 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
-      BucketsType: 844 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      BucketType: 823 GoHMapBucketType bucket<string,github.com/DataDog/go-tuf/data.HexBytes>
+      BucketsType: 851 GoSliceDataType []bucket<string,github.com/DataDog/go-tuf/data.HexBytes>.array
     - __kind: GoHMapHeaderType
       ID: 173
       Name: hash<string,int>
@@ -14156,7 +17150,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 175 GoHMapBucketType bucket<string,int>
-      BucketsType: 329 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 336 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 168
       Name: hash<string,main.nestedStruct>
@@ -14190,7 +17184,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 170 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 328 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 335 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: GoHMapHeaderType
       ID: 225
       Name: hash<struct {},int>
@@ -14224,9 +17218,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 227 GoHMapBucketType bucket<struct {},int>
-      BucketsType: 354 GoSliceDataType []bucket<struct {},int>.array
+      BucketsType: 361 GoSliceDataType []bucket<struct {},int>.array
     - __kind: GoHMapHeaderType
-      ID: 276
+      ID: 283
       Name: hash<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14247,20 +17241,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 277 PointerType *bucket<struct {},main.structWithCyclicMaps>
+          Type: 284 PointerType *bucket<struct {},main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 278 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
-      BucketsType: 385 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
+      BucketType: 285 GoHMapBucketType bucket<struct {},main.structWithCyclicMaps>
+      BucketsType: 392 GoSliceDataType []bucket<struct {},main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 281
+      ID: 288
       Name: hash<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14281,20 +17275,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 282 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 289 PointerType *bucket<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 283 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 387 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 290 GoHMapBucketType bucket<struct {},map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 394 GoSliceDataType []bucket<struct {},map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 286
+      ID: 293
       Name: hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14315,20 +17309,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 287 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType *bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 288 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 389 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 295 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 396 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 291
+      ID: 298
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14349,20 +17343,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 292 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 293 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 391 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 300 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 398 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 296
+      ID: 303
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14383,20 +17377,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 297 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 298 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 393 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 305 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 400 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
-      ID: 301
+      ID: 308
       Name: hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       RawFields:
@@ -14417,18 +17411,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: oldbuckets
           Offset: 24
-          Type: 302 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType *bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
-      BucketType: 303 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
-      BucketsType: 395 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      BucketType: 310 GoHMapBucketType bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      BucketsType: 402 GoSliceDataType []bucket<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
     - __kind: GoHMapHeaderType
       ID: 235
       Name: hash<struct {},struct {}>
@@ -14462,7 +17456,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 237 GoHMapBucketType bucket<struct {},struct {}>
-      BucketsType: 357 GoSliceDataType []bucket<struct {},struct {}>.array
+      BucketsType: 364 GoSliceDataType []bucket<struct {},struct {}>.array
     - __kind: GoHMapHeaderType
       ID: 210
       Name: hash<uint8,[4]int>
@@ -14496,7 +17490,7 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 212 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 349 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 356 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: GoHMapHeaderType
       ID: 205
       Name: hash<uint8,uint8>
@@ -14530,9 +17524,9 @@ Types:
           Offset: 40
           Type: 142 PointerType *runtime.mapextra
       BucketType: 207 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 346 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 353 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: UnresolvedPointeeType
-      ID: 655
+      ID: 662
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -14579,7 +17573,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 535
+      ID: 542
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -14605,25 +17599,25 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 850
+      ID: 857
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 744
+      ID: 751
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.293696e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 472
+      ID: 479
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -14704,11 +17698,11 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 896
+      ID: 903
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 937
+      ID: 944
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.104288e+06
@@ -14721,7 +17715,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 968
+      ID: 975
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 981504
@@ -14734,7 +17728,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 925
+      ID: 932
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.069056e+06
@@ -14760,25 +17754,25 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 894
+      ID: 901
       Name: io.discard
       GoRuntimeType: 1.281536e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 868
+      ID: 875
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 304
+      ID: 311
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14834,7 +17828,7 @@ Types:
           Offset: 0
           Type: 137 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 322
+      ID: 329
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.100576e+06
@@ -14842,9 +17836,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1064 GoMapType map[int]*main.deepMap3
+          Type: 1071 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1071
+      ID: 1078
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14856,9 +17850,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1092 GoMapType map[int]*main.deepMap8
+          Type: 1099 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1099
+      ID: 1106
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.099808e+06
@@ -14866,9 +17860,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1101 GoMapType map[int]*main.deepMap9
+          Type: 1108 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1108
+      ID: 1115
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.09968e+06
@@ -14876,7 +17870,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1110 GoMapType map[int]interface {}
+          Type: 1117 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 125
       Name: main.deepPtr1
@@ -14896,9 +17890,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1035 PointerType *main.deepPtr3
+          Type: 1042 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14910,9 +17904,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1073 PointerType *main.deepPtr8
+          Type: 1080 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1074
+      ID: 1081
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.10096e+06
@@ -14920,9 +17914,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1075 PointerType *main.deepPtr9
+          Type: 1082 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1076
+      ID: 1083
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.100832e+06
@@ -14942,7 +17936,7 @@ Types:
           Offset: 0
           Type: 131 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 315
+      ID: 322
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.10288e+06
@@ -14950,9 +17944,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1058 GoSliceHeaderType []*main.deepSlice3
+          Type: 1065 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14964,9 +17958,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1077 GoSliceHeaderType []*main.deepSlice8
+          Type: 1084 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1080
+      ID: 1087
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.102112e+06
@@ -14974,9 +17968,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1083 GoSliceHeaderType []*main.deepSlice9
+          Type: 1090 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1086
+      ID: 1093
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.101984e+06
@@ -14984,9 +17978,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1089 GoSliceHeaderType []interface {}
+          Type: 1096 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 305
+      ID: 312
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -15002,16 +17996,16 @@ Types:
           Type: 150 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1042 StructureType sync.Mutex
+          Type: 1049 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1043 StructureType sync.Once
+          Type: 1050 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1046 StructureType sync.WaitGroup
+          Type: 1053 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1050 StructureType sync/atomic.Int32
+          Type: 1057 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 150
       Name: main.esotericStack
@@ -15041,7 +18035,7 @@ Types:
           Offset: 56
           Type: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1052
+      ID: 1059
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.232128e+06
@@ -15050,6 +18044,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 11 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 245
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 9 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 249
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 17 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
     - __kind: StructureType
       ID: 116
       Name: main.nestedStruct
@@ -15077,7 +18122,7 @@ Types:
           Offset: 8
           Type: 242 PointerType *main.node
     - __kind: StructureType
-      ID: 259
+      ID: 266
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -15086,7 +18131,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1054
+      ID: 1061
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.232288e+06
@@ -15106,7 +18151,7 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1041
+      ID: 1048
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -15117,18 +18162,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1038 PointerType *main.stringType1.str
+          Type: 1045 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 1037 GoStringDataType main.stringType1.str
+      Data: 1044 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1037
+      ID: 1044
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1046
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -15142,53 +18187,65 @@ Types:
           Offset: 0
           Type: 152 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 273
+      ID: 251
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 106 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 9 BaseType int
+    - __kind: StructureType
+      ID: 280
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 274 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 281 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 279 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 284 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 260
+      ID: 267
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 261 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 268 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 263 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 270 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 265 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 272 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 267 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 274 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 269 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 276 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 271 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 278 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 160
       Name: main.structWithMap
@@ -15200,7 +18257,7 @@ Types:
           Offset: 0
           Type: 161 GoMapType map[int]int
     - __kind: StructureType
-      ID: 250
+      ID: 257
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -15231,22 +18288,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1055 PointerType **main.t
+          Type: 1062 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 9 BaseType int
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 1056 GoSliceDataType main.t.array
+      Data: 1063 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1056
+      ID: 1063
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 243 PointerType *main.t
     - __kind: StructureType
-      ID: 256
+      ID: 263
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -15265,6 +18322,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 250
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 9 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 9 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 9 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 9 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 9 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 9 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 9 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 9 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 9 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 9 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 9 BaseType int
     - __kind: GoMapType
       ID: 218
       Name: map[[4]int][4]int
@@ -15301,26 +18397,26 @@ Types:
       GoKind: 21
       HeaderType: 139 GoHMapHeaderType hash<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1064
+      ID: 1071
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 880000
       GoKind: 21
-      HeaderType: 1066 GoHMapHeaderType hash<int,*main.deepMap3>
+      HeaderType: 1073 GoHMapHeaderType hash<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1092
+      ID: 1099
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 879520
       GoKind: 21
-      HeaderType: 1094 GoHMapHeaderType hash<int,*main.deepMap8>
+      HeaderType: 1101 GoHMapHeaderType hash<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1101
+      ID: 1108
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 879424
       GoKind: 21
-      HeaderType: 1103 GoHMapHeaderType hash<int,*main.deepMap9>
+      HeaderType: 1110 GoHMapHeaderType hash<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 161
       Name: map[int]int
@@ -15329,12 +18425,12 @@ Types:
       GoKind: 21
       HeaderType: 163 GoHMapHeaderType hash<int,int>
     - __kind: GoMapType
-      ID: 1110
+      ID: 1117
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 879328
       GoKind: 21
-      HeaderType: 1112 GoHMapHeaderType hash<int,interface {}>
+      HeaderType: 1119 GoHMapHeaderType hash<int,interface {}>
     - __kind: GoMapType
       ID: 228
       Name: map[int]struct {}
@@ -15385,41 +18481,41 @@ Types:
       GoKind: 21
       HeaderType: 225 GoHMapHeaderType hash<struct {},int>
     - __kind: GoMapType
-      ID: 274
+      ID: 281
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 276 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
+      HeaderType: 283 GoHMapHeaderType hash<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 279
+      ID: 286
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 281 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 288 GoHMapHeaderType hash<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 284
+      ID: 291
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 286 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 293 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 289
+      ID: 296
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 291 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 298 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 294
+      ID: 301
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 296 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 303 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 299
+      ID: 306
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 301 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 308 GoHMapHeaderType hash<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 233
       Name: map[struct {}]struct {}
@@ -15442,7 +18538,7 @@ Types:
       GoKind: 21
       HeaderType: 205 GoHMapHeaderType hash<uint8,uint8>
     - __kind: StructureType
-      ID: 569
+      ID: 576
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.247968e+06
@@ -15452,7 +18548,7 @@ Types:
           Offset: 0
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 858
+      ID: 865
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.244768e+06
@@ -15462,11 +18558,11 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 771
+      ID: 778
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 834
+      ID: 841
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.406112e+06
@@ -15479,35 +18575,35 @@ Types:
           Offset: 8
           Type: 19 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 797
+      ID: 804
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 996
+      ID: 1003
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 795
+      ID: 802
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 773
+      ID: 780
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1006
+      ID: 1013
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1016
+      ID: 1023
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1004
+      ID: 1011
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 732
+      ID: 739
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.072256e+06
@@ -15515,28 +18611,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 734 PointerType *net.UnknownNetworkError.str
+          Type: 741 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 733 GoStringDataType net.UnknownNetworkError.str
+      Data: 740 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 733
+      ID: 740
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 701
+      ID: 708
       Name: net.canceledError
       GoRuntimeType: 1.196512e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 1.968704e+06
@@ -15544,7 +18640,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 18 GoInterfaceType error
@@ -15555,27 +18651,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1012
+      ID: 1019
       Name: net.noReadFrom
       GoRuntimeType: 1.072512e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1011
+      ID: 1018
       Name: net.noWriteTo
       GoRuntimeType: 1.072384e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 504
+      ID: 511
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 506
+      ID: 513
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.604128e+06
@@ -15583,7 +18679,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 822 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 829 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 11 GoStringHeaderType string
@@ -15591,7 +18687,7 @@ Types:
           Offset: 96
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 1000
+      ID: 1007
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.145024e+06
@@ -15599,12 +18695,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1012 StructureType net.noReadFrom
+          Type: 1019 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1005 PointerType *net.TCPConn
+          Type: 1012 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 998
+      ID: 1005
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.14448e+06
@@ -15612,24 +18708,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1011 StructureType net.noWriteTo
+          Type: 1018 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1005 PointerType *net.TCPConn
+          Type: 1012 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 775
+      ID: 782
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 799
+      ID: 806
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 691
+      ID: 698
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 852
+      ID: 859
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.236288e+06
@@ -15639,19 +18735,19 @@ Types:
           Offset: 0
           Type: 124 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 401
+      ID: 408
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 762496
       GoKind: 10
     - __kind: BaseType
-      ID: 811
+      ID: 818
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 949440
       GoKind: 10
     - __kind: StructureType
-      ID: 482
+      ID: 489
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.602208e+06
@@ -15662,12 +18758,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 791
+      ID: 798
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.767584e+06
@@ -15678,12 +18774,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 18 GoInterfaceType error
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.405632e+06
@@ -15691,16 +18787,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 811 BaseType net/http.http2ErrCode
+          Type: 818 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 405
+      ID: 412
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762688
@@ -15708,18 +18804,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 407 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 414 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 406 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 413 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 406
+      ID: 413
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 411
+      ID: 418
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 762880
@@ -15727,18 +18823,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 413 PointerType *net/http.http2headerFieldNameError.str
+          Type: 420 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 412 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 419 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 412
+      ID: 419
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 408
+      ID: 415
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 762784
@@ -15746,32 +18842,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 410 PointerType *net/http.http2headerFieldValueError.str
+          Type: 417 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 409 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 416 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 409
+      ID: 416
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 766
+      ID: 773
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.195872e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 965
+      ID: 972
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 402
+      ID: 409
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 762592
@@ -15779,18 +18875,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 404 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 411 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 403 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 410 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 403
+      ID: 410
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 854
+      ID: 861
       Name: net/http.http2stickyErrWriter
       ByteSize: 32
       GoRuntimeType: 1.602976e+06
@@ -15798,22 +18894,22 @@ Types:
       RawFields:
         - Name: conn
           Offset: 0
-          Type: 834 GoInterfaceType net.Conn
+          Type: 841 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 16
-          Type: 933 BaseType time.Duration
+          Type: 940 BaseType time.Duration
         - Name: err
           Offset: 24
           Type: 99 PointerType *error
     - __kind: ArrayType
-      ID: 934
+      ID: 941
       Name: net/http.incomparable
       GoRuntimeType: 831136
       GoKind: 17
       HasCount: true
       Element: 57 GoSubroutineType func()
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.36752e+06
@@ -15823,11 +18919,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 872
+      ID: 879
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.36736e+06
@@ -15835,9 +18931,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 915 PointerType *net/http.persistConn
+          Type: 922 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 898
+      ID: 905
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.674272e+06
@@ -15845,15 +18941,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 934 ArrayType net/http.incomparable
+          Type: 941 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 935 PointerType *bufio.Reader
+          Type: 942 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 937 GoInterfaceType io.ReadWriteCloser
+          Type: 944 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 490
+      ID: 497
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.237248e+06
@@ -15863,17 +18959,17 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 793
+      ID: 800
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.296416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.36768e+06
@@ -15883,11 +18979,11 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 479
+      ID: 486
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 967
+      ID: 974
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
@@ -15895,13 +18991,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 960 PointerType *bufio.Writer
+          Type: 967 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 882
+      ID: 889
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 561
+      ID: 568
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.607968e+06
@@ -15917,7 +19013,7 @@ Types:
           Offset: 32
           Type: 11 GoStringHeaderType string
     - __kind: StructureType
-      ID: 559
+      ID: 566
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.407552e+06
@@ -15930,11 +19026,11 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 924
+      ID: 931
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 884
+      ID: 891
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.409472e+06
@@ -15942,16 +19038,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 923 PointerType *net/smtp.Client
+          Type: 930 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 925 GoInterfaceType io.WriteCloser
+          Type: 932 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 545
+      ID: 552
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 436
+      ID: 443
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 765472
@@ -15959,26 +19055,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 438 PointerType *net/textproto.ProtocolError.str
+          Type: 445 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 437 GoStringDataType net/textproto.ProtocolError.str
+      Data: 444 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 437
+      ID: 444
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 880
+      ID: 887
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 801
+      ID: 808
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 414
+      ID: 421
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 763456
@@ -15986,18 +19082,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 416 PointerType *net/url.EscapeError.str
+          Type: 423 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 415 GoStringDataType net/url.EscapeError.str
+      Data: 422 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 415
+      ID: 422
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 417
+      ID: 424
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 763552
@@ -16005,30 +19101,30 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 419 PointerType *net/url.InvalidHostError.str
+          Type: 426 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 418 GoStringDataType net/url.InvalidHostError.str
+      Data: 425 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 418
+      ID: 425
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1024
+      ID: 1031
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 672
+      ID: 679
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 736
+      ID: 743
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1022
+      ID: 1029
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.213216e+06
@@ -16036,12 +19132,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1028 StructureType os.noReadFrom
+          Type: 1035 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1023 PointerType *os.File
+          Type: 1030 PointerType *os.File
     - __kind: StructureType
-      ID: 1020
+      ID: 1027
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.212416e+06
@@ -16049,36 +19145,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1027 StructureType os.noWriteTo
+          Type: 1034 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1023 PointerType *os.File
+          Type: 1030 PointerType *os.File
     - __kind: StructureType
-      ID: 1028
+      ID: 1035
       Name: os.noReadFrom
       GoRuntimeType: 1.069952e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: os.noWriteTo
       GoRuntimeType: 1.069824e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 710
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 842
+      ID: 849
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 902
+      ID: 909
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.510624e+06
@@ -16091,7 +19187,7 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 449
+      ID: 456
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 768640
@@ -16099,36 +19195,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 451 PointerType *os/user.UnknownGroupIdError.str
+          Type: 458 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 450 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 457 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 450
+      ID: 457
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 448
+      ID: 455
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 474
+      ID: 481
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 567
+      ID: 574
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 675
+      ID: 682
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 687
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -16140,7 +19236,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.757152e+06
@@ -16157,9 +19253,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 840 BaseType runtime.boundsErrorCode
+          Type: 847 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 840
+      ID: 847
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 532800
@@ -16179,7 +19275,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.628096e+06
@@ -16192,7 +19288,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 656
+      ID: 663
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 948288
@@ -16200,13 +19296,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 658 PointerType *runtime.errorString.str
+          Type: 665 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 657 GoStringDataType runtime.errorString.str
+      Data: 664 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 657
+      ID: 664
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16832,7 +19928,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 659
+      ID: 666
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 948864
@@ -16840,13 +19936,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 661 PointerType *runtime.plainError.str
+          Type: 668 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 660 GoStringDataType runtime.plainError.str
+      Data: 667 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 660
+      ID: 667
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -16928,7 +20024,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 689
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -16940,26 +20036,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 308 PointerType *string.str
+          Type: 315 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 307 GoStringDataType string.str
+      Data: 314 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 307
+      ID: 314
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 963
+      ID: 970
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 870
+      ID: 877
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.273216e+06
@@ -16975,7 +20071,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1042
+      ID: 1049
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.281856e+06
@@ -16988,7 +20084,7 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1043
+      ID: 1050
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.282976e+06
@@ -16996,12 +20092,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 1044 StructureType sync/atomic.Uint32
+          Type: 1051 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1042 StructureType sync.Mutex
+          Type: 1049 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.421824e+06
@@ -17009,21 +20105,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1047 StructureType sync.noCopy
+          Type: 1054 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1048 StructureType sync/atomic.Uint64
+          Type: 1055 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1047
+      ID: 1054
       Name: sync.noCopy
       GoRuntimeType: 947232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1050
+      ID: 1057
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.283296e+06
@@ -17031,12 +20127,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 13 BaseType int32
     - __kind: StructureType
-      ID: 1044
+      ID: 1051
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.283456e+06
@@ -17044,12 +20140,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1048
+      ID: 1055
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.422208e+06
@@ -17057,37 +20153,37 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1045 StructureType sync/atomic.noCopy
+          Type: 1052 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1049 StructureType sync/atomic.align64
+          Type: 1056 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 10 BaseType uint64
     - __kind: StructureType
-      ID: 1049
+      ID: 1056
       Name: sync/atomic.align64
       GoRuntimeType: 947424
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1045
+      ID: 1052
       Name: sync/atomic.noCopy
       GoRuntimeType: 947328
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 788
+      ID: 795
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.195104e+06
       GoKind: 12
     - __kind: UnresolvedPointeeType
-      ID: 994
+      ID: 1001
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.51504e+06
@@ -17100,21 +20196,21 @@ Types:
           Offset: 16
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 933
+      ID: 940
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.783424e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 806
+      ID: 813
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 477
+      ID: 484
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 804
+      ID: 811
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.22544e+06
@@ -17128,9 +20224,9 @@ Types:
           Type: 14 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 805 PointerType *time.Location
+          Type: 812 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 398
+      ID: 405
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 761632
@@ -17138,13 +20234,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 400 PointerType *time.fileSizeError.str
+          Type: 407 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 399 GoStringDataType time.fileSizeError.str
+      Data: 406 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 399
+      ID: 406
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -17191,11 +20287,11 @@ Types:
       GoRuntimeType: 532736
       GoKind: 26
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: vendor/golang.org/x/crypto/sha3.state
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 1.927552e+06
@@ -17206,10 +20302,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 823 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 830 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 824 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 831 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 9 BaseType int
@@ -17224,18 +20320,18 @@ Types:
           Type: 9 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 825 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 832 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 7 BaseType uint16
     - __kind: BaseType
-      ID: 825
+      ID: 832
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 953568
       GoKind: 9
     - __kind: StructureType
-      ID: 823
+      ID: 830
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.79392e+06
@@ -17260,21 +20356,21 @@ Types:
           Offset: 10
           Type: 7 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 563
+      ID: 570
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 824
+      ID: 831
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 536384
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 547
+      ID: 554
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.245088e+06
@@ -17284,13 +20380,13 @@ Types:
           Offset: 0
           Type: 18 GoInterfaceType error
     - __kind: BaseType
-      ID: 439
+      ID: 446
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 765568
       GoKind: 2
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.510816e+06
@@ -17303,12 +20399,12 @@ Types:
           Offset: 16
           Type: 11 GoStringHeaderType string
     - __kind: BaseType
-      ID: 664
+      ID: 671
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1286
+MaxTypeID: 1341
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -3128,7 +3128,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88da80..0x88da90, Pieces: []}]
+          Locations:
+            - Range: 0x88da80..0x88da88
+              Pieces: []
+            - Range: 0x88da88..0x88da89
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88da89..0x88da90
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3145,7 +3151,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x88da90..0x88daf0, Pieces: []}]
+          Locations:
+            - Range: 0x88da90..0x88dad8
+              Pieces: []
+            - Range: 0x88dad8..0x88dad9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88dad9..0x88daf0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3188,7 +3200,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88dd40..0x88ddb0, Pieces: []}]
+          Locations:
+            - Range: 0x88dd40..0x88dd84
+              Pieces: []
+            - Range: 0x88dd84..0x88dd85
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88dd85..0x88ddb0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3221,7 +3243,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x88ddc0..0x88de30, Pieces: []}]
+          Locations:
+            - Range: 0x88ddc0..0x88de04
+              Pieces: []
+            - Range: 0x88de04..0x88de05
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88de05..0x88de30
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3721,7 +3753,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x8901e0..0x890260, Pieces: []}]
+          Locations:
+            - Range: 0x8901e0..0x890238
+              Pieces: []
+            - Range: 0x890238..0x890239
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890239..0x890260
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3738,7 +3776,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 94 PointerType *int
-          Locations: [{Range: 0x890260..0x890300, Pieces: []}]
+          Locations:
+            - Range: 0x890260..0x8902d8
+              Pieces: []
+            - Range: 0x8902d8..0x8902d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8902d9..0x890300
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3766,7 +3810,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x890300..0x8903c0, Pieces: []}]
+          Locations:
+            - Range: 0x890300..0x8903a0
+              Pieces: []
+            - Range: 0x8903a0..0x8903a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8903a1..0x8903c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3797,7 +3847,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0x8903c0..0x890440, Pieces: []}]
+          Locations:
+            - Range: 0x8903c0..0x890408
+              Pieces: []
+            - Range: 0x890408..0x890409
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890409..0x89041c
+              Pieces: []
+            - Range: 0x89041c..0x89041d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89041d..0x890440
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3831,12 +3899,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x890440..0x8904e0, Pieces: []}]
+          Locations:
+            - Range: 0x890440..0x890498
+              Pieces: []
+            - Range: 0x890498..0x890499
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890499..0x8904ac
+              Pieces: []
+            - Range: 0x8904ac..0x8904ad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x8904ad..0x8904e0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 GoInterfaceType error
-          Locations: [{Range: 0x890440..0x8904e0, Pieces: []}]
+          Locations:
+            - Range: 0x890440..0x890498
+              Pieces: []
+            - Range: 0x890498..0x890499
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x890499..0x8904ac
+              Pieces: []
+            - Range: 0x8904ac..0x8904ad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x8904ad..0x8904e0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3869,7 +3973,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x8904e0..0x890580, Pieces: []}]
+          Locations:
+            - Range: 0x8904e0..0x89054c
+              Pieces: []
+            - Range: 0x89054c..0x89054d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89054d..0x890580
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3908,7 +4022,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
-          Locations: [{Range: 0x890580..0x8906b0, Pieces: []}]
+          Locations:
+            - Range: 0x890580..0x890628
+              Pieces: []
+            - Range: 0x890628..0x890629
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890629..0x89063c
+              Pieces: []
+            - Range: 0x89063c..0x89063d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x89063d..0x8906b0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3966,7 +4098,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0x8906b0..0x890750, Pieces: []}]
+          Locations:
+            - Range: 0x8906b0..0x890724
+              Pieces: []
+            - Range: 0x890724..0x890725
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x890725..0x890750
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3985,12 +4123,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 9 BaseType int
-          Locations: [{Range: 0x890750..0x890810, Pieces: []}]
+          Locations:
+            - Range: 0x890750..0x8907e4
+              Pieces: []
+            - Range: 0x8907e4..0x8907e5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8907e5..0x890810
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0x890750..0x890810, Pieces: []}]
+          Locations:
+            - Range: 0x890750..0x8907e4
+              Pieces: []
+            - Range: 0x8907e4..0x8907e5
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x8907e5..0x890810
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4009,17 +4159,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 BaseType int
-          Locations: [{Range: 0x890810..0x8908d0, Pieces: []}]
+          Locations:
+            - Range: 0x890810..0x8908a4
+              Pieces: []
+            - Range: 0x8908a4..0x8908a5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8908a5..0x8908d0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 9 BaseType int
-          Locations: [{Range: 0x890810..0x8908d0, Pieces: []}]
+          Locations:
+            - Range: 0x890810..0x8908a4
+              Pieces: []
+            - Range: 0x8908a4..0x8908a5
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x8908a5..0x8908d0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 9 BaseType int
-          Locations: [{Range: 0x890810..0x8908d0, Pieces: []}]
+          Locations:
+            - Range: 0x890810..0x8908a4
+              Pieces: []
+            - Range: 0x8908a4..0x8908a5
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x8908a5..0x8908d0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4262,7 +4430,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
-          Locations: [{Range: 0x890f10..0x890f80, Pieces: []}]
+          Locations:
+            - Range: 0x890f10..0x890f5c
+              Pieces: []
+            - Range: 0x890f5c..0x890f5d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x890f5d..0x890f80
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -3128,7 +3128,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84b190..0x84b1a0, Pieces: []}]
+          Locations:
+            - Range: 0x84b190..0x84b198
+              Pieces: []
+            - Range: 0x84b198..0x84b199
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b199..0x84b1a0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3145,7 +3151,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84b1a0..0x84b200, Pieces: []}]
+          Locations:
+            - Range: 0x84b1a0..0x84b1e8
+              Pieces: []
+            - Range: 0x84b1e8..0x84b1e9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84b1e9..0x84b200
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3188,7 +3200,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b440..0x84b4b0, Pieces: []}]
+          Locations:
+            - Range: 0x84b440..0x84b484
+              Pieces: []
+            - Range: 0x84b484..0x84b485
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84b485..0x84b4b0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3221,7 +3243,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84b4c0..0x84b530, Pieces: []}]
+          Locations:
+            - Range: 0x84b4c0..0x84b504
+              Pieces: []
+            - Range: 0x84b504..0x84b505
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84b505..0x84b530
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3721,7 +3753,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84d8c0..0x84d940, Pieces: []}]
+          Locations:
+            - Range: 0x84d8c0..0x84d918
+              Pieces: []
+            - Range: 0x84d918..0x84d919
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d919..0x84d940
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3738,7 +3776,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
-          Locations: [{Range: 0x84d940..0x84d9e0, Pieces: []}]
+          Locations:
+            - Range: 0x84d940..0x84d9b4
+              Pieces: []
+            - Range: 0x84d9b4..0x84d9b5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d9b5..0x84d9e0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3766,7 +3810,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84d9e0..0x84daa0, Pieces: []}]
+          Locations:
+            - Range: 0x84d9e0..0x84da80
+              Pieces: []
+            - Range: 0x84da80..0x84da81
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84da81..0x84daa0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3797,7 +3847,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x84daa0..0x84db20, Pieces: []}]
+          Locations:
+            - Range: 0x84daa0..0x84dae8
+              Pieces: []
+            - Range: 0x84dae8..0x84dae9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dae9..0x84dafc
+              Pieces: []
+            - Range: 0x84dafc..0x84dafd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dafd..0x84db20
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3831,12 +3899,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x84db20..0x84dbc0, Pieces: []}]
+          Locations:
+            - Range: 0x84db20..0x84db78
+              Pieces: []
+            - Range: 0x84db78..0x84db79
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84db79..0x84db8c
+              Pieces: []
+            - Range: 0x84db8c..0x84db8d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84db8d..0x84dbc0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x84db20..0x84dbc0, Pieces: []}]
+          Locations:
+            - Range: 0x84db20..0x84db78
+              Pieces: []
+            - Range: 0x84db78..0x84db79
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x84db79..0x84db8c
+              Pieces: []
+            - Range: 0x84db8c..0x84db8d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x84db8d..0x84dbc0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3869,7 +3973,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x84dbc0..0x84dc50, Pieces: []}]
+          Locations:
+            - Range: 0x84dbc0..0x84dc28
+              Pieces: []
+            - Range: 0x84dc28..0x84dc29
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dc29..0x84dc50
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3908,7 +4022,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
-          Locations: [{Range: 0x84dc50..0x84dd70, Pieces: []}]
+          Locations:
+            - Range: 0x84dc50..0x84dcf4
+              Pieces: []
+            - Range: 0x84dcf4..0x84dcf5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dcf5..0x84dd08
+              Pieces: []
+            - Range: 0x84dd08..0x84dd09
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dd09..0x84dd70
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3966,7 +4098,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x84dd70..0x84de10, Pieces: []}]
+          Locations:
+            - Range: 0x84dd70..0x84dde4
+              Pieces: []
+            - Range: 0x84dde4..0x84dde5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84dde5..0x84de10
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3985,12 +4123,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x84de10..0x84ded0, Pieces: []}]
+          Locations:
+            - Range: 0x84de10..0x84dea4
+              Pieces: []
+            - Range: 0x84dea4..0x84dea5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84dea5..0x84ded0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84de10..0x84ded0, Pieces: []}]
+          Locations:
+            - Range: 0x84de10..0x84dea4
+              Pieces: []
+            - Range: 0x84dea4..0x84dea5
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84dea5..0x84ded0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4009,17 +4159,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ded0..0x84df80, Pieces: []}]
+          Locations:
+            - Range: 0x84ded0..0x84df60
+              Pieces: []
+            - Range: 0x84df60..0x84df61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84df61..0x84df80
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ded0..0x84df80, Pieces: []}]
+          Locations:
+            - Range: 0x84ded0..0x84df60
+              Pieces: []
+            - Range: 0x84df60..0x84df61
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84df61..0x84df80
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0x84ded0..0x84df80, Pieces: []}]
+          Locations:
+            - Range: 0x84ded0..0x84df60
+              Pieces: []
+            - Range: 0x84df60..0x84df61
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84df61..0x84df80
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4262,7 +4430,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x84e5b0..0x84e620, Pieces: []}]
+          Locations:
+            - Range: 0x84e5b0..0x84e5fc
+              Pieces: []
+            - Range: 0x84e5fc..0x84e5fd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84e5fd..0x84e620
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1432 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84e5c8", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84fe58", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1433 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x84e5fc", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x84fe8c", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1359 EventRootType Probe[main.testAny]
+          Type: 1366 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84b458", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1360 EventRootType Probe[main.testAny]Return
+          Type: 1367 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x84b484", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testAnyPtr]
+          Type: 1369 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x84b4d8", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1370 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x84b504", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1459 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1460 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1310 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1317 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x849aa0", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1306 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1313 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1308 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1315 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1371 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1378 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84bb40", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1307 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1314 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1309 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1316 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testBigStruct]
+          Type: 1335 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849ff0", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1329 EventRootType Probe[main.testBigStruct]Return
+          Type: 1336 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x84a008", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1295 EventRootType Probe[main.testBoolArray]
+          Type: 1302 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1292 EventRootType Probe[main.testByteArray]
+          Type: 1299 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849980", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testChannel]
+          Type: 1398 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testCombinedByte]
+          Type: 1396 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testCycle]
+          Type: 1406 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d580", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testDeepMap1]
+          Type: 1341 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x84a3d0", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testDeepMap7]
+          Type: 1342 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x84a3e0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testDeepPtr1]
+          Type: 1337 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x84a0c0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testDeepPtr7]
+          Type: 1338 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x84a0d0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testDeepSlice1]
+          Type: 1339 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x84a270", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testDeepSlice7]
+          Type: 1340 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x84a280", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84e240", Frameless: true}]
+          Type: 1476 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1424 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84e270", Frameless: true}]
+          Type: 1479 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84e6a0", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84ff30", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84e9f0", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x850280", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x84ea00", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x850290", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1361 EventRootType Probe[main.testError]
+          Type: 1368 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84b4b0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testEsotericHeap]
+          Type: 1350 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x84aa78", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1344 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1351 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x84aab4", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testEsotericStack]
+          Type: 1348 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x84a9ac", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1342 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1349 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x84aa1c", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testFrameless]
+          Type: 1360 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84b190", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1354 EventRootType Probe[main.testFrameless]Return
+          Type: 1361 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x84b198", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testFramelessArray]
+          Type: 1362 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1356 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1363 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x84b1e8", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1357 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1364 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x84b1ac", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testInlinedBA]
+          Type: 1352 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84aeb8", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1346 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1353 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x84af10", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testInlinedBB]
+          Type: 1354 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84af48", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1348 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1355 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x84afd0", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testInlinedBBA]
+          Type: 1356 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84b008", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1350 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1357 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x84b044", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testInlinedBBB]
+          Type: 1509 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testInlinedBC]
+          Type: 1358 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84b088", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1352 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1359 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x84b178", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testInlinedBCA]
+          Type: 1510 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1456 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1511 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testInlinedBCB]
+          Type: 1512 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1458 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1513 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.testInlinedPrint]
+          Type: 1506 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0x84b00c"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1452 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1507 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1453 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1508 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testInlinedSq]
+          Type: 1514 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1460 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1515 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1516 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1298 EventRootType Probe[main.testInt16Array]
+          Type: 1305 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1299 EventRootType Probe[main.testInt32Array]
+          Type: 1306 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1300 EventRootType Probe[main.testInt64Array]
+          Type: 1307 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1297 EventRootType Probe[main.testInt8Array]
+          Type: 1304 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1296 EventRootType Probe[main.testIntArray]
+          Type: 1303 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1358 EventRootType Probe[main.testInterface]
+          Type: 1365 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84b430", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1457 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1458 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testLinkedList]
+          Type: 1400 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d490", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1338 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1345 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a42c", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1339 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1346 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a4bc", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1340 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1347 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x84a564", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1463 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x84efac", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1464 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x84f118", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1369 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1376 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84bb20", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1376 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1383 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84bb80", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1393 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x84bc20", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1395 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x84bc40", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1394 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x84bc30", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1373 EventRootType Probe[main.testMapIntToInt]
+          Type: 1380 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84bb60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1392 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84bc10", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1391 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84bc00", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testMapMassive]
+          Type: 1381 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1375 EventRootType Probe[main.testMapMassive]
+          Type: 1382 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84bb70", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1390 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84bbf0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1382 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1389 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84bbe0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1367 EventRootType Probe[main.testMapStringToInt]
+          Type: 1374 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84bb00", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1375 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84bb10", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1373 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84baf0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1384 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84bb90", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1387 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84bbc0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1388 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84bbd0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1378 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1385 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84bba0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1379 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1386 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84bbb0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84e680", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1496 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1465 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x84f180", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1466 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1469 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1470 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84e680", Frameless: true}]
+          Type: 1461 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1462 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1416 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84de28", Frameless: false}]
+          Type: 1423 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1417 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84dea4", Frameless: false}]
+          Type: 1424 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1397 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84dd88", Frameless: false}]
+          Type: 1421 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1415 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84dde4", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testNilPointer]
+          Type: 1405 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d560", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84e2b0", Frameless: true}]
+          Type: 1483 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84e280", Frameless: true}]
+          Type: 1480 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84e2a0", Frameless: true}]
+          Type: 1482 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84e670", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testPointerLoop]
+          Type: 1401 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testPointerToMap]
+          Type: 1379 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84bb50", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1399 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d480", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1410 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x84dbd8", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x84dcc8", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1411 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x84dc28", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0x84dd64"
+              Frameless: false
+            - PC: "0x84ddac"
+              Frameless: false
+            - PC: "0x84de70"
+              Frameless: false
+            - PC: "0x84de84"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x84db38", Frameless: false}]
+          Type: 1415 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x84db48", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1409 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1416 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x84db78"
+            - PC: "0x84db9c"
               Frameless: false
-            - PC: "0x84db8c"
+            - PC: "0x84dc00"
               Frameless: false
+            - PC: "0x84dc40"
+              Frameless: false
+            - PC: "0x84dc80"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1435 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1436 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x84e550", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1437 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x84e588", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1438 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1439 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1440 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x84e630", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1443 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1444 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1455 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1456 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1431 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1432 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,16 +1754,16 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x84dab8", Frameless: false}]
+          Type: 1413 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x84dac8", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1407 EventRootType Probe[main.testReturnsError]Return
+          Type: 1414 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x84dae8"
+            - PC: "0x84daf8"
               Frameless: false
-            - PC: "0x84dafc"
+            - PC: "0x84db0c"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testReturnsInt]
+          Type: 1407 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d8d8", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1401 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x84d918", Frameless: false}]
+          Type: 1408 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x84d91c", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1411 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84d9f8", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1405 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x84da80", Frameless: false}]
+          Type: 1412 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x84da90", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x84d95c", Frameless: false}]
+          Type: 1409 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x84d958", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1403 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x84d9b4", Frameless: false}]
+          Type: 1410 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x84d9b8", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1412 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x84dc68", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x84dec8", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1413 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1420 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x84dcf4"
+            - PC: "0x84df94"
               Frameless: false
-            - PC: "0x84dd08"
+            - PC: "0x84dfa8"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1433 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x84e430", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1434 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1429 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1430 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1447 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x84e868", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1448 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1441 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x84e668", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1442 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1453 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1454 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1451 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x84e988", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1452 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1427 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x84e258", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1428 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1449 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1450 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x84e950", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1445 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x84e790", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1446 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x84e834", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1293 EventRootType Probe[main.testRuneArray]
+          Type: 1300 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849990", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testSingleBool]
+          Type: 1321 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x849e10", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testSingleByte]
+          Type: 1319 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x849df0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testSingleFloat32]
+          Type: 1332 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849ec0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSingleFloat64]
+          Type: 1333 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849ed0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testSingleInt]
+          Type: 1322 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x849e20", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testSingleInt16]
+          Type: 1324 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x849e40", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testSingleInt32]
+          Type: 1325 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849e50", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSingleInt64]
+          Type: 1326 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849e60", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testSingleInt8]
+          Type: 1323 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x849e30", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testSingleRune]
+          Type: 1320 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x849e00", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1434 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84e620", Frameless: true}]
+          Type: 1489 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84feb0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testSingleUint]
+          Type: 1327 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849e70", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testSingleUint16]
+          Type: 1329 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849e90", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testSingleUint32]
+          Type: 1330 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849ea0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testSingleUint64]
+          Type: 1331 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849eb0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testSingleUint8]
+          Type: 1328 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849e80", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x84e2d0", Frameless: true}]
+          Type: 1486 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1422 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84e250", Frameless: true}]
+          Type: 1477 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testSmallMap]
+          Type: 1377 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84bb30", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x84dee8", Frameless: false}]
+          Type: 1425 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x84e198", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1419 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x84df60", Frameless: false}]
+          Type: 1426 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e220", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1467 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x84f388", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1468 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1294 EventRootType Probe[main.testStringArray]
+          Type: 1301 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1397 EventRootType Probe[main.testStringPointer]
+          Type: 1404 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d540", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1426 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84e290", Frameless: true}]
+          Type: 1481 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testStringType1]
+          Type: 1343 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x84a3f0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testStringType2]
+          Type: 1344 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x84a400", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84e8f0", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x850180", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1448 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x84e90c", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x85019c", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84e260", Frameless: true}]
+          Type: 1478 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testStructWithAny]
+          Type: 1371 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x84b530", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1471 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1472 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x84e800", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x850090", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1446 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x84e818", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x8500a8", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x84e7f0", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x850080", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1365 EventRootType Probe[main.testStructWithMap]
+          Type: 1372 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84bae0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84e630", Frameless: true}]
+          Type: 1490 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84fec0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1436 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84e640", Frameless: true}]
+          Type: 1491 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84fed0", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1437 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84e658", Frameless: true}]
+          Type: 1492 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x84fee8", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1438 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84e660", Frameless: true}]
+          Type: 1493 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84fef0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testTypeAlias]
+          Type: 1334 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849ee0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1303 EventRootType Probe[main.testUint16Array]
+          Type: 1310 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1304 EventRootType Probe[main.testUint32Array]
+          Type: 1311 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1305 EventRootType Probe[main.testUint64Array]
+          Type: 1312 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1302 EventRootType Probe[main.testUint8Array]
+          Type: 1309 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1301 EventRootType Probe[main.testUintArray]
+          Type: 1308 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testUintPointer]
+          Type: 1403 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1420 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84e230", Frameless: true}]
+          Type: 1475 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84e690", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testUnsafePointer]
+          Type: 1402 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d4b0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1318 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849ac0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84e2c0", Frameless: true}]
+          Type: 1484 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1430 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84e2c0", Frameless: true}]
+          Type: 1485 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1473 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1474 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84f640", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3745,23 +4213,30 @@ Subprograms:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d8c0..0x84d8e4
+            - Range: 0x84d8c0..0x84d8dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d8e4..0x84d940
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d8c0..0x84d918
+            - Range: 0x84d8c0..0x84d91c
               Pieces: []
-            - Range: 0x84d918..0x84d919
+            - Range: 0x84d91c..0x84d91d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d919..0x84d940
+            - Range: 0x84d91d..0x84d940
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d8dc..0x84d8e8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d8e8..0x84d940
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x84d940..0x84d9e0]
@@ -3772,117 +4247,144 @@ Subprograms:
           Locations:
             - Range: 0x84d940..0x84d964
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d964..0x84d9e0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d940..0x84d9b4
+            - Range: 0x84d940..0x84d9b8
               Pieces: []
-            - Range: 0x84d9b4..0x84d9b5
+            - Range: 0x84d9b8..0x84d9b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d9b5..0x84d9e0
+            - Range: 0x84d9b9..0x84d9e0
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d968..0x84d97c
+            - Range: 0x84d968..0x84d980
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d97c..0x84d9e0
+            - Range: 0x84d980..0x84d9e0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84d9e0..0x84daa0]
+      OutOfLinePCRanges: [0x84d9e0..0x84dab0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d9e0..0x84da2c
+            - Range: 0x84d9e0..0x84da38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84da2c..0x84daa0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d9e0..0x84da80
+            - Range: 0x84d9e0..0x84da90
               Pieces: []
-            - Range: 0x84da80..0x84da81
+            - Range: 0x84da90..0x84da91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84da81..0x84daa0
+            - Range: 0x84da91..0x84dab0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84d9e0..0x84daa0, Pieces: []}]
+          Locations: [{Range: 0x84d9e0..0x84dab0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84d9fc..0x84da3c
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84da3c..0x84dab0
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84da00..0x84da2c
+            - Range: 0x84da0c..0x84da3c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84da2c..0x84daa0
+            - Range: 0x84da3c..0x84dab0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
     - ID: 97
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84daa0..0x84db20]
+      OutOfLinePCRanges: [0x84dab0..0x84db30]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84daa0..0x84dac4
+            - Range: 0x84dab0..0x84dad4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84daa0..0x84dae8
+            - Range: 0x84dab0..0x84daf8
               Pieces: []
-            - Range: 0x84dae8..0x84dae9
+            - Range: 0x84daf8..0x84daf9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dae9..0x84dafc
+            - Range: 0x84daf9..0x84db0c
               Pieces: []
-            - Range: 0x84dafc..0x84dafd
+            - Range: 0x84db0c..0x84db0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dafd..0x84db20
+            - Range: 0x84db0d..0x84db30
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84db20..0x84dbc0]
+      OutOfLinePCRanges: [0x84db30..0x84dcb0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db20..0x84db4c
+            - Range: 0x84db30..0x84db80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db4c..0x84db50
+            - Range: 0x84db80..0x84db84
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x84dbd4..0x84dbd8
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dc14..0x84dc18
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dc54..0x84dc58
               Pieces:
                 - Size: 8
                   Op: null
@@ -3893,77 +4395,116 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84db20..0x84db50
+            - Range: 0x84db30..0x84db74
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db20..0x84db78
+            - Range: 0x84db30..0x84db9c
               Pieces: []
-            - Range: 0x84db78..0x84db79
+            - Range: 0x84db9c..0x84db9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db79..0x84db8c
+            - Range: 0x84db9d..0x84dc00
               Pieces: []
-            - Range: 0x84db8c..0x84db8d
+            - Range: 0x84dc00..0x84dc01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db8d..0x84dbc0
+            - Range: 0x84dc01..0x84dc40
+              Pieces: []
+            - Range: 0x84dc40..0x84dc41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dc41..0x84dc80
+              Pieces: []
+            - Range: 0x84dc80..0x84dc81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84dc81..0x84dcb0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84db20..0x84db78
+            - Range: 0x84db30..0x84db9c
               Pieces: []
-            - Range: 0x84db78..0x84db79
+            - Range: 0x84db9c..0x84db9d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84db79..0x84db8c
+            - Range: 0x84db9d..0x84dc00
               Pieces: []
-            - Range: 0x84db8c..0x84db8d
+            - Range: 0x84dc00..0x84dc01
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84db8d..0x84dbc0
+            - Range: 0x84dc01..0x84dc40
+              Pieces: []
+            - Range: 0x84dc40..0x84dc41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x84dc41..0x84dc80
+              Pieces: []
+            - Range: 0x84dc80..0x84dc81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x84dc81..0x84dcb0
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84db80..0x84db88
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 99
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84dbc0..0x84dc50]
+      OutOfLinePCRanges: [0x84dcb0..0x84deb0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dbc0..0x84dc08
+            - Range: 0x84dcb0..0x84dcf8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc08..0x84dc10
+            - Range: 0x84dcf8..0x84dd00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dc10..0x84dc50
+            - Range: 0x84dd00..0x84deb0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3974,267 +4515,1467 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dbc0..0x84dc28
+            - Range: 0x84dcb0..0x84dd64
               Pieces: []
-            - Range: 0x84dc28..0x84dc29
+            - Range: 0x84dd64..0x84dd65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc29..0x84dc50
+            - Range: 0x84dd65..0x84ddac
+              Pieces: []
+            - Range: 0x84ddac..0x84ddad
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84ddad..0x84de70
+              Pieces: []
+            - Range: 0x84de70..0x84de71
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84de71..0x84de84
+              Pieces: []
+            - Range: 0x84de84..0x84de85
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84de85..0x84deb0
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84dd98..0x84dda0
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 99 PointerType *int
+          Locations:
+            - Range: 0x84dd48..0x84dd64
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 100
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84dc50..0x84dd70]
+      OutOfLinePCRanges: [0x84deb0..0x84e010]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dc50..0x84dc8c
+            - Range: 0x84deb0..0x84deec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc8c..0x84dcd4
+            - Range: 0x84deec..0x84df34
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dcd4..0x84dd14
+            - Range: 0x84df34..0x84dfb4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dd14..0x84dd3c
+            - Range: 0x84dfb4..0x84dfdc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd3c..0x84dd40
+            - Range: 0x84dfdc..0x84dfe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd40..0x84dd70
+            - Range: 0x84dfe0..0x84e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84dc50..0x84dcf4
+            - Range: 0x84deb0..0x84df94
               Pieces: []
-            - Range: 0x84dcf4..0x84dcf5
+            - Range: 0x84df94..0x84df95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dcf5..0x84dd08
+            - Range: 0x84df95..0x84dfa8
               Pieces: []
-            - Range: 0x84dd08..0x84dd09
+            - Range: 0x84dfa8..0x84dfa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dd09..0x84dd70
+            - Range: 0x84dfa9..0x84e010
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84dc50..0x84dc8c
+            - Range: 0x84deb0..0x84deec
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc8c..0x84dcd4
+            - Range: 0x84deec..0x84df34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dcd4..0x84dcdc
+            - Range: 0x84df34..0x84df3c
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -48}
+                  Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dcdc..0x84dd00
+            - Range: 0x84df3c..0x84dfa0
               Pieces:
                 - Size: 8
-                  Op: {CfaOffset: -48}
+                  Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd00..0x84dd04
+            - Range: 0x84dfa0..0x84dfa4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd04..0x84dd08
+            - Range: 0x84dfa4..0x84dfa8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dd08..0x84dd70
+            - Range: 0x84dfa8..0x84e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84dd70..0x84de10]
+      OutOfLinePCRanges: [0x84e010..0x84e0b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84dd70..0x84ddb0
+            - Range: 0x84e010..0x84e02c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84ddb0..0x84de10
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84dd70..0x84dde4
+            - Range: 0x84e010..0x84e088
               Pieces: []
-            - Range: 0x84dde4..0x84dde5
+            - Range: 0x84e088..0x84e089
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dde5..0x84de10
+            - Range: 0x84e089..0x84e0b0
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84de10..0x84ded0]
+      OutOfLinePCRanges: [0x84e0b0..0x84e180]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84de10..0x84de54
+            - Range: 0x84e0b0..0x84e100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84de54..0x84ded0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84de10..0x84dea4
+            - Range: 0x84e0b0..0x84e154
               Pieces: []
-            - Range: 0x84dea4..0x84dea5
+            - Range: 0x84e154..0x84e155
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84dea5..0x84ded0
+            - Range: 0x84e155..0x84e180
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84de10..0x84dea4
+            - Range: 0x84e0b0..0x84e154
               Pieces: []
-            - Range: 0x84dea4..0x84dea5
+            - Range: 0x84e154..0x84e155
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84dea5..0x84ded0
+            - Range: 0x84e155..0x84e180
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84ded0..0x84df80]
+      OutOfLinePCRanges: [0x84e180..0x84e240]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ded0..0x84df10
+            - Range: 0x84e180..0x84e1c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84df10..0x84df80
+            - Range: 0x84e1c0..0x84e240
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ded0..0x84df60
+            - Range: 0x84e180..0x84e220
               Pieces: []
-            - Range: 0x84df60..0x84df61
+            - Range: 0x84e220..0x84e221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84df61..0x84df80
+            - Range: 0x84e221..0x84e240
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ded0..0x84df60
+            - Range: 0x84e180..0x84e220
               Pieces: []
-            - Range: 0x84df60..0x84df61
+            - Range: 0x84e220..0x84e221
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84df61..0x84df80
+            - Range: 0x84e221..0x84e240
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ded0..0x84df60
+            - Range: 0x84e180..0x84e220
               Pieces: []
-            - Range: 0x84df60..0x84df61
+            - Range: 0x84e220..0x84e221
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84df61..0x84df80
+            - Range: 0x84e221..0x84e240
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84e230..0x84e240]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0x84e240..0x84e2d0]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 248 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 16 BaseType int8
           Locations:
-            - Range: 0x84e230..0x84e240
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 94 BaseType int16
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 13 BaseType int64
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x84e240..0x84e2b0
+              Pieces: []
+            - Range: 0x84e2b0..0x84e2b1
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x84e2b1..0x84e2d0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84e240..0x84e250]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x84e2d0..0x84e390]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 248 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84e240..0x84e250
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 18 BaseType float64
+          Locations:
+            - Range: 0x84e2d0..0x84e36c
+              Pieces: []
+            - Range: 0x84e36c..0x84e36d
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x84e36d..0x84e390
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84e250..0x84e260]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x84e390..0x84e410]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 95 BaseType complex64
+          Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 96 BaseType complex128
+          Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0x84e410..0x84e4e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84e410..0x84e4c4
+              Pieces: []
+            - Range: 0x84e4c4..0x84e4c5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84e4c5..0x84e4e0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x84e4e0..0x84e570]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0x84e4e0..0x84e550
+              Pieces: []
+            - Range: 0x84e550..0x84e551
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x84e551..0x84e570
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x84e570..0x84e5e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 ArrayType [1]int
+          Locations:
+            - Range: 0x84e570..0x84e5c4
+              Pieces: []
+            - Range: 0x84e5c4..0x84e5c5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84e5c5..0x84e5e0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x84e5e0..0x84e650]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0x84e5e0..0x84e630
+              Pieces: []
+            - Range: 0x84e630..0x84e631
+              Pieces: []
+            - Range: 0x84e631..0x84e650
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x84e650..0x84e6d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 StructureType main.mixedStruct
+          Locations: [{Range: 0x84e650..0x84e6d0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0x84e6d0..0x84e770]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84e6d0..0x84e74c
+              Pieces: []
+            - Range: 0x84e74c..0x84e74d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84e74d..0x84e770
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0x84e770..0x84e850]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 253 StructureType main.wideStruct
+          Locations:
+            - Range: 0x84e770..0x84e834
+              Pieces: []
+            - Range: 0x84e834..0x84e835
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+            - Range: 0x84e835..0x84e850
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x84e850..0x84e8e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e850..0x84e8c0
+              Pieces: []
+            - Range: 0x84e8c0..0x84e8c1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84e8c1..0x84e8e0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84e850..0x84e8c0
+              Pieces: []
+            - Range: 0x84e8c0..0x84e8c1
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84e8c1..0x84e8e0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84e850..0x84e8c0
+              Pieces: []
+            - Range: 0x84e8c0..0x84e8c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x84e8c1..0x84e8e0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x84e8e0..0x84e970]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0x84e8e0..0x84e950
+              Pieces: []
+            - Range: 0x84e950..0x84e951
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x84e951..0x84e970
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x84e970..0x84e9e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e970..0x84e9e0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x84e9e0..0x84ea60]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 17 BaseType float32
+          Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 18 BaseType float64
+          Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0x84ea60..0x84ead0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x84ea60..0x84eab8
+              Pieces: []
+            - Range: 0x84eab8..0x84eab9
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84eab9..0x84ead0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0x84ea60..0x84eab8
+              Pieces: []
+            - Range: 0x84eab8..0x84eab9
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84eab9..0x84ead0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0x84ead0..0x84ec90]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84ead0..0x84eb3c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84eb3c..0x84eb50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84eb50..0x84eb54
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84ead0..0x84ec48
+              Pieces: []
+            - Range: 0x84ec48..0x84ec49
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84ec49..0x84ec90
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0x84ec90..0x84ed60]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0x84ec90..0x84ed60
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0x84ec90..0x84ed44
+              Pieces: []
+            - Range: 0x84ed44..0x84ed45
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x84ed45..0x84ed60
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0x84ed60..0x84ef90]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84ed60..0x84edd0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84edd0..0x84ede4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84ede4..0x84ede8
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84ed60..0x84ef90
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84ed60..0x84ef50
+              Pieces: []
+            - Range: 0x84ef50..0x84ef51
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84ef51..0x84ef90
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0x84ef90..0x84f160]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84eff4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84eff4..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84ef90..0x84f008
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0x84f008..0x84f160
+              Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0x84ef90..0x84f118
+              Pieces: []
+            - Range: 0x84f118..0x84f119
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+            - Range: 0x84f119..0x84f160
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0x84f160..0x84f370]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1d4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84f1d4..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x84f1e8..0x84f370
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84f160..0x84f1e8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84f1e8..0x84f370
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 248 StructureType main.largeStruct
+          Locations:
+            - Range: 0x84f160..0x84f32c
+              Pieces: []
+            - Range: 0x84f32c..0x84f32d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x84f32d..0x84f370
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0x84f370..0x84f410]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 159 ArrayType [5]int
+          Locations:
+            - Range: 0x84f370..0x84f410
+              Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f370..0x84f3ec
+              Pieces: []
+            - Range: 0x84f3ec..0x84f3ed
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f3ed..0x84f410
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f370..0x84f3ec
+              Pieces: []
+            - Range: 0x84f3ec..0x84f3ed
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x84f3ed..0x84f410
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f370..0x84f3ec
+              Pieces: []
+            - Range: 0x84f3ec..0x84f3ed
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x84f3ed..0x84f410
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0x84f410..0x84f4f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0x84f410..0x84f4f0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 249 ArrayType [3]int
+          Locations:
+            - Range: 0x84f410..0x84f4f0
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f410..0x84f4d4
+              Pieces: []
+            - Range: 0x84f4d4..0x84f4d5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f4d5..0x84f4f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 111 ArrayType [2]int
+          Locations:
+            - Range: 0x84f410..0x84f4d4
+              Pieces: []
+            - Range: 0x84f4d4..0x84f4d5
+              Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
+            - Range: 0x84f4d5..0x84f4f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0x84f4f0..0x84f5c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0x84f4f0..0x84f5c0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f4f0..0x84f59c
+              Pieces: []
+            - Range: 0x84f59c..0x84f59d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f59d..0x84f5c0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 254 StructureType main.structWithArray
+          Locations:
+            - Range: 0x84f4f0..0x84f59c
+              Pieces: []
+            - Range: 0x84f59c..0x84f59d
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x84f59d..0x84f5c0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f570..0x84f5c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0x84f5c0..0x84f660]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 251 ArrayType [0]int
+          Locations: [{Range: 0x84f5c0..0x84f660, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f5c0..0x84f600
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f600..0x84f61c
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x84f61c..0x84f624
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x84f624..0x84f660
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84f5c0..0x84f640
+              Pieces: []
+            - Range: 0x84f640..0x84f641
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84f641..0x84f660
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 251 ArrayType [0]int
+          Locations:
+            - Range: 0x84f5c0..0x84f640
+              Pieces: []
+            - Range: 0x84f640..0x84f641
+              Pieces: []
+            - Range: 0x84f641..0x84f660
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84fac0..0x84fad0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 249 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84e250..0x84e260
+            - Range: 0x84fac0..0x84fad0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4244,15 +5985,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84fad0..0x84fae0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84fad0..0x84fae0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84fae0..0x84faf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x84fae0..0x84faf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84e260..0x84e270]
+      OutOfLinePCRanges: [0x84faf0..0x84fb00]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84e260..0x84e270
+            - Range: 0x84faf0..0x84fb00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4265,19 +6042,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e260..0x84e270
+            - Range: 0x84faf0..0x84fb00
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84e270..0x84e280]
+      OutOfLinePCRanges: [0x84fb00..0x84fb10]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84e270..0x84e280
+            - Range: 0x84fb00..0x84fb10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4290,19 +6067,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e270..0x84e280
+            - Range: 0x84fb00..0x84fb10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84e280..0x84e290]
+      OutOfLinePCRanges: [0x84fb10..0x84fb20]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 251 GoSliceHeaderType []main.structWithNoStrings
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84e280..0x84e290
+            - Range: 0x84fb10..0x84fb20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4315,19 +6092,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e280..0x84e290
+            - Range: 0x84fb10..0x84fb20
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84e290..0x84e2a0]
+      OutOfLinePCRanges: [0x84fb20..0x84fb30]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84e290..0x84e2a0
+            - Range: 0x84fb20..0x84fb30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4337,22 +6114,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84e2a0..0x84e2b0]
+      OutOfLinePCRanges: [0x84fb30..0x84fb40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84fb30..0x84fb40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 255 GoSliceHeaderType []bool
+          Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84fb30..0x84fb40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -4365,19 +6142,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84e2a0..0x84e2b0
+            - Range: 0x84fb30..0x84fb40
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84e2b0..0x84e2c0]
+      OutOfLinePCRanges: [0x84fb40..0x84fb50]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 256 GoSliceHeaderType []uint16
+          Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84e2b0..0x84e2c0
+            - Range: 0x84fb40..0x84fb50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4387,15 +6164,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84e2c0..0x84e2d0]
+      OutOfLinePCRanges: [0x84fb50..0x84fb60]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 248 GoSliceHeaderType []uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84e2c0..0x84e2d0
+            - Range: 0x84fb50..0x84fb60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4405,15 +6182,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x84e2d0..0x84e2e0]
+      OutOfLinePCRanges: [0x84fb60..0x84fb70]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 257 GoSliceHeaderType []struct {}
+          Type: 264 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x84e2d0..0x84e2e0
+            - Range: 0x84fb60..0x84fb70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4423,35 +6200,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0x84e5b0..0x84e620]
+      OutOfLinePCRanges: [0x84fe40..0x84feb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e5b0..0x84e5fc
+            - Range: 0x84fe40..0x84fe8c
               Pieces: []
-            - Range: 0x84e5fc..0x84e5fd
+            - Range: 0x84fe8c..0x84fe8d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84e5fd..0x84e620
+            - Range: 0x84fe8d..0x84feb0
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84e620..0x84e630]
+      OutOfLinePCRanges: [0x84feb0..0x84fec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e620..0x84e630
+            - Range: 0x84feb0..0x84fec0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4459,15 +6236,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84e630..0x84e640]
+      OutOfLinePCRanges: [0x84fec0..0x84fed0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e630..0x84e640
+            - Range: 0x84fec0..0x84fed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4478,7 +6255,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e630..0x84e640
+            - Range: 0x84fec0..0x84fed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4489,7 +6266,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e630..0x84e640
+            - Range: 0x84fec0..0x84fed0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4497,15 +6274,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84e640..0x84e660]
+      OutOfLinePCRanges: [0x84fed0..0x84fef0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 259 StructureType main.threeStringStruct
+          Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84e640..0x84e660
+            - Range: 0x84fed0..0x84fef0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4521,39 +6298,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84e660..0x84e670]
+      OutOfLinePCRanges: [0x84fef0..0x84ff00]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 260 PointerType *main.threeStringStruct
+          Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84e660..0x84e670
+            - Range: 0x84fef0..0x84ff00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84e670..0x84e680]
+      OutOfLinePCRanges: [0x84ff00..0x84ff10]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 261 PointerType *main.oneStringStruct
+          Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84e670..0x84e680
+            - Range: 0x84ff00..0x84ff10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84e680..0x84e690]
+      OutOfLinePCRanges: [0x84ff10..0x84ff20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e680..0x84e690
+            - Range: 0x84ff10..0x84ff20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4561,15 +6338,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84e690..0x84e6a0]
+      OutOfLinePCRanges: [0x84ff20..0x84ff30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e690..0x84e6a0
+            - Range: 0x84ff20..0x84ff30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4577,15 +6354,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84e6a0..0x84e6b0]
+      OutOfLinePCRanges: [0x84ff30..0x84ff40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e6a0..0x84e6b0
+            - Range: 0x84ff30..0x84ff40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4593,27 +6370,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x84e7f0..0x84e800]
+      OutOfLinePCRanges: [0x850080..0x850090]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 263 StructureType main.structWithCyclicSlices
+          Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x84e7f0..0x84e800
+            - Range: 0x850080..0x850090
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x84e800..0x84e820]
+      OutOfLinePCRanges: [0x850090..0x8500b0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 276 StructureType main.structWithCyclicMaps
+          Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x84e800..0x84e820
+            - Range: 0x850090..0x8500b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4629,15 +6406,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84e8f0..0x84e910]
+      OutOfLinePCRanges: [0x850180..0x8501a0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 307 StructureType main.aStruct
+          Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x84e8f0..0x84e910
+            - Range: 0x850180..0x8501a0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4655,29 +6432,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84e9f0..0x84ea00]
+      OutOfLinePCRanges: [0x850280..0x850290]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 308 StructureType main.emptyStruct
-          Locations: [{Range: 0x84e9f0..0x84ea00, Pieces: []}]
+          Type: 315 StructureType main.emptyStruct
+          Locations: [{Range: 0x850280..0x850290, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x84ea00..0x84ea10]
+      OutOfLinePCRanges: [0x850290..0x8502a0]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 309 PointerType *main.emptyStruct
+          Type: 316 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x84ea00..0x84ea10
+            - Range: 0x850290..0x8502a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84ad00..0x84ad70]
       InlinePCRanges:
@@ -4707,28 +6484,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af98..0x84afd0]
           RootRanges: [0x84af30..0x84aff0]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b08c..0x84b0d0]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b140..0x84b178]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4742,7 +6519,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4767,20 +6544,20 @@ Types:
       ByteSize: 8
       Pointee: 138 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1210
+      ID: 1217
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1211 PointerType *main.deepSlice3
+      Pointee: 1218 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1236 PointerType *main.deepSlice8
+      Pointee: 1243 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1242 PointerType *main.deepSlice9
+      Pointee: 1249 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 151
       Name: '**main.stringType2'
@@ -4788,7 +6565,7 @@ Types:
       GoKind: 22
       Pointee: 152 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1206
+      ID: 1213
       Name: '**main.t'
       ByteSize: 8
       Pointee: 246 PointerType *main.t
@@ -4825,30 +6602,30 @@ Types:
       ByteSize: 8
       Pointee: 146 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1218
+      ID: 1225
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1219 PointerType *table<int,*main.deepMap3>
+      Pointee: 1226 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1252
+      ID: 1259
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1253 PointerType *table<int,*main.deepMap8>
+      Pointee: 1260 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1268 PointerType *table<int,*main.deepMap9>
+      Pointee: 1275 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 168 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1282
+      ID: 1289
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1283 PointerType *table<int,interface {}>
+      Pointee: 1290 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '**table<int,struct {}>'
@@ -4870,10 +6647,10 @@ Types:
       ByteSize: 8
       Pointee: 183 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 953 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 960 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '**table<string,int>'
@@ -4890,35 +6667,35 @@ Types:
       ByteSize: 8
       Pointee: 230 PointerType *table<struct {},int>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '**table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 PointerType *table<struct {},main.structWithCyclicMaps>
+      Pointee: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 305
+      ID: 312
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 306 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 239
       Name: '**table<struct {},struct {}>'
@@ -4935,115 +6712,115 @@ Types:
       ByteSize: 8
       Pointee: 210 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 320
+      ID: 327
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 326 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1214
+      ID: 1221
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1213 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1220 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1239
+      ID: 1246
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1238 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1245 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1245
+      ID: 1252
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1244 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1251 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []*string.array
+      Pointee: 323 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 480
+      ID: 487
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 479 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 486 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 478
+      ID: 485
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 477 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 484 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 273
+      ID: 280
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 476
+      ID: 483
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 475 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 482 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 271
+      ID: 278
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 474
+      ID: 481
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 473 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 480 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 269
+      ID: 276
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 472
+      ID: 479
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 471 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 478 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 458
+      ID: 465
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 457 GoSliceDataType [][]uint.array
+      Pointee: 464 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 464
+      ID: 471
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 463 GoSliceDataType []bool.array
+      Pointee: 470 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 989
+      ID: 996
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 988 GoSliceDataType []float64.array
+      Pointee: 995 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1248
+      ID: 1255
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1247 GoSliceDataType []interface {}.array
+      Pointee: 1254 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 267
+      ID: 274
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 264 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 470
+      ID: 477
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 469 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 476 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 530
+      ID: 537
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 529 GoSliceDataType []main.structWithMap.array
+      Pointee: 536 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 460
+      ID: 467
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 459 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 466 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -5052,101 +6829,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 462
+      ID: 469
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 461 GoSliceDataType []string.array
+      Pointee: 468 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 468
+      ID: 475
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 467 GoSliceDataType []struct {}.array
+      Pointee: 474 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 250
+      ID: 257
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 248 GoSliceHeaderType []uint
+      Pointee: 255 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 456
+      ID: 463
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 455 GoSliceDataType []uint.array
+      Pointee: 462 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 466
+      ID: 473
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 465 GoSliceDataType []uint16.array
+      Pointee: 472 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 313
+      ID: 320
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 312 GoSliceDataType []uint8.array
+      Pointee: 319 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 315
+      ID: 322
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []uintptr.array
+      Pointee: 321 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.978304e+06
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1127 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 760
+      ID: 767
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 926944
       GoKind: 22
-      Pointee: 761 GoSliceHeaderType archive/tar.headerError
+      Pointee: 768 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 762 GoSliceDataType archive/tar.headerError.array
+      Pointee: 769 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1054
+      ID: 1061
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.432192e+06
       GoKind: 22
-      Pointee: 1055 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1062 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1002
+      ID: 1009
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 927136
       GoKind: 22
-      Pointee: 1003 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1010 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1004
+      ID: 1011
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 927232
       GoKind: 22
-      Pointee: 1005 StructureType archive/zip.dirWriter
+      Pointee: 1012 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1102
+      ID: 1109
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.897984e+06
       GoKind: 22
-      Pointee: 1103 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1110 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1030
+      ID: 1037
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.053568e+06
       GoKind: 22
-      Pointee: 1031 StructureType archive/zip.nopCloser
+      Pointee: 1038 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1032
+      ID: 1039
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.053824e+06
       GoKind: 22
-      Pointee: 1033 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1040 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -5155,421 +6932,421 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.166432e+06
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType bufio.Reader
+      Pointee: 1085 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1106
+      ID: 1113
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.942496e+06
       GoKind: 22
-      Pointee: 1107 UnresolvedPointeeType bufio.Writer
+      Pointee: 1114 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1157
+      ID: 1164
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.263712e+06
       GoKind: 22
-      Pointee: 1158 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1165 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 909568
       GoKind: 22
-      Pointee: 564 BaseType compress/flate.CorruptInputError
+      Pointee: 571 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 909664
       GoKind: 22
-      Pointee: 565 GoStringHeaderType compress/flate.InternalError
+      Pointee: 572 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 567
+      ID: 574
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 566 GoStringDataType compress/flate.InternalError.str
+      Pointee: 573 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1052
+      ID: 1059
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.421632e+06
       GoKind: 22
-      Pointee: 1053 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1060 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 998
+      ID: 1005
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 909760
       GoKind: 22
-      Pointee: 999 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1006 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1074
+      ID: 1081
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.719968e+06
       GoKind: 22
-      Pointee: 1075 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1082 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 904
+      ID: 911
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.20016e+06
       GoKind: 22
-      Pointee: 905 StructureType context.deadlineExceededError
+      Pointee: 912 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921568
       GoKind: 22
-      Pointee: 578 BaseType crypto/aes.KeySizeError
+      Pointee: 585 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 753
+      ID: 760
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 921760
       GoKind: 22
-      Pointee: 579 BaseType crypto/des.KeySizeError
+      Pointee: 586 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922048
       GoKind: 22
-      Pointee: 580 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 587 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1064
+      ID: 1071
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.562272e+06
       GoKind: 22
-      Pointee: 1065 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1072 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 1098
+      ID: 1105
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.85664e+06
       GoKind: 22
-      Pointee: 1099 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1106 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1130
+      ID: 1137
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.11376e+06
       GoKind: 22
-      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1138 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1104
+      ID: 1111
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.898496e+06
       GoKind: 22
-      Pointee: 1105 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1112 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1100
+      ID: 1107
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.857088e+06
       GoKind: 22
-      Pointee: 1101 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1108 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1096
+      ID: 1103
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.849472e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1104 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 922336
       GoKind: 22
-      Pointee: 581 BaseType crypto/rc4.KeySizeError
+      Pointee: 588 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1114
+      ID: 1121
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.947872e+06
       GoKind: 22
-      Pointee: 1115 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1122 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1086
+      ID: 1093
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.803456e+06
       GoKind: 22
-      Pointee: 1087 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1094 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 911200
       GoKind: 22
-      Pointee: 568 BaseType crypto/tls.AlertError
+      Pointee: 575 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.042176e+06
       GoKind: 22
-      Pointee: 845 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 852 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1183
+      ID: 1190
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.375584e+06
       GoKind: 22
-      Pointee: 1184 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1191 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 911008
       GoKind: 22
-      Pointee: 677 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 684 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 674
+      ID: 681
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 910912
       GoKind: 22
-      Pointee: 675 StructureType crypto/tls.RecordHeaderError
+      Pointee: 682 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 843
+      ID: 850
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.040512e+06
       GoKind: 22
-      Pointee: 800 BaseType crypto/tls.alert
+      Pointee: 807 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1062
+      ID: 1069
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.555232e+06
       GoKind: 22
-      Pointee: 1063 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1070 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.637664e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1077 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 939
+      ID: 946
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.421952e+06
       GoKind: 22
-      Pointee: 940 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 947 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.036352e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 962 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 748
+      ID: 755
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 920608
       GoKind: 22
-      Pointee: 749 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 756 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 742
+      ID: 749
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 920128
       GoKind: 22
-      Pointee: 743 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 750 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 744
+      ID: 751
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 920224
       GoKind: 22
-      Pointee: 745 StructureType crypto/x509.HostnameError
+      Pointee: 752 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 920032
       GoKind: 22
-      Pointee: 577 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 584 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 849
+      ID: 856
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.047936e+06
       GoKind: 22
-      Pointee: 850 StructureType crypto/x509.SystemRootsError
+      Pointee: 857 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 750
+      ID: 757
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 920704
       GoKind: 22
-      Pointee: 751 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 758 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 746
+      ID: 753
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 920512
       GoKind: 22
-      Pointee: 747 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 754 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 764
+      ID: 771
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 927424
       GoKind: 22
-      Pointee: 765 StructureType encoding/asn1.StructuralError
+      Pointee: 772 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 927616
       GoKind: 22
-      Pointee: 769 StructureType encoding/asn1.SyntaxError
+      Pointee: 776 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 927520
       GoKind: 22
-      Pointee: 767 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 774 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 907648
       GoKind: 22
-      Pointee: 562 BaseType encoding/base64.CorruptInputError
+      Pointee: 569 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1020
+      ID: 1027
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.037696e+06
       GoKind: 22
-      Pointee: 1021 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1028 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 665
+      ID: 672
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 908512
       GoKind: 22
-      Pointee: 563 BaseType encoding/hex.InvalidByteError
+      Pointee: 570 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 902368
       GoKind: 22
-      Pointee: 634 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 641 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 835
+      ID: 842
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.033984e+06
       GoKind: 22
-      Pointee: 836 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 843 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 625
+      ID: 632
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 901984
       GoKind: 22
-      Pointee: 626 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 633 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 902272
       GoKind: 22
-      Pointee: 632 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 639 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 902176
       GoKind: 22
-      Pointee: 630 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 637 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 902080
       GoKind: 22
-      Pointee: 628 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 635 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1163
+      ID: 1170
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.288736e+06
       GoKind: 22
-      Pointee: 1164 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1171 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 902752
       GoKind: 22
-      Pointee: 636 StructureType encoding/json.jsonError
+      Pointee: 643 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1028
+      ID: 1035
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.050496e+06
       GoKind: 22
-      Pointee: 1029 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1036 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 736
+      ID: 743
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 919072
       GoKind: 22
-      Pointee: 737 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 744 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 734
+      ID: 741
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 918976
       GoKind: 22
-      Pointee: 735 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 742 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 738
+      ID: 745
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 919168
       GoKind: 22
-      Pointee: 574 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 581 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 576
+      ID: 583
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 575 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 582 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 919264
       GoKind: 22
-      Pointee: 740 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 747 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1141
+      ID: 1148
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.152192e+06
       GoKind: 22
-      Pointee: 1142 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1149 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 104
       Name: '*error'
@@ -5578,19 +7355,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 892672
       GoKind: 22
-      Pointee: 604 UnresolvedPointeeType errors.errorString
+      Pointee: 611 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 802
+      ID: 809
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.01888e+06
       GoKind: 22
-      Pointee: 803 UnresolvedPointeeType errors.joinError
+      Pointee: 810 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 106
       Name: '*float32'
@@ -5606,813 +7383,813 @@ Types:
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
-      ID: 1151
+      ID: 1158
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.256032e+06
       GoKind: 22
-      Pointee: 1152 UnresolvedPointeeType fmt.pp
+      Pointee: 1159 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.019008e+06
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType fmt.wrapError
+      Pointee: 812 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 806
+      ID: 813
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.019136e+06
       GoKind: 22
-      Pointee: 807 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 814 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 663
+      ID: 670
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 908032
       GoKind: 22
-      Pointee: 664 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 671 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 644
+      ID: 651
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 905152
       GoKind: 22
-      Pointee: 645 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 652 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 646
+      ID: 653
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 905248
       GoKind: 22
-      Pointee: 647 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 654 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 966
+      ID: 973
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 904960
       GoKind: 22
-      Pointee: 967 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 974 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 650
+      ID: 657
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 905536
       GoKind: 22
-      Pointee: 651 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 658 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 968
+      ID: 975
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 905056
       GoKind: 22
-      Pointee: 969 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 976 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 648
+      ID: 655
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 905344
       GoKind: 22
-      Pointee: 556 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 563 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 558
+      ID: 565
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 557 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 904864
       GoKind: 22
-      Pointee: 553 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 560 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 555
+      ID: 562
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 554 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 905440
       GoKind: 22
-      Pointee: 559 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 566 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 561
+      ID: 568
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 560 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1042
+      ID: 1049
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.205664e+06
       GoKind: 22
-      Pointee: 1043 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1050 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.05136e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1135 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 758
+      ID: 765
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 925888
       GoKind: 22
-      Pointee: 759 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 766 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.209248e+06
       GoKind: 22
-      Pointee: 914 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 921 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1159
+      ID: 1166
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.26576e+06
       GoKind: 22
-      Pointee: 1160 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1167 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 914560
       GoKind: 22
-      Pointee: 686 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 693 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 915616
       GoKind: 22
-      Pointee: 693 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 700 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 915328
       GoKind: 22
-      Pointee: 573 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 580 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 690
+      ID: 697
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 915520
       GoKind: 22
-      Pointee: 691 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 698 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 688
+      ID: 695
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 915424
       GoKind: 22
-      Pointee: 689 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 696 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 708
+      ID: 715
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 917536
       GoKind: 22
-      Pointee: 709 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 716 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 712
+      ID: 719
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 917728
       GoKind: 22
-      Pointee: 713 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 720 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 710
+      ID: 717
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 917632
       GoKind: 22
-      Pointee: 711 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 718 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 706
+      ID: 713
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 917440
       GoKind: 22
-      Pointee: 707 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 714 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 991
+      ID: 998
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 990 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 997 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 720
+      ID: 727
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 918112
       GoKind: 22
-      Pointee: 721 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 728 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 714
+      ID: 721
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 917824
       GoKind: 22
-      Pointee: 715 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 722 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 718
+      ID: 725
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 918016
       GoKind: 22
-      Pointee: 719 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 726 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 716
+      ID: 723
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 917920
       GoKind: 22
-      Pointee: 717 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 724 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 722
+      ID: 729
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 918208
       GoKind: 22
-      Pointee: 723 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 730 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 728
+      ID: 735
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 918496
       GoKind: 22
-      Pointee: 729 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 736 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 730
+      ID: 737
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 918592
       GoKind: 22
-      Pointee: 731 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 738 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 726
+      ID: 733
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 918400
       GoKind: 22
-      Pointee: 727 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 734 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 724
+      ID: 731
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 918304
       GoKind: 22
-      Pointee: 725 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 732 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 732
+      ID: 739
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 918784
       GoKind: 22
-      Pointee: 733 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 906688
       GoKind: 22
-      Pointee: 653 StructureType github.com/cihub/seelog.baseError
+      Pointee: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1080
+      ID: 1087
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.796064e+06
       GoKind: 22
-      Pointee: 1081 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1088 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 906784
       GoKind: 22
-      Pointee: 655 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 662 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1060
+      ID: 1067
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.554112e+06
       GoKind: 22
-      Pointee: 1061 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1068 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1016
+      ID: 1023
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.036672e+06
       GoKind: 22
-      Pointee: 1017 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1024 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1050
+      ID: 1057
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.419712e+06
       GoKind: 22
-      Pointee: 1051 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1058 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 906976
       GoKind: 22
-      Pointee: 659 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 666 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1117
+      ID: 1124
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.968224e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1125 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.125344e+06
       GoKind: 22
-      Pointee: 1129 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1136 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1133
+      ID: 1140
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.12496e+06
       GoKind: 22
-      Pointee: 1132 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1139 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1018
+      ID: 1025
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.0368e+06
       GoKind: 22
-      Pointee: 1019 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1026 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 906880
       GoKind: 22
-      Pointee: 657 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 664 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 907072
       GoKind: 22
-      Pointee: 661 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 668 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1082
+      ID: 1089
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.797856e+06
       GoKind: 22
-      Pointee: 1083 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1090 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.00496e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1131 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.036032e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1133 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.434592e+06
       GoKind: 22
-      Pointee: 945 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 952 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 857
+      ID: 864
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.062016e+06
       GoKind: 22
-      Pointee: 858 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 865 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 855
+      ID: 862
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.061888e+06
       GoKind: 22
-      Pointee: 856 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 863 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.065984e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 867 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.066112e+06
       GoKind: 22
-      Pointee: 862 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 869 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.664736e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1079 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 851
+      ID: 858
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.048576e+06
       GoKind: 22
-      Pointee: 852 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 859 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 908704
       GoKind: 22
-      Pointee: 667 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 674 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1175
+      ID: 1182
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.351808e+06
       GoKind: 22
-      Pointee: 1176 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1183 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.217696e+06
       GoKind: 22
-      Pointee: 916 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 923 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.196448e+06
       GoKind: 22
-      Pointee: 889 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 896 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.196064e+06
       GoKind: 22
-      Pointee: 883 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 890 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.027968e+06
       GoKind: 22
-      Pointee: 822 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 829 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 894
+      ID: 901
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196832e+06
       GoKind: 22
-      Pointee: 895 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 820
+      ID: 827
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.02784e+06
       GoKind: 22
-      Pointee: 799 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 806 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 886
+      ID: 893
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.19632e+06
       GoKind: 22
-      Pointee: 887 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 894 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.196192e+06
       GoKind: 22
-      Pointee: 885 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 892 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 892
+      ID: 899
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.196704e+06
       GoKind: 22
-      Pointee: 893 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 900 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 890
+      ID: 897
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.196576e+06
       GoKind: 22
-      Pointee: 891 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 898 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1179
+      ID: 1186
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.363616e+06
       GoKind: 22
-      Pointee: 1180 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1187 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 898
+      ID: 905
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.197216e+06
       GoKind: 22
-      Pointee: 899 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.028224e+06
       GoKind: 22
-      Pointee: 826 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 833 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.028096e+06
       GoKind: 22
-      Pointee: 824 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 831 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 896
+      ID: 903
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.197088e+06
       GoKind: 22
-      Pointee: 897 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 780
+      ID: 787
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 940384
       GoKind: 22
-      Pointee: 586 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 593 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 588
+      ID: 595
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 587 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 594 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 957
+      ID: 964
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.6632e+06
       GoKind: 22
-      Pointee: 958 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 965 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 865
+      ID: 872
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.080832e+06
       GoKind: 22
-      Pointee: 866 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 873 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1048
+      ID: 1055
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.257248e+06
       GoKind: 22
-      Pointee: 1049 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1056 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1139
+      ID: 1146
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.14032e+06
       GoKind: 22
-      Pointee: 1140 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1147 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1034
+      ID: 1041
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.083136e+06
       GoKind: 22
-      Pointee: 1035 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1042 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 941632
       GoKind: 22
-      Pointee: 589 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 596 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.258912e+06
       GoKind: 22
-      Pointee: 924 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 931 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 784
+      ID: 791
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 941920
       GoKind: 22
-      Pointee: 785 StructureType golang.org/x/net/http2.connError
+      Pointee: 792 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941824
       GoKind: 22
-      Pointee: 593 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 600 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 595
+      ID: 602
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 594 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 601 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 942112
       GoKind: 22
-      Pointee: 599 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 606 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 601
+      ID: 608
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 600 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 607 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 786
+      ID: 793
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 942016
       GoKind: 22
-      Pointee: 596 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 603 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 598
+      ID: 605
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 597 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 604 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 782
+      ID: 789
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 941728
       GoKind: 22
-      Pointee: 590 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 597 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 592
+      ID: 599
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 591 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 598 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1137
+      ID: 1144
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.1384e+06
       GoKind: 22
-      Pointee: 1138 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1145 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 942208
       GoKind: 22
-      Pointee: 789 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 796 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 790
+      ID: 797
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 942304
       GoKind: 22
-      Pointee: 602 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 609 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 935584
       GoKind: 22
-      Pointee: 777 StructureType google.golang.org/grpc.dropError
+      Pointee: 784 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.255968e+06
       GoKind: 22
-      Pointee: 922 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 929 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.441952e+06
       GoKind: 22
-      Pointee: 947 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 954 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 778
+      ID: 785
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 938656
       GoKind: 22
-      Pointee: 779 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 786 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.803904e+06
       GoKind: 22
-      Pointee: 1089 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1096 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1046
+      ID: 1053
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.252512e+06
       GoKind: 22
-      Pointee: 1047 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1054 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.075072e+06
       GoKind: 22
-      Pointee: 864 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 871 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1006
+      ID: 1013
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 938752
       GoKind: 22
-      Pointee: 1007 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1014 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 756
+      ID: 763
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 923776
       GoKind: 22
-      Pointee: 757 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 764 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 853
+      ID: 860
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.051904e+06
       GoKind: 22
-      Pointee: 854 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 861 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.223968e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 927 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.223712e+06
       GoKind: 22
-      Pointee: 918 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 925 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 770
+      ID: 777
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 928480
       GoKind: 22
-      Pointee: 771 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 778 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 772
+      ID: 779
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 928576
       GoKind: 22
-      Pointee: 773 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 780 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 916000
       GoKind: 22
-      Pointee: 701 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 708 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1094
+      ID: 1101
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.844544e+06
       GoKind: 22
-      Pointee: 1095 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1102 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 943072
       GoKind: 22
-      Pointee: 792 UnresolvedPointeeType html/template.Error
+      Pointee: 799 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 99
       Name: '*int'
@@ -6456,103 +8233,103 @@ Types:
       GoKind: 22
       Pointee: 155 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 909280
       GoKind: 22
-      Pointee: 671 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 678 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 909184
       GoKind: 22
-      Pointee: 669 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 676 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 992
+      ID: 999
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 897184
       GoKind: 22
-      Pointee: 993 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1000 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.195296e+06
       GoKind: 22
-      Pointee: 881 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 888 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1181
+      ID: 1188
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.369248e+06
       GoKind: 22
-      Pointee: 1182 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1189 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.195168e+06
       GoKind: 22
-      Pointee: 879 StructureType internal/poll.errNetClosing
+      Pointee: 886 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 605
+      ID: 612
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 896416
       GoKind: 22
-      Pointee: 606 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 613 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 1038
+      ID: 1045
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.186976e+06
       GoKind: 22
-      Pointee: 1039 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1046 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1036
+      ID: 1043
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.186592e+06
       GoKind: 22
-      Pointee: 1037 StructureType io.discard
+      Pointee: 1044 StructureType io.discard
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.019904e+06
       GoKind: 22
-      Pointee: 1011 UnresolvedPointeeType io.multiWriter
+      Pointee: 1018 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.194912e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType io/fs.PathError
+      Pointee: 884 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1084
+      ID: 1091
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.79808e+06
       GoKind: 22
-      Pointee: 1085 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1092 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 327
+      ID: 334
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 383680
       GoKind: 22
-      Pointee: 328 StructureType main.deepMap2
+      Pointee: 335 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1226
+      ID: 1233
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 383616
       GoKind: 22
-      Pointee: 1227 UnresolvedPointeeType main.deepMap3
+      Pointee: 1234 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 147
       Name: '*main.deepMap7'
@@ -6561,19 +8338,19 @@ Types:
       GoKind: 22
       Pointee: 148 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 383296
       GoKind: 22
-      Pointee: 1261 StructureType main.deepMap8
+      Pointee: 1268 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 383232
       GoKind: 22
-      Pointee: 1276 StructureType main.deepMap9
+      Pointee: 1283 StructureType main.deepMap9
     - __kind: PointerType
       ID: 131
       Name: '*main.deepPtr2'
@@ -6582,12 +8359,12 @@ Types:
       GoKind: 22
       Pointee: 132 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1185
+      ID: 1192
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 384192
       GoKind: 22
-      Pointee: 1186 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1193 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr7'
@@ -6596,33 +8373,33 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 383872
       GoKind: 22
-      Pointee: 1231 StructureType main.deepPtr8
+      Pointee: 1238 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1232
+      ID: 1239
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 383808
       GoKind: 22
-      Pointee: 1233 StructureType main.deepPtr9
+      Pointee: 1240 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 138
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 384832
       GoKind: 22
-      Pointee: 318 StructureType main.deepSlice2
+      Pointee: 325 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1211
+      ID: 1218
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 384768
       GoKind: 22
-      Pointee: 1212 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1219 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 139
       Name: '*main.deepSlice7'
@@ -6631,25 +8408,25 @@ Types:
       GoKind: 22
       Pointee: 140 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1236
+      ID: 1243
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 384448
       GoKind: 22
-      Pointee: 1237 StructureType main.deepSlice8
+      Pointee: 1244 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1242
+      ID: 1249
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 384384
       GoKind: 22
-      Pointee: 1243 StructureType main.deepSlice9
+      Pointee: 1250 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 309
+      ID: 316
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 308 StructureType main.emptyStruct
+      Pointee: 315 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 157
       Name: '*main.esotericHeap'
@@ -6658,12 +8435,12 @@ Types:
       GoKind: 22
       Pointee: 158 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 892384
       GoKind: 22
-      Pointee: 1203 StructureType main.firstBehavior
+      Pointee: 1210 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 245
       Name: '*main.node'
@@ -6672,25 +8449,25 @@ Types:
       GoKind: 22
       Pointee: 244 StructureType main.node
     - __kind: PointerType
-      ID: 261
+      ID: 268
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 262 StructureType main.oneStringStruct
+      Pointee: 269 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 892480
       GoKind: 22
-      Pointee: 1205 StructureType main.secondBehavior
+      Pointee: 1212 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 892576
       GoKind: 22
-      Pointee: 1191 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1198 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 149
       Name: '*main.stringType1'
@@ -6698,33 +8475,33 @@ Types:
       GoKind: 22
       Pointee: 150 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1187 GoStringDataType main.stringType1.str
+      Pointee: 1194 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 152
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1189 UnresolvedPointeeType main.stringType2
+      Pointee: 1196 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 265
+      ID: 272
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 263 StructureType main.structWithCyclicSlices
+      Pointee: 270 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 383168
       GoKind: 22
       Pointee: 163 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 252
+      ID: 259
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 253 StructureType main.structWithNoStrings
+      Pointee: 260 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 242
       Name: '*main.structWithTwoValues'
@@ -6738,16 +8515,16 @@ Types:
       GoKind: 22
       Pointee: 247 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1208
+      ID: 1215
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1207 GoSliceDataType main.t.array
+      Pointee: 1214 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 260
+      ID: 267
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 259 StructureType main.threeStringStruct
+      Pointee: 266 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 222
       Name: '*map<[4]int,[4]int>'
@@ -6774,30 +8551,30 @@ Types:
       ByteSize: 8
       Pointee: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1216
+      ID: 1223
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1217 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1224 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1250
+      ID: 1257
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1251 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1258 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1265
+      ID: 1272
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1266 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1273 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 165
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 166 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1280
+      ID: 1287
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1281 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1288 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 232
       Name: '*map<int,struct {}>'
@@ -6819,10 +8596,10 @@ Types:
       ByteSize: 8
       Pointee: 181 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 951 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 958 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 175
       Name: '*map<string,int>'
@@ -6839,35 +8616,35 @@ Types:
       ByteSize: 8
       Pointee: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: PointerType
-      ID: 278
+      ID: 285
       Name: '*map<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 279 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      Pointee: 286 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 283
+      ID: 290
       Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 284 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 291 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 288
+      ID: 295
       Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 289 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 293
+      ID: 300
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 294 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 298
+      ID: 305
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 299 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 303
+      ID: 310
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 304 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 311 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 237
       Name: '*map<struct {},struct {}>'
@@ -6890,696 +8667,696 @@ Types:
       GoKind: 22
       Pointee: 174 GoMapType map[string]int
     - __kind: PointerType
-      ID: 704
+      ID: 711
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 916864
       GoKind: 22
-      Pointee: 705 StructureType math/big.ErrNaN
+      Pointee: 712 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1000
+      ID: 1007
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 911680
       GoKind: 22
-      Pointee: 1001 StructureType mime/multipart.writerOnly·1
+      Pointee: 1008 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.203488e+06
       GoKind: 22
-      Pointee: 908 UnresolvedPointeeType net.AddrError
+      Pointee: 915 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 933
+      ID: 940
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.417952e+06
       GoKind: 22
-      Pointee: 934 UnresolvedPointeeType net.DNSError
+      Pointee: 941 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1145
+      ID: 1152
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.226368e+06
       GoKind: 22
-      Pointee: 1146 UnresolvedPointeeType net.IPConn
+      Pointee: 1153 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 931
+      ID: 938
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.417632e+06
       GoKind: 22
-      Pointee: 932 UnresolvedPointeeType net.OpError
+      Pointee: 939 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.203616e+06
       GoKind: 22
-      Pointee: 910 UnresolvedPointeeType net.ParseError
+      Pointee: 917 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1155
+      ID: 1162
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.257056e+06
       GoKind: 22
-      Pointee: 1156 UnresolvedPointeeType net.TCPConn
+      Pointee: 1163 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1165
+      ID: 1172
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.302048e+06
       GoKind: 22
-      Pointee: 1166 UnresolvedPointeeType net.UDPConn
+      Pointee: 1173 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.256544e+06
       GoKind: 22
-      Pointee: 1154 UnresolvedPointeeType net.UnixConn
+      Pointee: 1161 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 906
+      ID: 913
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.20272e+06
       GoKind: 22
-      Pointee: 869 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 876 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 871
+      ID: 878
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 870 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 877 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 837
+      ID: 844
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.03488e+06
       GoKind: 22
-      Pointee: 838 StructureType net.canceledError
+      Pointee: 845 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.00208e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType net.conn
+      Pointee: 1129 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 975
+      ID: 982
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.83984e+06
       GoKind: 22
-      Pointee: 976 StructureType net.dialResult·1
+      Pointee: 983 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1167
+      ID: 1174
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.306304e+06
       GoKind: 22
-      Pointee: 1168 UnresolvedPointeeType net.netFD
+      Pointee: 1175 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 903712
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType net.notFoundError
+      Pointee: 645 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 904384
       GoKind: 22
-      Pointee: 640 StructureType net.result·2
+      Pointee: 647 StructureType net.result·2
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.242592e+06
       GoKind: 22
-      Pointee: 1150 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1157 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1147
+      ID: 1154
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.242112e+06
       GoKind: 22
-      Pointee: 1148 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1155 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.204256e+06
       GoKind: 22
-      Pointee: 912 UnresolvedPointeeType net.temporaryError
+      Pointee: 919 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 935
+      ID: 942
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.418112e+06
       GoKind: 22
-      Pointee: 936 UnresolvedPointeeType net.timeoutError
+      Pointee: 943 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.030656e+06
       GoKind: 22
-      Pointee: 828 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 835 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 899488
       GoKind: 22
-      Pointee: 995 StructureType net/http.bufioFlushWriter
+      Pointee: 1002 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 614
+      ID: 621
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 900160
       GoKind: 22
-      Pointee: 534 BaseType net/http.http2ConnectionError
+      Pointee: 541 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 900256
       GoKind: 22
-      Pointee: 616 StructureType net/http.http2GoAwayError
+      Pointee: 623 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 927
+      ID: 934
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.413792e+06
       GoKind: 22
-      Pointee: 928 StructureType net/http.http2StreamError
+      Pointee: 935 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 900832
       GoKind: 22
-      Pointee: 620 StructureType net/http.http2connError
+      Pointee: 627 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1056
+      ID: 1063
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.550592e+06
       GoKind: 22
-      Pointee: 1057 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1064 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 618
+      ID: 625
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900736
       GoKind: 22
-      Pointee: 538 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 545 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 540
+      ID: 547
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 539 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 546 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 901024
       GoKind: 22
-      Pointee: 544 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 551 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 546
+      ID: 553
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 545 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 552 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 621
+      ID: 628
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 900928
       GoKind: 22
-      Pointee: 541 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 548 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 543
+      ID: 550
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 542 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 549 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 902
+      ID: 909
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.199264e+06
       GoKind: 22
-      Pointee: 903 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 910 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.031296e+06
       GoKind: 22
-      Pointee: 834 StructureType net/http.http2noCachedConnError
+      Pointee: 841 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1110
+      ID: 1117
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.944544e+06
       GoKind: 22
-      Pointee: 1111 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1118 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 900640
       GoKind: 22
-      Pointee: 535 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 542 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 537
+      ID: 544
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 536 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 543 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 996
+      ID: 1003
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 901120
       GoKind: 22
-      Pointee: 997 StructureType net/http.http2stickyErrWriter
+      Pointee: 1004 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.030912e+06
       GoKind: 22
-      Pointee: 830 StructureType net/http.nothingWrittenError
+      Pointee: 837 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1058
+      ID: 1065
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.16768e+06
       GoKind: 22
-      Pointee: 1059 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1066 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1014
+      ID: 1021
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.030784e+06
       GoKind: 22
-      Pointee: 1015 StructureType net/http.persistConnWriter
+      Pointee: 1022 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1040
+      ID: 1047
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.198368e+06
       GoKind: 22
-      Pointee: 1041 StructureType net/http.readWriteCloserBody
+      Pointee: 1048 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 623
+      ID: 630
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 901216
       GoKind: 22
-      Pointee: 624 StructureType net/http.requestBodyReadError
+      Pointee: 631 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 929
+      ID: 936
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.414912e+06
       GoKind: 22
-      Pointee: 930 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 937 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 900
+      ID: 907
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.199136e+06
       GoKind: 22
-      Pointee: 901 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 908 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.03104e+06
       GoKind: 22
-      Pointee: 832 StructureType net/http.transportReadFromServerError
+      Pointee: 839 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1092
+      ID: 1099
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.83648e+06
       GoKind: 22
-      Pointee: 1093 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1100 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 612
+      ID: 619
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 899392
       GoKind: 22
-      Pointee: 613 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 620 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1112
+      ID: 1119
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.94608e+06
       GoKind: 22
-      Pointee: 1113 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1120 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1024
+      ID: 1031
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.043328e+06
       GoKind: 22
-      Pointee: 1025 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1032 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 696
+      ID: 703
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 915808
       GoKind: 22
-      Pointee: 697 StructureType net/netip.parseAddrError
+      Pointee: 704 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 694
+      ID: 701
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 915712
       GoKind: 22
-      Pointee: 695 StructureType net/netip.parsePrefixError
+      Pointee: 702 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1066
+      ID: 1073
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.112352e+06
       GoKind: 22
-      Pointee: 1067 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1074 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1026
+      ID: 1033
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.048192e+06
       GoKind: 22
-      Pointee: 1027 StructureType net/smtp.dataCloser
+      Pointee: 1034 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 680
+      ID: 687
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 911872
       GoKind: 22
-      Pointee: 681 UnresolvedPointeeType net/textproto.Error
+      Pointee: 688 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 911776
       GoKind: 22
-      Pointee: 569 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 576 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 577 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1022
+      ID: 1029
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.04256e+06
       GoKind: 22
-      Pointee: 1023 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1030 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 937
+      ID: 944
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.418432e+06
       GoKind: 22
-      Pointee: 938 UnresolvedPointeeType net/url.Error
+      Pointee: 945 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 904480
       GoKind: 22
-      Pointee: 547 GoStringHeaderType net/url.EscapeError
+      Pointee: 554 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 549
+      ID: 556
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 548 GoStringDataType net/url.EscapeError.str
+      Pointee: 555 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 642
+      ID: 649
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 904576
       GoKind: 22
-      Pointee: 550 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 557 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 552
+      ID: 559
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 551 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 558 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 425
+      ID: 432
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 426 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 417
+      ID: 424
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 418 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 365
+      ID: 372
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 366 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 384
+      ID: 391
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 385 StructureType noalg.map.group[bool]main.node
+      Pointee: 392 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 323
+      ID: 330
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 324 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1222
+      ID: 1229
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1256
+      ID: 1263
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 333
+      ID: 340
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 334 StructureType noalg.map.group[int]int
+      Pointee: 341 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1287 StructureType noalg.map.group[int]interface {}
+      Pointee: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 441
+      ID: 448
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 442 StructureType noalg.map.group[int]struct {}
+      Pointee: 449 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 392
+      ID: 399
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 393 StructureType noalg.map.group[int]uint8
+      Pointee: 400 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 374
+      ID: 381
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 375 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 357
+      ID: 364
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 358 StructureType noalg.map.group[string][]string
+      Pointee: 365 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 982
+      ID: 989
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 349
+      ID: 356
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 350 StructureType noalg.map.group[string]int
+      Pointee: 357 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 341
+      ID: 348
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 342 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 433
+      ID: 440
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 434 StructureType noalg.map.group[struct {}]int
+      Pointee: 441 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 491
+      ID: 498
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 499
+      ID: 506
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 507
+      ID: 514
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 515
+      ID: 522
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 523
+      ID: 530
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 449
+      ID: 456
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 450 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 408
+      ID: 415
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 409 StructureType noalg.map.group[uint8][4]int
+      Pointee: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 400
+      ID: 407
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 401 StructureType noalg.map.group[uint8]uint8
+      Pointee: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1173
+      ID: 1180
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.34496e+06
       GoKind: 22
-      Pointee: 1174 UnresolvedPointeeType os.File
+      Pointee: 1181 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.021952e+06
       GoKind: 22
-      Pointee: 809 UnresolvedPointeeType os.LinkError
+      Pointee: 816 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.188256e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType os.SyscallError
+      Pointee: 880 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1171
+      ID: 1178
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.34128e+06
       GoKind: 22
-      Pointee: 1172 StructureType os.fileWithoutReadFrom
+      Pointee: 1179 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1169
+      ID: 1176
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.340544e+06
       GoKind: 22
-      Pointee: 1170 StructureType os.fileWithoutWriteTo
+      Pointee: 1177 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 839
+      ID: 846
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.039232e+06
       GoKind: 22
-      Pointee: 840 UnresolvedPointeeType os/exec.Error
+      Pointee: 847 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 978
+      ID: 985
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.082208e+06
       GoKind: 22
-      Pointee: 979 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 986 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1044
+      ID: 1051
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 1045 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1052 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 841
+      ID: 848
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.03936e+06
       GoKind: 22
-      Pointee: 842 StructureType os/exec.wrappedError
+      Pointee: 849 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 775
+      ID: 782
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 933664
       GoKind: 22
-      Pointee: 583 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 590 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 585
+      ID: 592
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 584 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 591 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 774
+      ID: 781
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 933568
       GoKind: 22
-      Pointee: 582 BaseType os/user.UnknownUserIdError
+      Pointee: 589 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 607
+      ID: 614
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 897088
       GoKind: 22
-      Pointee: 608 UnresolvedPointeeType reflect.ValueError
+      Pointee: 615 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 702
+      ID: 709
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 916480
       GoKind: 22
-      Pointee: 703 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 710 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 812
+      ID: 819
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.023488e+06
       GoKind: 22
-      Pointee: 813 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 820 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 816
+      ID: 823
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.02528e+06
       GoKind: 22
-      Pointee: 817 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 824 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7595,12 +9372,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 814
+      ID: 821
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.023616e+06
       GoKind: 22
-      Pointee: 815 StructureType runtime.boundsError
+      Pointee: 822 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
@@ -7616,24 +9393,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.193632e+06
       GoKind: 22
-      Pointee: 875 StructureType runtime.errorAddressString
+      Pointee: 882 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 810
+      ID: 817
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.023104e+06
       GoKind: 22
-      Pointee: 793 GoStringHeaderType runtime.errorString
+      Pointee: 800 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 794 GoStringDataType runtime.errorString.str
+      Pointee: 801 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -7649,17 +9426,17 @@ Types:
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.023232e+06
       GoKind: 22
-      Pointee: 796 GoStringHeaderType runtime.plainError
+      Pointee: 803 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 798
+      ID: 805
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 797 GoStringDataType runtime.plainError.str
+      Pointee: 804 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7689,12 +9466,12 @@ Types:
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 818
+      ID: 825
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.025536e+06
       GoKind: 22
-      Pointee: 819 UnresolvedPointeeType strconv.NumError
+      Pointee: 826 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 93
       Name: '*string'
@@ -7703,218 +9480,218 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 311
+      ID: 318
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 310 GoStringDataType string.str
+      Pointee: 317 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1108
+      ID: 1115
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.943264e+06
       GoKind: 22
-      Pointee: 1109 UnresolvedPointeeType strings.Builder
+      Pointee: 1116 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1012
+      ID: 1019
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.025664e+06
       GoKind: 22
-      Pointee: 1013 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1020 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 966464
       GoKind: 22
-      Pointee: 1009 StructureType struct { io.Writer }
+      Pointee: 1016 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 258
+      ID: 265
       Name: '*struct {}'
       ByteSize: 8
       Pointee: 123 StructureType struct {}
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.413152e+06
       GoKind: 22
-      Pointee: 925 BaseType syscall.Errno
+      Pointee: 932 BaseType syscall.Errno
     - __kind: PointerType
       ID: 225
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 423 StructureType table<[4]int,[4]int>
+      Pointee: 430 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 220
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 415 StructureType table<[4]int,uint8>
+      Pointee: 422 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 188
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 363 StructureType table<[4]string,[2]int>
+      Pointee: 370 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 200
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 382 StructureType table<bool,main.node>
+      Pointee: 389 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 146
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 321 StructureType table<int,*main.deepMap2>
+      Pointee: 328 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1219
+      ID: 1226
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1220 StructureType table<int,*main.deepMap3>
+      Pointee: 1227 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1253
+      ID: 1260
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1254 StructureType table<int,*main.deepMap8>
+      Pointee: 1261 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1268
+      ID: 1275
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1269 StructureType table<int,*main.deepMap9>
+      Pointee: 1276 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 168
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 331 StructureType table<int,int>
+      Pointee: 338 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1283
+      ID: 1290
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1284 StructureType table<int,interface {}>
+      Pointee: 1291 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 235
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 439 StructureType table<int,struct {}>
+      Pointee: 446 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 205
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 390 StructureType table<int,uint8>
+      Pointee: 397 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 195
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 372 StructureType table<string,[]main.structWithMap>
+      Pointee: 379 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 183
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 355 StructureType table<string,[]string>
+      Pointee: 362 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 953
+      ID: 960
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 980 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 987 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 178
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 347 StructureType table<string,int>
+      Pointee: 354 StructureType table<string,int>
     - __kind: PointerType
       ID: 173
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 339 StructureType table<string,main.nestedStruct>
+      Pointee: 346 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 230
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 431 StructureType table<struct {},int>
+      Pointee: 438 StructureType table<struct {},int>
     - __kind: PointerType
-      ID: 281
+      ID: 288
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 481 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 488 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 286
+      ID: 293
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 489 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 496 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 291
+      ID: 298
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 497 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 504 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 296
+      ID: 303
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 505 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 512 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 301
+      ID: 308
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 513 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 520 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 306
+      ID: 313
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 521 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 528 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 240
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 447 StructureType table<struct {},struct {}>
+      Pointee: 454 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 215
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 406 StructureType table<uint8,[4]int>
+      Pointee: 413 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 210
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 398 StructureType table<uint8,uint8>
+      Pointee: 405 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1143
+      ID: 1150
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.152576e+06
       GoKind: 22
-      Pointee: 1144 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1151 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 867
+      ID: 874
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.084672e+06
       GoKind: 22
-      Pointee: 868 StructureType text/template.ExecError
+      Pointee: 875 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 942
+      ID: 949
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.618656e+06
       GoKind: 22
-      Pointee: 943 UnresolvedPointeeType time.Location
+      Pointee: 950 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 610
+      ID: 617
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 897952
       GoKind: 22
-      Pointee: 611 UnresolvedPointeeType time.ParseError
+      Pointee: 618 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 897856
       GoKind: 22
-      Pointee: 531 GoStringHeaderType time.fileSizeError
+      Pointee: 538 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 533
+      ID: 540
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 532 GoStringDataType time.fileSizeError.str
+      Pointee: 539 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -7958,52 +9735,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 915904
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 706 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1135
+      ID: 1142
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.128032e+06
       GoKind: 22
-      Pointee: 1136 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1143 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 682
+      ID: 689
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 912064
       GoKind: 22
-      Pointee: 683 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 690 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 912160
       GoKind: 22
-      Pointee: 572 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 579 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.043072e+06
       GoKind: 22
-      Pointee: 847 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 854 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.0432e+06
       GoKind: 22
-      Pointee: 801 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 808 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1432
+      ID: 1487
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1433
+      ID: 1488
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8015,11 +9792,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1369
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8035,7 +9812,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1370
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8051,7 +9828,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1359
+      ID: 1366
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8067,7 +9844,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1360
+      ID: 1367
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8083,7 +9860,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1310
+      ID: 1459
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1317
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8099,7 +9908,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1308
+      ID: 1315
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8115,7 +9924,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1306
+      ID: 1313
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8131,7 +9940,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1371
+      ID: 1378
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8147,7 +9956,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1314
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8163,7 +9972,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1309
+      ID: 1316
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8179,7 +9988,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1328
+      ID: 1335
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8195,10 +10004,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1329
+      ID: 1336
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1295
+      ID: 1302
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8214,7 +10023,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1292
+      ID: 1299
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8230,7 +10039,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1391
+      ID: 1398
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8246,7 +10055,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1389
+      ID: 1396
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -8282,7 +10091,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1399
+      ID: 1406
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8298,7 +10107,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1334
+      ID: 1341
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8314,7 +10123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
+      ID: 1342
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8330,7 +10139,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1337
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8346,7 +10155,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1331
+      ID: 1338
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8362,7 +10171,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1339
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8378,7 +10187,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1333
+      ID: 1340
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8394,7 +10203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1479
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8403,10 +10212,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8416,11 +10225,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1476
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8429,14 +10238,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1443
+      ID: 1498
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8448,11 +10257,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1450
+      ID: 1505
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8461,14 +10270,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 309 PointerType *main.emptyStruct
+            Type: 316 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1449
+      ID: 1504
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8477,14 +10286,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 308 StructureType main.emptyStruct
+            Type: 315 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1361
+      ID: 1368
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8500,7 +10309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1343
+      ID: 1350
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8516,10 +10325,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1344
+      ID: 1351
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1341
+      ID: 1348
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8535,10 +10344,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1342
+      ID: 1349
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1355
+      ID: 1362
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8554,7 +10363,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1357
+      ID: 1364
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8580,7 +10389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1363
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8596,7 +10405,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1360
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8612,7 +10421,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1361
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8628,7 +10437,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1345
+      ID: 1352
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8644,10 +10453,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1346
+      ID: 1353
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1349
+      ID: 1356
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8663,13 +10472,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1357
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1509
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1347
+      ID: 1354
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8695,28 +10504,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1348
+      ID: 1355
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1455
+      ID: 1510
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1456
+      ID: 1511
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1457
+      ID: 1512
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1458
+      ID: 1513
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1351
+      ID: 1358
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1359
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1451
+      ID: 1506
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8728,11 +10537,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1508
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8744,14 +10553,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1507
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1459
+      ID: 1514
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8763,11 +10572,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1515
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8779,11 +10588,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1516
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8795,11 +10604,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1298
+      ID: 1305
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8815,7 +10624,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1299
+      ID: 1306
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8831,7 +10640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1300
+      ID: 1307
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8847,7 +10656,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1304
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8863,7 +10672,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1296
+      ID: 1303
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8879,7 +10688,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1358
+      ID: 1365
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8895,7 +10704,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1393
+      ID: 1457
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1400
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8911,36 +10752,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1345
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1339
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1340
+      ID: 1346
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8966,7 +10781,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1347
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1376
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8982,7 +10935,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1376
+      ID: 1383
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8998,7 +10951,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1395
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9014,7 +10967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1393
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9030,7 +10983,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1394
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9046,7 +10999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1380
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9062,7 +11015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1392
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9078,7 +11031,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1384
+      ID: 1391
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9094,7 +11047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1374
+      ID: 1381
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9110,7 +11063,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1382
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9126,7 +11079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1390
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9142,7 +11095,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
+      ID: 1389
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9158,7 +11111,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1374
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9174,7 +11127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1368
+      ID: 1375
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9190,7 +11143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1373
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9206,7 +11159,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1377
+      ID: 1384
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9222,7 +11175,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1381
+      ID: 1388
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9238,7 +11191,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1380
+      ID: 1387
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9254,7 +11207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1379
+      ID: 1386
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9270,7 +11223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1378
+      ID: 1385
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9286,7 +11239,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1495
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9298,11 +11251,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1441
+      ID: 1496
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9314,11 +11267,217 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1416
+      ID: 1465
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1466
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9334,7 +11493,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1424
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9360,7 +11519,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1390
+      ID: 1397
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9416,7 +11575,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1421
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9432,7 +11591,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1415
+      ID: 1422
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9448,7 +11607,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1405
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9474,7 +11633,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1480
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9483,10 +11642,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9496,11 +11655,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1482
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9512,17 +11671,17 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 255 GoSliceHeaderType []bool
+            Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9532,11 +11691,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1428
+      ID: 1483
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9545,14 +11704,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 GoSliceHeaderType []uint16
+            Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1439
+      ID: 1494
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9561,14 +11720,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 261 PointerType *main.oneStringStruct
+            Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1401
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9584,7 +11743,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1379
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9600,7 +11759,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1399
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9616,7 +11775,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1415
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9642,7 +11801,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1409
+      ID: 1416
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9668,7 +11827,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1410
+      ID: 1417
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9684,7 +11843,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1411
+      ID: 1418
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9700,7 +11859,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1406
+      ID: 1437
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1443
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1444
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1432
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1413
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9716,7 +12089,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1407
+      ID: 1414
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9732,7 +12105,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1404
+      ID: 1411
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9748,7 +12121,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1412
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9774,7 +12147,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9790,7 +12163,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1410
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9806,7 +12179,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1407
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9822,7 +12195,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1401
+      ID: 1408
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9838,7 +12211,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1412
+      ID: 1419
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9854,7 +12227,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1413
+      ID: 1420
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9870,7 +12243,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1433
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1429
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1430
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 17 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1427
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 94 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1446
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1300
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9886,7 +12710,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1314
+      ID: 1321
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9902,7 +12726,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1312
+      ID: 1319
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9918,7 +12742,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1325
+      ID: 1332
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9934,7 +12758,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1326
+      ID: 1333
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9950,7 +12774,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1324
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -9966,7 +12790,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1318
+      ID: 1325
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9982,7 +12806,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1319
+      ID: 1326
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9998,7 +12822,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1323
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10014,7 +12838,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1315
+      ID: 1322
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10030,7 +12854,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1320
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10046,7 +12870,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1434
+      ID: 1489
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10058,11 +12882,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1322
+      ID: 1329
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10078,7 +12902,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1323
+      ID: 1330
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10094,7 +12918,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1324
+      ID: 1331
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10110,7 +12934,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1328
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10126,7 +12950,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1320
+      ID: 1327
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10142,7 +12966,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1486
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10151,14 +12975,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 257 GoSliceHeaderType []struct {}
+            Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1422
+      ID: 1477
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10167,14 +12991,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 249 GoSliceHeaderType [][]uint
+            Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1370
+      ID: 1377
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10190,7 +13014,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1418
+      ID: 1425
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10206,7 +13030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1426
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10242,7 +13066,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1294
+      ID: 1467
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 159 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1301
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10258,7 +13134,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1397
+      ID: 1404
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10274,7 +13150,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1426
+      ID: 1481
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10283,14 +13159,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 254 GoSliceHeaderType []string
+            Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1336
+      ID: 1343
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10306,7 +13182,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1344
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10322,7 +13198,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1478
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10331,10 +13207,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType []main.structWithNoStrings
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10344,11 +13220,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1371
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10364,7 +13240,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
+      ID: 1471
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1500
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10373,17 +13291,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 276 StructureType main.structWithCyclicMaps
+            Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1446
+      ID: 1501
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1444
+      ID: 1499
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10392,14 +13310,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 263 StructureType main.structWithCyclicSlices
+            Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1365
+      ID: 1372
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10415,7 +13333,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1502
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10424,17 +13342,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 307 StructureType main.aStruct
+            Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1448
+      ID: 1503
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1438
+      ID: 1493
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10443,14 +13361,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 260 PointerType *main.threeStringStruct
+            Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1491
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10459,17 +13377,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 259 StructureType main.threeStringStruct
+            Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1437
+      ID: 1492
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1435
+      ID: 1490
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10481,7 +13399,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10491,7 +13409,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10501,11 +13419,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1327
+      ID: 1334
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10521,7 +13439,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1303
+      ID: 1310
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10537,7 +13455,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1304
+      ID: 1311
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10553,7 +13471,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1312
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10569,7 +13487,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1302
+      ID: 1309
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10585,7 +13503,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1301
+      ID: 1308
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10601,7 +13519,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1396
+      ID: 1403
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10617,7 +13535,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1475
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10626,14 +13544,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1442
+      ID: 1497
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10645,11 +13563,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1395
+      ID: 1402
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10665,7 +13583,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1311
+      ID: 1318
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10681,7 +13599,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1429
+      ID: 1484
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10690,14 +13608,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1430
+      ID: 1485
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10706,16 +13624,74 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 248 GoSliceHeaderType []uint
+            Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 251
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 7 BaseType int
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 682816
+      GoRuntimeType: 682912
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -10731,16 +13707,25 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 697760
+      GoRuntimeType: 697856
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 250
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 683008
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 697376
+      GoRuntimeType: 697472
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10749,7 +13734,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 697472
+      GoRuntimeType: 697568
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10774,7 +13759,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 697664
+      GoRuntimeType: 697760
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10916,22 +13901,31 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 697184
+      GoRuntimeType: 697280
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 249
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 681952
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 696896
+      GoRuntimeType: 696992
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 412
+      ID: 419
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 679648
@@ -10940,7 +13934,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 369
+      ID: 376
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 679936
@@ -10952,7 +13946,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 688384
+      GoRuntimeType: 688480
       GoKind: 17
       Count: 4
       HasCount: true
@@ -10966,7 +13960,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 970
+      ID: 977
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 681472
@@ -10978,7 +13972,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 694112
+      GoRuntimeType: 694208
       GoKind: 17
       Count: 6
       HasCount: true
@@ -10987,7 +13981,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 697568
+      GoRuntimeType: 697664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -11008,15 +14002,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 319 GoSliceDataType []*main.deepSlice2.array
+      Data: 326 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 326
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 138 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1209
+      ID: 1216
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 475328
@@ -11024,22 +14018,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1210 PointerType **main.deepSlice3
+          Type: 1217 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1213 GoSliceDataType []*main.deepSlice3.array
+      Data: 1220 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1213
+      ID: 1220
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1211 PointerType *main.deepSlice3
+      Element: 1218 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1234
+      ID: 1241
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 475008
@@ -11047,22 +14041,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1235 PointerType **main.deepSlice8
+          Type: 1242 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1238 GoSliceDataType []*main.deepSlice8.array
+      Data: 1245 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1238
+      ID: 1245
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1236 PointerType *main.deepSlice8
+      Element: 1243 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1240
+      ID: 1247
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 474944
@@ -11070,20 +14064,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1241 PointerType **main.deepSlice9
+          Type: 1248 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1244 GoSliceDataType []*main.deepSlice9.array
+      Data: 1251 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1244
+      ID: 1251
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1242 PointerType *main.deepSlice9
+      Element: 1249 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 127
       Name: '[]*string'
@@ -11100,309 +14094,309 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 316 GoSliceDataType []*string.array
+      Data: 323 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 93 PointerType *string
     - __kind: GoSliceDataType
-      ID: 429
+      ID: 436
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 225 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 421
+      ID: 428
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 220 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 370
+      ID: 377
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 188 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 388
+      ID: 395
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 200 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 329
+      ID: 336
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 146 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1228
+      ID: 1235
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1219 PointerType *table<int,*main.deepMap3>
+      Element: 1226 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1262
+      ID: 1269
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1253 PointerType *table<int,*main.deepMap8>
+      Element: 1260 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1277
+      ID: 1284
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1268 PointerType *table<int,*main.deepMap9>
+      Element: 1275 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 337
+      ID: 344
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 168 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1290
+      ID: 1297
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1283 PointerType *table<int,interface {}>
+      Element: 1290 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 445
+      ID: 452
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 235 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 396
+      ID: 403
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 205 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 380
+      ID: 387
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 195 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 361
+      ID: 368
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 183 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 986
+      ID: 993
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 953 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 960 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 353
+      ID: 360
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 178 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 345
+      ID: 352
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 173 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 437
+      ID: 444
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 230 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 487
+      ID: 494
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 281 PointerType *table<struct {},main.structWithCyclicMaps>
+      Element: 288 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 495
+      ID: 502
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 286 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 293 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 503
+      ID: 510
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 291 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 511
+      ID: 518
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 296 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 519
+      ID: 526
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 301 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 527
+      ID: 534
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 306 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 313 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 453
+      ID: 460
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 240 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 413
+      ID: 420
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 215 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 404
+      ID: 411
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 210 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 274
+      ID: 281
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 275 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 282 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 479 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 486 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 479
+      ID: 486
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 272
+      ID: 279
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 273 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 280 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 477 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 484 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 477
+      ID: 484
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 277
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType *[][][]main.structWithCyclicSlices
+          Type: 278 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 475 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 482 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 475
+      ID: 482
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 275
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 269 PointerType *[][]main.structWithCyclicSlices
+          Type: 276 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 473 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 480 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 473
+      ID: 480
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 266
+      ID: 273
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 267 PointerType *[]main.structWithCyclicSlices
+          Type: 274 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 471 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 478 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 471
+      ID: 478
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 264 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 271 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 249
+      ID: 256
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 250 PointerType *[]uint
+          Type: 257 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 457 GoSliceDataType [][]uint.array
+      Data: 464 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 457
+      ID: 464
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 248 GoSliceHeaderType []uint
+      Element: 255 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 255
+      ID: 262
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 484480
@@ -11417,15 +14411,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 463 GoSliceDataType []bool.array
+      Data: 470 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 463
+      ID: 470
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 965
+      ID: 972
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 484352
@@ -11440,15 +14434,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 988 GoSliceDataType []float64.array
+      Data: 995 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 988
+      ID: 995
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 18 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1246
+      ID: 1253
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 484800
@@ -11463,37 +14457,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1247 GoSliceDataType []interface {}.array
+      Data: 1254 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1254
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 155 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 264
+      ID: 271
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 265 PointerType *main.structWithCyclicSlices
+          Type: 272 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 469 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 476 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 469
+      ID: 476
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 263 StructureType main.structWithCyclicSlices
+      Element: 270 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 378
+      ID: 385
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 475648
@@ -11501,210 +14495,210 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 379 PointerType *main.structWithMap
+          Type: 386 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 529 GoSliceDataType []main.structWithMap.array
+      Data: 536 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 529
+      ID: 536
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 163 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *main.structWithNoStrings
+          Type: 259 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 459 GoSliceDataType []main.structWithNoStrings.array
+      Data: 466 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 466
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 253 StructureType main.structWithNoStrings
+      Element: 260 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 430
+      ID: 437
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 426 StructureType noalg.map.group[[4]int][4]int
+      Element: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 422
+      ID: 429
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 418 StructureType noalg.map.group[[4]int]uint8
+      Element: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 371
+      ID: 378
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 366 StructureType noalg.map.group[[4]string][2]int
+      Element: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 389
+      ID: 396
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 385 StructureType noalg.map.group[bool]main.node
+      Element: 392 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 330
+      ID: 337
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 324 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1229
+      ID: 1236
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1270
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1278
+      ID: 1285
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 338
+      ID: 345
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 334 StructureType noalg.map.group[int]int
+      Element: 341 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1291
+      ID: 1298
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1287 StructureType noalg.map.group[int]interface {}
+      Element: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 446
+      ID: 453
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 442 StructureType noalg.map.group[int]struct {}
+      Element: 449 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 397
+      ID: 404
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 393 StructureType noalg.map.group[int]uint8
+      Element: 400 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 381
+      ID: 388
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 375 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 362
+      ID: 369
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 358 StructureType noalg.map.group[string][]string
+      Element: 365 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 987
+      ID: 994
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 354
+      ID: 361
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 350 StructureType noalg.map.group[string]int
+      Element: 357 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 346
+      ID: 353
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 342 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 438
+      ID: 445
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 434 StructureType noalg.map.group[struct {}]int
+      Element: 441 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 488
+      ID: 495
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 496
+      ID: 503
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 504
+      ID: 511
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 512
+      ID: 519
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 520
+      ID: 527
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 528
+      ID: 535
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 454
+      ID: 461
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 450 StructureType noalg.map.group[struct {}]struct {}
+      Element: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 414
+      ID: 421
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 409 StructureType noalg.map.group[uint8][4]int
+      Element: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 405
+      ID: 412
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 401 StructureType noalg.map.group[uint8]uint8
+      Element: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 254
+      ID: 261
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 484608
@@ -11719,36 +14713,36 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 461 GoSliceDataType []string.array
+      Data: 468 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 461
+      ID: 468
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 257
+      ID: 264
       Name: '[]struct {}'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 258 PointerType *struct {}
+          Type: 265 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 467 GoSliceDataType []struct {}.array
+      Data: 474 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 467
+      ID: 474
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 123 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 248
+      ID: 255
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 484096
@@ -11763,15 +14757,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 455 GoSliceDataType []uint.array
+      Data: 462 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 455
+      ID: 462
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 263
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 483456
@@ -11786,9 +14780,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 465 GoSliceDataType []uint16.array
+      Data: 472 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 465
+      ID: 472
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11809,9 +14803,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 312 GoSliceDataType []uint8.array
+      Data: 319 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 312
+      ID: 319
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11832,19 +14826,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []uintptr.array
+      Data: 321 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 321
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 761
+      ID: 768
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 927040
@@ -11859,33 +14853,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 762 GoSliceDataType archive/tar.headerError.array
+      Data: 769 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 762
+      ID: 769
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1055
+      ID: 1062
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1003
+      ID: 1010
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1005
+      ID: 1012
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.115808e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1103
+      ID: 1110
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1031
+      ID: 1038
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.561152e+06
@@ -11895,7 +14889,7 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1033
+      ID: 1040
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11905,15 +14899,15 @@ Types:
       GoRuntimeType: 581920
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1107
+      ID: 1114
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1158
+      ID: 1165
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -11939,13 +14933,13 @@ Types:
       GoRuntimeType: 581664
       GoKind: 15
     - __kind: BaseType
-      ID: 564
+      ID: 571
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831552
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 565
+      ID: 572
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 831648
@@ -11953,110 +14947,110 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 567 PointerType *compress/flate.InternalError.str
+          Type: 574 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 566 GoStringDataType compress/flate.InternalError.str
+      Data: 573 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 566
+      ID: 573
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1053
+      ID: 1060
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 999
+      ID: 1006
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1075
+      ID: 1082
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 905
+      ID: 912
       Name: context.deadlineExceededError
       GoRuntimeType: 1.475392e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 578
+      ID: 585
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834144
       GoKind: 2
     - __kind: BaseType
-      ID: 579
+      ID: 586
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834240
       GoKind: 2
     - __kind: BaseType
-      ID: 580
+      ID: 587
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834336
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1065
+      ID: 1072
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1099
+      ID: 1106
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1131
+      ID: 1138
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1105
+      ID: 1112
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1101
+      ID: 1108
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1104
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 581
+      ID: 588
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 834432
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1115
+      ID: 1122
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1087
+      ID: 1094
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 568
+      ID: 575
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 832128
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 845
+      ID: 852
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1184
+      ID: 1191
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 677
+      ID: 684
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 675
+      ID: 682
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.724576e+06
@@ -12067,34 +15061,34 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 970 ArrayType [5]uint8
+          Type: 977 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 800
+      ID: 807
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 989280
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1063
+      ID: 1070
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1077
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 940
+      ID: 947
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 749
+      ID: 756
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.727456e+06
@@ -12102,21 +15096,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 973 BaseType crypto/x509.InvalidReason
+          Type: 980 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 743
+      ID: 750
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.113376e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 745
+      ID: 752
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.595872e+06
@@ -12124,24 +15118,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 577
+      ID: 584
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 833760
       GoKind: 2
     - __kind: BaseType
-      ID: 973
+      ID: 980
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 587104
       GoKind: 2
     - __kind: StructureType
-      ID: 850
+      ID: 857
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.557152e+06
@@ -12151,13 +15145,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 751
+      ID: 758
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.113632e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 747
+      ID: 754
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.727264e+06
@@ -12165,15 +15159,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 954 PointerType *crypto/x509.Certificate
+          Type: 961 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 765
+      ID: 772
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.432832e+06
@@ -12183,7 +15177,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 769
+      ID: 776
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.432992e+06
@@ -12193,55 +15187,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 767
+      ID: 774
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 562
+      ID: 569
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 831168
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1021
+      ID: 1028
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 563
+      ID: 570
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 831360
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 634
+      ID: 641
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 836
+      ID: 843
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 626
+      ID: 633
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 632
+      ID: 639
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 630
+      ID: 637
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 628
+      ID: 635
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1164
+      ID: 1171
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 636
+      ID: 643
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.416672e+06
@@ -12251,19 +15245,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1029
+      ID: 1036
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 737
+      ID: 744
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 735
+      ID: 742
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 574
+      ID: 581
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 833664
@@ -12271,22 +15265,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 576 PointerType *encoding/xml.UnmarshalError.str
+          Type: 583 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 575 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 582 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 575
+      ID: 582
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 740
+      ID: 747
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1142
+      ID: 1149
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12303,11 +15297,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 604
+      ID: 611
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 803
+      ID: 810
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12323,15 +15317,15 @@ Types:
       GoRuntimeType: 581856
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1152
+      ID: 1159
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 807
+      ID: 814
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12347,11 +15341,11 @@ Types:
       GoRuntimeType: 845280
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 664
+      ID: 671
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 645
+      ID: 652
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.723424e+06
@@ -12359,7 +15353,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 963 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 970 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -12367,25 +15361,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 647
+      ID: 654
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 967
+      ID: 974
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 651
+      ID: 658
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.109664e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 969
+      ID: 976
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 556
+      ID: 563
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 830592
@@ -12393,18 +15387,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 558 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 565 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 557 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 564 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 557
+      ID: 564
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 963
+      ID: 970
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.212384e+06
@@ -12412,13 +15406,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 964 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 971 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 9 GoStringHeaderType string
@@ -12427,7 +15421,7 @@ Types:
           Type: 18 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 965 GoSliceHeaderType []float64
+          Type: 972 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -12436,13 +15430,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 966 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 973 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 968 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 975 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 9 GoStringHeaderType string
@@ -12453,13 +15447,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 964
+      ID: 971
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 583712
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 553
+      ID: 560
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 830496
@@ -12467,18 +15461,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 555 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 562 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 554 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 561 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 554
+      ID: 561
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 559
+      ID: 566
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 830688
@@ -12486,60 +15480,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 561 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 568 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 560 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 567 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 560
+      ID: 567
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1043
+      ID: 1050
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 759
+      ID: 766
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 914
+      ID: 921
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1160
+      ID: 1167
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 686
+      ID: 693
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 693
+      ID: 700
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.112608e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 573
+      ID: 580
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 832800
       GoKind: 2
     - __kind: StructureType
-      ID: 691
+      ID: 698
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11248e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 689
+      ID: 696
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.593952e+06
@@ -12552,7 +15546,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 709
+      ID: 716
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.594752e+06
@@ -12565,7 +15559,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 713
+      ID: 720
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.726688e+06
@@ -12581,7 +15575,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 711
+      ID: 718
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.426432e+06
@@ -12591,7 +15585,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 707
+      ID: 714
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.426112e+06
@@ -12601,14 +15595,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 949
+      ID: 956
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.496512e+06
       GoKind: 21
-      HeaderType: 951 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 958 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 972
+      ID: 979
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.046656e+06
@@ -12623,15 +15617,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 990 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 997 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 990
+      ID: 997
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 721
+      ID: 728
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.595072e+06
@@ -12639,12 +15633,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 949 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 956 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 949 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 956 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 715
+      ID: 722
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.426592e+06
@@ -12654,7 +15648,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 719
+      ID: 726
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.72688e+06
@@ -12665,12 +15659,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 717
+      ID: 724
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.594912e+06
@@ -12683,7 +15677,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 723
+      ID: 730
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.426752e+06
@@ -12691,9 +15685,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 941 StructureType time.Time
+          Type: 948 StructureType time.Time
     - __kind: StructureType
-      ID: 729
+      ID: 736
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.595392e+06
@@ -12706,7 +15700,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 731
+      ID: 738
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.427072e+06
@@ -12716,7 +15710,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 727
+      ID: 734
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.595232e+06
@@ -12729,7 +15723,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 725
+      ID: 732
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.426912e+06
@@ -12739,7 +15733,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 733
+      ID: 740
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.595552e+06
@@ -12752,7 +15746,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 653
+      ID: 660
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.418912e+06
@@ -12762,11 +15756,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1081
+      ID: 1088
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.419072e+06
@@ -12774,21 +15768,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1061
+      ID: 1068
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1017
+      ID: 1024
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1051
+      ID: 1058
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 659
+      ID: 666
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.419392e+06
@@ -12796,13 +15790,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1125
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1129
+      ID: 1136
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.100768e+06
@@ -12810,12 +15804,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1117 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1124 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1132
+      ID: 1139
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.124576e+06
@@ -12823,7 +15817,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1117 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1124 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -12831,11 +15825,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1019
+      ID: 1026
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 657
+      ID: 664
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.419232e+06
@@ -12843,9 +15837,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 661
+      ID: 668
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.419552e+06
@@ -12853,64 +15847,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 653 StructureType github.com/cihub/seelog.baseError
+          Type: 660 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1083
+      ID: 1090
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1131
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 945
+      ID: 952
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 858
+      ID: 865
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 856
+      ID: 863
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 862
+      ID: 869
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 852
+      ID: 859
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.420512e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1176
+      ID: 1183
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 916
+      ID: 923
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 889
+      ID: 896
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.834688e+06
@@ -12926,11 +15920,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 883
+      ID: 890
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 822
+      ID: 829
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.697472e+06
@@ -12943,7 +15937,7 @@ Types:
           Offset: 1
           Type: 16 BaseType int8
     - __kind: StructureType
-      ID: 895
+      ID: 902
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.835136e+06
@@ -12959,13 +15953,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 799
+      ID: 806
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 986592
       GoKind: 8
     - __kind: StructureType
-      ID: 887
+      ID: 894
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.834464e+06
@@ -12981,13 +15975,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 974
+      ID: 981
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 828768
       GoKind: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.83424e+06
@@ -12995,15 +15989,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 974 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 981 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 974 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 981 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 893
+      ID: 900
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.748928e+06
@@ -13016,7 +16010,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 891
+      ID: 898
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.834912e+06
@@ -13032,11 +16026,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1180
+      ID: 1187
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 899
+      ID: 906
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.619616e+06
@@ -13046,19 +16040,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 826
+      ID: 833
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.279456e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 824
+      ID: 831
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.279328e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 897
+      ID: 904
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.74912e+06
@@ -13071,7 +16065,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 586
+      ID: 593
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 836256
@@ -13079,22 +16073,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 588 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 595 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 587 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 594 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 587
+      ID: 594
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 958
+      ID: 965
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 866
+      ID: 873
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.444672e+06
@@ -13104,7 +16098,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1049
+      ID: 1056
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.673568e+06
@@ -13112,13 +16106,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1073 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1080 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1140
+      ID: 1147
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1073
+      ID: 1080
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12336e+06
@@ -13131,7 +16125,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1035
+      ID: 1042
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.566112e+06
@@ -13141,19 +16135,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 589
+      ID: 596
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 836832
       GoKind: 10
     - __kind: BaseType
-      ID: 956
+      ID: 963
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 999744
       GoKind: 10
     - __kind: StructureType
-      ID: 924
+      ID: 931
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.873664e+06
@@ -13164,12 +16158,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 956 BaseType golang.org/x/net/http2.ErrCode
+          Type: 963 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 785
+      ID: 792
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.602592e+06
@@ -13177,12 +16171,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 956 BaseType golang.org/x/net/http2.ErrCode
+          Type: 963 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 593
+      ID: 600
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 837024
@@ -13190,18 +16184,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 595 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 602 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 594 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 601 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 594
+      ID: 601
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 599
+      ID: 606
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 837216
@@ -13209,18 +16203,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 601 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 608 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 600 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 607 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 600
+      ID: 607
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 596
+      ID: 603
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 837120
@@ -13228,18 +16222,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 598 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 605 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 597 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 604 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 597
+      ID: 604
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 590
+      ID: 597
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 836928
@@ -13247,22 +16241,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 592 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 599 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 591 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 598 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 591
+      ID: 598
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1138
+      ID: 1145
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 789
+      ID: 796
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.445312e+06
@@ -13272,13 +16266,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 602
+      ID: 609
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 837312
       GoKind: 2
     - __kind: StructureType
-      ID: 777
+      ID: 784
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.440352e+06
@@ -13288,11 +16282,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 922
+      ID: 929
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 947
+      ID: 954
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.901568e+06
@@ -13308,7 +16302,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 779
+      ID: 786
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.602112e+06
@@ -13321,7 +16315,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1089
+      ID: 1096
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.959136e+06
@@ -13329,16 +16323,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1116 GoInterfaceType io.Reader
+          Type: 1123 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1047
+      ID: 1054
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 864
+      ID: 871
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.563712e+06
@@ -13348,29 +16342,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1007
+      ID: 1014
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 757
+      ID: 764
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 854
+      ID: 861
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.507072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 771
+      ID: 778
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.433632e+06
@@ -13380,7 +16374,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 773
+      ID: 780
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.433792e+06
@@ -13390,393 +16384,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 701
+      ID: 708
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 424
+      ID: 431
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 425 PointerType *noalg.map.group[[4]int][4]int
+          Type: 432 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 426 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 430 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 433 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 437 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 416
+      ID: 423
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 417 PointerType *noalg.map.group[[4]int]uint8
+          Type: 424 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 418 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 422 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 425 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 429 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 364
+      ID: 371
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 365 PointerType *noalg.map.group[[4]string][2]int
+          Type: 372 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 366 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 371 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 373 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 378 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 383
+      ID: 390
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 384 PointerType *noalg.map.group[bool]main.node
+          Type: 391 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 385 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 389 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 392 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 396 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 322
+      ID: 329
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 323 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 330 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 330 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 331 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 337 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1221
+      ID: 1228
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1222 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1229 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1223 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1229 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1230 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1236 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1255
+      ID: 1262
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1256 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1263 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1257 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1263 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1264 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1270 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1270
+      ID: 1277
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1271 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1278 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1272 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1278 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1279 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1285 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 332
+      ID: 339
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 333 PointerType *noalg.map.group[int]int
+          Type: 340 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 334 StructureType noalg.map.group[int]int
-      GroupSliceType: 338 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 341 StructureType noalg.map.group[int]int
+      GroupSliceType: 345 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1285
+      ID: 1292
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1286 PointerType *noalg.map.group[int]interface {}
+          Type: 1293 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1287 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1291 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1294 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1298 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 440
+      ID: 447
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 441 PointerType *noalg.map.group[int]struct {}
+          Type: 448 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 442 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 446 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 449 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 453 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 391
+      ID: 398
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 392 PointerType *noalg.map.group[int]uint8
+          Type: 399 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 393 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 397 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 400 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 404 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 373
+      ID: 380
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 374 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 381 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 375 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 381 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 382 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 388 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 356
+      ID: 363
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 357 PointerType *noalg.map.group[string][]string
+          Type: 364 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 358 StructureType noalg.map.group[string][]string
-      GroupSliceType: 362 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 365 StructureType noalg.map.group[string][]string
+      GroupSliceType: 369 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 981
+      ID: 988
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 982 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 989 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 987 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 994 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 348
+      ID: 355
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 349 PointerType *noalg.map.group[string]int
+          Type: 356 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 350 StructureType noalg.map.group[string]int
-      GroupSliceType: 354 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 357 StructureType noalg.map.group[string]int
+      GroupSliceType: 361 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 340
+      ID: 347
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 341 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 348 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 342 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 346 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 349 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 353 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 432
+      ID: 439
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 433 PointerType *noalg.map.group[struct {}]int
+          Type: 440 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 434 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 438 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 441 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 445 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 482
+      ID: 489
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 483 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 490 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 488 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 495 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 490
+      ID: 497
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 491 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 498 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 496 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 503 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 498
+      ID: 505
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 499 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 506 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 504 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 511 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 506
+      ID: 513
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 507 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 514 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 512 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 519 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 514
+      ID: 521
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 515 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 522 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 520 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 527 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 522
+      ID: 529
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 523 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 530 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 528 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 535 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 448
+      ID: 455
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 449 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 456 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 450 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 454 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 457 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 461 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 407
+      ID: 414
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 408 PointerType *noalg.map.group[uint8][4]int
+          Type: 415 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 409 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 414 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 416 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 421 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 399
+      ID: 406
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 400 PointerType *noalg.map.group[uint8]uint8
+          Type: 407 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 401 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 405 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 408 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 412 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1095
+      ID: 1102
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 792
+      ID: 799
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -13823,7 +16817,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 671
+      ID: 678
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -13849,29 +16843,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 669
+      ID: 676
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 993
+      ID: 1000
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 881
+      ID: 888
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1182
+      ID: 1189
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 879
+      ID: 886
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.472192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 606
+      ID: 613
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -13952,7 +16946,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1194
+      ID: 1201
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.469632e+06
@@ -13965,11 +16959,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1039
+      ID: 1046
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1079
+      ID: 1086
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.18672e+06
@@ -13982,7 +16976,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1116
+      ID: 1123
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.020032e+06
@@ -13995,7 +16989,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1068
+      ID: 1075
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.105952e+06
@@ -14021,25 +17015,25 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1037
+      ID: 1044
       Name: io.discard
       GoRuntimeType: 1.460032e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1011
+      ID: 1018
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1085
+      ID: 1092
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 307
+      ID: 314
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14095,7 +17089,7 @@ Types:
           Offset: 0
           Type: 142 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 328
+      ID: 335
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.183008e+06
@@ -14103,9 +17097,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1215 GoMapType map[int]*main.deepMap3
+          Type: 1222 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1227
+      ID: 1234
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14117,9 +17111,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 GoMapType map[int]*main.deepMap8
+          Type: 1256 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1261
+      ID: 1268
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.18224e+06
@@ -14127,9 +17121,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1264 GoMapType map[int]*main.deepMap9
+          Type: 1271 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1276
+      ID: 1283
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.182112e+06
@@ -14137,7 +17131,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1279 GoMapType map[int]interface {}
+          Type: 1286 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 130
       Name: main.deepPtr1
@@ -14157,9 +17151,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1185 PointerType *main.deepPtr3
+          Type: 1192 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1186
+      ID: 1193
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14171,9 +17165,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1230 PointerType *main.deepPtr8
+          Type: 1237 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1231
+      ID: 1238
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.183392e+06
@@ -14181,9 +17175,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1232 PointerType *main.deepPtr9
+          Type: 1239 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1233
+      ID: 1240
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.183264e+06
@@ -14203,7 +17197,7 @@ Types:
           Offset: 0
           Type: 136 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 318
+      ID: 325
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.185312e+06
@@ -14211,9 +17205,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1209 GoSliceHeaderType []*main.deepSlice3
+          Type: 1216 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1212
+      ID: 1219
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14225,9 +17219,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoSliceHeaderType []*main.deepSlice8
+          Type: 1241 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1237
+      ID: 1244
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.184544e+06
@@ -14235,9 +17229,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1240 GoSliceHeaderType []*main.deepSlice9
+          Type: 1247 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1243
+      ID: 1250
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.184416e+06
@@ -14245,9 +17239,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1246 GoSliceHeaderType []interface {}
+          Type: 1253 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 308
+      ID: 315
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -14263,16 +17257,16 @@ Types:
           Type: 153 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1192 StructureType sync.Mutex
+          Type: 1199 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1195 StructureType sync.Once
+          Type: 1202 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1198 StructureType sync.WaitGroup
+          Type: 1205 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1201 StructureType sync/atomic.Int32
+          Type: 1208 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 153
       Name: main.esotericStack
@@ -14302,7 +17296,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1203
+      ID: 1210
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.409792e+06
@@ -14311,6 +17305,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 248
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 252
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 18 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
     - __kind: StructureType
       ID: 121
       Name: main.nestedStruct
@@ -14338,7 +17383,7 @@ Types:
           Offset: 8
           Type: 245 PointerType *main.node
     - __kind: StructureType
-      ID: 262
+      ID: 269
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -14347,7 +17392,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1205
+      ID: 1212
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.409952e+06
@@ -14367,7 +17412,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1191
+      ID: 1198
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14378,18 +17423,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1188 PointerType *main.stringType1.str
+          Type: 1195 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1187 GoStringDataType main.stringType1.str
+      Data: 1194 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1187
+      ID: 1194
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1189
+      ID: 1196
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -14403,53 +17448,65 @@ Types:
           Offset: 0
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 276
+      ID: 254
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 111 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 283
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 277 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 282 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 287 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 292 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 302 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 309 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 263
+      ID: 270
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 264 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 271 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 266 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 273 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 268 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 275 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 270 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 277 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 272 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 279 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 274 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 281 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 163
       Name: main.structWithMap
@@ -14461,7 +17518,7 @@ Types:
           Offset: 0
           Type: 164 GoMapType map[int]int
     - __kind: StructureType
-      ID: 253
+      ID: 260
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -14492,22 +17549,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1206 PointerType **main.t
+          Type: 1213 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1207 GoSliceDataType main.t.array
+      Data: 1214 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1207
+      ID: 1214
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 246 PointerType *main.t
     - __kind: StructureType
-      ID: 259
+      ID: 266
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -14526,6 +17583,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 253
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 7 BaseType int
     - __kind: GoSwissMapHeaderType
       ID: 223
       Name: map<[4]int,[4]int>
@@ -14556,8 +17652,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 429 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 426 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 436 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 433 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 218
       Name: map<[4]int,uint8>
@@ -14588,8 +17684,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 421 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 418 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 428 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 425 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 186
       Name: map<[4]string,[2]int>
@@ -14620,8 +17716,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 370 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 366 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 377 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 373 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 198
       Name: map<bool,main.node>
@@ -14652,8 +17748,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 388 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 385 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 395 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 392 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 144
       Name: map<int,*main.deepMap2>
@@ -14684,10 +17780,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 329 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 324 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 336 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 331 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1217
+      ID: 1224
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -14700,7 +17796,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1218 PointerType **table<int,*main.deepMap3>
+          Type: 1225 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14716,10 +17812,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1228 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1223 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1235 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1230 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1251
+      ID: 1258
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -14732,7 +17828,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1252 PointerType **table<int,*main.deepMap8>
+          Type: 1259 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14748,10 +17844,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1262 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1257 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1269 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1264 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1266
+      ID: 1273
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -14764,7 +17860,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1267 PointerType **table<int,*main.deepMap9>
+          Type: 1274 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14780,8 +17876,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1277 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1272 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1284 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1279 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 166
       Name: map<int,int>
@@ -14812,10 +17908,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 337 GoSliceDataType []*table<int,int>.array
-      GroupType: 334 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 344 GoSliceDataType []*table<int,int>.array
+      GroupType: 341 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1281
+      ID: 1288
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -14828,7 +17924,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1282 PointerType **table<int,interface {}>
+          Type: 1289 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14844,8 +17940,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1290 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1287 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1297 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1294 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 233
       Name: map<int,struct {}>
@@ -14876,8 +17972,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 445 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 442 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 452 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 449 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 203
       Name: map<int,uint8>
@@ -14908,8 +18004,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 396 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 393 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 403 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 400 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 193
       Name: map<string,[]main.structWithMap>
@@ -14940,8 +18036,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 380 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 375 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 387 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 382 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 181
       Name: map<string,[]string>
@@ -14972,10 +18068,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 361 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 358 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 368 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 365 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 951
+      ID: 958
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -14988,7 +18084,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 952 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 959 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15004,8 +18100,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 986 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 983 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 993 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 990 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 176
       Name: map<string,int>
@@ -15036,8 +18132,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 353 GoSliceDataType []*table<string,int>.array
-      GroupType: 350 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 360 GoSliceDataType []*table<string,int>.array
+      GroupType: 357 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 171
       Name: map<string,main.nestedStruct>
@@ -15068,8 +18164,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 345 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 342 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 352 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 349 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 228
       Name: map<struct {},int>
@@ -15100,10 +18196,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 437 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 434 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 444 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 441 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
-      ID: 279
+      ID: 286
       Name: map<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15116,7 +18212,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 280 PointerType **table<struct {},main.structWithCyclicMaps>
+          Type: 287 PointerType **table<struct {},main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15132,10 +18228,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 487 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 484 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 494 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 491 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 284
+      ID: 291
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15148,7 +18244,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 285 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 292 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15164,10 +18260,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 495 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 492 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 502 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 499 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 289
+      ID: 296
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15180,7 +18276,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 290 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 297 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15196,10 +18292,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 503 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 500 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 510 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 507 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 294
+      ID: 301
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15212,7 +18308,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 295 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 302 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15228,10 +18324,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 511 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 508 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 518 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 515 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 299
+      ID: 306
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15244,7 +18340,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 300 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 307 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15260,10 +18356,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 519 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 516 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 526 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 523 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 304
+      ID: 311
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15276,7 +18372,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 305 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 312 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15292,8 +18388,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 527 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 524 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 534 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 531 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 238
       Name: map<struct {},struct {}>
@@ -15324,8 +18420,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 453 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 450 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 460 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 457 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 213
       Name: map<uint8,[4]int>
@@ -15356,8 +18452,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 413 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 409 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 420 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 416 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 208
       Name: map<uint8,uint8>
@@ -15388,8 +18484,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 404 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 401 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 411 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 408 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 221
       Name: map[[4]int][4]int
@@ -15426,26 +18522,26 @@ Types:
       GoKind: 21
       HeaderType: 144 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1215
+      ID: 1222
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.125024e+06
       GoKind: 21
-      HeaderType: 1217 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1224 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1249
+      ID: 1256
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.124384e+06
       GoKind: 21
-      HeaderType: 1251 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1258 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1264
+      ID: 1271
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.124256e+06
       GoKind: 21
-      HeaderType: 1266 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1273 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 164
       Name: map[int]int
@@ -15454,12 +18550,12 @@ Types:
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1279
+      ID: 1286
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.124128e+06
       GoKind: 21
-      HeaderType: 1281 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1288 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 231
       Name: map[int]struct {}
@@ -15510,41 +18606,41 @@ Types:
       GoKind: 21
       HeaderType: 228 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
-      ID: 277
+      ID: 284
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 279 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      HeaderType: 286 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 282
+      ID: 289
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 284 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 291 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 287
+      ID: 294
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 289 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 292
+      ID: 299
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 294 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 297
+      ID: 304
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 299 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 302
+      ID: 309
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 304 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 311 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 236
       Name: map[struct {}]struct {}
@@ -15567,7 +18663,7 @@ Types:
       GoKind: 21
       HeaderType: 208 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 705
+      ID: 712
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.425792e+06
@@ -15577,7 +18673,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1001
+      ID: 1008
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.422592e+06
@@ -15587,11 +18683,11 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 908
+      ID: 915
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 971
+      ID: 978
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.592672e+06
@@ -15604,35 +18700,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 934
+      ID: 941
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1146
+      ID: 1153
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 932
+      ID: 939
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 910
+      ID: 917
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1156
+      ID: 1163
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1166
+      ID: 1173
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1154
+      ID: 1161
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 869
+      ID: 876
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.10928e+06
@@ -15640,28 +18736,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 871 PointerType *net.UnknownNetworkError.str
+          Type: 878 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 870 GoStringDataType net.UnknownNetworkError.str
+      Data: 877 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 870
+      ID: 877
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 838
+      ID: 845
       Name: net.canceledError
       GoRuntimeType: 1.28048e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 976
+      ID: 983
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.100064e+06
@@ -15669,7 +18765,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -15680,27 +18776,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1168
+      ID: 1175
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1162
+      ID: 1169
       Name: net.noReadFrom
       GoRuntimeType: 1.109536e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1161
+      ID: 1168
       Name: net.noWriteTo
       GoRuntimeType: 1.109408e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 645
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 640
+      ID: 647
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.723232e+06
@@ -15708,7 +18804,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 959 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 966 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -15716,7 +18812,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1150
+      ID: 1157
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.2848e+06
@@ -15724,12 +18820,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1162 StructureType net.noReadFrom
+          Type: 1169 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1155 PointerType *net.TCPConn
+          Type: 1162 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1148
+      ID: 1155
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.284256e+06
@@ -15737,24 +18833,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1161 StructureType net.noWriteTo
+          Type: 1168 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1155 PointerType *net.TCPConn
+          Type: 1162 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 912
+      ID: 919
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 936
+      ID: 943
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 828
+      ID: 835
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.414112e+06
@@ -15764,19 +18860,19 @@ Types:
           Offset: 0
           Type: 129 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 534
+      ID: 541
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 829248
       GoKind: 10
     - __kind: BaseType
-      ID: 948
+      ID: 955
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 986688
       GoKind: 10
     - __kind: StructureType
-      ID: 616
+      ID: 623
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.721504e+06
@@ -15787,12 +18883,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 928
+      ID: 935
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.892864e+06
@@ -15803,12 +18899,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 620
+      ID: 627
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.592192e+06
@@ -15816,16 +18912,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 948 BaseType net/http.http2ErrCode
+          Type: 955 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1057
+      ID: 1064
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 538
+      ID: 545
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829440
@@ -15833,18 +18929,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 540 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 547 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 539 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 546 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 539
+      ID: 546
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 544
+      ID: 551
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 829632
@@ -15852,18 +18948,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 546 PointerType *net/http.http2headerFieldNameError.str
+          Type: 553 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 545 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 552 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 545
+      ID: 552
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 541
+      ID: 548
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 829536
@@ -15871,32 +18967,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 543 PointerType *net/http.http2headerFieldValueError.str
+          Type: 550 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 542 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 549 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 542
+      ID: 549
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 903
+      ID: 910
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 834
+      ID: 841
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.279712e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1111
+      ID: 1118
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 535
+      ID: 542
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 829344
@@ -15904,18 +19000,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 537 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 544 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 536 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 543 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 536
+      ID: 543
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 997
+      ID: 1004
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.817376e+06
@@ -15923,18 +19019,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1090 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1097 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1091 BaseType time.Duration
+          Type: 1098 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 104 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1090
+      ID: 1097
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.413472e+06
@@ -15947,14 +19043,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1076
+      ID: 1083
       Name: net/http.incomparable
       GoRuntimeType: 899200
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 830
+      ID: 837
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.551232e+06
@@ -15964,11 +19060,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1059
+      ID: 1066
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1015
+      ID: 1022
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.551072e+06
@@ -15976,9 +19072,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1058 PointerType *net/http.persistConn
+          Type: 1065 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1041
+      ID: 1048
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.793376e+06
@@ -15986,15 +19082,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1076 ArrayType net/http.incomparable
+          Type: 1083 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1077 PointerType *bufio.Reader
+          Type: 1084 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1079 GoInterfaceType io.ReadWriteCloser
+          Type: 1086 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 624
+      ID: 631
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.415072e+06
@@ -16004,17 +19100,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 930
+      ID: 937
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 901
+      ID: 908
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.475072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 832
+      ID: 839
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.551392e+06
@@ -16024,7 +19120,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1093
+      ID: 1100
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.01904e+06
@@ -16032,16 +19128,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 971 GoInterfaceType net.Conn
+          Type: 978 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 613
+      ID: 620
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1113
+      ID: 1120
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.035072e+06
@@ -16049,13 +19145,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1106 PointerType *bufio.Writer
+          Type: 1113 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1025
+      ID: 1032
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 697
+      ID: 704
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.726304e+06
@@ -16071,7 +19167,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 695
+      ID: 702
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.594112e+06
@@ -16084,11 +19180,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1067
+      ID: 1074
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1027
+      ID: 1034
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.596032e+06
@@ -16096,16 +19192,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1066 PointerType *net/smtp.Client
+          Type: 1073 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1068 GoInterfaceType io.WriteCloser
+          Type: 1075 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 681
+      ID: 688
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 576
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 832224
@@ -16113,26 +19209,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *net/textproto.ProtocolError.str
+          Type: 578 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType net/textproto.ProtocolError.str
+      Data: 577 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 577
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1023
+      ID: 1030
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 938
+      ID: 945
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 547
+      ID: 554
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 830208
@@ -16140,18 +19236,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 549 PointerType *net/url.EscapeError.str
+          Type: 556 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 548 GoStringDataType net/url.EscapeError.str
+      Data: 555 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 548
+      ID: 555
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 550
+      ID: 557
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 830304
@@ -16159,254 +19255,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 552 PointerType *net/url.InvalidHostError.str
+          Type: 559 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 551 GoStringDataType net/url.InvalidHostError.str
+      Data: 558 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 551
+      ID: 558
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 427
+      ID: 434
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 679744
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 428 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 435 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 419
+      ID: 426
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 679840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 420 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 427 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 367
+      ID: 374
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 680128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 368 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 375 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 386
+      ID: 393
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 680224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 387 StructureType noalg.struct { key bool; elem main.node }
+      Element: 394 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 325
+      ID: 332
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 679072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 326 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 333 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1224
+      ID: 1231
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 678976
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1225 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1232 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1258
+      ID: 1265
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 678496
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1259 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1266 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1273
+      ID: 1280
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 678400
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1274 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1281 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 335
+      ID: 342
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 677248
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 336 StructureType noalg.struct { key int; elem int }
+      Element: 343 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1288
+      ID: 1295
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 678304
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1289 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1296 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 443
+      ID: 450
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 680320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 444 StructureType noalg.struct { key int; elem struct {} }
+      Element: 451 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 394
+      ID: 401
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 680416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 395 StructureType noalg.struct { key int; elem uint8 }
+      Element: 402 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 376
+      ID: 383
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 680512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 377 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 384 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 359
+      ID: 366
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 680608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 360 StructureType noalg.struct { key string; elem []string }
+      Element: 367 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 984
+      ID: 991
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 755616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 985 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 992 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 351
+      ID: 358
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 680704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 352 StructureType noalg.struct { key string; elem int }
+      Element: 359 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 343
+      ID: 350
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 680800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 344 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 351 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 435
+      ID: 442
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 680896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 436 StructureType noalg.struct { key struct {}; elem int }
+      Element: 443 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 485
+      ID: 492
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 486 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 493 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 493
+      ID: 500
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 494 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 501 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 501
+      ID: 508
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 502 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 509 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 509
+      ID: 516
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 510 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 517 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 517
+      ID: 524
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 518 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 525 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 525
+      ID: 532
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 526 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 533 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 451
+      ID: 458
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 680992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 452 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 459 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 410
+      ID: 417
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 681088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 411 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 418 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 402
+      ID: 409
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 681184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 403 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 410 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 426
+      ID: 433
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.291488e+06
@@ -16417,9 +19513,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 427 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 434 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 418
+      ID: 425
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.291744e+06
@@ -16430,9 +19526,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 419 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 426 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 366
+      ID: 373
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.292e+06
@@ -16443,9 +19539,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 367 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 374 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 385
+      ID: 392
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.292256e+06
@@ -16456,9 +19552,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 386 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 393 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 324
+      ID: 331
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.291232e+06
@@ -16469,9 +19565,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 325 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 332 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1223
+      ID: 1230
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.290976e+06
@@ -16482,9 +19578,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1224 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1231 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1257
+      ID: 1264
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.289696e+06
@@ -16495,9 +19591,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1258 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1265 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1272
+      ID: 1279
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.28944e+06
@@ -16508,9 +19604,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1273 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1280 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 334
+      ID: 341
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.288416e+06
@@ -16521,9 +19617,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 335 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 342 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1287
+      ID: 1294
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.289184e+06
@@ -16534,9 +19630,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1288 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1295 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 442
+      ID: 449
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.292512e+06
@@ -16547,9 +19643,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 443 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 450 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 393
+      ID: 400
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.292768e+06
@@ -16560,9 +19656,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 394 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 401 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 375
+      ID: 382
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.293024e+06
@@ -16573,9 +19669,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 376 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 383 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 358
+      ID: 365
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29328e+06
@@ -16586,9 +19682,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 359 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 366 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 983
+      ID: 990
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.354976e+06
@@ -16599,9 +19695,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 984 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 991 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 350
+      ID: 357
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.293536e+06
@@ -16612,9 +19708,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 351 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 358 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 342
+      ID: 349
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.293792e+06
@@ -16625,9 +19721,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 343 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 350 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 434
+      ID: 441
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.294048e+06
@@ -16638,9 +19734,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 435 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 442 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 484
+      ID: 491
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -16650,9 +19746,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 485 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 492 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 492
+      ID: 499
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16662,9 +19758,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 493 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 500 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 500
+      ID: 507
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16674,9 +19770,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 501 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 508 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 508
+      ID: 515
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16686,9 +19782,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 509 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 516 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 516
+      ID: 523
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16698,9 +19794,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 517 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 524 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 524
+      ID: 531
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16710,9 +19806,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 525 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 532 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 450
+      ID: 457
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.294304e+06
@@ -16723,9 +19819,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 451 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 458 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 409
+      ID: 416
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.29456e+06
@@ -16736,9 +19832,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 410 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 417 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 401
+      ID: 408
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.294816e+06
@@ -16749,9 +19845,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 402 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 409 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 428
+      ID: 435
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.29136e+06
@@ -16759,12 +19855,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
     - __kind: StructureType
-      ID: 420
+      ID: 427
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.291616e+06
@@ -16772,12 +19868,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 368
+      ID: 375
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.291872e+06
@@ -16785,12 +19881,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 369 ArrayType [4]string
+          Type: 376 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 111 ArrayType [2]int
     - __kind: StructureType
-      ID: 387
+      ID: 394
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.292128e+06
@@ -16803,7 +19899,7 @@ Types:
           Offset: 8
           Type: 244 StructureType main.node
     - __kind: StructureType
-      ID: 326
+      ID: 333
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.291104e+06
@@ -16814,9 +19910,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 327 PointerType *main.deepMap2
+          Type: 334 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1225
+      ID: 1232
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.290848e+06
@@ -16827,9 +19923,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1226 PointerType *main.deepMap3
+          Type: 1233 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1259
+      ID: 1266
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.289568e+06
@@ -16840,9 +19936,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1260 PointerType *main.deepMap8
+          Type: 1267 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1274
+      ID: 1281
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.289312e+06
@@ -16853,9 +19949,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1275 PointerType *main.deepMap9
+          Type: 1282 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 336
+      ID: 343
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.288288e+06
@@ -16868,7 +19964,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1289
+      ID: 1296
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.289056e+06
@@ -16881,7 +19977,7 @@ Types:
           Offset: 8
           Type: 155 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 444
+      ID: 451
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.292384e+06
@@ -16894,7 +19990,7 @@ Types:
           Offset: 8
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 395
+      ID: 402
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29264e+06
@@ -16907,7 +20003,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 377
+      ID: 384
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.292896e+06
@@ -16918,9 +20014,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 378 GoSliceHeaderType []main.structWithMap
+          Type: 385 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 360
+      ID: 367
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.293152e+06
@@ -16931,9 +20027,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 254 GoSliceHeaderType []string
+          Type: 261 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 985
+      ID: 992
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.354848e+06
@@ -16944,9 +20040,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 972 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 979 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 352
+      ID: 359
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.293408e+06
@@ -16959,7 +20055,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 344
+      ID: 351
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.293664e+06
@@ -16972,7 +20068,7 @@ Types:
           Offset: 16
           Type: 121 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 436
+      ID: 443
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.29392e+06
@@ -16985,7 +20081,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -16995,9 +20091,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 276 StructureType main.structWithCyclicMaps
+          Type: 283 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17007,9 +20103,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 277 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 284 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17019,9 +20115,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 282 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 289 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 510
+      ID: 517
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17031,9 +20127,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 287 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 518
+      ID: 525
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17043,9 +20139,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 292 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17055,9 +20151,9 @@ Types:
           Type: 123 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 297 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.294176e+06
       GoKind: 25
@@ -17069,7 +20165,7 @@ Types:
           Offset: 0
           Type: 123 StructureType struct {}
     - __kind: StructureType
-      ID: 411
+      ID: 418
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.294432e+06
@@ -17080,9 +20176,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 412 ArrayType [4]int
+          Type: 419 ArrayType [4]int
     - __kind: StructureType
-      ID: 403
+      ID: 410
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.294688e+06
@@ -17095,19 +20191,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1174
+      ID: 1181
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 809
+      ID: 816
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1172
+      ID: 1179
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.353408e+06
@@ -17115,12 +20211,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1178 StructureType os.noReadFrom
+          Type: 1185 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1173 PointerType *os.File
+          Type: 1180 PointerType *os.File
     - __kind: StructureType
-      ID: 1170
+      ID: 1177
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.352608e+06
@@ -17128,36 +20224,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1177 StructureType os.noWriteTo
+          Type: 1184 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1173 PointerType *os.File
+          Type: 1180 PointerType *os.File
     - __kind: StructureType
-      ID: 1178
+      ID: 1185
       Name: os.noReadFrom
       GoRuntimeType: 1.106848e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1177
+      ID: 1184
       Name: os.noWriteTo
       GoRuntimeType: 1.10672e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 840
+      ID: 847
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 979
+      ID: 986
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1045
+      ID: 1052
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 842
+      ID: 849
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.698048e+06
@@ -17170,7 +20266,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 583
+      ID: 590
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 835488
@@ -17178,36 +20274,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 585 PointerType *os/user.UnknownGroupIdError.str
+          Type: 592 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 584 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 591 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 584
+      ID: 591
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 582
+      ID: 589
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 835392
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 608
+      ID: 615
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 703
+      ID: 710
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 813
+      ID: 820
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 817
+      ID: 824
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -17219,7 +20315,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 815
+      ID: 822
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.88128e+06
@@ -17236,9 +20332,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 977 BaseType runtime.boundsErrorCode
+          Type: 984 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 977
+      ID: 984
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 582048
@@ -17258,7 +20354,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 875
+      ID: 882
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.745856e+06
@@ -17271,7 +20367,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 793
+      ID: 800
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 985344
@@ -17279,13 +20375,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 795 PointerType *runtime.errorString.str
+          Type: 802 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 794 GoStringDataType runtime.errorString.str
+      Data: 801 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 794
+      ID: 801
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -17941,7 +21037,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 796
+      ID: 803
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 985440
@@ -17949,13 +21045,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 798 PointerType *runtime.plainError.str
+          Type: 805 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 797 GoStringDataType runtime.plainError.str
+      Data: 804 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 797
+      ID: 804
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18041,7 +21137,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 819
+      ID: 826
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -18053,26 +21149,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 311 PointerType *string.str
+          Type: 318 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 310 GoStringDataType string.str
+      Data: 317 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 310
+      ID: 317
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1109
+      ID: 1116
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1013
+      ID: 1020
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1009
+      ID: 1016
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.451872e+06
@@ -18088,7 +21184,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1192
+      ID: 1199
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.460352e+06
@@ -18096,12 +21192,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1194 StructureType internal/sync.Mutex
+          Type: 1201 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1195
+      ID: 1202
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.608864e+06
@@ -18109,15 +21205,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1196 StructureType sync/atomic.Uint32
+          Type: 1203 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 1192 StructureType sync.Mutex
+          Type: 1199 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1198
+      ID: 1205
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.609056e+06
@@ -18125,21 +21221,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1193 StructureType sync.noCopy
+          Type: 1200 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1199 StructureType sync/atomic.Uint64
+          Type: 1206 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1193
+      ID: 1200
       Name: sync.noCopy
       GoRuntimeType: 984288
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1201
+      ID: 1208
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.461632e+06
@@ -18147,12 +21243,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.461792e+06
@@ -18160,12 +21256,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1199
+      ID: 1206
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.60944e+06
@@ -18173,33 +21269,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1197 StructureType sync/atomic.noCopy
+          Type: 1204 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1200 StructureType sync/atomic.align64
+          Type: 1207 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1200
+      ID: 1207
       Name: sync/atomic.align64
       GoRuntimeType: 984480
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: sync/atomic.noCopy
       GoRuntimeType: 984384
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 925
+      ID: 932
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.279072e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 423
+      ID: 430
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18221,9 +21317,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 424 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 431 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 415
+      ID: 422
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18245,9 +21341,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 416 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 423 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 363
+      ID: 370
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -18269,9 +21365,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 364 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 371 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 382
+      ID: 389
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -18293,9 +21389,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 383 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 390 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 321
+      ID: 328
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -18317,9 +21413,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 322 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 329 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1220
+      ID: 1227
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -18341,9 +21437,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1221 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1228 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1254
+      ID: 1261
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -18365,9 +21461,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1255 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1262 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1269
+      ID: 1276
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -18389,9 +21485,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1270 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1277 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 331
+      ID: 338
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -18413,9 +21509,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 332 GoSwissMapGroupsType groupReference<int,int>
+          Type: 339 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1284
+      ID: 1291
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -18437,9 +21533,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1285 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1292 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 439
+      ID: 446
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18461,9 +21557,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 440 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 447 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 390
+      ID: 397
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18485,9 +21581,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 391 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 398 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 372
+      ID: 379
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -18509,9 +21605,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 373 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 380 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 355
+      ID: 362
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -18533,9 +21629,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 356 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 363 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 980
+      ID: 987
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -18557,9 +21653,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 981 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 988 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 347
+      ID: 354
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -18581,9 +21677,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 348 GoSwissMapGroupsType groupReference<string,int>
+          Type: 355 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 339
+      ID: 346
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -18605,9 +21701,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 340 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 347 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 431
+      ID: 438
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -18629,9 +21725,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 432 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 439 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 481
+      ID: 488
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18653,9 +21749,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 482 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 489 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18677,9 +21773,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 490 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 497 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 497
+      ID: 504
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18701,9 +21797,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 498 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 505 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18725,9 +21821,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 506 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 513 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18749,9 +21845,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 514 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 521 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18773,9 +21869,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 522 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 529 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18797,9 +21893,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 448 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 455 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 406
+      ID: 413
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18821,9 +21917,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 407 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 414 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 398
+      ID: 405
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18845,13 +21941,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 399 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 406 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1144
+      ID: 1151
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 868
+      ID: 875
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.702464e+06
@@ -18864,21 +21960,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1091
+      ID: 1098
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.907424e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 943
+      ID: 950
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 611
+      ID: 618
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.368288e+06
@@ -18892,9 +21988,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 942 PointerType *time.Location
+          Type: 949 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 531
+      ID: 538
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 828384
@@ -18902,13 +21998,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 533 PointerType *time.fileSizeError.str
+          Type: 540 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 532 GoStringDataType time.fileSizeError.str
+      Data: 539 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 532
+      ID: 539
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18955,7 +22051,7 @@ Types:
       GoRuntimeType: 581984
       GoKind: 26
     - __kind: StructureType
-      ID: 959
+      ID: 966
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.05648e+06
@@ -18966,10 +22062,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 960 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 967 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 961 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 968 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -18984,18 +22080,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 962 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 969 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 962
+      ID: 969
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 990912
       GoKind: 9
     - __kind: StructureType
-      ID: 960
+      ID: 967
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.918176e+06
@@ -19020,21 +22116,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 961
+      ID: 968
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 585632
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1136
+      ID: 1143
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 683
+      ID: 690
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.422912e+06
@@ -19044,13 +22140,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 572
+      ID: 579
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 832320
       GoKind: 2
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.69824e+06
@@ -19063,12 +22159,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 801
+      ID: 808
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1461
+MaxTypeID: 1516
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,17 +8,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 139}
       events:
-        - ID: 142
+        - ID: 190
           Kind: Entry
-          Type: 1451 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x80abb8", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x80c2e8", Frameless: false}]
           Condition: null
-        - ID: 141
+        - ID: 189
           Kind: Return
-          Type: 1452 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x80abe8", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x80c318", Frameless: false}]
           Condition: null
     - id: testAny
       version: 0
@@ -32,12 +32,12 @@ Probes:
       events:
         - ID: 69
           Kind: Entry
-          Type: 1378 EventRootType Probe[main.testAny]
+          Type: 1385 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x807c18", Frameless: false}]
           Condition: null
         - ID: 68
           Kind: Return
-          Type: 1379 EventRootType Probe[main.testAny]Return
+          Type: 1386 EventRootType Probe[main.testAny]Return
           InjectionPoints: [{PC: "0x807c40", Frameless: false}]
           Condition: null
     - id: testAnyPtr
@@ -52,13 +52,32 @@ Probes:
       events:
         - ID: 72
           Kind: Entry
-          Type: 1381 EventRootType Probe[main.testAnyPtr]
+          Type: 1388 EventRootType Probe[main.testAnyPtr]
           InjectionPoints: [{PC: "0x807c88", Frameless: false}]
           Condition: null
         - ID: 71
           Kind: Return
-          Type: 1382 EventRootType Probe[main.testAnyPtr]Return
+          Type: 1389 EventRootType Probe[main.testAnyPtr]Return
           InjectionPoints: [{PC: "0x807cb0", Frameless: false}]
+          Condition: null
+    - id: testArrayArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testArrayArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 120}
+      events:
+        - ID: 162
+          Kind: Entry
+          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
+          Condition: null
+        - ID: 161
+          Kind: Return
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
           Condition: null
     - id: testArrayEmptyStructs
       version: 0
@@ -72,7 +91,7 @@ Probes:
       events:
         - ID: 19
           Kind: Entry
-          Type: 1329 EventRootType Probe[main.testArrayEmptyStructs]
+          Type: 1336 EventRootType Probe[main.testArrayEmptyStructs]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -87,7 +106,7 @@ Probes:
       events:
         - ID: 15
           Kind: Entry
-          Type: 1325 EventRootType Probe[main.testArrayOfArrays]
+          Type: 1332 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -102,7 +121,7 @@ Probes:
       events:
         - ID: 17
           Kind: Entry
-          Type: 1327 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 1334 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -117,7 +136,7 @@ Probes:
       events:
         - ID: 80
           Kind: Entry
-          Type: 1390 EventRootType Probe[main.testArrayOfMaps]
+          Type: 1397 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x808280", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -132,7 +151,7 @@ Probes:
       events:
         - ID: 16
           Kind: Entry
-          Type: 1326 EventRootType Probe[main.testArrayOfStrings]
+          Type: 1333 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x806380", Frameless: true}]
           Condition: null
     - id: testArrayOfStructs
@@ -146,7 +165,7 @@ Probes:
       events:
         - ID: 18
           Kind: Entry
-          Type: 1328 EventRootType Probe[main.testArrayOfStructs]
+          Type: 1335 EventRootType Probe[main.testArrayOfStructs]
           InjectionPoints: [{PC: "0x8063a0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -161,12 +180,12 @@ Probes:
       events:
         - ID: 38
           Kind: Entry
-          Type: 1347 EventRootType Probe[main.testBigStruct]
+          Type: 1354 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x8068f0", Frameless: true}]
           Condition: null
         - ID: 37
           Kind: Return
-          Type: 1348 EventRootType Probe[main.testBigStruct]Return
+          Type: 1355 EventRootType Probe[main.testBigStruct]Return
           InjectionPoints: [{PC: "0x8068fc", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -181,7 +200,7 @@ Probes:
       events:
         - ID: 4
           Kind: Entry
-          Type: 1314 EventRootType Probe[main.testBoolArray]
+          Type: 1321 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -196,7 +215,7 @@ Probes:
       events:
         - ID: 1
           Kind: Entry
-          Type: 1311 EventRootType Probe[main.testByteArray]
+          Type: 1318 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x806290", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -211,7 +230,7 @@ Probes:
       events:
         - ID: 100
           Kind: Entry
-          Type: 1410 EventRootType Probe[main.testChannel]
+          Type: 1417 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -226,7 +245,7 @@ Probes:
       events:
         - ID: 98
           Kind: Entry
-          Type: 1408 EventRootType Probe[main.testCombinedByte]
+          Type: 1415 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x809750", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -241,7 +260,7 @@ Probes:
       events:
         - ID: 108
           Kind: Entry
-          Type: 1418 EventRootType Probe[main.testCycle]
+          Type: 1425 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809c50", Frameless: true}]
           Condition: null
     - id: testDeepMap1
@@ -256,7 +275,7 @@ Probes:
       events:
         - ID: 43
           Kind: Entry
-          Type: 1353 EventRootType Probe[main.testDeepMap1]
+          Type: 1360 EventRootType Probe[main.testDeepMap1]
           InjectionPoints: [{PC: "0x806c90", Frameless: true}]
           Condition: null
     - id: testDeepMap7
@@ -271,7 +290,7 @@ Probes:
       events:
         - ID: 44
           Kind: Entry
-          Type: 1354 EventRootType Probe[main.testDeepMap7]
+          Type: 1361 EventRootType Probe[main.testDeepMap7]
           InjectionPoints: [{PC: "0x806ca0", Frameless: true}]
           Condition: null
     - id: testDeepPtr1
@@ -286,7 +305,7 @@ Probes:
       events:
         - ID: 39
           Kind: Entry
-          Type: 1349 EventRootType Probe[main.testDeepPtr1]
+          Type: 1356 EventRootType Probe[main.testDeepPtr1]
           InjectionPoints: [{PC: "0x8069b0", Frameless: true}]
           Condition: null
     - id: testDeepPtr7
@@ -301,7 +320,7 @@ Probes:
       events:
         - ID: 40
           Kind: Entry
-          Type: 1350 EventRootType Probe[main.testDeepPtr7]
+          Type: 1357 EventRootType Probe[main.testDeepPtr7]
           InjectionPoints: [{PC: "0x8069c0", Frameless: true}]
           Condition: null
     - id: testDeepSlice1
@@ -316,7 +335,7 @@ Probes:
       events:
         - ID: 41
           Kind: Entry
-          Type: 1351 EventRootType Probe[main.testDeepSlice1]
+          Type: 1358 EventRootType Probe[main.testDeepSlice1]
           InjectionPoints: [{PC: "0x806b30", Frameless: true}]
           Condition: null
     - id: testDeepSlice7
@@ -331,7 +350,7 @@ Probes:
       events:
         - ID: 42
           Kind: Entry
-          Type: 1352 EventRootType Probe[main.testDeepSlice7]
+          Type: 1359 EventRootType Probe[main.testDeepSlice7]
           InjectionPoints: [{PC: "0x806b40", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -342,12 +361,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 129}
       events:
-        - ID: 130
+        - ID: 178
           Kind: Entry
-          Type: 1440 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x80a860", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -357,12 +376,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 132}
       events:
-        - ID: 133
+        - ID: 181
           Kind: Entry
-          Type: 1443 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x80a890", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -373,12 +392,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 147}
       events:
-        - ID: 152
+        - ID: 200
           Kind: Entry
-          Type: 1462 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80ac70", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -388,12 +407,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 151}
       events:
-        - ID: 158
+        - ID: 206
           Kind: Entry
-          Type: 1468 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80af40", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
     - id: testEmptyStructPointer
       version: 0
@@ -402,12 +421,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 152}
       events:
-        - ID: 159
+        - ID: 207
           Kind: Entry
-          Type: 1469 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80af50", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -421,7 +440,7 @@ Probes:
       events:
         - ID: 70
           Kind: Entry
-          Type: 1380 EventRootType Probe[main.testError]
+          Type: 1387 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x807c60", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -436,12 +455,12 @@ Probes:
       events:
         - ID: 53
           Kind: Entry
-          Type: 1362 EventRootType Probe[main.testEsotericHeap]
+          Type: 1369 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x8072b8", Frameless: false}]
           Condition: null
         - ID: 52
           Kind: Return
-          Type: 1363 EventRootType Probe[main.testEsotericHeap]Return
+          Type: 1370 EventRootType Probe[main.testEsotericHeap]Return
           InjectionPoints: [{PC: "0x8072f0", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -456,12 +475,12 @@ Probes:
       events:
         - ID: 51
           Kind: Entry
-          Type: 1360 EventRootType Probe[main.testEsotericStack]
+          Type: 1367 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x8071fc", Frameless: false}]
           Condition: null
         - ID: 50
           Kind: Return
-          Type: 1361 EventRootType Probe[main.testEsotericStack]Return
+          Type: 1368 EventRootType Probe[main.testEsotericStack]Return
           InjectionPoints: [{PC: "0x807258", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -476,12 +495,12 @@ Probes:
       events:
         - ID: 63
           Kind: Entry
-          Type: 1372 EventRootType Probe[main.testFrameless]
+          Type: 1379 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x807980", Frameless: true}]
           Condition: null
         - ID: 62
           Kind: Return
-          Type: 1373 EventRootType Probe[main.testFrameless]Return
+          Type: 1380 EventRootType Probe[main.testFrameless]Return
           InjectionPoints: [{PC: "0x807988", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -496,12 +515,12 @@ Probes:
       events:
         - ID: 65
           Kind: Entry
-          Type: 1374 EventRootType Probe[main.testFramelessArray]
+          Type: 1381 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
         - ID: 64
           Kind: Return
-          Type: 1375 EventRootType Probe[main.testFramelessArray]Return
+          Type: 1382 EventRootType Probe[main.testFramelessArray]Return
           InjectionPoints: [{PC: "0x8079d0", Frameless: false}]
           Condition: null
     - id: testFramelessArrayLine
@@ -519,7 +538,7 @@ Probes:
       events:
         - ID: 66
           Kind: Line
-          Type: 1376 EventRootType Probe[main.testFramelessArray]Line
+          Type: 1383 EventRootType Probe[main.testFramelessArray]Line
           InjectionPoints: [{PC: "0x80799c", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -534,12 +553,12 @@ Probes:
       events:
         - ID: 55
           Kind: Entry
-          Type: 1364 EventRootType Probe[main.testInlinedBA]
+          Type: 1371 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x8076c8", Frameless: false}]
           Condition: null
         - ID: 54
           Kind: Return
-          Type: 1365 EventRootType Probe[main.testInlinedBA]Return
+          Type: 1372 EventRootType Probe[main.testInlinedBA]Return
           InjectionPoints: [{PC: "0x80771c", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -554,12 +573,12 @@ Probes:
       events:
         - ID: 57
           Kind: Entry
-          Type: 1366 EventRootType Probe[main.testInlinedBB]
+          Type: 1373 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x807758", Frameless: false}]
           Condition: null
         - ID: 56
           Kind: Return
-          Type: 1367 EventRootType Probe[main.testInlinedBB]Return
+          Type: 1374 EventRootType Probe[main.testInlinedBB]Return
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -574,12 +593,12 @@ Probes:
       events:
         - ID: 59
           Kind: Entry
-          Type: 1368 EventRootType Probe[main.testInlinedBBA]
+          Type: 1375 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x807818", Frameless: false}]
           Condition: null
         - ID: 58
           Kind: Return
-          Type: 1369 EventRootType Probe[main.testInlinedBBA]Return
+          Type: 1376 EventRootType Probe[main.testInlinedBBA]Return
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -590,11 +609,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 154}
       events:
-        - ID: 163
+        - ID: 211
           Kind: Entry
-          Type: 1473 EventRootType Probe[main.testInlinedBBB]
+          Type: 1528 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -609,12 +628,12 @@ Probes:
       events:
         - ID: 61
           Kind: Entry
-          Type: 1370 EventRootType Probe[main.testInlinedBC]
+          Type: 1377 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x807888", Frameless: false}]
           Condition: null
         - ID: 60
           Kind: Return
-          Type: 1371 EventRootType Probe[main.testInlinedBC]Return
+          Type: 1378 EventRootType Probe[main.testInlinedBC]Return
           InjectionPoints: [{PC: "0x807964", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -625,11 +644,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 164
+        - ID: 212
           Kind: Entry
-          Type: 1474 EventRootType Probe[main.testInlinedBCA]
+          Type: 1529 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCALine
@@ -643,11 +662,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 155}
       events:
-        - ID: 165
+        - ID: 213
           Kind: Line
-          Type: 1475 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1530 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -658,11 +677,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 166
+        - ID: 214
           Kind: Entry
-          Type: 1476 EventRootType Probe[main.testInlinedBCB]
+          Type: 1531 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedBCBLine
@@ -676,11 +695,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 156}
       events:
-        - ID: 167
+        - ID: 215
           Kind: Line
-          Type: 1477 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1532 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -692,11 +711,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 161
+        - ID: 209
           Kind: Entry
-          Type: 1470 EventRootType Probe[main.testInlinedPrint]
+          Type: 1525 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -709,9 +728,9 @@ Probes:
             - PC: "0x80781c"
               Frameless: false
           Condition: null
-        - ID: 160
+        - ID: 208
           Kind: Return
-          Type: 1471 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1526 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
     - id: testInlinedPrintLine
@@ -725,11 +744,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 153}
       events:
-        - ID: 162
+        - ID: 210
           Kind: Line
-          Type: 1472 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1527 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -750,11 +769,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 168
+        - ID: 216
           Kind: Entry
-          Type: 1478 EventRootType Probe[main.testInlinedSq]
+          Type: 1533 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSqLine
@@ -768,11 +787,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 157}
       events:
-        - ID: 169
+        - ID: 217
           Kind: Line
-          Type: 1479 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1534 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -784,11 +803,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 158}
       events:
-        - ID: 170
+        - ID: 218
           Kind: Entry
-          Type: 1480 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1535 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -807,7 +826,7 @@ Probes:
       events:
         - ID: 7
           Kind: Entry
-          Type: 1317 EventRootType Probe[main.testInt16Array]
+          Type: 1324 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8062f0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -822,7 +841,7 @@ Probes:
       events:
         - ID: 8
           Kind: Entry
-          Type: 1318 EventRootType Probe[main.testInt32Array]
+          Type: 1325 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -837,7 +856,7 @@ Probes:
       events:
         - ID: 9
           Kind: Entry
-          Type: 1319 EventRootType Probe[main.testInt64Array]
+          Type: 1326 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x806310", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -852,7 +871,7 @@ Probes:
       events:
         - ID: 6
           Kind: Entry
-          Type: 1316 EventRootType Probe[main.testInt8Array]
+          Type: 1323 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -867,7 +886,7 @@ Probes:
       events:
         - ID: 5
           Kind: Entry
-          Type: 1315 EventRootType Probe[main.testIntArray]
+          Type: 1322 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -882,8 +901,27 @@ Probes:
       events:
         - ID: 67
           Kind: Entry
-          Type: 1377 EventRootType Probe[main.testInterface]
+          Type: 1384 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x807bf0", Frameless: true}]
+          Condition: null
+    - id: testLargeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testLargeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 119}
+      events:
+        - ID: 160
+          Kind: Entry
+          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
+          Condition: null
+        - ID: 159
+          Kind: Return
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -897,7 +935,7 @@ Probes:
       events:
         - ID: 102
           Kind: Entry
-          Type: 1412 EventRootType Probe[main.testLinkedList]
+          Type: 1419 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x809b60", Frameless: true}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineA
@@ -915,7 +953,7 @@ Probes:
       events:
         - ID: 47
           Kind: Line
-          Type: 1357 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1364 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806cec", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineB
@@ -933,7 +971,7 @@ Probes:
       events:
         - ID: 48
           Kind: Line
-          Type: 1358 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1365 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806d70", Frameless: false}]
           Condition: null
     - id: testLongFunctionWithChangingStateLineC
@@ -951,8 +989,27 @@ Probes:
       events:
         - ID: 49
           Kind: Line
-          Type: 1359 EventRootType Probe[main.testLongFunctionWithChangingState]Line
+          Type: 1366 EventRootType Probe[main.testLongFunctionWithChangingState]Line
           InjectionPoints: [{PC: "0x806e0c", Frameless: false}]
+          Condition: null
+    - id: testManyArgsArrayReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testManyArgsArrayReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 122}
+      events:
+        - ID: 166
+          Kind: Entry
+          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
+          Condition: null
+        - ID: 165
+          Kind: Return
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -966,7 +1023,7 @@ Probes:
       events:
         - ID: 78
           Kind: Entry
-          Type: 1388 EventRootType Probe[main.testMapArrayToArray]
+          Type: 1395 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x808260", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -981,7 +1038,7 @@ Probes:
       events:
         - ID: 85
           Kind: Entry
-          Type: 1395 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 1402 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x8082c0", Frameless: true}]
           Condition: null
     - id: testMapEmptyKey
@@ -996,7 +1053,7 @@ Probes:
       events:
         - ID: 95
           Kind: Entry
-          Type: 1405 EventRootType Probe[main.testMapEmptyKey]
+          Type: 1412 EventRootType Probe[main.testMapEmptyKey]
           InjectionPoints: [{PC: "0x808360", Frameless: true}]
           Condition: null
     - id: testMapEmptyKeyAndValue
@@ -1011,7 +1068,7 @@ Probes:
       events:
         - ID: 97
           Kind: Entry
-          Type: 1407 EventRootType Probe[main.testMapEmptyKeyAndValue]
+          Type: 1414 EventRootType Probe[main.testMapEmptyKeyAndValue]
           InjectionPoints: [{PC: "0x808380", Frameless: true}]
           Condition: null
     - id: testMapEmptyValue
@@ -1026,7 +1083,7 @@ Probes:
       events:
         - ID: 96
           Kind: Entry
-          Type: 1406 EventRootType Probe[main.testMapEmptyValue]
+          Type: 1413 EventRootType Probe[main.testMapEmptyValue]
           InjectionPoints: [{PC: "0x808370", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -1041,7 +1098,7 @@ Probes:
       events:
         - ID: 82
           Kind: Entry
-          Type: 1392 EventRootType Probe[main.testMapIntToInt]
+          Type: 1399 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x8082a0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -1056,7 +1113,7 @@ Probes:
       events:
         - ID: 94
           Kind: Entry
-          Type: 1404 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 1411 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x808350", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -1071,7 +1128,7 @@ Probes:
       events:
         - ID: 93
           Kind: Entry
-          Type: 1403 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 1410 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x808340", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -1086,7 +1143,7 @@ Probes:
       events:
         - ID: 83
           Kind: Entry
-          Type: 1393 EventRootType Probe[main.testMapMassive]
+          Type: 1400 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
     - id: testMapMassiveWithSizeLimit
@@ -1101,7 +1158,7 @@ Probes:
       events:
         - ID: 84
           Kind: Entry
-          Type: 1394 EventRootType Probe[main.testMapMassive]
+          Type: 1401 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x8082b0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -1116,7 +1173,7 @@ Probes:
       events:
         - ID: 92
           Kind: Entry
-          Type: 1402 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 1409 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x808330", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -1131,7 +1188,7 @@ Probes:
       events:
         - ID: 91
           Kind: Entry
-          Type: 1401 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 1408 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x808320", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -1146,7 +1203,7 @@ Probes:
       events:
         - ID: 76
           Kind: Entry
-          Type: 1386 EventRootType Probe[main.testMapStringToInt]
+          Type: 1393 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x808240", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -1161,7 +1218,7 @@ Probes:
       events:
         - ID: 77
           Kind: Entry
-          Type: 1387 EventRootType Probe[main.testMapStringToSlice]
+          Type: 1394 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x808250", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -1176,7 +1233,7 @@ Probes:
       events:
         - ID: 75
           Kind: Entry
-          Type: 1385 EventRootType Probe[main.testMapStringToStruct]
+          Type: 1392 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x808230", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -1191,7 +1248,7 @@ Probes:
       events:
         - ID: 86
           Kind: Entry
-          Type: 1396 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 1403 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x8082d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -1206,7 +1263,7 @@ Probes:
       events:
         - ID: 89
           Kind: Entry
-          Type: 1399 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 1406 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x808300", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -1221,7 +1278,7 @@ Probes:
       events:
         - ID: 90
           Kind: Entry
-          Type: 1400 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 1407 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x808310", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -1236,7 +1293,7 @@ Probes:
       events:
         - ID: 87
           Kind: Entry
-          Type: 1397 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 1404 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x8082e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -1251,7 +1308,7 @@ Probes:
       events:
         - ID: 88
           Kind: Entry
-          Type: 1398 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 1405 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x8082f0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -1262,12 +1319,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 145}
       events:
-        - ID: 149
+        - ID: 197
           Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80ac50", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c380", Frameless: true}]
           Condition: null
     - id: testMassiveStringWithSizeLimit
       version: 0
@@ -1278,12 +1335,69 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
+      subprogram: {subprogram: 145}
+      events:
+        - ID: 198
+          Kind: Entry
+          Type: 1515 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c380", Frameless: true}]
+          Condition: null
+    - id: testMixedArgsStackReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMixedArgsStackReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 123}
+      events:
+        - ID: 168
+          Kind: Entry
+          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
+          Condition: null
+        - ID: 167
+          Kind: Return
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x80b848", Frameless: false}]
+          Condition: null
+    - id: testMultipleArrayArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleArrayArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 125}
+      events:
+        - ID: 172
+          Kind: Entry
+          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
+          Condition: null
+        - ID: 171
+          Kind: Return
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
+          Condition: null
+    - id: testMultipleLargeArgs
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testMultipleLargeArgs}
+      template: ""
+      segments: []
+      captureSnapshot: true
       subprogram: {subprogram: 121}
       events:
-        - ID: 150
+        - ID: 164
           Kind: Entry
-          Type: 1460 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80ac50", Frameless: true}]
+          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x80b310", Frameless: false}]
+          Condition: null
+        - ID: 163
+          Kind: Return
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
           Condition: null
     - id: testMultipleNamedReturn
       version: 0
@@ -1296,13 +1410,13 @@ Probes:
       events:
         - ID: 126
           Kind: Entry
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a478", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
           Condition: null
         - ID: 125
           Kind: Return
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a4e8", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -1316,7 +1430,7 @@ Probes:
       events:
         - ID: 99
           Kind: Entry
-          Type: 1409 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1416 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x809830", Frameless: true}]
           Condition: null
     - id: testNamedReturn
@@ -1330,13 +1444,13 @@ Probes:
       events:
         - ID: 124
           Kind: Entry
-          Type: 1433 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a3e8", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
           Condition: null
         - ID: 123
           Kind: Return
-          Type: 1434 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a43c", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -1350,7 +1464,7 @@ Probes:
       events:
         - ID: 107
           Kind: Entry
-          Type: 1417 EventRootType Probe[main.testNilPointer]
+          Type: 1424 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809c30", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -1361,12 +1475,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 136}
       events:
-        - ID: 137
+        - ID: 185
           Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x80a8d0", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -1376,12 +1490,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 133}
       events:
-        - ID: 134
+        - ID: 182
           Kind: Entry
-          Type: 1444 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x80a8a0", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -1391,12 +1505,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 135}
       events:
-        - ID: 136
+        - ID: 184
           Kind: Entry
-          Type: 1446 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x80a8c0", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -1406,12 +1520,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 144}
       events:
-        - ID: 148
+        - ID: 196
           Kind: Entry
-          Type: 1458 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80ac40", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80c370", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -1425,7 +1539,7 @@ Probes:
       events:
         - ID: 103
           Kind: Entry
-          Type: 1413 EventRootType Probe[main.testPointerLoop]
+          Type: 1420 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x809b70", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -1440,7 +1554,7 @@ Probes:
       events:
         - ID: 81
           Kind: Entry
-          Type: 1391 EventRootType Probe[main.testPointerToMap]
+          Type: 1398 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x808290", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -1455,7 +1569,7 @@ Probes:
       events:
         - ID: 101
           Kind: Entry
-          Type: 1411 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1418 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x809b50", Frameless: true}]
           Condition: null
     - id: testReturnsAny
@@ -1470,13 +1584,21 @@ Probes:
       events:
         - ID: 120
           Kind: Entry
-          Type: 1429 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x80a258", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x80a358", Frameless: false}]
           Condition: null
         - ID: 119
           Kind: Return
-          Type: 1430 EventRootType Probe[main.testReturnsAny]Return
-          InjectionPoints: [{PC: "0x80a2a0", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsAny]Return
+          InjectionPoints:
+            - PC: "0x80a3e0"
+              Frameless: false
+            - PC: "0x80a434"
+              Frameless: false
+            - PC: "0x80a4e4"
+              Frameless: false
+            - PC: "0x80a4f8"
+              Frameless: false
           Condition: null
     - id: testReturnsAnyAndError
       version: 0
@@ -1490,17 +1612,135 @@ Probes:
       events:
         - ID: 118
           Kind: Entry
-          Type: 1427 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x80a1c8", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x80a1e8", Frameless: false}]
           Condition: null
         - ID: 117
           Kind: Return
-          Type: 1428 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1435 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x80a204"
+            - PC: "0x80a23c"
               Frameless: false
-            - PC: "0x80a218"
+            - PC: "0x80a298"
               Frameless: false
+            - PC: "0x80a2d8"
+              Frameless: false
+            - PC: "0x80a314"
+              Frameless: false
+          Condition: null
+    - id: testReturnsArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 108}
+      events:
+        - ID: 138
+          Kind: Entry
+          Type: 1454 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
+          Condition: null
+        - ID: 137
+          Kind: Return
+          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayOne
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayOne}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 109}
+      events:
+        - ID: 140
+          Kind: Entry
+          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
+          Condition: null
+        - ID: 139
+          Kind: Return
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
+          Condition: null
+    - id: testReturnsArrayZero
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsArrayZero}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 110}
+      events:
+        - ID: 142
+          Kind: Entry
+          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
+          Condition: null
+        - ID: 141
+          Kind: Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
+          Condition: null
+    - id: testReturnsBacktrackInt
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBacktrackInt}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 112}
+      events:
+        - ID: 146
+          Kind: Entry
+          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
+          Condition: null
+        - ID: 145
+          Kind: Return
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
+          Condition: null
+    - id: testReturnsBoolAndUintptr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsBoolAndUintptr}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 118}
+      events:
+        - ID: 158
+          Kind: Entry
+          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x80b048", Frameless: false}]
+          Condition: null
+        - ID: 157
+          Kind: Return
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x80b084", Frameless: false}]
+          Condition: null
+    - id: testReturnsComplex
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsComplex}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 106}
+      events:
+        - ID: 134
+          Kind: Entry
+          Type: 1450 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
+          Condition: null
+        - ID: 133
+          Kind: Return
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
           Condition: null
     - id: testReturnsError
       version: 0
@@ -1514,16 +1754,16 @@ Probes:
       events:
         - ID: 116
           Kind: Entry
-          Type: 1425 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x80a148", Frameless: false}]
+          Type: 1432 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x80a168", Frameless: false}]
           Condition: null
         - ID: 115
           Kind: Return
-          Type: 1426 EventRootType Probe[main.testReturnsError]Return
+          Type: 1433 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x80a174"
+            - PC: "0x80a194"
               Frameless: false
-            - PC: "0x80a188"
+            - PC: "0x80a1a8"
               Frameless: false
           Condition: null
     - id: testReturnsInt
@@ -1537,13 +1777,13 @@ Probes:
       events:
         - ID: 110
           Kind: Entry
-          Type: 1419 EventRootType Probe[main.testReturnsInt]
+          Type: 1426 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809f78", Frameless: false}]
           Condition: null
         - ID: 109
           Kind: Return
-          Type: 1420 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x809fb4", Frameless: false}]
+          Type: 1427 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x809fb8", Frameless: false}]
           Condition: null
     - id: testReturnsIntAndFloat
       version: 0
@@ -1556,13 +1796,13 @@ Probes:
       events:
         - ID: 114
           Kind: Entry
-          Type: 1423 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x80a088", Frameless: false}]
+          Type: 1430 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x80a098", Frameless: false}]
           Condition: null
         - ID: 113
           Kind: Return
-          Type: 1424 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x80a104", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x80a124", Frameless: false}]
           Condition: null
     - id: testReturnsIntPointer
       version: 0
@@ -1575,13 +1815,13 @@ Probes:
       events:
         - ID: 112
           Kind: Entry
-          Type: 1421 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x809ffc", Frameless: false}]
+          Type: 1428 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x809ff8", Frameless: false}]
           Condition: null
         - ID: 111
           Kind: Return
-          Type: 1422 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x80a050", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x80a054", Frameless: false}]
           Condition: null
     - id: testReturnsInterface
       version: 0
@@ -1595,17 +1835,188 @@ Probes:
       events:
         - ID: 122
           Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x80a2d8", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x80a538", Frameless: false}]
           Condition: null
         - ID: 121
           Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1439 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x80a35c"
+            - PC: "0x80a5f0"
               Frameless: false
-            - PC: "0x80a370"
+            - PC: "0x80a604"
               Frameless: false
+          Condition: null
+    - id: testReturnsLargeStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsLargeStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 107}
+      events:
+        - ID: 136
+          Kind: Entry
+          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
+          Condition: null
+        - ID: 135
+          Kind: Return
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
+          Condition: null
+    - id: testReturnsManyFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsManyFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 105}
+      events:
+        - ID: 132
+          Kind: Entry
+          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x80a928", Frameless: false}]
+          Condition: null
+        - ID: 131
+          Kind: Return
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixed
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixed}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 114}
+      events:
+        - ID: 150
+          Kind: Entry
+          Type: 1466 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+          Condition: null
+        - ID: 149
+          Kind: Return
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
+          Condition: null
+    - id: testReturnsMixedStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMixedStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 111}
+      events:
+        - ID: 144
+          Kind: Entry
+          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
+          Condition: null
+        - ID: 143
+          Kind: Return
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
+          Condition: null
+    - id: testReturnsMultipleFloats
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsMultipleFloats}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 117}
+      events:
+        - ID: 156
+          Kind: Entry
+          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
+          Condition: null
+        - ID: 155
+          Kind: Return
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x80b018", Frameless: false}]
+          Condition: null
+    - id: testReturnsOnlyFloat
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsOnlyFloat}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 116}
+      events:
+        - ID: 154
+          Kind: Entry
+          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x80af68", Frameless: false}]
+          Condition: null
+        - ID: 153
+          Kind: Return
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
+          Condition: null
+    - id: testReturnsPrimitives
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsPrimitives}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 104}
+      events:
+        - ID: 130
+          Kind: Entry
+          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x80a898", Frameless: false}]
+          Condition: null
+        - ID: 129
+          Kind: Return
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
+          Condition: null
+    - id: testReturnsStructWithArray
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsStructWithArray}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 115}
+      events:
+        - ID: 152
+          Kind: Entry
+          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
+          Condition: null
+        - ID: 151
+          Kind: Return
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x80af38", Frameless: false}]
+          Condition: null
+    - id: testReturnsWideStruct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testReturnsWideStruct}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 113}
+      events:
+        - ID: 148
+          Kind: Entry
+          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
+          Condition: null
+        - ID: 147
+          Kind: Return
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -1619,7 +2030,7 @@ Probes:
       events:
         - ID: 2
           Kind: Entry
-          Type: 1312 EventRootType Probe[main.testRuneArray]
+          Type: 1319 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x8062a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -1634,7 +2045,7 @@ Probes:
       events:
         - ID: 23
           Kind: Entry
-          Type: 1333 EventRootType Probe[main.testSingleBool]
+          Type: 1340 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x806720", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -1649,7 +2060,7 @@ Probes:
       events:
         - ID: 21
           Kind: Entry
-          Type: 1331 EventRootType Probe[main.testSingleByte]
+          Type: 1338 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x806700", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -1664,7 +2075,7 @@ Probes:
       events:
         - ID: 34
           Kind: Entry
-          Type: 1344 EventRootType Probe[main.testSingleFloat32]
+          Type: 1351 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x8067d0", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -1679,7 +2090,7 @@ Probes:
       events:
         - ID: 35
           Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSingleFloat64]
+          Type: 1352 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x8067e0", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -1694,7 +2105,7 @@ Probes:
       events:
         - ID: 24
           Kind: Entry
-          Type: 1334 EventRootType Probe[main.testSingleInt]
+          Type: 1341 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x806730", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1709,7 +2120,7 @@ Probes:
       events:
         - ID: 26
           Kind: Entry
-          Type: 1336 EventRootType Probe[main.testSingleInt16]
+          Type: 1343 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x806750", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1724,7 +2135,7 @@ Probes:
       events:
         - ID: 27
           Kind: Entry
-          Type: 1337 EventRootType Probe[main.testSingleInt32]
+          Type: 1344 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x806760", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1739,7 +2150,7 @@ Probes:
       events:
         - ID: 28
           Kind: Entry
-          Type: 1338 EventRootType Probe[main.testSingleInt64]
+          Type: 1345 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x806770", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1754,7 +2165,7 @@ Probes:
       events:
         - ID: 25
           Kind: Entry
-          Type: 1335 EventRootType Probe[main.testSingleInt8]
+          Type: 1342 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x806740", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1769,7 +2180,7 @@ Probes:
       events:
         - ID: 22
           Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleRune]
+          Type: 1339 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x806710", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1780,12 +2191,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 140}
       events:
-        - ID: 143
+        - ID: 191
           Kind: Entry
-          Type: 1453 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x80ac00", Frameless: true}]
+          Type: 1508 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x80c330", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1799,7 +2210,7 @@ Probes:
       events:
         - ID: 29
           Kind: Entry
-          Type: 1339 EventRootType Probe[main.testSingleUint]
+          Type: 1346 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x806780", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1814,7 +2225,7 @@ Probes:
       events:
         - ID: 31
           Kind: Entry
-          Type: 1341 EventRootType Probe[main.testSingleUint16]
+          Type: 1348 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x8067a0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1829,7 +2240,7 @@ Probes:
       events:
         - ID: 32
           Kind: Entry
-          Type: 1342 EventRootType Probe[main.testSingleUint32]
+          Type: 1349 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x8067b0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1844,7 +2255,7 @@ Probes:
       events:
         - ID: 33
           Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSingleUint64]
+          Type: 1350 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x8067c0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1859,7 +2270,7 @@ Probes:
       events:
         - ID: 30
           Kind: Entry
-          Type: 1340 EventRootType Probe[main.testSingleUint8]
+          Type: 1347 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x806790", Frameless: true}]
           Condition: null
     - id: testSliceEmptyStructs
@@ -1870,12 +2281,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 138}
       events:
-        - ID: 140
+        - ID: 188
           Kind: Entry
-          Type: 1450 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x80a8f0", Frameless: true}]
+          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1885,12 +2296,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 130}
       events:
-        - ID: 131
+        - ID: 179
           Kind: Entry
-          Type: 1441 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x80a870", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1904,7 +2315,7 @@ Probes:
       events:
         - ID: 79
           Kind: Entry
-          Type: 1389 EventRootType Probe[main.testSmallMap]
+          Type: 1396 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x808270", Frameless: true}]
           Condition: null
     - id: testSomeNamedReturn
@@ -1918,13 +2329,32 @@ Probes:
       events:
         - ID: 128
           Kind: Entry
-          Type: 1437 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x80a528", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
           Condition: null
         - ID: 127
           Kind: Return
-          Type: 1438 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a598", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
+          Condition: null
+    - id: testStackArgRegReturns
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStackArgRegReturns}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 124}
+      events:
+        - ID: 170
+          Kind: Entry
+          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
+          Condition: null
+        - ID: 169
+          Kind: Return
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x80b900", Frameless: false}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1938,7 +2368,7 @@ Probes:
       events:
         - ID: 3
           Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStringArray]
+          Type: 1320 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1953,7 +2383,7 @@ Probes:
       events:
         - ID: 106
           Kind: Entry
-          Type: 1416 EventRootType Probe[main.testStringPointer]
+          Type: 1423 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809c10", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1964,12 +2394,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 134}
       events:
-        - ID: 135
+        - ID: 183
           Kind: Entry
-          Type: 1445 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x80a8b0", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
     - id: testStringType1
       version: 0
@@ -1983,7 +2413,7 @@ Probes:
       events:
         - ID: 45
           Kind: Entry
-          Type: 1355 EventRootType Probe[main.testStringType1]
+          Type: 1362 EventRootType Probe[main.testStringType1]
           InjectionPoints: [{PC: "0x806cb0", Frameless: true}]
           Condition: null
     - id: testStringType2
@@ -1998,7 +2428,7 @@ Probes:
       events:
         - ID: 46
           Kind: Entry
-          Type: 1356 EventRootType Probe[main.testStringType2]
+          Type: 1363 EventRootType Probe[main.testStringType2]
           InjectionPoints: [{PC: "0x806cc0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -2009,17 +2439,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 150}
       events:
-        - ID: 157
+        - ID: 205
           Kind: Entry
-          Type: 1466 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80ae70", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80c5a0", Frameless: true}]
           Condition: null
-        - ID: 156
+        - ID: 204
           Kind: Return
-          Type: 1467 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x80ae80", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -2029,12 +2459,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 131}
       events:
-        - ID: 132
+        - ID: 180
           Kind: Entry
-          Type: 1442 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x80a880", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
           Condition: null
     - id: testStructWithAny
       version: 0
@@ -2048,8 +2478,27 @@ Probes:
       events:
         - ID: 73
           Kind: Entry
-          Type: 1383 EventRootType Probe[main.testStructWithAny]
+          Type: 1390 EventRootType Probe[main.testStructWithAny]
           InjectionPoints: [{PC: "0x807cd0", Frameless: true}]
+          Condition: null
+    - id: testStructWithArrayArg
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStructWithArrayArg}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 126}
+      events:
+        - ID: 174
+          Kind: Entry
+          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
+          Condition: null
+        - ID: 173
+          Kind: Return
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
           Condition: null
     - id: testStructWithCyclicMaps
       version: 0
@@ -2058,17 +2507,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 149}
       events:
-        - ID: 155
+        - ID: 203
           Kind: Entry
-          Type: 1464 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x80adc0", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x80c4f0", Frameless: true}]
           Condition: null
-        - ID: 154
+        - ID: 202
           Kind: Return
-          Type: 1465 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x80adcc", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x80c4fc", Frameless: true}]
           Condition: null
     - id: testStructWithCyclicSlices
       version: 0
@@ -2077,12 +2526,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 148}
       events:
-        - ID: 153
+        - ID: 201
           Kind: Entry
-          Type: 1463 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x80adb0", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x80c4e0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -2096,7 +2545,7 @@ Probes:
       events:
         - ID: 74
           Kind: Entry
-          Type: 1384 EventRootType Probe[main.testStructWithMap]
+          Type: 1391 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x808220", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -2107,12 +2556,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 141}
       events:
-        - ID: 144
+        - ID: 192
           Kind: Entry
-          Type: 1454 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x80ac10", Frameless: true}]
+          Type: 1509 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x80c340", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -2122,17 +2571,17 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 142}
       events:
-        - ID: 146
+        - ID: 194
           Kind: Entry
-          Type: 1455 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80ac20", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80c350", Frameless: true}]
           Condition: null
-        - ID: 145
+        - ID: 193
           Kind: Return
-          Type: 1456 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80ac2c", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80c35c", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -2142,12 +2591,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 143}
       events:
-        - ID: 147
+        - ID: 195
           Kind: Entry
-          Type: 1457 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80ac30", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80c360", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -2161,7 +2610,7 @@ Probes:
       events:
         - ID: 36
           Kind: Entry
-          Type: 1346 EventRootType Probe[main.testTypeAlias]
+          Type: 1353 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x8067f0", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -2176,7 +2625,7 @@ Probes:
       events:
         - ID: 12
           Kind: Entry
-          Type: 1322 EventRootType Probe[main.testUint16Array]
+          Type: 1329 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x806340", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -2191,7 +2640,7 @@ Probes:
       events:
         - ID: 13
           Kind: Entry
-          Type: 1323 EventRootType Probe[main.testUint32Array]
+          Type: 1330 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x806350", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -2206,7 +2655,7 @@ Probes:
       events:
         - ID: 14
           Kind: Entry
-          Type: 1324 EventRootType Probe[main.testUint64Array]
+          Type: 1331 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x806360", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -2221,7 +2670,7 @@ Probes:
       events:
         - ID: 11
           Kind: Entry
-          Type: 1321 EventRootType Probe[main.testUint8Array]
+          Type: 1328 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x806330", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -2236,7 +2685,7 @@ Probes:
       events:
         - ID: 10
           Kind: Entry
-          Type: 1320 EventRootType Probe[main.testUintArray]
+          Type: 1327 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x806320", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -2251,7 +2700,7 @@ Probes:
       events:
         - ID: 105
           Kind: Entry
-          Type: 1415 EventRootType Probe[main.testUintPointer]
+          Type: 1422 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -2262,12 +2711,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 128}
       events:
-        - ID: 129
+        - ID: 177
           Kind: Entry
-          Type: 1439 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x80a850", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -2277,12 +2726,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 146}
       events:
-        - ID: 151
+        - ID: 199
           Kind: Entry
-          Type: 1461 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80ac60", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80c390", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -2296,7 +2745,7 @@ Probes:
       events:
         - ID: 104
           Kind: Entry
-          Type: 1414 EventRootType Probe[main.testUnsafePointer]
+          Type: 1421 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809b80", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -2311,7 +2760,7 @@ Probes:
       events:
         - ID: 20
           Kind: Entry
-          Type: 1330 EventRootType Probe[main.testVeryLargeArray]
+          Type: 1337 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x8063d0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -2322,12 +2771,12 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 138
+        - ID: 186
           Kind: Entry
-          Type: 1448 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80a8e0", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
@@ -2337,12 +2786,31 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 137}
       events:
-        - ID: 139
+        - ID: 187
           Kind: Entry
-          Type: 1449 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80a8e0", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
+          Condition: null
+    - id: testZeroSizeArgAndReturn
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testZeroSizeArgAndReturn}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 127}
+      events:
+        - ID: 176
+          Kind: Entry
+          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+          Condition: null
+        - ID: 175
+          Kind: Return
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
@@ -3741,26 +4209,33 @@ Subprograms:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809f60..0x809f84
+            - Range: 0x809f60..0x809f7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f84..0x809fe0
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809f60..0x809fb4
+            - Range: 0x809f60..0x809fb8
               Pieces: []
-            - Range: 0x809fb4..0x809fb5
+            - Range: 0x809fb8..0x809fb9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809fb5..0x809fe0
+            - Range: 0x809fb9..0x809fe0
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x809f7c..0x809f88
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x809f88..0x809fe0
+              Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 95
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x809fe0..0x80a070]
+      OutOfLinePCRanges: [0x809fe0..0x80a080]
       InlinePCRanges: []
       Variables:
         - Name: i
@@ -3768,117 +4243,138 @@ Subprograms:
           Locations:
             - Range: 0x809fe0..0x80a004
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a004..0x80a080
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x809fe0..0x80a050
+            - Range: 0x809fe0..0x80a054
               Pieces: []
-            - Range: 0x80a050..0x80a051
+            - Range: 0x80a054..0x80a055
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a051..0x80a070
+            - Range: 0x80a055..0x80a080
               Pieces: []
           IsParameter: true
           IsReturn: true
-        - Name: '&i'
+        - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a008..0x80a01c
+            - Range: 0x80a008..0x80a020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a01c..0x80a070
+            - Range: 0x80a020..0x80a080
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           IsParameter: false
           IsReturn: false
     - ID: 96
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80a070..0x80a130]
+      OutOfLinePCRanges: [0x80a080..0x80a150]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a070..0x80a0b8
+            - Range: 0x80a080..0x80a0d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a0b8..0x80a130
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a070..0x80a104
+            - Range: 0x80a080..0x80a124
               Pieces: []
-            - Range: 0x80a104..0x80a105
+            - Range: 0x80a124..0x80a125
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a105..0x80a130
+            - Range: 0x80a125..0x80a150
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a070..0x80a130, Pieces: []}]
+          Locations: [{Range: 0x80a080..0x80a150, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: f
+        - Name: resultInt
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a09c..0x80a0d8
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80a0d8..0x80a150
+              Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80a090..0x80a0b8
+            - Range: 0x80a0ac..0x80a0d8
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80a0b8..0x80a130
+            - Range: 0x80a0d8..0x80a150
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           IsParameter: false
           IsReturn: false
     - ID: 97
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80a130..0x80a1b0]
+      OutOfLinePCRanges: [0x80a150..0x80a1d0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a130..0x80a154
+            - Range: 0x80a150..0x80a174
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a130..0x80a174
+            - Range: 0x80a150..0x80a194
               Pieces: []
-            - Range: 0x80a174..0x80a175
+            - Range: 0x80a194..0x80a195
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a175..0x80a188
+            - Range: 0x80a195..0x80a1a8
               Pieces: []
-            - Range: 0x80a188..0x80a189
+            - Range: 0x80a1a8..0x80a1a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a189..0x80a1b0
+            - Range: 0x80a1a9..0x80a1d0
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80a1b0..0x80a240]
+      OutOfLinePCRanges: [0x80a1d0..0x80a340]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a1b0..0x80a1dc
+            - Range: 0x80a1d0..0x80a220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1dc..0x80a1e0
+            - Range: 0x80a220..0x80a224
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+            - Range: 0x80a2ac..0x80a2b0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a2ec..0x80a2f0
               Pieces:
                 - Size: 8
                   Op: null
@@ -3889,77 +4385,116 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a1b0..0x80a1e0
+            - Range: 0x80a1d0..0x80a214
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a1b0..0x80a204
+            - Range: 0x80a1d0..0x80a23c
               Pieces: []
-            - Range: 0x80a204..0x80a205
+            - Range: 0x80a23c..0x80a23d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a205..0x80a218
+            - Range: 0x80a23d..0x80a298
               Pieces: []
-            - Range: 0x80a218..0x80a219
+            - Range: 0x80a298..0x80a299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a219..0x80a240
+            - Range: 0x80a299..0x80a2d8
+              Pieces: []
+            - Range: 0x80a2d8..0x80a2d9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a2d9..0x80a314
+              Pieces: []
+            - Range: 0x80a314..0x80a315
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a315..0x80a340
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a1b0..0x80a204
+            - Range: 0x80a1d0..0x80a23c
               Pieces: []
-            - Range: 0x80a204..0x80a205
+            - Range: 0x80a23c..0x80a23d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a205..0x80a218
+            - Range: 0x80a23d..0x80a298
               Pieces: []
-            - Range: 0x80a218..0x80a219
+            - Range: 0x80a298..0x80a299
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a219..0x80a240
+            - Range: 0x80a299..0x80a2d8
+              Pieces: []
+            - Range: 0x80a2d8..0x80a2d9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80a2d9..0x80a314
+              Pieces: []
+            - Range: 0x80a314..0x80a315
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80a315..0x80a340
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a220..0x80a228
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 99
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80a240..0x80a2c0]
+      OutOfLinePCRanges: [0x80a340..0x80a520]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a240..0x80a280
+            - Range: 0x80a340..0x80a380
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a280..0x80a288
+            - Range: 0x80a380..0x80a388
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a288..0x80a2c0
+            - Range: 0x80a388..0x80a520
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -3970,267 +4505,1511 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a240..0x80a2a0
+            - Range: 0x80a340..0x80a3e0
               Pieces: []
-            - Range: 0x80a2a0..0x80a2a1
+            - Range: 0x80a3e0..0x80a3e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2a1..0x80a2c0
+            - Range: 0x80a3e1..0x80a434
+              Pieces: []
+            - Range: 0x80a434..0x80a435
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a435..0x80a4e4
+              Pieces: []
+            - Range: 0x80a4e4..0x80a4e5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a4e5..0x80a4f8
+              Pieces: []
+            - Range: 0x80a4f8..0x80a4f9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a4f9..0x80a520
               Pieces: []
           IsParameter: true
           IsReturn: true
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80a3cc..0x80a3d4
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+        - Name: '&result'
+          Type: 100 PointerType *int
+          Locations:
+            - Range: 0x80a418..0x80a434
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
     - ID: 100
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80a2c0..0x80a3d0]
+      OutOfLinePCRanges: [0x80a520..0x80a670]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a2c0..0x80a2fc
+            - Range: 0x80a520..0x80a55c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2fc..0x80a33c
+            - Range: 0x80a55c..0x80a59c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a33c..0x80a37c
+            - Range: 0x80a59c..0x80a610
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a37c..0x80a3a4
+            - Range: 0x80a610..0x80a638
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a3a4..0x80a3a8
+            - Range: 0x80a638..0x80a63c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a3a8..0x80a3d0
+            - Range: 0x80a63c..0x80a670
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a2c0..0x80a35c
+            - Range: 0x80a520..0x80a5f0
               Pieces: []
-            - Range: 0x80a35c..0x80a35d
+            - Range: 0x80a5f0..0x80a5f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a35d..0x80a370
+            - Range: 0x80a5f1..0x80a604
               Pieces: []
-            - Range: 0x80a370..0x80a371
+            - Range: 0x80a604..0x80a605
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a371..0x80a3d0
+            - Range: 0x80a605..0x80a670
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a2c0..0x80a2fc
+            - Range: 0x80a520..0x80a55c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2fc..0x80a33c
+            - Range: 0x80a55c..0x80a59c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a33c..0x80a344
+            - Range: 0x80a59c..0x80a5a4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a344..0x80a368
+            - Range: 0x80a5a4..0x80a5fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a368..0x80a36c
+            - Range: 0x80a5fc..0x80a600
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a36c..0x80a370
+            - Range: 0x80a600..0x80a604
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a370..0x80a3d0
+            - Range: 0x80a604..0x80a670
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           IsParameter: false
           IsReturn: false
     - ID: 101
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a3d0..0x80a460]
+      OutOfLinePCRanges: [0x80a670..0x80a700]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a3d0..0x80a40c
+            - Range: 0x80a670..0x80a68c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a40c..0x80a460
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a3d0..0x80a43c
+            - Range: 0x80a670..0x80a6e0
               Pieces: []
-            - Range: 0x80a43c..0x80a43d
+            - Range: 0x80a6e0..0x80a6e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a43d..0x80a460
+            - Range: 0x80a6e1..0x80a700
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a460..0x80a510]
+      OutOfLinePCRanges: [0x80a700..0x80a7c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a460..0x80a4a0
+            - Range: 0x80a700..0x80a74c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a4a0..0x80a510
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a460..0x80a4e8
+            - Range: 0x80a700..0x80a798
               Pieces: []
-            - Range: 0x80a4e8..0x80a4e9
+            - Range: 0x80a798..0x80a799
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a4e9..0x80a510
+            - Range: 0x80a799..0x80a7c0
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a460..0x80a4e8
+            - Range: 0x80a700..0x80a798
               Pieces: []
-            - Range: 0x80a4e8..0x80a4e9
+            - Range: 0x80a798..0x80a799
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a4e9..0x80a510
+            - Range: 0x80a799..0x80a7c0
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a510..0x80a5c0]
+      OutOfLinePCRanges: [0x80a7c0..0x80a880]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a510..0x80a54c
+            - Range: 0x80a7c0..0x80a7fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a54c..0x80a5c0
+            - Range: 0x80a7fc..0x80a880
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a510..0x80a598
+            - Range: 0x80a7c0..0x80a85c
               Pieces: []
-            - Range: 0x80a598..0x80a599
+            - Range: 0x80a85c..0x80a85d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a599..0x80a5c0
+            - Range: 0x80a85d..0x80a880
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a510..0x80a598
+            - Range: 0x80a7c0..0x80a85c
               Pieces: []
-            - Range: 0x80a598..0x80a599
+            - Range: 0x80a85c..0x80a85d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a599..0x80a5c0
+            - Range: 0x80a85d..0x80a880
               Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a510..0x80a598
+            - Range: 0x80a7c0..0x80a85c
               Pieces: []
-            - Range: 0x80a598..0x80a599
+            - Range: 0x80a85c..0x80a85d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a599..0x80a5c0
+            - Range: 0x80a85d..0x80a880
               Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80a850..0x80a860]
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0x80a880..0x80a910]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 250 GoSliceHeaderType []uint
+        - Name: ~r0
+          Type: 17 BaseType int8
           Locations:
-            - Range: 0x80a850..0x80a860
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 96 BaseType int16
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 12 BaseType int32
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 13 BaseType int64
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x80a880..0x80a8ec
+              Pieces: []
+            - Range: 0x80a8ec..0x80a8ed
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x80a8ed..0x80a910
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 105
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80a860..0x80a870]
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0x80a910..0x80a9c0]
       InlinePCRanges: []
       Variables:
-        - Name: u
-          Type: 250 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80a860..0x80a870
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
+        - Name: ~r0
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
           IsParameter: true
-          IsReturn: false
+          IsReturn: true
+        - Name: ~r1
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r9
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r10
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r11
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r12
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r13
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r14
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: onlyOnAmd64_16
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: bothArmAndAmd64
+          Type: 16 BaseType float64
+          Locations:
+            - Range: 0x80a910..0x80a9a8
+              Pieces: []
+            - Range: 0x80a9a8..0x80a9a9
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x80a9a9..0x80a9c0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
     - ID: 106
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80a870..0x80a880]
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0x80a9c0..0x80aa40]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 97 BaseType complex64
+          Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 98 BaseType complex128
+          Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 107
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0x80aa40..0x80ab00]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80aa40..0x80aadc
+              Pieces: []
+            - Range: 0x80aadc..0x80aadd
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80aadd..0x80ab00
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 108
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0x80ab00..0x80ab80]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0x80ab00..0x80ab68
+              Pieces: []
+            - Range: 0x80ab68..0x80ab69
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x80ab69..0x80ab80
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 109
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0x80ab80..0x80abf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 252 ArrayType [1]int
+          Locations:
+            - Range: 0x80ab80..0x80abd0
+              Pieces: []
+            - Range: 0x80abd0..0x80abd1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80abd1..0x80abf0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 110
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0x80abf0..0x80ac60]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0x80abf0..0x80ac3c
+              Pieces: []
+            - Range: 0x80ac3c..0x80ac3d
+              Pieces: []
+            - Range: 0x80ac3d..0x80ac60
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 111
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0x80ac60..0x80ace0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 254 StructureType main.mixedStruct
+          Locations: [{Range: 0x80ac60..0x80ace0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 112
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0x80ace0..0x80ad70]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r5
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r6
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r7
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r8
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80ace0..0x80ad58
+              Pieces: []
+            - Range: 0x80ad58..0x80ad59
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80ad59..0x80ad70
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 113
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0x80ad70..0x80ae40]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 255 StructureType main.wideStruct
+          Locations:
+            - Range: 0x80ad70..0x80ae1c
+              Pieces: []
+            - Range: 0x80ae1c..0x80ae1d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 10, Shift: 0}
+            - Range: 0x80ae1d..0x80ae40
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 114
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0x80ae40..0x80aed0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ae40..0x80aeac
+              Pieces: []
+            - Range: 0x80aeac..0x80aead
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80aead..0x80aed0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ae40..0x80aeac
+              Pieces: []
+            - Range: 0x80aeac..0x80aead
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80aead..0x80aed0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r3
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80ae40..0x80aeac
+              Pieces: []
+            - Range: 0x80aeac..0x80aead
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80aead..0x80aed0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 115
+      Name: main.testReturnsStructWithArray
+      OutOfLinePCRanges: [0x80aed0..0x80af50]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0x80aed0..0x80af38
+              Pieces: []
+            - Range: 0x80af38..0x80af39
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+            - Range: 0x80af39..0x80af50
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 116
+      Name: main.testReturnsOnlyFloat
+      OutOfLinePCRanges: [0x80af50..0x80afc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80af50..0x80afc0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 117
+      Name: main.testReturnsMultipleFloats
+      OutOfLinePCRanges: [0x80afc0..0x80b030]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 18 BaseType float32
+          Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 16 BaseType float64
+          Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 118
+      Name: main.testReturnsBoolAndUintptr
+      OutOfLinePCRanges: [0x80b030..0x80b0a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0x80b030..0x80b084
+              Pieces: []
+            - Range: 0x80b084..0x80b085
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80b085..0x80b0a0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 1 BaseType uintptr
+          Locations:
+            - Range: 0x80b030..0x80b084
+              Pieces: []
+            - Range: 0x80b084..0x80b085
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80b085..0x80b0a0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 119
+      Name: main.testLargeArgAndReturn
+      OutOfLinePCRanges: [0x80b0a0..0x80b230]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b0a0..0x80b0f8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b0f8..0x80b100
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b100..0x80b108
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b108..0x80b10c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b0a0..0x80b1e8
+              Pieces: []
+            - Range: 0x80b1e8..0x80b1e9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b1e9..0x80b230
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 120
+      Name: main.testArrayArgAndReturn
+      OutOfLinePCRanges: [0x80b230..0x80b2f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0x80b230..0x80b2f0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0x80b230..0x80b2d8
+              Pieces: []
+            - Range: 0x80b2d8..0x80b2d9
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x80b2d9..0x80b2f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 121
+      Name: main.testMultipleLargeArgs
+      OutOfLinePCRanges: [0x80b2f0..0x80b500]
+      InlinePCRanges: []
+      Variables:
+        - Name: s1
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b2f0..0x80b34c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b34c..0x80b354
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b354..0x80b35c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b35c..0x80b360
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: s2
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b2f0..0x80b500
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b2f0..0x80b4b4
+              Pieces: []
+            - Range: 0x80b4b4..0x80b4b5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b4b5..0x80b500
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 122
+      Name: main.testManyArgsArrayReturn
+      OutOfLinePCRanges: [0x80b500..0x80b6a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b564
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80b564..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b56c
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80b56c..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b500..0x80b574
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0x80b574..0x80b6a0
+              Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0x80b500..0x80b65c
+              Pieces: []
+            - Range: 0x80b65c..0x80b65d
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+            - Range: 0x80b65d..0x80b6a0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 123
+      Name: main.testMixedArgsStackReturn
+      OutOfLinePCRanges: [0x80b6a0..0x80b890]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b714
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80b714..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: c
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b71c
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80b71c..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: d
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: e
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: f
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: g
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: h
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
+            - Range: 0x80b724..0x80b890
+              Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80b6a0..0x80b724
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b724..0x80b890
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 250 StructureType main.largeStruct
+          Locations:
+            - Range: 0x80b6a0..0x80b848
+              Pieces: []
+            - Range: 0x80b848..0x80b849
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 6, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 7, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 8, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 9, Shift: 0}
+            - Range: 0x80b849..0x80b890
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 124
+      Name: main.testStackArgRegReturns
+      OutOfLinePCRanges: [0x80b890..0x80b920]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 161 ArrayType [5]int
+          Locations:
+            - Range: 0x80b890..0x80b920
+              Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b890..0x80b900
+              Pieces: []
+            - Range: 0x80b900..0x80b901
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80b901..0x80b920
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b890..0x80b900
+              Pieces: []
+            - Range: 0x80b900..0x80b901
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80b901..0x80b920
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b890..0x80b900
+              Pieces: []
+            - Range: 0x80b900..0x80b901
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80b901..0x80b920
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 125
+      Name: main.testMultipleArrayArgs
+      OutOfLinePCRanges: [0x80b920..0x80b9f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0x80b920..0x80b9f0
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 251 ArrayType [3]int
+          Locations:
+            - Range: 0x80b920..0x80b9f0
+              Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b920..0x80b9d4
+              Pieces: []
+            - Range: 0x80b9d4..0x80b9d5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80b9d5..0x80b9f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 113 ArrayType [2]int
+          Locations:
+            - Range: 0x80b920..0x80b9d4
+              Pieces: []
+            - Range: 0x80b9d4..0x80b9d5
+              Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
+            - Range: 0x80b9d5..0x80b9f0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 126
+      Name: main.testStructWithArrayArg
+      OutOfLinePCRanges: [0x80b9f0..0x80bab0]
+      InlinePCRanges: []
+      Variables:
+        - Name: arg
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0x80b9f0..0x80bab0
+              Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80b9f0..0x80ba90
+              Pieces: []
+            - Range: 0x80ba90..0x80ba91
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80ba91..0x80bab0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 256 StructureType main.structWithArray
+          Locations:
+            - Range: 0x80b9f0..0x80ba90
+              Pieces: []
+            - Range: 0x80ba90..0x80ba91
+              Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
+            - Range: 0x80ba91..0x80bab0
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80ba68..0x80bab0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: false
+          IsReturn: false
+    - ID: 127
+      Name: main.testZeroSizeArgAndReturn
+      OutOfLinePCRanges: [0x80bab0..0x80bb50]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 253 ArrayType [0]int
+          Locations: [{Range: 0x80bab0..0x80bb50, Pieces: []}]
+          IsParameter: true
+          IsReturn: false
+        - Name: b
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80bab0..0x80baec
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80baec..0x80bb04
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x80bb04..0x80bb0c
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+            - Range: 0x80bb0c..0x80bb50
+              Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80bab0..0x80bb28
+              Pieces: []
+            - Range: 0x80bb28..0x80bb29
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80bb29..0x80bb50
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+        - Name: ~r1
+          Type: 253 ArrayType [0]int
+          Locations:
+            - Range: 0x80bab0..0x80bb28
+              Pieces: []
+            - Range: 0x80bb28..0x80bb29
+              Pieces: []
+            - Range: 0x80bb29..0x80bb50
+              Pieces: []
+          IsParameter: true
+          IsReturn: true
+    - ID: 128
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80bf80..0x80bf90]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 251 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a870..0x80a880
+            - Range: 0x80bf80..0x80bf90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4240,15 +6019,51 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 107
+    - ID: 129
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x80bf90..0x80bfa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x80bf90..0x80bfa0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 130
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x80bfa0..0x80bfb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x80bfa0..0x80bfb0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 131
       Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80a880..0x80a890]
+      OutOfLinePCRanges: [0x80bfb0..0x80bfc0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a880..0x80a890
+            - Range: 0x80bfb0..0x80bfc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4261,19 +6076,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a880..0x80a890
+            - Range: 0x80bfb0..0x80bfc0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 108
+    - ID: 132
       Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80a890..0x80a8a0]
+      OutOfLinePCRanges: [0x80bfc0..0x80bfd0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a890..0x80a8a0
+            - Range: 0x80bfc0..0x80bfd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4286,19 +6101,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a890..0x80a8a0
+            - Range: 0x80bfc0..0x80bfd0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 109
+    - ID: 133
       Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80a8a0..0x80a8b0]
+      OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 253 GoSliceHeaderType []main.structWithNoStrings
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x80a8a0..0x80a8b0
+            - Range: 0x80bfd0..0x80bfe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4311,19 +6126,19 @@ Subprograms:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a8a0..0x80a8b0
+            - Range: 0x80bfd0..0x80bfe0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 110
+    - ID: 134
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x80a8b0..0x80a8c0]
+      OutOfLinePCRanges: [0x80bfe0..0x80bff0]
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
           Locations:
-            - Range: 0x80a8b0..0x80a8c0
+            - Range: 0x80bfe0..0x80bff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4333,22 +6148,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 111
+    - ID: 135
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x80a8c0..0x80a8d0]
+      OutOfLinePCRanges: [0x80bff0..0x80c000]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80a8c0..0x80a8d0
+            - Range: 0x80bff0..0x80c000
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 257 GoSliceHeaderType []bool
+          Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80a8c0..0x80a8d0
+            - Range: 0x80bff0..0x80c000
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -4361,19 +6176,19 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80a8c0..0x80a8d0
+            - Range: 0x80bff0..0x80c000
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 112
+    - ID: 136
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80a8d0..0x80a8e0]
+      OutOfLinePCRanges: [0x80c000..0x80c010]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 258 GoSliceHeaderType []uint16
+          Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80a8d0..0x80a8e0
+            - Range: 0x80c000..0x80c010
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4383,15 +6198,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 113
+    - ID: 137
       Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80a8e0..0x80a8f0]
+      OutOfLinePCRanges: [0x80c010..0x80c020]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 250 GoSliceHeaderType []uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80a8e0..0x80a8f0
+            - Range: 0x80c010..0x80c020
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4401,15 +6216,15 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 114
+    - ID: 138
       Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80a8f0..0x80a900]
+      OutOfLinePCRanges: [0x80c020..0x80c030]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 259 GoSliceHeaderType []struct {}
+          Type: 266 GoSliceHeaderType []struct {}
           Locations:
-            - Range: 0x80a8f0..0x80a900
+            - Range: 0x80c020..0x80c030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4419,35 +6234,35 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 115
+    - ID: 139
       Name: main.stackC
-      OutOfLinePCRanges: [0x80aba0..0x80ac00]
+      OutOfLinePCRanges: [0x80c2d0..0x80c330]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80aba0..0x80abe8
+            - Range: 0x80c2d0..0x80c318
               Pieces: []
-            - Range: 0x80abe8..0x80abe9
+            - Range: 0x80c318..0x80c319
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80abe9..0x80ac00
+            - Range: 0x80c319..0x80c330
               Pieces: []
           IsParameter: true
           IsReturn: true
-    - ID: 116
+    - ID: 140
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x80ac00..0x80ac10]
+      OutOfLinePCRanges: [0x80c330..0x80c340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac00..0x80ac10
+            - Range: 0x80c330..0x80c340
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4455,15 +6270,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 117
+    - ID: 141
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80ac10..0x80ac20]
+      OutOfLinePCRanges: [0x80c340..0x80c350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac10..0x80ac20
+            - Range: 0x80c340..0x80c350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4474,7 +6289,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac10..0x80ac20
+            - Range: 0x80c340..0x80c350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -4485,7 +6300,7 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac10..0x80ac20
+            - Range: 0x80c340..0x80c350
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -4493,15 +6308,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 118
+    - ID: 142
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80ac20..0x80ac30]
+      OutOfLinePCRanges: [0x80c350..0x80c360]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 261 StructureType main.threeStringStruct
+          Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x80ac20..0x80ac30
+            - Range: 0x80c350..0x80c360
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4517,39 +6332,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 119
+    - ID: 143
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80ac30..0x80ac40]
+      OutOfLinePCRanges: [0x80c360..0x80c370]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 262 PointerType *main.threeStringStruct
+          Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x80ac30..0x80ac40
+            - Range: 0x80c360..0x80c370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 120
+    - ID: 144
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80ac40..0x80ac50]
+      OutOfLinePCRanges: [0x80c370..0x80c380]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 263 PointerType *main.oneStringStruct
+          Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x80ac40..0x80ac50
+            - Range: 0x80c370..0x80c380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 121
+    - ID: 145
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x80ac50..0x80ac60]
+      OutOfLinePCRanges: [0x80c380..0x80c390]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac50..0x80ac60
+            - Range: 0x80c380..0x80c390
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4557,15 +6372,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 122
+    - ID: 146
       Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x80ac60..0x80ac70]
+      OutOfLinePCRanges: [0x80c390..0x80c3a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac60..0x80ac70
+            - Range: 0x80c390..0x80c3a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4573,15 +6388,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 123
+    - ID: 147
       Name: main.testEmptyString
-      OutOfLinePCRanges: [0x80ac70..0x80ac80]
+      OutOfLinePCRanges: [0x80c3a0..0x80c3b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ac70..0x80ac80
+            - Range: 0x80c3a0..0x80c3b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4589,27 +6404,27 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 124
+    - ID: 148
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80adb0..0x80adc0]
+      OutOfLinePCRanges: [0x80c4e0..0x80c4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 265 StructureType main.structWithCyclicSlices
+          Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80adb0..0x80adc0
+            - Range: 0x80c4e0..0x80c4f0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
-    - ID: 125
+    - ID: 149
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80adc0..0x80add0]
+      OutOfLinePCRanges: [0x80c4f0..0x80c500]
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 278 StructureType main.structWithCyclicMaps
+          Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80adc0..0x80add0
+            - Range: 0x80c4f0..0x80c500
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4625,15 +6440,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 126
+    - ID: 150
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80ae70..0x80ae90]
+      OutOfLinePCRanges: [0x80c5a0..0x80c5c0]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 309 StructureType main.aStruct
+          Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80ae70..0x80ae90
+            - Range: 0x80c5a0..0x80c5c0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -4651,29 +6466,29 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 127
+    - ID: 151
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80af40..0x80af50]
+      OutOfLinePCRanges: [0x80c670..0x80c680]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 310 StructureType main.emptyStruct
-          Locations: [{Range: 0x80af40..0x80af50, Pieces: []}]
+          Type: 317 StructureType main.emptyStruct
+          Locations: [{Range: 0x80c670..0x80c680, Pieces: []}]
           IsParameter: true
           IsReturn: false
-    - ID: 128
+    - ID: 152
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80af50..0x80af60]
+      OutOfLinePCRanges: [0x80c680..0x80c690]
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 311 PointerType *main.emptyStruct
+          Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80af50..0x80af60
+            - Range: 0x80c680..0x80c690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 129
+    - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807520..0x807590]
       InlinePCRanges:
@@ -4703,28 +6518,28 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 130
+    - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8077a4..0x8077d8]
           RootRanges: [0x807740..0x807800]
       Variables: []
-    - ID: 131
+    - ID: 155
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80788c..0x8078c0, 0x8078c8..0x8078cc]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 132
+    - ID: 156
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807930..0x807964]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 133
+    - ID: 157
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4738,7 +6553,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 134
+    - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -4763,20 +6578,20 @@ Types:
       ByteSize: 8
       Pointee: 140 PointerType *main.deepSlice2
     - __kind: PointerType
-      ID: 1229
+      ID: 1236
       Name: '**main.deepSlice3'
       ByteSize: 8
-      Pointee: 1230 PointerType *main.deepSlice3
+      Pointee: 1237 PointerType *main.deepSlice3
     - __kind: PointerType
-      ID: 1254
+      ID: 1261
       Name: '**main.deepSlice8'
       ByteSize: 8
-      Pointee: 1255 PointerType *main.deepSlice8
+      Pointee: 1262 PointerType *main.deepSlice8
     - __kind: PointerType
-      ID: 1260
+      ID: 1267
       Name: '**main.deepSlice9'
       ByteSize: 8
-      Pointee: 1261 PointerType *main.deepSlice9
+      Pointee: 1268 PointerType *main.deepSlice9
     - __kind: PointerType
       ID: 153
       Name: '**main.stringType2'
@@ -4784,7 +6599,7 @@ Types:
       GoKind: 22
       Pointee: 154 PointerType *main.stringType2
     - __kind: PointerType
-      ID: 1225
+      ID: 1232
       Name: '**main.t'
       ByteSize: 8
       Pointee: 248 PointerType *main.t
@@ -4827,30 +6642,30 @@ Types:
       ByteSize: 8
       Pointee: 148 PointerType *table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1237
+      ID: 1244
       Name: '**table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1238 PointerType *table<int,*main.deepMap3>
+      Pointee: 1245 PointerType *table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1271
+      ID: 1278
       Name: '**table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1272 PointerType *table<int,*main.deepMap8>
+      Pointee: 1279 PointerType *table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1286
+      ID: 1293
       Name: '**table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1287 PointerType *table<int,*main.deepMap9>
+      Pointee: 1294 PointerType *table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 169
       Name: '**table<int,int>'
       ByteSize: 8
       Pointee: 170 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 1301
+      ID: 1308
       Name: '**table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1302 PointerType *table<int,interface {}>
+      Pointee: 1309 PointerType *table<int,interface {}>
     - __kind: PointerType
       ID: 236
       Name: '**table<int,struct {}>'
@@ -4872,10 +6687,10 @@ Types:
       ByteSize: 8
       Pointee: 185 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 971
+      ID: 978
       Name: '**table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 972 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 179
       Name: '**table<string,int>'
@@ -4892,35 +6707,35 @@ Types:
       ByteSize: 8
       Pointee: 232 PointerType *table<struct {},int>
     - __kind: PointerType
-      ID: 282
+      ID: 289
       Name: '**table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 283 PointerType *table<struct {},main.structWithCyclicMaps>
+      Pointee: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 287
+      ID: 294
       Name: '**table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 288 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 292
+      ID: 299
       Name: '**table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 293 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 297
+      ID: 304
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 298 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 302
+      ID: 309
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 307
+      ID: 314
       Name: '**table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 241
       Name: '**table<struct {},struct {}>'
@@ -4937,120 +6752,120 @@ Types:
       ByteSize: 8
       Pointee: 212 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 325
+      ID: 332
       Name: '*[]*main.deepSlice2.array'
       ByteSize: 8
-      Pointee: 324 GoSliceDataType []*main.deepSlice2.array
+      Pointee: 331 GoSliceDataType []*main.deepSlice2.array
     - __kind: PointerType
-      ID: 1233
+      ID: 1240
       Name: '*[]*main.deepSlice3.array'
       ByteSize: 8
-      Pointee: 1232 GoSliceDataType []*main.deepSlice3.array
+      Pointee: 1239 GoSliceDataType []*main.deepSlice3.array
     - __kind: PointerType
-      ID: 1258
+      ID: 1265
       Name: '*[]*main.deepSlice8.array'
       ByteSize: 8
-      Pointee: 1257 GoSliceDataType []*main.deepSlice8.array
+      Pointee: 1264 GoSliceDataType []*main.deepSlice8.array
     - __kind: PointerType
-      ID: 1264
+      ID: 1271
       Name: '*[]*main.deepSlice9.array'
       ByteSize: 8
-      Pointee: 1263 GoSliceDataType []*main.deepSlice9.array
+      Pointee: 1270 GoSliceDataType []*main.deepSlice9.array
     - __kind: PointerType
-      ID: 320
+      ID: 327
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 319 GoSliceDataType []*runtime.p.array
+      Pointee: 326 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 322
+      ID: 329
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 321 GoSliceDataType []*string.array
+      Pointee: 328 GoSliceDataType []*string.array
     - __kind: PointerType
-      ID: 485
+      ID: 492
       Name: '*[][][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 484 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Pointee: 491 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 277
+      ID: 284
       Name: '*[][][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Pointee: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 483
+      ID: 490
       Name: '*[][][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 482 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Pointee: 489 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 275
+      ID: 282
       Name: '*[][][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Pointee: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 481
+      ID: 488
       Name: '*[][][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 480 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Pointee: 487 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 273
+      ID: 280
       Name: '*[][][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Pointee: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 479
+      ID: 486
       Name: '*[][][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 478 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Pointee: 485 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 271
+      ID: 278
       Name: '*[][]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Pointee: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 477
+      ID: 484
       Name: '*[][]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 476 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Pointee: 483 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 463
+      ID: 470
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 462 GoSliceDataType [][]uint.array
+      Pointee: 469 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 469
+      ID: 476
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 468 GoSliceDataType []bool.array
+      Pointee: 475 GoSliceDataType []bool.array
     - __kind: PointerType
-      ID: 1008
+      ID: 1015
       Name: '*[]float64.array'
       ByteSize: 8
-      Pointee: 1007 GoSliceDataType []float64.array
+      Pointee: 1014 GoSliceDataType []float64.array
     - __kind: PointerType
-      ID: 1267
+      ID: 1274
       Name: '*[]interface {}.array'
       ByteSize: 8
-      Pointee: 1266 GoSliceDataType []interface {}.array
+      Pointee: 1273 GoSliceDataType []interface {}.array
     - __kind: PointerType
-      ID: 269
+      ID: 276
       Name: '*[]main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 266 GoSliceHeaderType []main.structWithCyclicSlices
+      Pointee: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 475
+      ID: 482
       Name: '*[]main.structWithCyclicSlices.array'
       ByteSize: 8
-      Pointee: 474 GoSliceDataType []main.structWithCyclicSlices.array
+      Pointee: 481 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: PointerType
-      ID: 535
+      ID: 542
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 534 GoSliceDataType []main.structWithMap.array
+      Pointee: 541 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 465
+      ID: 472
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 464 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -5059,101 +6874,101 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 467
+      ID: 474
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 466 GoSliceDataType []string.array
+      Pointee: 473 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 473
+      ID: 480
       Name: '*[]struct {}.array'
       ByteSize: 8
-      Pointee: 472 GoSliceDataType []struct {}.array
+      Pointee: 479 GoSliceDataType []struct {}.array
     - __kind: PointerType
-      ID: 252
+      ID: 259
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 250 GoSliceHeaderType []uint
+      Pointee: 257 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 461
+      ID: 468
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 460 GoSliceDataType []uint.array
+      Pointee: 467 GoSliceDataType []uint.array
     - __kind: PointerType
-      ID: 471
+      ID: 478
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 470 GoSliceDataType []uint16.array
+      Pointee: 477 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 315
+      ID: 322
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 314 GoSliceDataType []uint8.array
+      Pointee: 321 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 317
+      ID: 324
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 316 GoSliceDataType []uintptr.array
+      Pointee: 323 GoSliceDataType []uintptr.array
     - __kind: PointerType
-      ID: 1138
+      ID: 1145
       Name: '*archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 1.987328e+06
       GoKind: 22
-      Pointee: 1139 UnresolvedPointeeType archive/tar.Writer
+      Pointee: 1146 UnresolvedPointeeType archive/tar.Writer
     - __kind: PointerType
-      ID: 773
+      ID: 780
       Name: '*archive/tar.headerError'
       ByteSize: 8
       GoRuntimeType: 931680
       GoKind: 22
-      Pointee: 774 GoSliceHeaderType archive/tar.headerError
+      Pointee: 781 GoSliceHeaderType archive/tar.headerError
     - __kind: PointerType
-      ID: 776
+      ID: 783
       Name: '*archive/tar.headerError.array'
       ByteSize: 8
-      Pointee: 775 GoSliceDataType archive/tar.headerError.array
+      Pointee: 782 GoSliceDataType archive/tar.headerError.array
     - __kind: PointerType
-      ID: 1073
+      ID: 1080
       Name: '*archive/tar.regFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.436512e+06
       GoKind: 22
-      Pointee: 1074 UnresolvedPointeeType archive/tar.regFileWriter
+      Pointee: 1081 UnresolvedPointeeType archive/tar.regFileWriter
     - __kind: PointerType
-      ID: 1021
+      ID: 1028
       Name: '*archive/zip.countWriter'
       ByteSize: 8
       GoRuntimeType: 931872
       GoKind: 22
-      Pointee: 1022 UnresolvedPointeeType archive/zip.countWriter
+      Pointee: 1029 UnresolvedPointeeType archive/zip.countWriter
     - __kind: PointerType
-      ID: 1023
+      ID: 1030
       Name: '*archive/zip.dirWriter'
       ByteSize: 8
       GoRuntimeType: 931968
       GoKind: 22
-      Pointee: 1024 StructureType archive/zip.dirWriter
+      Pointee: 1031 StructureType archive/zip.dirWriter
     - __kind: PointerType
-      ID: 1117
+      ID: 1124
       Name: '*archive/zip.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.905472e+06
       GoKind: 22
-      Pointee: 1118 UnresolvedPointeeType archive/zip.fileWriter
+      Pointee: 1125 UnresolvedPointeeType archive/zip.fileWriter
     - __kind: PointerType
-      ID: 1049
+      ID: 1056
       Name: '*archive/zip.nopCloser'
       ByteSize: 8
       GoRuntimeType: 1.05808e+06
       GoKind: 22
-      Pointee: 1050 StructureType archive/zip.nopCloser
+      Pointee: 1057 StructureType archive/zip.nopCloser
     - __kind: PointerType
-      ID: 1051
+      ID: 1058
       Name: '*archive/zip.pooledFlateWriter'
       ByteSize: 8
       GoRuntimeType: 1.058336e+06
       GoKind: 22
-      Pointee: 1052 UnresolvedPointeeType archive/zip.pooledFlateWriter
+      Pointee: 1059 UnresolvedPointeeType archive/zip.pooledFlateWriter
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -5162,435 +6977,435 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 1096
+      ID: 1103
       Name: '*bufio.Reader'
       ByteSize: 8
       GoRuntimeType: 2.175424e+06
       GoKind: 22
-      Pointee: 1097 UnresolvedPointeeType bufio.Reader
+      Pointee: 1104 UnresolvedPointeeType bufio.Reader
     - __kind: PointerType
-      ID: 1125
+      ID: 1132
       Name: '*bufio.Writer'
       ByteSize: 8
       GoRuntimeType: 1.950208e+06
       GoKind: 22
-      Pointee: 1126 UnresolvedPointeeType bufio.Writer
+      Pointee: 1133 UnresolvedPointeeType bufio.Writer
     - __kind: PointerType
-      ID: 1176
+      ID: 1183
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.268288e+06
       GoKind: 22
-      Pointee: 1177 UnresolvedPointeeType bytes.Buffer
+      Pointee: 1184 UnresolvedPointeeType bytes.Buffer
     - __kind: PointerType
-      ID: 683
+      ID: 690
       Name: '*compress/flate.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 914208
       GoKind: 22
-      Pointee: 572 BaseType compress/flate.CorruptInputError
+      Pointee: 579 BaseType compress/flate.CorruptInputError
     - __kind: PointerType
-      ID: 684
+      ID: 691
       Name: '*compress/flate.InternalError'
       ByteSize: 8
       GoRuntimeType: 914304
       GoKind: 22
-      Pointee: 573 GoStringHeaderType compress/flate.InternalError
+      Pointee: 580 GoStringHeaderType compress/flate.InternalError
     - __kind: PointerType
-      ID: 575
+      ID: 582
       Name: '*compress/flate.InternalError.str'
       ByteSize: 8
-      Pointee: 574 GoStringDataType compress/flate.InternalError.str
+      Pointee: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: PointerType
-      ID: 1071
+      ID: 1078
       Name: '*compress/flate.Writer'
       ByteSize: 8
       GoRuntimeType: 1.426112e+06
       GoKind: 22
-      Pointee: 1072 UnresolvedPointeeType compress/flate.Writer
+      Pointee: 1079 UnresolvedPointeeType compress/flate.Writer
     - __kind: PointerType
-      ID: 1017
+      ID: 1024
       Name: '*compress/flate.dictWriter'
       ByteSize: 8
       GoRuntimeType: 914400
       GoKind: 22
-      Pointee: 1018 UnresolvedPointeeType compress/flate.dictWriter
+      Pointee: 1025 UnresolvedPointeeType compress/flate.dictWriter
     - __kind: PointerType
-      ID: 1093
+      ID: 1100
       Name: '*compress/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.726976e+06
       GoKind: 22
-      Pointee: 1094 UnresolvedPointeeType compress/gzip.Writer
+      Pointee: 1101 UnresolvedPointeeType compress/gzip.Writer
     - __kind: PointerType
-      ID: 921
+      ID: 928
       Name: '*context.deadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.204e+06
       GoKind: 22
-      Pointee: 922 StructureType context.deadlineExceededError
+      Pointee: 929 StructureType context.deadlineExceededError
     - __kind: PointerType
-      ID: 765
+      ID: 772
       Name: '*crypto/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926304
       GoKind: 22
-      Pointee: 586 BaseType crypto/aes.KeySizeError
+      Pointee: 593 BaseType crypto/aes.KeySizeError
     - __kind: PointerType
-      ID: 766
+      ID: 773
       Name: '*crypto/des.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926496
       GoKind: 22
-      Pointee: 587 BaseType crypto/des.KeySizeError
+      Pointee: 594 BaseType crypto/des.KeySizeError
     - __kind: PointerType
-      ID: 767
+      ID: 774
       Name: '*crypto/internal/fips140/aes.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 926784
       GoKind: 22
-      Pointee: 588 BaseType crypto/internal/fips140/aes.KeySizeError
+      Pointee: 595 BaseType crypto/internal/fips140/aes.KeySizeError
     - __kind: PointerType
-      ID: 1088
+      ID: 1095
       Name: '*crypto/internal/fips140/hmac.HMAC'
       ByteSize: 8
       GoRuntimeType: 1.667712e+06
       GoKind: 22
-      Pointee: 1089 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
+      Pointee: 1096 UnresolvedPointeeType crypto/internal/fips140/hmac.HMAC
     - __kind: PointerType
-      ID: 870
+      ID: 877
       Name: '*crypto/internal/fips140/hmac.errCloneUnsupported'
       ByteSize: 8
       GoRuntimeType: 1.065888e+06
       GoKind: 22
-      Pointee: 871 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
+      Pointee: 878 StructureType crypto/internal/fips140/hmac.errCloneUnsupported
     - __kind: PointerType
-      ID: 1119
+      ID: 1126
       Name: '*crypto/internal/fips140/sha256.Digest'
       ByteSize: 8
       GoRuntimeType: 1.905984e+06
       GoKind: 22
-      Pointee: 1120 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
+      Pointee: 1127 UnresolvedPointeeType crypto/internal/fips140/sha256.Digest
     - __kind: PointerType
-      ID: 1149
+      ID: 1156
       Name: '*crypto/internal/fips140/sha3.Digest'
       ByteSize: 8
       GoRuntimeType: 2.120576e+06
       GoKind: 22
-      Pointee: 1150 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
+      Pointee: 1157 UnresolvedPointeeType crypto/internal/fips140/sha3.Digest
     - __kind: PointerType
-      ID: 1123
+      ID: 1130
       Name: '*crypto/internal/fips140/sha3.SHAKE'
       ByteSize: 8
       GoRuntimeType: 1.906496e+06
       GoKind: 22
-      Pointee: 1124 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
+      Pointee: 1131 UnresolvedPointeeType crypto/internal/fips140/sha3.SHAKE
     - __kind: PointerType
-      ID: 1121
+      ID: 1128
       Name: '*crypto/internal/fips140/sha512.Digest'
       ByteSize: 8
       GoRuntimeType: 1.90624e+06
       GoKind: 22
-      Pointee: 1122 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
+      Pointee: 1129 UnresolvedPointeeType crypto/internal/fips140/sha512.Digest
     - __kind: PointerType
-      ID: 1115
+      ID: 1122
       Name: '*crypto/md5.digest'
       ByteSize: 8
       GoRuntimeType: 1.90368e+06
       GoKind: 22
-      Pointee: 1116 UnresolvedPointeeType crypto/md5.digest
+      Pointee: 1123 UnresolvedPointeeType crypto/md5.digest
     - __kind: PointerType
-      ID: 768
+      ID: 775
       Name: '*crypto/rc4.KeySizeError'
       ByteSize: 8
       GoRuntimeType: 927072
       GoKind: 22
-      Pointee: 589 BaseType crypto/rc4.KeySizeError
+      Pointee: 596 BaseType crypto/rc4.KeySizeError
     - __kind: PointerType
-      ID: 1136
+      ID: 1143
       Name: '*crypto/sha1.digest'
       ByteSize: 8
       GoRuntimeType: 1.984448e+06
       GoKind: 22
-      Pointee: 1137 UnresolvedPointeeType crypto/sha1.digest
+      Pointee: 1144 UnresolvedPointeeType crypto/sha1.digest
     - __kind: PointerType
-      ID: 1111
+      ID: 1118
       Name: '*crypto/sha3.SHA3'
       ByteSize: 8
       GoRuntimeType: 1.873056e+06
       GoKind: 22
-      Pointee: 1112 UnresolvedPointeeType crypto/sha3.SHA3
+      Pointee: 1119 UnresolvedPointeeType crypto/sha3.SHA3
     - __kind: PointerType
-      ID: 691
+      ID: 698
       Name: '*crypto/tls.AlertError'
       ByteSize: 8
       GoRuntimeType: 915936
       GoKind: 22
-      Pointee: 576 BaseType crypto/tls.AlertError
+      Pointee: 583 BaseType crypto/tls.AlertError
     - __kind: PointerType
-      ID: 859
+      ID: 866
       Name: '*crypto/tls.CertificateVerificationError'
       ByteSize: 8
       GoRuntimeType: 1.046688e+06
       GoKind: 22
-      Pointee: 860 UnresolvedPointeeType crypto/tls.CertificateVerificationError
+      Pointee: 867 UnresolvedPointeeType crypto/tls.CertificateVerificationError
     - __kind: PointerType
-      ID: 1202
+      ID: 1209
       Name: '*crypto/tls.Conn'
       ByteSize: 8
       GoRuntimeType: 2.379808e+06
       GoKind: 22
-      Pointee: 1203 UnresolvedPointeeType crypto/tls.Conn
+      Pointee: 1210 UnresolvedPointeeType crypto/tls.Conn
     - __kind: PointerType
-      ID: 687
+      ID: 694
       Name: '*crypto/tls.ECHRejectionError'
       ByteSize: 8
       GoRuntimeType: 915648
       GoKind: 22
-      Pointee: 688 UnresolvedPointeeType crypto/tls.ECHRejectionError
+      Pointee: 695 UnresolvedPointeeType crypto/tls.ECHRejectionError
     - __kind: PointerType
-      ID: 685
+      ID: 692
       Name: '*crypto/tls.RecordHeaderError'
       ByteSize: 8
       GoRuntimeType: 915552
       GoKind: 22
-      Pointee: 686 StructureType crypto/tls.RecordHeaderError
+      Pointee: 693 StructureType crypto/tls.RecordHeaderError
     - __kind: PointerType
-      ID: 858
+      ID: 865
       Name: '*crypto/tls.alert'
       ByteSize: 8
       GoRuntimeType: 1.045024e+06
       GoKind: 22
-      Pointee: 813 BaseType crypto/tls.alert
+      Pointee: 820 BaseType crypto/tls.alert
     - __kind: PointerType
-      ID: 1081
+      ID: 1088
       Name: '*crypto/tls.cthWrapper'
       ByteSize: 8
       GoRuntimeType: 1.560576e+06
       GoKind: 22
-      Pointee: 1082 UnresolvedPointeeType crypto/tls.cthWrapper
+      Pointee: 1089 UnresolvedPointeeType crypto/tls.cthWrapper
     - __kind: PointerType
-      ID: 689
+      ID: 696
       Name: '*crypto/tls.echConfigErr'
       ByteSize: 8
       GoRuntimeType: 915744
       GoKind: 22
-      Pointee: 690 UnresolvedPointeeType crypto/tls.echConfigErr
+      Pointee: 697 UnresolvedPointeeType crypto/tls.echConfigErr
     - __kind: PointerType
-      ID: 1086
+      ID: 1093
       Name: '*crypto/tls.finishedHash'
       ByteSize: 8
       GoRuntimeType: 1.642752e+06
       GoKind: 22
-      Pointee: 1087 UnresolvedPointeeType crypto/tls.finishedHash
+      Pointee: 1094 UnresolvedPointeeType crypto/tls.finishedHash
     - __kind: PointerType
-      ID: 956
+      ID: 963
       Name: '*crypto/tls.permanentError'
       ByteSize: 8
       GoRuntimeType: 1.426592e+06
       GoKind: 22
-      Pointee: 957 UnresolvedPointeeType crypto/tls.permanentError
+      Pointee: 964 UnresolvedPointeeType crypto/tls.permanentError
     - __kind: PointerType
-      ID: 973
+      ID: 980
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.043616e+06
       GoKind: 22
-      Pointee: 974 UnresolvedPointeeType crypto/x509.Certificate
+      Pointee: 981 UnresolvedPointeeType crypto/x509.Certificate
     - __kind: PointerType
-      ID: 761
+      ID: 768
       Name: '*crypto/x509.CertificateInvalidError'
       ByteSize: 8
       GoRuntimeType: 925344
       GoKind: 22
-      Pointee: 762 StructureType crypto/x509.CertificateInvalidError
+      Pointee: 769 StructureType crypto/x509.CertificateInvalidError
     - __kind: PointerType
-      ID: 755
+      ID: 762
       Name: '*crypto/x509.ConstraintViolationError'
       ByteSize: 8
       GoRuntimeType: 924864
       GoKind: 22
-      Pointee: 756 StructureType crypto/x509.ConstraintViolationError
+      Pointee: 763 StructureType crypto/x509.ConstraintViolationError
     - __kind: PointerType
-      ID: 757
+      ID: 764
       Name: '*crypto/x509.HostnameError'
       ByteSize: 8
       GoRuntimeType: 924960
       GoKind: 22
-      Pointee: 758 StructureType crypto/x509.HostnameError
+      Pointee: 765 StructureType crypto/x509.HostnameError
     - __kind: PointerType
-      ID: 754
+      ID: 761
       Name: '*crypto/x509.InsecureAlgorithmError'
       ByteSize: 8
       GoRuntimeType: 924768
       GoKind: 22
-      Pointee: 585 BaseType crypto/x509.InsecureAlgorithmError
+      Pointee: 592 BaseType crypto/x509.InsecureAlgorithmError
     - __kind: PointerType
-      ID: 864
+      ID: 871
       Name: '*crypto/x509.SystemRootsError'
       ByteSize: 8
       GoRuntimeType: 1.052448e+06
       GoKind: 22
-      Pointee: 865 StructureType crypto/x509.SystemRootsError
+      Pointee: 872 StructureType crypto/x509.SystemRootsError
     - __kind: PointerType
-      ID: 763
+      ID: 770
       Name: '*crypto/x509.UnhandledCriticalExtension'
       ByteSize: 8
       GoRuntimeType: 925440
       GoKind: 22
-      Pointee: 764 StructureType crypto/x509.UnhandledCriticalExtension
+      Pointee: 771 StructureType crypto/x509.UnhandledCriticalExtension
     - __kind: PointerType
-      ID: 759
+      ID: 766
       Name: '*crypto/x509.UnknownAuthorityError'
       ByteSize: 8
       GoRuntimeType: 925248
       GoKind: 22
-      Pointee: 760 StructureType crypto/x509.UnknownAuthorityError
+      Pointee: 767 StructureType crypto/x509.UnknownAuthorityError
     - __kind: PointerType
-      ID: 777
+      ID: 784
       Name: '*encoding/asn1.StructuralError'
       ByteSize: 8
       GoRuntimeType: 932160
       GoKind: 22
-      Pointee: 778 StructureType encoding/asn1.StructuralError
+      Pointee: 785 StructureType encoding/asn1.StructuralError
     - __kind: PointerType
-      ID: 781
+      ID: 788
       Name: '*encoding/asn1.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 932352
       GoKind: 22
-      Pointee: 782 StructureType encoding/asn1.SyntaxError
+      Pointee: 789 StructureType encoding/asn1.SyntaxError
     - __kind: PointerType
-      ID: 779
+      ID: 786
       Name: '*encoding/asn1.invalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 932256
       GoKind: 22
-      Pointee: 780 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
+      Pointee: 787 UnresolvedPointeeType encoding/asn1.invalidUnmarshalError
     - __kind: PointerType
-      ID: 672
+      ID: 679
       Name: '*encoding/base64.CorruptInputError'
       ByteSize: 8
       GoRuntimeType: 912192
       GoKind: 22
-      Pointee: 567 BaseType encoding/base64.CorruptInputError
+      Pointee: 574 BaseType encoding/base64.CorruptInputError
     - __kind: PointerType
-      ID: 1039
+      ID: 1046
       Name: '*encoding/base64.encoder'
       ByteSize: 8
       GoRuntimeType: 1.04208e+06
       GoKind: 22
-      Pointee: 1040 UnresolvedPointeeType encoding/base64.encoder
+      Pointee: 1047 UnresolvedPointeeType encoding/base64.encoder
     - __kind: PointerType
-      ID: 675
+      ID: 682
       Name: '*encoding/hex.InvalidByteError'
       ByteSize: 8
       GoRuntimeType: 913056
       GoKind: 22
-      Pointee: 568 BaseType encoding/hex.InvalidByteError
+      Pointee: 575 BaseType encoding/hex.InvalidByteError
     - __kind: PointerType
-      ID: 643
+      ID: 650
       Name: '*encoding/json.InvalidUnmarshalError'
       ByteSize: 8
       GoRuntimeType: 907008
       GoKind: 22
-      Pointee: 644 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
+      Pointee: 651 UnresolvedPointeeType encoding/json.InvalidUnmarshalError
     - __kind: PointerType
-      ID: 848
+      ID: 855
       Name: '*encoding/json.MarshalerError'
       ByteSize: 8
       GoRuntimeType: 1.03824e+06
       GoKind: 22
-      Pointee: 849 UnresolvedPointeeType encoding/json.MarshalerError
+      Pointee: 856 UnresolvedPointeeType encoding/json.MarshalerError
     - __kind: PointerType
-      ID: 635
+      ID: 642
       Name: '*encoding/json.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 906624
       GoKind: 22
-      Pointee: 636 UnresolvedPointeeType encoding/json.SyntaxError
+      Pointee: 643 UnresolvedPointeeType encoding/json.SyntaxError
     - __kind: PointerType
-      ID: 641
+      ID: 648
       Name: '*encoding/json.UnmarshalTypeError'
       ByteSize: 8
       GoRuntimeType: 906912
       GoKind: 22
-      Pointee: 642 UnresolvedPointeeType encoding/json.UnmarshalTypeError
+      Pointee: 649 UnresolvedPointeeType encoding/json.UnmarshalTypeError
     - __kind: PointerType
-      ID: 639
+      ID: 646
       Name: '*encoding/json.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 906816
       GoKind: 22
-      Pointee: 640 UnresolvedPointeeType encoding/json.UnsupportedTypeError
+      Pointee: 647 UnresolvedPointeeType encoding/json.UnsupportedTypeError
     - __kind: PointerType
-      ID: 637
+      ID: 644
       Name: '*encoding/json.UnsupportedValueError'
       ByteSize: 8
       GoRuntimeType: 906720
       GoKind: 22
-      Pointee: 638 UnresolvedPointeeType encoding/json.UnsupportedValueError
+      Pointee: 645 UnresolvedPointeeType encoding/json.UnsupportedValueError
     - __kind: PointerType
-      ID: 1182
+      ID: 1189
       Name: '*encoding/json.encodeState'
       ByteSize: 8
       GoRuntimeType: 2.293824e+06
       GoKind: 22
-      Pointee: 1183 UnresolvedPointeeType encoding/json.encodeState
+      Pointee: 1190 UnresolvedPointeeType encoding/json.encodeState
     - __kind: PointerType
-      ID: 645
+      ID: 652
       Name: '*encoding/json.jsonError'
       ByteSize: 8
       GoRuntimeType: 907392
       GoKind: 22
-      Pointee: 646 StructureType encoding/json.jsonError
+      Pointee: 653 StructureType encoding/json.jsonError
     - __kind: PointerType
-      ID: 1047
+      ID: 1054
       Name: '*encoding/pem.lineBreaker'
       ByteSize: 8
       GoRuntimeType: 1.055008e+06
       GoKind: 22
-      Pointee: 1048 UnresolvedPointeeType encoding/pem.lineBreaker
+      Pointee: 1055 UnresolvedPointeeType encoding/pem.lineBreaker
     - __kind: PointerType
-      ID: 749
+      ID: 756
       Name: '*encoding/xml.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 923808
       GoKind: 22
-      Pointee: 750 UnresolvedPointeeType encoding/xml.SyntaxError
+      Pointee: 757 UnresolvedPointeeType encoding/xml.SyntaxError
     - __kind: PointerType
-      ID: 747
+      ID: 754
       Name: '*encoding/xml.TagPathError'
       ByteSize: 8
       GoRuntimeType: 923712
       GoKind: 22
-      Pointee: 748 UnresolvedPointeeType encoding/xml.TagPathError
+      Pointee: 755 UnresolvedPointeeType encoding/xml.TagPathError
     - __kind: PointerType
-      ID: 751
+      ID: 758
       Name: '*encoding/xml.UnmarshalError'
       ByteSize: 8
       GoRuntimeType: 923904
       GoKind: 22
-      Pointee: 582 GoStringHeaderType encoding/xml.UnmarshalError
+      Pointee: 589 GoStringHeaderType encoding/xml.UnmarshalError
     - __kind: PointerType
-      ID: 584
+      ID: 591
       Name: '*encoding/xml.UnmarshalError.str'
       ByteSize: 8
-      Pointee: 583 GoStringDataType encoding/xml.UnmarshalError.str
+      Pointee: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: PointerType
-      ID: 752
+      ID: 759
       Name: '*encoding/xml.UnsupportedTypeError'
       ByteSize: 8
       GoRuntimeType: 924000
       GoKind: 22
-      Pointee: 753 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
+      Pointee: 760 UnresolvedPointeeType encoding/xml.UnsupportedTypeError
     - __kind: PointerType
-      ID: 1160
+      ID: 1167
       Name: '*encoding/xml.printer'
       ByteSize: 8
       GoRuntimeType: 2.160416e+06
       GoKind: 22
-      Pointee: 1161 UnresolvedPointeeType encoding/xml.printer
+      Pointee: 1168 UnresolvedPointeeType encoding/xml.printer
     - __kind: PointerType
       ID: 106
       Name: '*error'
@@ -5599,19 +7414,19 @@ Types:
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
-      ID: 611
+      ID: 618
       Name: '*errors.errorString'
       ByteSize: 8
       GoRuntimeType: 897024
       GoKind: 22
-      Pointee: 612 UnresolvedPointeeType errors.errorString
+      Pointee: 619 UnresolvedPointeeType errors.errorString
     - __kind: PointerType
-      ID: 815
+      ID: 822
       Name: '*errors.joinError'
       ByteSize: 8
       GoRuntimeType: 1.023136e+06
       GoKind: 22
-      Pointee: 816 UnresolvedPointeeType errors.joinError
+      Pointee: 823 UnresolvedPointeeType errors.joinError
     - __kind: PointerType
       ID: 108
       Name: '*float32'
@@ -5627,813 +7442,813 @@ Types:
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
-      ID: 1170
+      ID: 1177
       Name: '*fmt.pp'
       ByteSize: 8
       GoRuntimeType: 2.260608e+06
       GoKind: 22
-      Pointee: 1171 UnresolvedPointeeType fmt.pp
+      Pointee: 1178 UnresolvedPointeeType fmt.pp
     - __kind: PointerType
-      ID: 817
+      ID: 824
       Name: '*fmt.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.023264e+06
       GoKind: 22
-      Pointee: 818 UnresolvedPointeeType fmt.wrapError
+      Pointee: 825 UnresolvedPointeeType fmt.wrapError
     - __kind: PointerType
-      ID: 819
+      ID: 826
       Name: '*fmt.wrapErrors'
       ByteSize: 8
       GoRuntimeType: 1.023392e+06
       GoKind: 22
-      Pointee: 820 UnresolvedPointeeType fmt.wrapErrors
+      Pointee: 827 UnresolvedPointeeType fmt.wrapErrors
     - __kind: PointerType
-      ID: 673
+      ID: 680
       Name: '*github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError'
       ByteSize: 8
       GoRuntimeType: 912576
       GoKind: 22
-      Pointee: 674 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
+      Pointee: 681 UnresolvedPointeeType github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
     - __kind: PointerType
-      ID: 654
+      ID: 661
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull'
       ByteSize: 8
       GoRuntimeType: 909792
       GoKind: 22
-      Pointee: 655 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
+      Pointee: 662 StructureType github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
     - __kind: PointerType
-      ID: 656
+      ID: 663
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull'
       ByteSize: 8
       GoRuntimeType: 909888
       GoKind: 22
-      Pointee: 657 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
+      Pointee: 664 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
     - __kind: PointerType
-      ID: 985
+      ID: 992
       Name: '*github.com/DataDog/datadog-go/v5/statsd.Event'
       ByteSize: 8
       GoRuntimeType: 909600
       GoKind: 22
-      Pointee: 986 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
+      Pointee: 993 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.Event
     - __kind: PointerType
-      ID: 660
+      ID: 667
       Name: '*github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError'
       ByteSize: 8
       GoRuntimeType: 910176
       GoKind: 22
-      Pointee: 661 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
+      Pointee: 668 StructureType github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
     - __kind: PointerType
-      ID: 987
+      ID: 994
       Name: '*github.com/DataDog/datadog-go/v5/statsd.ServiceCheck'
       ByteSize: 8
       GoRuntimeType: 909696
       GoKind: 22
-      Pointee: 988 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+      Pointee: 995 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
     - __kind: PointerType
-      ID: 658
+      ID: 665
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr'
       ByteSize: 8
       GoRuntimeType: 909984
       GoKind: 22
-      Pointee: 561 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
+      Pointee: 568 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
     - __kind: PointerType
-      ID: 563
+      ID: 570
       Name: '*github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str'
       ByteSize: 8
-      Pointee: 562 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Pointee: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: PointerType
-      ID: 653
+      ID: 660
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr'
       ByteSize: 8
       GoRuntimeType: 909504
       GoKind: 22
-      Pointee: 558 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
+      Pointee: 565 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.noClientErr
     - __kind: PointerType
-      ID: 560
+      ID: 567
       Name: '*github.com/DataDog/datadog-go/v5/statsd.noClientErr.str'
       ByteSize: 8
-      Pointee: 559 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Pointee: 566 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: PointerType
-      ID: 659
+      ID: 666
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError'
       ByteSize: 8
       GoRuntimeType: 910080
       GoKind: 22
-      Pointee: 564 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
+      Pointee: 571 GoStringHeaderType github.com/DataDog/datadog-go/v5/statsd.partialWriteError
     - __kind: PointerType
-      ID: 566
+      ID: 573
       Name: '*github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str'
       ByteSize: 8
-      Pointee: 565 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Pointee: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: PointerType
-      ID: 1059
+      ID: 1066
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udpWriter'
       ByteSize: 8
       GoRuntimeType: 1.209504e+06
       GoKind: 22
-      Pointee: 1060 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
+      Pointee: 1067 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udpWriter
     - __kind: PointerType
-      ID: 1146
+      ID: 1153
       Name: '*github.com/DataDog/datadog-go/v5/statsd.udsWriter'
       ByteSize: 8
       GoRuntimeType: 2.058624e+06
       GoKind: 22
-      Pointee: 1147 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
+      Pointee: 1154 UnresolvedPointeeType github.com/DataDog/datadog-go/v5/statsd.udsWriter
     - __kind: PointerType
-      ID: 771
+      ID: 778
       Name: '*github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent'
       ByteSize: 8
       GoRuntimeType: 930624
       GoKind: 22
-      Pointee: 772 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
+      Pointee: 779 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
     - __kind: PointerType
-      ID: 930
+      ID: 937
       Name: '*github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError'
       ByteSize: 8
       GoRuntimeType: 1.213088e+06
       GoKind: 22
-      Pointee: 931 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
+      Pointee: 938 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
     - __kind: PointerType
-      ID: 1178
+      ID: 1185
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer'
       ByteSize: 8
       GoRuntimeType: 2.270336e+06
       GoKind: 22
-      Pointee: 1179 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
+      Pointee: 1186 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
     - __kind: PointerType
-      ID: 698
+      ID: 705
       Name: '*github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError'
       ByteSize: 8
       GoRuntimeType: 919296
       GoKind: 22
-      Pointee: 699 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
+      Pointee: 706 UnresolvedPointeeType github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
     - __kind: PointerType
-      ID: 705
+      ID: 712
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError'
       ByteSize: 8
       GoRuntimeType: 920352
       GoKind: 22
-      Pointee: 706 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
+      Pointee: 713 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
     - __kind: PointerType
-      ID: 700
+      ID: 707
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.RunError'
       ByteSize: 8
       GoRuntimeType: 920064
       GoKind: 22
-      Pointee: 581 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
+      Pointee: 588 BaseType github.com/DataDog/go-libddwaf/v4/waferrors.RunError
     - __kind: PointerType
-      ID: 703
+      ID: 710
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError'
       ByteSize: 8
       GoRuntimeType: 920256
       GoKind: 22
-      Pointee: 704 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
+      Pointee: 711 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
     - __kind: PointerType
-      ID: 701
+      ID: 708
       Name: '*github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError'
       ByteSize: 8
       GoRuntimeType: 920160
       GoKind: 22
-      Pointee: 702 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
+      Pointee: 709 StructureType github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
     - __kind: PointerType
-      ID: 721
+      ID: 728
       Name: '*github.com/DataDog/go-tuf/client.ErrDownloadFailed'
       ByteSize: 8
       GoRuntimeType: 922272
       GoKind: 22
-      Pointee: 722 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
+      Pointee: 729 StructureType github.com/DataDog/go-tuf/client.ErrDownloadFailed
     - __kind: PointerType
-      ID: 725
+      ID: 732
       Name: '*github.com/DataDog/go-tuf/client.ErrMetaTooLarge'
       ByteSize: 8
       GoRuntimeType: 922464
       GoKind: 22
-      Pointee: 726 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
+      Pointee: 733 StructureType github.com/DataDog/go-tuf/client.ErrMetaTooLarge
     - __kind: PointerType
-      ID: 723
+      ID: 730
       Name: '*github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata'
       ByteSize: 8
       GoRuntimeType: 922368
       GoKind: 22
-      Pointee: 724 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
+      Pointee: 731 StructureType github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
     - __kind: PointerType
-      ID: 719
+      ID: 726
       Name: '*github.com/DataDog/go-tuf/client.ErrNotFound'
       ByteSize: 8
       GoRuntimeType: 922176
       GoKind: 22
-      Pointee: 720 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
+      Pointee: 727 StructureType github.com/DataDog/go-tuf/client.ErrNotFound
     - __kind: PointerType
-      ID: 1010
+      ID: 1017
       Name: '*github.com/DataDog/go-tuf/data.HexBytes.array'
       ByteSize: 8
-      Pointee: 1009 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Pointee: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: PointerType
-      ID: 733
+      ID: 740
       Name: '*github.com/DataDog/go-tuf/util.ErrNoCommonHash'
       ByteSize: 8
       GoRuntimeType: 922848
       GoKind: 22
-      Pointee: 734 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
+      Pointee: 741 StructureType github.com/DataDog/go-tuf/util.ErrNoCommonHash
     - __kind: PointerType
-      ID: 727
+      ID: 734
       Name: '*github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm'
       ByteSize: 8
       GoRuntimeType: 922560
       GoKind: 22
-      Pointee: 728 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
+      Pointee: 735 StructureType github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
     - __kind: PointerType
-      ID: 731
+      ID: 738
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongHash'
       ByteSize: 8
       GoRuntimeType: 922752
       GoKind: 22
-      Pointee: 732 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
+      Pointee: 739 StructureType github.com/DataDog/go-tuf/util.ErrWrongHash
     - __kind: PointerType
-      ID: 729
+      ID: 736
       Name: '*github.com/DataDog/go-tuf/util.ErrWrongLength'
       ByteSize: 8
       GoRuntimeType: 922656
       GoKind: 22
-      Pointee: 730 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
+      Pointee: 737 StructureType github.com/DataDog/go-tuf/util.ErrWrongLength
     - __kind: PointerType
-      ID: 735
+      ID: 742
       Name: '*github.com/DataDog/go-tuf/verify.ErrExpired'
       ByteSize: 8
       GoRuntimeType: 922944
       GoKind: 22
-      Pointee: 736 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
+      Pointee: 743 StructureType github.com/DataDog/go-tuf/verify.ErrExpired
     - __kind: PointerType
-      ID: 741
+      ID: 748
       Name: '*github.com/DataDog/go-tuf/verify.ErrLowVersion'
       ByteSize: 8
       GoRuntimeType: 923232
       GoKind: 22
-      Pointee: 742 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
+      Pointee: 749 StructureType github.com/DataDog/go-tuf/verify.ErrLowVersion
     - __kind: PointerType
-      ID: 743
+      ID: 750
       Name: '*github.com/DataDog/go-tuf/verify.ErrRepeatID'
       ByteSize: 8
       GoRuntimeType: 923328
       GoKind: 22
-      Pointee: 744 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
+      Pointee: 751 StructureType github.com/DataDog/go-tuf/verify.ErrRepeatID
     - __kind: PointerType
-      ID: 739
+      ID: 746
       Name: '*github.com/DataDog/go-tuf/verify.ErrRoleThreshold'
       ByteSize: 8
       GoRuntimeType: 923136
       GoKind: 22
-      Pointee: 740 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
+      Pointee: 747 StructureType github.com/DataDog/go-tuf/verify.ErrRoleThreshold
     - __kind: PointerType
-      ID: 737
+      ID: 744
       Name: '*github.com/DataDog/go-tuf/verify.ErrUnknownRole'
       ByteSize: 8
       GoRuntimeType: 923040
       GoKind: 22
-      Pointee: 738 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
+      Pointee: 745 StructureType github.com/DataDog/go-tuf/verify.ErrUnknownRole
     - __kind: PointerType
-      ID: 745
+      ID: 752
       Name: '*github.com/DataDog/go-tuf/verify.ErrWrongVersion'
       ByteSize: 8
       GoRuntimeType: 923520
       GoKind: 22
-      Pointee: 746 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
+      Pointee: 753 StructureType github.com/DataDog/go-tuf/verify.ErrWrongVersion
     - __kind: PointerType
-      ID: 662
+      ID: 669
       Name: '*github.com/cihub/seelog.baseError'
       ByteSize: 8
       GoRuntimeType: 911328
       GoKind: 22
-      Pointee: 663 StructureType github.com/cihub/seelog.baseError
+      Pointee: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: PointerType
-      ID: 1099
+      ID: 1106
       Name: '*github.com/cihub/seelog.bufferedWriter'
       ByteSize: 8
       GoRuntimeType: 1.80384e+06
       GoKind: 22
-      Pointee: 1100 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
+      Pointee: 1107 UnresolvedPointeeType github.com/cihub/seelog.bufferedWriter
     - __kind: PointerType
-      ID: 664
+      ID: 671
       Name: '*github.com/cihub/seelog.cannotOpenFileError'
       ByteSize: 8
       GoRuntimeType: 911424
       GoKind: 22
-      Pointee: 665 StructureType github.com/cihub/seelog.cannotOpenFileError
+      Pointee: 672 StructureType github.com/cihub/seelog.cannotOpenFileError
     - __kind: PointerType
-      ID: 1079
+      ID: 1086
       Name: '*github.com/cihub/seelog.connWriter'
       ByteSize: 8
       GoRuntimeType: 1.559296e+06
       GoKind: 22
-      Pointee: 1080 UnresolvedPointeeType github.com/cihub/seelog.connWriter
+      Pointee: 1087 UnresolvedPointeeType github.com/cihub/seelog.connWriter
     - __kind: PointerType
-      ID: 1035
+      ID: 1042
       Name: '*github.com/cihub/seelog.consoleWriter'
       ByteSize: 8
       GoRuntimeType: 1.040928e+06
       GoKind: 22
-      Pointee: 1036 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
+      Pointee: 1043 UnresolvedPointeeType github.com/cihub/seelog.consoleWriter
     - __kind: PointerType
-      ID: 1069
+      ID: 1076
       Name: '*github.com/cihub/seelog.fileWriter'
       ByteSize: 8
       GoRuntimeType: 1.424192e+06
       GoKind: 22
-      Pointee: 1070 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
+      Pointee: 1077 UnresolvedPointeeType github.com/cihub/seelog.fileWriter
     - __kind: PointerType
-      ID: 668
+      ID: 675
       Name: '*github.com/cihub/seelog.missingArgumentError'
       ByteSize: 8
       GoRuntimeType: 911616
       GoKind: 22
-      Pointee: 669 StructureType github.com/cihub/seelog.missingArgumentError
+      Pointee: 676 StructureType github.com/cihub/seelog.missingArgumentError
     - __kind: PointerType
-      ID: 1134
+      ID: 1141
       Name: '*github.com/cihub/seelog.rollingFileWriter'
       ByteSize: 8
       GoRuntimeType: 1.976672e+06
       GoKind: 22
-      Pointee: 1135 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
+      Pointee: 1142 UnresolvedPointeeType github.com/cihub/seelog.rollingFileWriter
     - __kind: PointerType
-      ID: 1153
+      ID: 1160
       Name: '*github.com/cihub/seelog.rollingFileWriterSize'
       ByteSize: 8
       GoRuntimeType: 2.133216e+06
       GoKind: 22
-      Pointee: 1148 StructureType github.com/cihub/seelog.rollingFileWriterSize
+      Pointee: 1155 StructureType github.com/cihub/seelog.rollingFileWriterSize
     - __kind: PointerType
-      ID: 1152
+      ID: 1159
       Name: '*github.com/cihub/seelog.rollingFileWriterTime'
       ByteSize: 8
       GoRuntimeType: 2.132832e+06
       GoKind: 22
-      Pointee: 1151 StructureType github.com/cihub/seelog.rollingFileWriterTime
+      Pointee: 1158 StructureType github.com/cihub/seelog.rollingFileWriterTime
     - __kind: PointerType
-      ID: 1037
+      ID: 1044
       Name: '*github.com/cihub/seelog.smtpWriter'
       ByteSize: 8
       GoRuntimeType: 1.041056e+06
       GoKind: 22
-      Pointee: 1038 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
+      Pointee: 1045 UnresolvedPointeeType github.com/cihub/seelog.smtpWriter
     - __kind: PointerType
-      ID: 666
+      ID: 673
       Name: '*github.com/cihub/seelog.unexpectedAttributeError'
       ByteSize: 8
       GoRuntimeType: 911520
       GoKind: 22
-      Pointee: 667 StructureType github.com/cihub/seelog.unexpectedAttributeError
+      Pointee: 674 StructureType github.com/cihub/seelog.unexpectedAttributeError
     - __kind: PointerType
-      ID: 670
+      ID: 677
       Name: '*github.com/cihub/seelog.unexpectedChildElementError'
       ByteSize: 8
       GoRuntimeType: 911712
       GoKind: 22
-      Pointee: 671 StructureType github.com/cihub/seelog.unexpectedChildElementError
+      Pointee: 678 StructureType github.com/cihub/seelog.unexpectedChildElementError
     - __kind: PointerType
-      ID: 1101
+      ID: 1108
       Name: '*github.com/cihub/seelog/archive/gzip.Writer'
       ByteSize: 8
       GoRuntimeType: 1.805632e+06
       GoKind: 22
-      Pointee: 1102 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
+      Pointee: 1109 UnresolvedPointeeType github.com/cihub/seelog/archive/gzip.Writer
     - __kind: PointerType
-      ID: 1142
+      ID: 1149
       Name: '*github.com/cihub/seelog/archive/tar.Writer'
       ByteSize: 8
       GoRuntimeType: 2.0128e+06
       GoKind: 22
-      Pointee: 1143 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
+      Pointee: 1150 UnresolvedPointeeType github.com/cihub/seelog/archive/tar.Writer
     - __kind: PointerType
-      ID: 1144
+      ID: 1151
       Name: '*github.com/cihub/seelog/archive/zip.Writer'
       ByteSize: 8
       GoRuntimeType: 2.043296e+06
       GoKind: 22
-      Pointee: 1145 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
+      Pointee: 1152 UnresolvedPointeeType github.com/cihub/seelog/archive/zip.Writer
     - __kind: PointerType
-      ID: 961
+      ID: 968
       Name: '*github.com/go-viper/mapstructure/v2.DecodeError'
       ByteSize: 8
       GoRuntimeType: 1.438912e+06
       GoKind: 22
-      Pointee: 962 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
+      Pointee: 969 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.DecodeError
     - __kind: PointerType
-      ID: 874
+      ID: 881
       Name: '*github.com/go-viper/mapstructure/v2.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.066656e+06
       GoKind: 22
-      Pointee: 875 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
+      Pointee: 882 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.ParseError
     - __kind: PointerType
-      ID: 872
+      ID: 879
       Name: '*github.com/go-viper/mapstructure/v2.UnconvertibleTypeError'
       ByteSize: 8
       GoRuntimeType: 1.066528e+06
       GoKind: 22
-      Pointee: 873 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
+      Pointee: 880 UnresolvedPointeeType github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
     - __kind: PointerType
-      ID: 876
+      ID: 883
       Name: '*github.com/gogo/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.070624e+06
       GoKind: 22
-      Pointee: 877 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
+      Pointee: 884 UnresolvedPointeeType github.com/gogo/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 878
+      ID: 885
       Name: '*github.com/gogo/protobuf/proto.invalidUTF8Error'
       ByteSize: 8
       GoRuntimeType: 1.070752e+06
       GoKind: 22
-      Pointee: 879 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
+      Pointee: 886 UnresolvedPointeeType github.com/gogo/protobuf/proto.invalidUTF8Error
     - __kind: PointerType
-      ID: 1090
+      ID: 1097
       Name: '*github.com/gogo/protobuf/proto.textWriter'
       ByteSize: 8
       GoRuntimeType: 1.670016e+06
       GoKind: 22
-      Pointee: 1091 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
+      Pointee: 1098 UnresolvedPointeeType github.com/gogo/protobuf/proto.textWriter
     - __kind: PointerType
-      ID: 866
+      ID: 873
       Name: '*github.com/golang/protobuf/proto.RequiredNotSetError'
       ByteSize: 8
       GoRuntimeType: 1.053088e+06
       GoKind: 22
-      Pointee: 867 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
+      Pointee: 874 UnresolvedPointeeType github.com/golang/protobuf/proto.RequiredNotSetError
     - __kind: PointerType
-      ID: 676
+      ID: 683
       Name: '*github.com/google/uuid.invalidLengthError'
       ByteSize: 8
       GoRuntimeType: 913248
       GoKind: 22
-      Pointee: 677 StructureType github.com/google/uuid.invalidLengthError
+      Pointee: 684 StructureType github.com/google/uuid.invalidLengthError
     - __kind: PointerType
-      ID: 1194
+      ID: 1201
       Name: '*github.com/json-iterator/go.Stream'
       ByteSize: 8
       GoRuntimeType: 2.356256e+06
       GoKind: 22
-      Pointee: 1195 UnresolvedPointeeType github.com/json-iterator/go.Stream
+      Pointee: 1202 UnresolvedPointeeType github.com/json-iterator/go.Stream
     - __kind: PointerType
-      ID: 932
+      ID: 939
       Name: '*github.com/pkg/errors.fundamental'
       ByteSize: 8
       GoRuntimeType: 1.221664e+06
       GoKind: 22
-      Pointee: 933 UnresolvedPointeeType github.com/pkg/errors.fundamental
+      Pointee: 940 UnresolvedPointeeType github.com/pkg/errors.fundamental
     - __kind: PointerType
-      ID: 905
+      ID: 912
       Name: '*github.com/tinylib/msgp/msgp.ArrayError'
       ByteSize: 8
       GoRuntimeType: 1.200544e+06
       GoKind: 22
-      Pointee: 906 StructureType github.com/tinylib/msgp/msgp.ArrayError
+      Pointee: 913 StructureType github.com/tinylib/msgp/msgp.ArrayError
     - __kind: PointerType
-      ID: 899
+      ID: 906
       Name: '*github.com/tinylib/msgp/msgp.ErrUnsupportedType'
       ByteSize: 8
       GoRuntimeType: 1.20016e+06
       GoKind: 22
-      Pointee: 900 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
+      Pointee: 907 UnresolvedPointeeType github.com/tinylib/msgp/msgp.ErrUnsupportedType
     - __kind: PointerType
-      ID: 834
+      ID: 841
       Name: '*github.com/tinylib/msgp/msgp.ExtensionTypeError'
       ByteSize: 8
       GoRuntimeType: 1.032224e+06
       GoKind: 22
-      Pointee: 835 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
+      Pointee: 842 StructureType github.com/tinylib/msgp/msgp.ExtensionTypeError
     - __kind: PointerType
-      ID: 911
+      ID: 918
       Name: '*github.com/tinylib/msgp/msgp.IntOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200928e+06
       GoKind: 22
-      Pointee: 912 StructureType github.com/tinylib/msgp/msgp.IntOverflow
+      Pointee: 919 StructureType github.com/tinylib/msgp/msgp.IntOverflow
     - __kind: PointerType
-      ID: 833
+      ID: 840
       Name: '*github.com/tinylib/msgp/msgp.InvalidPrefixError'
       ByteSize: 8
       GoRuntimeType: 1.032096e+06
       GoKind: 22
-      Pointee: 812 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
+      Pointee: 819 BaseType github.com/tinylib/msgp/msgp.InvalidPrefixError
     - __kind: PointerType
-      ID: 903
+      ID: 910
       Name: '*github.com/tinylib/msgp/msgp.InvalidTimestamp'
       ByteSize: 8
       GoRuntimeType: 1.200416e+06
       GoKind: 22
-      Pointee: 904 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
+      Pointee: 911 StructureType github.com/tinylib/msgp/msgp.InvalidTimestamp
     - __kind: PointerType
-      ID: 901
+      ID: 908
       Name: '*github.com/tinylib/msgp/msgp.TypeError'
       ByteSize: 8
       GoRuntimeType: 1.200288e+06
       GoKind: 22
-      Pointee: 902 StructureType github.com/tinylib/msgp/msgp.TypeError
+      Pointee: 909 StructureType github.com/tinylib/msgp/msgp.TypeError
     - __kind: PointerType
-      ID: 909
+      ID: 916
       Name: '*github.com/tinylib/msgp/msgp.UintBelowZero'
       ByteSize: 8
       GoRuntimeType: 1.2008e+06
       GoKind: 22
-      Pointee: 910 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
+      Pointee: 917 StructureType github.com/tinylib/msgp/msgp.UintBelowZero
     - __kind: PointerType
-      ID: 907
+      ID: 914
       Name: '*github.com/tinylib/msgp/msgp.UintOverflow'
       ByteSize: 8
       GoRuntimeType: 1.200672e+06
       GoKind: 22
-      Pointee: 908 StructureType github.com/tinylib/msgp/msgp.UintOverflow
+      Pointee: 915 StructureType github.com/tinylib/msgp/msgp.UintOverflow
     - __kind: PointerType
-      ID: 1198
+      ID: 1205
       Name: '*github.com/tinylib/msgp/msgp.Writer'
       ByteSize: 8
       GoRuntimeType: 2.368864e+06
       GoKind: 22
-      Pointee: 1199 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
+      Pointee: 1206 UnresolvedPointeeType github.com/tinylib/msgp/msgp.Writer
     - __kind: PointerType
-      ID: 915
+      ID: 922
       Name: '*github.com/tinylib/msgp/msgp.errFatal'
       ByteSize: 8
       GoRuntimeType: 1.201312e+06
       GoKind: 22
-      Pointee: 916 StructureType github.com/tinylib/msgp/msgp.errFatal
+      Pointee: 923 StructureType github.com/tinylib/msgp/msgp.errFatal
     - __kind: PointerType
-      ID: 838
+      ID: 845
       Name: '*github.com/tinylib/msgp/msgp.errRecursion'
       ByteSize: 8
       GoRuntimeType: 1.03248e+06
       GoKind: 22
-      Pointee: 839 StructureType github.com/tinylib/msgp/msgp.errRecursion
+      Pointee: 846 StructureType github.com/tinylib/msgp/msgp.errRecursion
     - __kind: PointerType
-      ID: 836
+      ID: 843
       Name: '*github.com/tinylib/msgp/msgp.errShort'
       ByteSize: 8
       GoRuntimeType: 1.032352e+06
       GoKind: 22
-      Pointee: 837 StructureType github.com/tinylib/msgp/msgp.errShort
+      Pointee: 844 StructureType github.com/tinylib/msgp/msgp.errShort
     - __kind: PointerType
-      ID: 913
+      ID: 920
       Name: '*github.com/tinylib/msgp/msgp.errWrapped'
       ByteSize: 8
       GoRuntimeType: 1.201184e+06
       GoKind: 22
-      Pointee: 914 StructureType github.com/tinylib/msgp/msgp.errWrapped
+      Pointee: 921 StructureType github.com/tinylib/msgp/msgp.errWrapped
     - __kind: PointerType
-      ID: 793
+      ID: 800
       Name: '*go.opentelemetry.io/otel/trace.errorConst'
       ByteSize: 8
       GoRuntimeType: 945120
       GoKind: 22
-      Pointee: 594 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
+      Pointee: 601 GoStringHeaderType go.opentelemetry.io/otel/trace.errorConst
     - __kind: PointerType
-      ID: 596
+      ID: 603
       Name: '*go.opentelemetry.io/otel/trace.errorConst.str'
       ByteSize: 8
-      Pointee: 595 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Pointee: 602 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: PointerType
-      ID: 976
+      ID: 983
       Name: '*go.uber.org/multierr.multiError'
       ByteSize: 8
       GoRuntimeType: 1.66848e+06
       GoKind: 22
-      Pointee: 977 UnresolvedPointeeType go.uber.org/multierr.multiError
+      Pointee: 984 UnresolvedPointeeType go.uber.org/multierr.multiError
     - __kind: PointerType
-      ID: 882
+      ID: 889
       Name: '*go.uber.org/zap.errArrayElem'
       ByteSize: 8
       GoRuntimeType: 1.085472e+06
       GoKind: 22
-      Pointee: 883 StructureType go.uber.org/zap.errArrayElem
+      Pointee: 890 StructureType go.uber.org/zap.errArrayElem
     - __kind: PointerType
-      ID: 1065
+      ID: 1072
       Name: '*go.uber.org/zap.nopCloserSink'
       ByteSize: 8
       GoRuntimeType: 1.261472e+06
       GoKind: 22
-      Pointee: 1066 StructureType go.uber.org/zap.nopCloserSink
+      Pointee: 1073 StructureType go.uber.org/zap.nopCloserSink
     - __kind: PointerType
-      ID: 1158
+      ID: 1165
       Name: '*go.uber.org/zap/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.148576e+06
       GoKind: 22
-      Pointee: 1159 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
+      Pointee: 1166 UnresolvedPointeeType go.uber.org/zap/buffer.Buffer
     - __kind: PointerType
-      ID: 1053
+      ID: 1060
       Name: '*go.uber.org/zap/zapcore.writerWrapper'
       ByteSize: 8
       GoRuntimeType: 1.087776e+06
       GoKind: 22
-      Pointee: 1054 StructureType go.uber.org/zap/zapcore.writerWrapper
+      Pointee: 1061 StructureType go.uber.org/zap/zapcore.writerWrapper
     - __kind: PointerType
-      ID: 794
+      ID: 801
       Name: '*golang.org/x/net/http2.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 946368
       GoKind: 22
-      Pointee: 597 BaseType golang.org/x/net/http2.ConnectionError
+      Pointee: 604 BaseType golang.org/x/net/http2.ConnectionError
     - __kind: PointerType
-      ID: 940
+      ID: 947
       Name: '*golang.org/x/net/http2.StreamError'
       ByteSize: 8
       GoRuntimeType: 1.263136e+06
       GoKind: 22
-      Pointee: 941 StructureType golang.org/x/net/http2.StreamError
+      Pointee: 948 StructureType golang.org/x/net/http2.StreamError
     - __kind: PointerType
-      ID: 797
+      ID: 804
       Name: '*golang.org/x/net/http2.connError'
       ByteSize: 8
       GoRuntimeType: 946656
       GoKind: 22
-      Pointee: 798 StructureType golang.org/x/net/http2.connError
+      Pointee: 805 StructureType golang.org/x/net/http2.connError
     - __kind: PointerType
-      ID: 796
+      ID: 803
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946560
       GoKind: 22
-      Pointee: 601 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
+      Pointee: 608 GoStringHeaderType golang.org/x/net/http2.duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 603
+      ID: 610
       Name: '*golang.org/x/net/http2.duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 602 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Pointee: 609 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 800
+      ID: 807
       Name: '*golang.org/x/net/http2.headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 946848
       GoKind: 22
-      Pointee: 607 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
+      Pointee: 614 GoStringHeaderType golang.org/x/net/http2.headerFieldNameError
     - __kind: PointerType
-      ID: 609
+      ID: 616
       Name: '*golang.org/x/net/http2.headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 608 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Pointee: 615 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: PointerType
-      ID: 799
+      ID: 806
       Name: '*golang.org/x/net/http2.headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 946752
       GoKind: 22
-      Pointee: 604 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
+      Pointee: 611 GoStringHeaderType golang.org/x/net/http2.headerFieldValueError
     - __kind: PointerType
-      ID: 606
+      ID: 613
       Name: '*golang.org/x/net/http2.headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 605 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Pointee: 612 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: PointerType
-      ID: 795
+      ID: 802
       Name: '*golang.org/x/net/http2.pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 946464
       GoKind: 22
-      Pointee: 598 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
+      Pointee: 605 GoStringHeaderType golang.org/x/net/http2.pseudoHeaderError
     - __kind: PointerType
-      ID: 600
+      ID: 607
       Name: '*golang.org/x/net/http2.pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 599 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Pointee: 606 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1156
+      ID: 1163
       Name: '*golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.146656e+06
       GoKind: 22
-      Pointee: 1157 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1164 UnresolvedPointeeType golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 801
+      ID: 808
       Name: '*golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 946944
       GoKind: 22
-      Pointee: 802 StructureType golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 809 StructureType golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 803
+      ID: 810
       Name: '*golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 947040
       GoKind: 22
-      Pointee: 610 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 617 BaseType golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 789
+      ID: 796
       Name: '*google.golang.org/grpc.dropError'
       ByteSize: 8
       GoRuntimeType: 940320
       GoKind: 22
-      Pointee: 790 StructureType google.golang.org/grpc.dropError
+      Pointee: 797 StructureType google.golang.org/grpc.dropError
     - __kind: PointerType
-      ID: 938
+      ID: 945
       Name: '*google.golang.org/grpc/internal/status.Error'
       ByteSize: 8
       GoRuntimeType: 1.260192e+06
       GoKind: 22
-      Pointee: 939 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
+      Pointee: 946 UnresolvedPointeeType google.golang.org/grpc/internal/status.Error
     - __kind: PointerType
-      ID: 963
+      ID: 970
       Name: '*google.golang.org/grpc/internal/transport.ConnectionError'
       ByteSize: 8
       GoRuntimeType: 1.446272e+06
       GoKind: 22
-      Pointee: 964 StructureType google.golang.org/grpc/internal/transport.ConnectionError
+      Pointee: 971 StructureType google.golang.org/grpc/internal/transport.ConnectionError
     - __kind: PointerType
-      ID: 791
+      ID: 798
       Name: '*google.golang.org/grpc/internal/transport.NewStreamError'
       ByteSize: 8
       GoRuntimeType: 943392
       GoKind: 22
-      Pointee: 792 StructureType google.golang.org/grpc/internal/transport.NewStreamError
+      Pointee: 799 StructureType google.golang.org/grpc/internal/transport.NewStreamError
     - __kind: PointerType
-      ID: 1105
+      ID: 1112
       Name: '*google.golang.org/grpc/internal/transport.bufConn'
       ByteSize: 8
       GoRuntimeType: 1.811232e+06
       GoKind: 22
-      Pointee: 1106 StructureType google.golang.org/grpc/internal/transport.bufConn
+      Pointee: 1113 StructureType google.golang.org/grpc/internal/transport.bufConn
     - __kind: PointerType
-      ID: 1063
+      ID: 1070
       Name: '*google.golang.org/grpc/internal/transport.bufWriter'
       ByteSize: 8
       GoRuntimeType: 1.256736e+06
       GoKind: 22
-      Pointee: 1064 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
+      Pointee: 1071 UnresolvedPointeeType google.golang.org/grpc/internal/transport.bufWriter
     - __kind: PointerType
-      ID: 880
+      ID: 887
       Name: '*google.golang.org/grpc/internal/transport.ioError'
       ByteSize: 8
       GoRuntimeType: 1.079712e+06
       GoKind: 22
-      Pointee: 881 StructureType google.golang.org/grpc/internal/transport.ioError
+      Pointee: 888 StructureType google.golang.org/grpc/internal/transport.ioError
     - __kind: PointerType
-      ID: 1025
+      ID: 1032
       Name: '*google.golang.org/grpc/mem.writer'
       ByteSize: 8
       GoRuntimeType: 943488
       GoKind: 22
-      Pointee: 1026 UnresolvedPointeeType google.golang.org/grpc/mem.writer
+      Pointee: 1033 UnresolvedPointeeType google.golang.org/grpc/mem.writer
     - __kind: PointerType
-      ID: 769
+      ID: 776
       Name: '*google.golang.org/protobuf/internal/errors.SizeMismatchError'
       ByteSize: 8
       GoRuntimeType: 928512
       GoKind: 22
-      Pointee: 770 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
+      Pointee: 777 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.SizeMismatchError
     - __kind: PointerType
-      ID: 868
+      ID: 875
       Name: '*google.golang.org/protobuf/internal/errors.prefixError'
       ByteSize: 8
       GoRuntimeType: 1.056416e+06
       GoKind: 22
-      Pointee: 869 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
+      Pointee: 876 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.prefixError
     - __kind: PointerType
-      ID: 936
+      ID: 943
       Name: '*google.golang.org/protobuf/internal/errors.wrapError'
       ByteSize: 8
       GoRuntimeType: 1.228064e+06
       GoKind: 22
-      Pointee: 937 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
+      Pointee: 944 UnresolvedPointeeType google.golang.org/protobuf/internal/errors.wrapError
     - __kind: PointerType
-      ID: 934
+      ID: 941
       Name: '*google.golang.org/protobuf/internal/impl.errInvalidUTF8'
       ByteSize: 8
       GoRuntimeType: 1.227808e+06
       GoKind: 22
-      Pointee: 935 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
+      Pointee: 942 StructureType google.golang.org/protobuf/internal/impl.errInvalidUTF8
     - __kind: PointerType
-      ID: 783
+      ID: 790
       Name: '*gopkg.in/ini%2ev1.ErrDelimiterNotFound'
       ByteSize: 8
       GoRuntimeType: 933216
       GoKind: 22
-      Pointee: 784 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
+      Pointee: 791 StructureType gopkg.in/ini%2ev1.ErrDelimiterNotFound
     - __kind: PointerType
-      ID: 785
+      ID: 792
       Name: '*gopkg.in/ini%2ev1.ErrEmptyKeyName'
       ByteSize: 8
       GoRuntimeType: 933312
       GoKind: 22
-      Pointee: 786 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
+      Pointee: 793 StructureType gopkg.in/ini%2ev1.ErrEmptyKeyName
     - __kind: PointerType
-      ID: 713
+      ID: 720
       Name: '*gopkg.in/yaml%2ev3.TypeError'
       ByteSize: 8
       GoRuntimeType: 920736
       GoKind: 22
-      Pointee: 714 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
+      Pointee: 721 UnresolvedPointeeType gopkg.in/yaml%2ev3.TypeError
     - __kind: PointerType
-      ID: 1113
+      ID: 1120
       Name: '*hash/crc32.digest'
       ByteSize: 8
       GoRuntimeType: 1.901632e+06
       GoKind: 22
-      Pointee: 1114 UnresolvedPointeeType hash/crc32.digest
+      Pointee: 1121 UnresolvedPointeeType hash/crc32.digest
     - __kind: PointerType
-      ID: 804
+      ID: 811
       Name: '*html/template.Error'
       ByteSize: 8
       GoRuntimeType: 947808
       GoKind: 22
-      Pointee: 805 UnresolvedPointeeType html/template.Error
+      Pointee: 812 UnresolvedPointeeType html/template.Error
     - __kind: PointerType
       ID: 100
       Name: '*int'
@@ -6477,129 +8292,129 @@ Types:
       GoKind: 22
       Pointee: 157 GoEmptyInterfaceType interface {}
     - __kind: PointerType
-      ID: 965
+      ID: 972
       Name: '*internal/abi.Type'
       ByteSize: 8
       GoRuntimeType: 2.212928e+06
       GoKind: 22
-      Pointee: 966 UnresolvedPointeeType internal/abi.Type
+      Pointee: 973 UnresolvedPointeeType internal/abi.Type
     - __kind: PointerType
-      ID: 681
+      ID: 688
       Name: '*internal/bisect.parseError'
       ByteSize: 8
       GoRuntimeType: 913920
       GoKind: 22
-      Pointee: 682 UnresolvedPointeeType internal/bisect.parseError
+      Pointee: 689 UnresolvedPointeeType internal/bisect.parseError
     - __kind: PointerType
-      ID: 679
+      ID: 686
       Name: '*internal/chacha8rand.errUnmarshalChaCha8'
       ByteSize: 8
       GoRuntimeType: 913824
       GoKind: 22
-      Pointee: 680 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
+      Pointee: 687 UnresolvedPointeeType internal/chacha8rand.errUnmarshalChaCha8
     - __kind: PointerType
-      ID: 1011
+      ID: 1018
       Name: '*internal/godebug.runtimeStderr'
       ByteSize: 8
       GoRuntimeType: 901824
       GoKind: 22
-      Pointee: 1012 UnresolvedPointeeType internal/godebug.runtimeStderr
+      Pointee: 1019 UnresolvedPointeeType internal/godebug.runtimeStderr
     - __kind: PointerType
-      ID: 897
+      ID: 904
       Name: '*internal/poll.DeadlineExceededError'
       ByteSize: 8
       GoRuntimeType: 1.199392e+06
       GoKind: 22
-      Pointee: 898 UnresolvedPointeeType internal/poll.DeadlineExceededError
+      Pointee: 905 UnresolvedPointeeType internal/poll.DeadlineExceededError
     - __kind: PointerType
-      ID: 1200
+      ID: 1207
       Name: '*internal/poll.FD'
       ByteSize: 8
       GoRuntimeType: 2.374528e+06
       GoKind: 22
-      Pointee: 1201 UnresolvedPointeeType internal/poll.FD
+      Pointee: 1208 UnresolvedPointeeType internal/poll.FD
     - __kind: PointerType
-      ID: 895
+      ID: 902
       Name: '*internal/poll.errNetClosing'
       ByteSize: 8
       GoRuntimeType: 1.199264e+06
       GoKind: 22
-      Pointee: 896 StructureType internal/poll.errNetClosing
+      Pointee: 903 StructureType internal/poll.errNetClosing
     - __kind: PointerType
-      ID: 615
+      ID: 622
       Name: '*internal/reflectlite.ValueError'
       ByteSize: 8
       GoRuntimeType: 901056
       GoKind: 22
-      Pointee: 616 UnresolvedPointeeType internal/reflectlite.ValueError
+      Pointee: 623 UnresolvedPointeeType internal/reflectlite.ValueError
     - __kind: PointerType
-      ID: 678
+      ID: 685
       Name: '*internal/runtime/cgroup.stringError'
       ByteSize: 8
       GoRuntimeType: 913632
       GoKind: 22
-      Pointee: 569 GoStringHeaderType internal/runtime/cgroup.stringError
+      Pointee: 576 GoStringHeaderType internal/runtime/cgroup.stringError
     - __kind: PointerType
-      ID: 571
+      ID: 578
       Name: '*internal/runtime/cgroup.stringError.str'
       ByteSize: 8
-      Pointee: 570 GoStringDataType internal/runtime/cgroup.stringError.str
+      Pointee: 577 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: PointerType
-      ID: 852
+      ID: 859
       Name: '*internal/runtime/maps.unhashableTypeError'
       ByteSize: 8
       GoRuntimeType: 1.04336e+06
       GoKind: 22
-      Pointee: 853 StructureType internal/runtime/maps.unhashableTypeError
+      Pointee: 860 StructureType internal/runtime/maps.unhashableTypeError
     - __kind: PointerType
-      ID: 1057
+      ID: 1064
       Name: '*io.PipeWriter'
       ByteSize: 8
       GoRuntimeType: 1.190944e+06
       GoKind: 22
-      Pointee: 1058 UnresolvedPointeeType io.PipeWriter
+      Pointee: 1065 UnresolvedPointeeType io.PipeWriter
     - __kind: PointerType
-      ID: 1055
+      ID: 1062
       Name: '*io.discard'
       ByteSize: 8
       GoRuntimeType: 1.19056e+06
       GoKind: 22
-      Pointee: 1056 StructureType io.discard
+      Pointee: 1063 StructureType io.discard
     - __kind: PointerType
-      ID: 1029
+      ID: 1036
       Name: '*io.multiWriter'
       ByteSize: 8
       GoRuntimeType: 1.02416e+06
       GoKind: 22
-      Pointee: 1030 UnresolvedPointeeType io.multiWriter
+      Pointee: 1037 UnresolvedPointeeType io.multiWriter
     - __kind: PointerType
-      ID: 893
+      ID: 900
       Name: '*io/fs.PathError'
       ByteSize: 8
       GoRuntimeType: 1.198752e+06
       GoKind: 22
-      Pointee: 894 UnresolvedPointeeType io/fs.PathError
+      Pointee: 901 UnresolvedPointeeType io/fs.PathError
     - __kind: PointerType
-      ID: 1103
+      ID: 1110
       Name: '*log/slog/internal/buffer.Buffer'
       ByteSize: 8
       GoRuntimeType: 1.805856e+06
       GoKind: 22
-      Pointee: 1104 UnresolvedPointeeType log/slog/internal/buffer.Buffer
+      Pointee: 1111 UnresolvedPointeeType log/slog/internal/buffer.Buffer
     - __kind: PointerType
-      ID: 332
+      ID: 339
       Name: '*main.deepMap2'
       ByteSize: 8
       GoRuntimeType: 386464
       GoKind: 22
-      Pointee: 333 StructureType main.deepMap2
+      Pointee: 340 StructureType main.deepMap2
     - __kind: PointerType
-      ID: 1245
+      ID: 1252
       Name: '*main.deepMap3'
       ByteSize: 8
       GoRuntimeType: 386400
       GoKind: 22
-      Pointee: 1246 UnresolvedPointeeType main.deepMap3
+      Pointee: 1253 UnresolvedPointeeType main.deepMap3
     - __kind: PointerType
       ID: 149
       Name: '*main.deepMap7'
@@ -6608,19 +8423,19 @@ Types:
       GoKind: 22
       Pointee: 150 StructureType main.deepMap7
     - __kind: PointerType
-      ID: 1279
+      ID: 1286
       Name: '*main.deepMap8'
       ByteSize: 8
       GoRuntimeType: 386080
       GoKind: 22
-      Pointee: 1280 StructureType main.deepMap8
+      Pointee: 1287 StructureType main.deepMap8
     - __kind: PointerType
-      ID: 1294
+      ID: 1301
       Name: '*main.deepMap9'
       ByteSize: 8
       GoRuntimeType: 386016
       GoKind: 22
-      Pointee: 1295 StructureType main.deepMap9
+      Pointee: 1302 StructureType main.deepMap9
     - __kind: PointerType
       ID: 133
       Name: '*main.deepPtr2'
@@ -6629,12 +8444,12 @@ Types:
       GoKind: 22
       Pointee: 134 StructureType main.deepPtr2
     - __kind: PointerType
-      ID: 1204
+      ID: 1211
       Name: '*main.deepPtr3'
       ByteSize: 8
       GoRuntimeType: 386976
       GoKind: 22
-      Pointee: 1205 UnresolvedPointeeType main.deepPtr3
+      Pointee: 1212 UnresolvedPointeeType main.deepPtr3
     - __kind: PointerType
       ID: 135
       Name: '*main.deepPtr7'
@@ -6643,33 +8458,33 @@ Types:
       GoKind: 22
       Pointee: 136 StructureType main.deepPtr7
     - __kind: PointerType
-      ID: 1249
+      ID: 1256
       Name: '*main.deepPtr8'
       ByteSize: 8
       GoRuntimeType: 386656
       GoKind: 22
-      Pointee: 1250 StructureType main.deepPtr8
+      Pointee: 1257 StructureType main.deepPtr8
     - __kind: PointerType
-      ID: 1251
+      ID: 1258
       Name: '*main.deepPtr9'
       ByteSize: 8
       GoRuntimeType: 386592
       GoKind: 22
-      Pointee: 1252 StructureType main.deepPtr9
+      Pointee: 1259 StructureType main.deepPtr9
     - __kind: PointerType
       ID: 140
       Name: '*main.deepSlice2'
       ByteSize: 8
       GoRuntimeType: 387616
       GoKind: 22
-      Pointee: 323 StructureType main.deepSlice2
+      Pointee: 330 StructureType main.deepSlice2
     - __kind: PointerType
-      ID: 1230
+      ID: 1237
       Name: '*main.deepSlice3'
       ByteSize: 8
       GoRuntimeType: 387552
       GoKind: 22
-      Pointee: 1231 UnresolvedPointeeType main.deepSlice3
+      Pointee: 1238 UnresolvedPointeeType main.deepSlice3
     - __kind: PointerType
       ID: 141
       Name: '*main.deepSlice7'
@@ -6678,25 +8493,25 @@ Types:
       GoKind: 22
       Pointee: 142 StructureType main.deepSlice7
     - __kind: PointerType
-      ID: 1255
+      ID: 1262
       Name: '*main.deepSlice8'
       ByteSize: 8
       GoRuntimeType: 387232
       GoKind: 22
-      Pointee: 1256 StructureType main.deepSlice8
+      Pointee: 1263 StructureType main.deepSlice8
     - __kind: PointerType
-      ID: 1261
+      ID: 1268
       Name: '*main.deepSlice9'
       ByteSize: 8
       GoRuntimeType: 387168
       GoKind: 22
-      Pointee: 1262 StructureType main.deepSlice9
+      Pointee: 1269 StructureType main.deepSlice9
     - __kind: PointerType
-      ID: 311
+      ID: 318
       Name: '*main.emptyStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 310 StructureType main.emptyStruct
+      Pointee: 317 StructureType main.emptyStruct
     - __kind: PointerType
       ID: 159
       Name: '*main.esotericHeap'
@@ -6705,12 +8520,12 @@ Types:
       GoKind: 22
       Pointee: 160 StructureType main.esotericHeap
     - __kind: PointerType
-      ID: 1221
+      ID: 1228
       Name: '*main.firstBehavior'
       ByteSize: 8
       GoRuntimeType: 896736
       GoKind: 22
-      Pointee: 1222 StructureType main.firstBehavior
+      Pointee: 1229 StructureType main.firstBehavior
     - __kind: PointerType
       ID: 247
       Name: '*main.node'
@@ -6719,25 +8534,25 @@ Types:
       GoKind: 22
       Pointee: 246 StructureType main.node
     - __kind: PointerType
-      ID: 263
+      ID: 270
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 264 StructureType main.oneStringStruct
+      Pointee: 271 StructureType main.oneStringStruct
     - __kind: PointerType
-      ID: 1223
+      ID: 1230
       Name: '*main.secondBehavior'
       ByteSize: 8
       GoRuntimeType: 896832
       GoKind: 22
-      Pointee: 1224 StructureType main.secondBehavior
+      Pointee: 1231 StructureType main.secondBehavior
     - __kind: PointerType
-      ID: 1209
+      ID: 1216
       Name: '*main.somethingImpl'
       ByteSize: 8
       GoRuntimeType: 896928
       GoKind: 22
-      Pointee: 1210 UnresolvedPointeeType main.somethingImpl
+      Pointee: 1217 UnresolvedPointeeType main.somethingImpl
     - __kind: PointerType
       ID: 151
       Name: '*main.stringType1'
@@ -6745,33 +8560,33 @@ Types:
       GoKind: 22
       Pointee: 152 GoStringHeaderType main.stringType1
     - __kind: PointerType
-      ID: 1207
+      ID: 1214
       Name: '*main.stringType1.str'
       ByteSize: 8
-      Pointee: 1206 GoStringDataType main.stringType1.str
+      Pointee: 1213 GoStringDataType main.stringType1.str
     - __kind: PointerType
       ID: 154
       Name: '*main.stringType2'
       ByteSize: 8
       GoKind: 22
-      Pointee: 1208 UnresolvedPointeeType main.stringType2
+      Pointee: 1215 UnresolvedPointeeType main.stringType2
     - __kind: PointerType
-      ID: 267
+      ID: 274
       Name: '*main.structWithCyclicSlices'
       ByteSize: 8
-      Pointee: 265 StructureType main.structWithCyclicSlices
+      Pointee: 272 StructureType main.structWithCyclicSlices
     - __kind: PointerType
-      ID: 384
+      ID: 391
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 385952
       GoKind: 22
       Pointee: 165 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 254
+      ID: 261
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 255 StructureType main.structWithNoStrings
+      Pointee: 262 StructureType main.structWithNoStrings
     - __kind: PointerType
       ID: 244
       Name: '*main.structWithTwoValues'
@@ -6785,16 +8600,16 @@ Types:
       GoKind: 22
       Pointee: 249 GoSliceHeaderType main.t
     - __kind: PointerType
-      ID: 1227
+      ID: 1234
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 1226 GoSliceDataType main.t.array
+      Pointee: 1233 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 262
+      ID: 269
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 261 StructureType main.threeStringStruct
+      Pointee: 268 StructureType main.threeStringStruct
     - __kind: PointerType
       ID: 224
       Name: '*map<[4]int,[4]int>'
@@ -6821,30 +8636,30 @@ Types:
       ByteSize: 8
       Pointee: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1235
+      ID: 1242
       Name: '*map<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1236 GoSwissMapHeaderType map<int,*main.deepMap3>
+      Pointee: 1243 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1269
+      ID: 1276
       Name: '*map<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1270 GoSwissMapHeaderType map<int,*main.deepMap8>
+      Pointee: 1277 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1284
+      ID: 1291
       Name: '*map<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1285 GoSwissMapHeaderType map<int,*main.deepMap9>
+      Pointee: 1292 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: PointerType
       ID: 167
       Name: '*map<int,int>'
       ByteSize: 8
       Pointee: 168 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 1299
+      ID: 1306
       Name: '*map<int,interface {}>'
       ByteSize: 8
-      Pointee: 1300 GoSwissMapHeaderType map<int,interface {}>
+      Pointee: 1307 GoSwissMapHeaderType map<int,interface {}>
     - __kind: PointerType
       ID: 234
       Name: '*map<int,struct {}>'
@@ -6866,10 +8681,10 @@ Types:
       ByteSize: 8
       Pointee: 183 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 969
+      ID: 976
       Name: '*map<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 970 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 177
       Name: '*map<string,int>'
@@ -6886,35 +8701,35 @@ Types:
       ByteSize: 8
       Pointee: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: PointerType
-      ID: 280
+      ID: 287
       Name: '*map<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 281 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      Pointee: 288 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 285
+      ID: 292
       Name: '*map<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 286 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 293 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 290
+      ID: 297
       Name: '*map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 291 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 298 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 295
+      ID: 302
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 303 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 300
+      ID: 307
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 308 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 305
+      ID: 312
       Name: '*map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 313 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 239
       Name: '*map<struct {},struct {}>'
@@ -6937,696 +8752,696 @@ Types:
       GoKind: 22
       Pointee: 176 GoMapType map[string]int
     - __kind: PointerType
-      ID: 717
+      ID: 724
       Name: '*math/big.ErrNaN'
       ByteSize: 8
       GoRuntimeType: 921600
       GoKind: 22
-      Pointee: 718 StructureType math/big.ErrNaN
+      Pointee: 725 StructureType math/big.ErrNaN
     - __kind: PointerType
-      ID: 1019
+      ID: 1026
       Name: '*mime/multipart.writerOnly·1'
       ByteSize: 8
       GoRuntimeType: 916416
       GoKind: 22
-      Pointee: 1020 StructureType mime/multipart.writerOnly·1
+      Pointee: 1027 StructureType mime/multipart.writerOnly·1
     - __kind: PointerType
-      ID: 924
+      ID: 931
       Name: '*net.AddrError'
       ByteSize: 8
       GoRuntimeType: 1.207328e+06
       GoKind: 22
-      Pointee: 925 UnresolvedPointeeType net.AddrError
+      Pointee: 932 UnresolvedPointeeType net.AddrError
     - __kind: PointerType
-      ID: 950
+      ID: 957
       Name: '*net.DNSError'
       ByteSize: 8
       GoRuntimeType: 1.422432e+06
       GoKind: 22
-      Pointee: 951 UnresolvedPointeeType net.DNSError
+      Pointee: 958 UnresolvedPointeeType net.DNSError
     - __kind: PointerType
-      ID: 1164
+      ID: 1171
       Name: '*net.IPConn'
       ByteSize: 8
       GoRuntimeType: 2.2328e+06
       GoKind: 22
-      Pointee: 1165 UnresolvedPointeeType net.IPConn
+      Pointee: 1172 UnresolvedPointeeType net.IPConn
     - __kind: PointerType
-      ID: 948
+      ID: 955
       Name: '*net.OpError'
       ByteSize: 8
       GoRuntimeType: 1.422112e+06
       GoKind: 22
-      Pointee: 949 UnresolvedPointeeType net.OpError
+      Pointee: 956 UnresolvedPointeeType net.OpError
     - __kind: PointerType
-      ID: 926
+      ID: 933
       Name: '*net.ParseError'
       ByteSize: 8
       GoRuntimeType: 1.207456e+06
       GoKind: 22
-      Pointee: 927 UnresolvedPointeeType net.ParseError
+      Pointee: 934 UnresolvedPointeeType net.ParseError
     - __kind: PointerType
-      ID: 1174
+      ID: 1181
       Name: '*net.TCPConn'
       ByteSize: 8
       GoRuntimeType: 2.261632e+06
       GoKind: 22
-      Pointee: 1175 UnresolvedPointeeType net.TCPConn
+      Pointee: 1182 UnresolvedPointeeType net.TCPConn
     - __kind: PointerType
-      ID: 1184
+      ID: 1191
       Name: '*net.UDPConn'
       ByteSize: 8
       GoRuntimeType: 2.307136e+06
       GoKind: 22
-      Pointee: 1185 UnresolvedPointeeType net.UDPConn
+      Pointee: 1192 UnresolvedPointeeType net.UDPConn
     - __kind: PointerType
-      ID: 1172
+      ID: 1179
       Name: '*net.UnixConn'
       ByteSize: 8
       GoRuntimeType: 2.26112e+06
       GoKind: 22
-      Pointee: 1173 UnresolvedPointeeType net.UnixConn
+      Pointee: 1180 UnresolvedPointeeType net.UnixConn
     - __kind: PointerType
-      ID: 923
+      ID: 930
       Name: '*net.UnknownNetworkError'
       ByteSize: 8
       GoRuntimeType: 1.20656e+06
       GoKind: 22
-      Pointee: 886 GoStringHeaderType net.UnknownNetworkError
+      Pointee: 893 GoStringHeaderType net.UnknownNetworkError
     - __kind: PointerType
-      ID: 888
+      ID: 895
       Name: '*net.UnknownNetworkError.str'
       ByteSize: 8
-      Pointee: 887 GoStringDataType net.UnknownNetworkError.str
+      Pointee: 894 GoStringDataType net.UnknownNetworkError.str
     - __kind: PointerType
-      ID: 850
+      ID: 857
       Name: '*net.canceledError'
       ByteSize: 8
       GoRuntimeType: 1.039136e+06
       GoKind: 22
-      Pointee: 851 StructureType net.canceledError
+      Pointee: 858 StructureType net.canceledError
     - __kind: PointerType
-      ID: 1140
+      ID: 1147
       Name: '*net.conn'
       ByteSize: 8
       GoRuntimeType: 2.010208e+06
       GoKind: 22
-      Pointee: 1141 UnresolvedPointeeType net.conn
+      Pointee: 1148 UnresolvedPointeeType net.conn
     - __kind: PointerType
-      ID: 994
+      ID: 1001
       Name: '*net.dialResult·1'
       ByteSize: 8
       GoRuntimeType: 1.84864e+06
       GoKind: 22
-      Pointee: 995 StructureType net.dialResult·1
+      Pointee: 1002 StructureType net.dialResult·1
     - __kind: PointerType
-      ID: 1186
+      ID: 1193
       Name: '*net.netFD'
       ByteSize: 8
       GoRuntimeType: 2.311392e+06
       GoKind: 22
-      Pointee: 1187 UnresolvedPointeeType net.netFD
+      Pointee: 1194 UnresolvedPointeeType net.netFD
     - __kind: PointerType
-      ID: 647
+      ID: 654
       Name: '*net.notFoundError'
       ByteSize: 8
       GoRuntimeType: 908352
       GoKind: 22
-      Pointee: 648 UnresolvedPointeeType net.notFoundError
+      Pointee: 655 UnresolvedPointeeType net.notFoundError
     - __kind: PointerType
-      ID: 649
+      ID: 656
       Name: '*net.result·2'
       ByteSize: 8
       GoRuntimeType: 909024
       GoKind: 22
-      Pointee: 650 StructureType net.result·2
+      Pointee: 657 StructureType net.result·2
     - __kind: PointerType
-      ID: 1168
+      ID: 1175
       Name: '*net.tcpConnWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.247168e+06
       GoKind: 22
-      Pointee: 1169 StructureType net.tcpConnWithoutReadFrom
+      Pointee: 1176 StructureType net.tcpConnWithoutReadFrom
     - __kind: PointerType
-      ID: 1166
+      ID: 1173
       Name: '*net.tcpConnWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.246688e+06
       GoKind: 22
-      Pointee: 1167 StructureType net.tcpConnWithoutWriteTo
+      Pointee: 1174 StructureType net.tcpConnWithoutWriteTo
     - __kind: PointerType
-      ID: 928
+      ID: 935
       Name: '*net.temporaryError'
       ByteSize: 8
       GoRuntimeType: 1.208096e+06
       GoKind: 22
-      Pointee: 929 UnresolvedPointeeType net.temporaryError
+      Pointee: 936 UnresolvedPointeeType net.temporaryError
     - __kind: PointerType
-      ID: 952
+      ID: 959
       Name: '*net.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.422592e+06
       GoKind: 22
-      Pointee: 953 UnresolvedPointeeType net.timeoutError
+      Pointee: 960 UnresolvedPointeeType net.timeoutError
     - __kind: PointerType
-      ID: 840
+      ID: 847
       Name: '*net/http.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 1.034912e+06
       GoKind: 22
-      Pointee: 841 UnresolvedPointeeType net/http.ProtocolError
+      Pointee: 848 UnresolvedPointeeType net/http.ProtocolError
     - __kind: PointerType
-      ID: 1013
+      ID: 1020
       Name: '*net/http.bufioFlushWriter'
       ByteSize: 8
       GoRuntimeType: 904128
       GoKind: 22
-      Pointee: 1014 StructureType net/http.bufioFlushWriter
+      Pointee: 1021 StructureType net/http.bufioFlushWriter
     - __kind: PointerType
-      ID: 624
+      ID: 631
       Name: '*net/http.http2ConnectionError'
       ByteSize: 8
       GoRuntimeType: 904800
       GoKind: 22
-      Pointee: 539 BaseType net/http.http2ConnectionError
+      Pointee: 546 BaseType net/http.http2ConnectionError
     - __kind: PointerType
-      ID: 625
+      ID: 632
       Name: '*net/http.http2GoAwayError'
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 22
-      Pointee: 626 StructureType net/http.http2GoAwayError
+      Pointee: 633 StructureType net/http.http2GoAwayError
     - __kind: PointerType
-      ID: 944
+      ID: 951
       Name: '*net/http.http2StreamError'
       ByteSize: 8
       GoRuntimeType: 1.418112e+06
       GoKind: 22
-      Pointee: 945 StructureType net/http.http2StreamError
+      Pointee: 952 StructureType net/http.http2StreamError
     - __kind: PointerType
-      ID: 629
+      ID: 636
       Name: '*net/http.http2connError'
       ByteSize: 8
       GoRuntimeType: 905472
       GoKind: 22
-      Pointee: 630 StructureType net/http.http2connError
+      Pointee: 637 StructureType net/http.http2connError
     - __kind: PointerType
-      ID: 1075
+      ID: 1082
       Name: '*net/http.http2dataBuffer'
       ByteSize: 8
       GoRuntimeType: 1.555776e+06
       GoKind: 22
-      Pointee: 1076 UnresolvedPointeeType net/http.http2dataBuffer
+      Pointee: 1083 UnresolvedPointeeType net/http.http2dataBuffer
     - __kind: PointerType
-      ID: 628
+      ID: 635
       Name: '*net/http.http2duplicatePseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905376
       GoKind: 22
-      Pointee: 543 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
+      Pointee: 550 GoStringHeaderType net/http.http2duplicatePseudoHeaderError
     - __kind: PointerType
-      ID: 545
+      ID: 552
       Name: '*net/http.http2duplicatePseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 544 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Pointee: 551 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: PointerType
-      ID: 632
+      ID: 639
       Name: '*net/http.http2headerFieldNameError'
       ByteSize: 8
       GoRuntimeType: 905664
       GoKind: 22
-      Pointee: 549 GoStringHeaderType net/http.http2headerFieldNameError
+      Pointee: 556 GoStringHeaderType net/http.http2headerFieldNameError
     - __kind: PointerType
-      ID: 551
+      ID: 558
       Name: '*net/http.http2headerFieldNameError.str'
       ByteSize: 8
-      Pointee: 550 GoStringDataType net/http.http2headerFieldNameError.str
+      Pointee: 557 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: PointerType
-      ID: 631
+      ID: 638
       Name: '*net/http.http2headerFieldValueError'
       ByteSize: 8
       GoRuntimeType: 905568
       GoKind: 22
-      Pointee: 546 GoStringHeaderType net/http.http2headerFieldValueError
+      Pointee: 553 GoStringHeaderType net/http.http2headerFieldValueError
     - __kind: PointerType
-      ID: 548
+      ID: 555
       Name: '*net/http.http2headerFieldValueError.str'
       ByteSize: 8
-      Pointee: 547 GoStringDataType net/http.http2headerFieldValueError.str
+      Pointee: 554 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: PointerType
-      ID: 919
+      ID: 926
       Name: '*net/http.http2httpError'
       ByteSize: 8
       GoRuntimeType: 1.203232e+06
       GoKind: 22
-      Pointee: 920 UnresolvedPointeeType net/http.http2httpError
+      Pointee: 927 UnresolvedPointeeType net/http.http2httpError
     - __kind: PointerType
-      ID: 846
+      ID: 853
       Name: '*net/http.http2noCachedConnError'
       ByteSize: 8
       GoRuntimeType: 1.035552e+06
       GoKind: 22
-      Pointee: 847 StructureType net/http.http2noCachedConnError
+      Pointee: 854 StructureType net/http.http2noCachedConnError
     - __kind: PointerType
-      ID: 1129
+      ID: 1136
       Name: '*net/http.http2pipe'
       ByteSize: 8
       GoRuntimeType: 1.952512e+06
       GoKind: 22
-      Pointee: 1130 UnresolvedPointeeType net/http.http2pipe
+      Pointee: 1137 UnresolvedPointeeType net/http.http2pipe
     - __kind: PointerType
-      ID: 627
+      ID: 634
       Name: '*net/http.http2pseudoHeaderError'
       ByteSize: 8
       GoRuntimeType: 905280
       GoKind: 22
-      Pointee: 540 GoStringHeaderType net/http.http2pseudoHeaderError
+      Pointee: 547 GoStringHeaderType net/http.http2pseudoHeaderError
     - __kind: PointerType
-      ID: 542
+      ID: 549
       Name: '*net/http.http2pseudoHeaderError.str'
       ByteSize: 8
-      Pointee: 541 GoStringDataType net/http.http2pseudoHeaderError.str
+      Pointee: 548 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: PointerType
-      ID: 1015
+      ID: 1022
       Name: '*net/http.http2stickyErrWriter'
       ByteSize: 8
       GoRuntimeType: 905760
       GoKind: 22
-      Pointee: 1016 StructureType net/http.http2stickyErrWriter
+      Pointee: 1023 StructureType net/http.http2stickyErrWriter
     - __kind: PointerType
-      ID: 842
+      ID: 849
       Name: '*net/http.nothingWrittenError'
       ByteSize: 8
       GoRuntimeType: 1.035168e+06
       GoKind: 22
-      Pointee: 843 StructureType net/http.nothingWrittenError
+      Pointee: 850 StructureType net/http.nothingWrittenError
     - __kind: PointerType
-      ID: 1077
+      ID: 1084
       Name: '*net/http.persistConn'
       ByteSize: 8
       GoRuntimeType: 2.176672e+06
       GoKind: 22
-      Pointee: 1078 UnresolvedPointeeType net/http.persistConn
+      Pointee: 1085 UnresolvedPointeeType net/http.persistConn
     - __kind: PointerType
-      ID: 1033
+      ID: 1040
       Name: '*net/http.persistConnWriter'
       ByteSize: 8
       GoRuntimeType: 1.03504e+06
       GoKind: 22
-      Pointee: 1034 StructureType net/http.persistConnWriter
+      Pointee: 1041 StructureType net/http.persistConnWriter
     - __kind: PointerType
-      ID: 1067
+      ID: 1074
       Name: '*net/http.readWriteCloserBody'
       ByteSize: 8
       GoRuntimeType: 1.418272e+06
       GoKind: 22
-      Pointee: 1068 StructureType net/http.readWriteCloserBody
+      Pointee: 1075 StructureType net/http.readWriteCloserBody
     - __kind: PointerType
-      ID: 633
+      ID: 640
       Name: '*net/http.requestBodyReadError'
       ByteSize: 8
       GoRuntimeType: 905856
       GoKind: 22
-      Pointee: 634 StructureType net/http.requestBodyReadError
+      Pointee: 641 StructureType net/http.requestBodyReadError
     - __kind: PointerType
-      ID: 946
+      ID: 953
       Name: '*net/http.timeoutError'
       ByteSize: 8
       GoRuntimeType: 1.419392e+06
       GoKind: 22
-      Pointee: 947 UnresolvedPointeeType net/http.timeoutError
+      Pointee: 954 UnresolvedPointeeType net/http.timeoutError
     - __kind: PointerType
-      ID: 917
+      ID: 924
       Name: '*net/http.tlsHandshakeTimeoutError'
       ByteSize: 8
       GoRuntimeType: 1.203104e+06
       GoKind: 22
-      Pointee: 918 StructureType net/http.tlsHandshakeTimeoutError
+      Pointee: 925 StructureType net/http.tlsHandshakeTimeoutError
     - __kind: PointerType
-      ID: 844
+      ID: 851
       Name: '*net/http.transportReadFromServerError'
       ByteSize: 8
       GoRuntimeType: 1.035296e+06
       GoKind: 22
-      Pointee: 845 StructureType net/http.transportReadFromServerError
+      Pointee: 852 StructureType net/http.transportReadFromServerError
     - __kind: PointerType
-      ID: 1109
+      ID: 1116
       Name: '*net/http.unencryptedNetConnInTLSConn'
       ByteSize: 8
       GoRuntimeType: 1.84528e+06
       GoKind: 22
-      Pointee: 1110 StructureType net/http.unencryptedNetConnInTLSConn
+      Pointee: 1117 StructureType net/http.unencryptedNetConnInTLSConn
     - __kind: PointerType
-      ID: 622
+      ID: 629
       Name: '*net/http.unsupportedTEError'
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 22
-      Pointee: 623 UnresolvedPointeeType net/http.unsupportedTEError
+      Pointee: 630 UnresolvedPointeeType net/http.unsupportedTEError
     - __kind: PointerType
-      ID: 1131
+      ID: 1138
       Name: '*net/http/internal.FlushAfterChunkWriter'
       ByteSize: 8
       GoRuntimeType: 1.954304e+06
       GoKind: 22
-      Pointee: 1132 StructureType net/http/internal.FlushAfterChunkWriter
+      Pointee: 1139 StructureType net/http/internal.FlushAfterChunkWriter
     - __kind: PointerType
-      ID: 1043
+      ID: 1050
       Name: '*net/http/internal.chunkedWriter'
       ByteSize: 8
       GoRuntimeType: 1.04784e+06
       GoKind: 22
-      Pointee: 1044 UnresolvedPointeeType net/http/internal.chunkedWriter
+      Pointee: 1051 UnresolvedPointeeType net/http/internal.chunkedWriter
     - __kind: PointerType
-      ID: 709
+      ID: 716
       Name: '*net/netip.parseAddrError'
       ByteSize: 8
       GoRuntimeType: 920544
       GoKind: 22
-      Pointee: 710 StructureType net/netip.parseAddrError
+      Pointee: 717 StructureType net/netip.parseAddrError
     - __kind: PointerType
-      ID: 707
+      ID: 714
       Name: '*net/netip.parsePrefixError'
       ByteSize: 8
       GoRuntimeType: 920448
       GoKind: 22
-      Pointee: 708 StructureType net/netip.parsePrefixError
+      Pointee: 715 StructureType net/netip.parsePrefixError
     - __kind: PointerType
-      ID: 1083
+      ID: 1090
       Name: '*net/smtp.Client'
       ByteSize: 8
       GoRuntimeType: 2.119168e+06
       GoKind: 22
-      Pointee: 1084 UnresolvedPointeeType net/smtp.Client
+      Pointee: 1091 UnresolvedPointeeType net/smtp.Client
     - __kind: PointerType
-      ID: 1045
+      ID: 1052
       Name: '*net/smtp.dataCloser'
       ByteSize: 8
       GoRuntimeType: 1.052704e+06
       GoKind: 22
-      Pointee: 1046 StructureType net/smtp.dataCloser
+      Pointee: 1053 StructureType net/smtp.dataCloser
     - __kind: PointerType
-      ID: 693
+      ID: 700
       Name: '*net/textproto.Error'
       ByteSize: 8
       GoRuntimeType: 916608
       GoKind: 22
-      Pointee: 694 UnresolvedPointeeType net/textproto.Error
+      Pointee: 701 UnresolvedPointeeType net/textproto.Error
     - __kind: PointerType
-      ID: 692
+      ID: 699
       Name: '*net/textproto.ProtocolError'
       ByteSize: 8
       GoRuntimeType: 916512
       GoKind: 22
-      Pointee: 577 GoStringHeaderType net/textproto.ProtocolError
+      Pointee: 584 GoStringHeaderType net/textproto.ProtocolError
     - __kind: PointerType
-      ID: 579
+      ID: 586
       Name: '*net/textproto.ProtocolError.str'
       ByteSize: 8
-      Pointee: 578 GoStringDataType net/textproto.ProtocolError.str
+      Pointee: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: PointerType
-      ID: 1041
+      ID: 1048
       Name: '*net/textproto.dotWriter'
       ByteSize: 8
       GoRuntimeType: 1.047072e+06
       GoKind: 22
-      Pointee: 1042 UnresolvedPointeeType net/textproto.dotWriter
+      Pointee: 1049 UnresolvedPointeeType net/textproto.dotWriter
     - __kind: PointerType
-      ID: 954
+      ID: 961
       Name: '*net/url.Error'
       ByteSize: 8
       GoRuntimeType: 1.422912e+06
       GoKind: 22
-      Pointee: 955 UnresolvedPointeeType net/url.Error
+      Pointee: 962 UnresolvedPointeeType net/url.Error
     - __kind: PointerType
-      ID: 651
+      ID: 658
       Name: '*net/url.EscapeError'
       ByteSize: 8
       GoRuntimeType: 909120
       GoKind: 22
-      Pointee: 552 GoStringHeaderType net/url.EscapeError
+      Pointee: 559 GoStringHeaderType net/url.EscapeError
     - __kind: PointerType
-      ID: 554
+      ID: 561
       Name: '*net/url.EscapeError.str'
       ByteSize: 8
-      Pointee: 553 GoStringDataType net/url.EscapeError.str
+      Pointee: 560 GoStringDataType net/url.EscapeError.str
     - __kind: PointerType
-      ID: 652
+      ID: 659
       Name: '*net/url.InvalidHostError'
       ByteSize: 8
       GoRuntimeType: 909216
       GoKind: 22
-      Pointee: 555 GoStringHeaderType net/url.InvalidHostError
+      Pointee: 562 GoStringHeaderType net/url.InvalidHostError
     - __kind: PointerType
-      ID: 557
+      ID: 564
       Name: '*net/url.InvalidHostError.str'
       ByteSize: 8
-      Pointee: 556 GoStringDataType net/url.InvalidHostError.str
+      Pointee: 563 GoStringDataType net/url.InvalidHostError.str
     - __kind: PointerType
-      ID: 430
+      ID: 437
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 431 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 422
+      ID: 429
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 423 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 370
+      ID: 377
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 371 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 389
+      ID: 396
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 390 StructureType noalg.map.group[bool]main.node
+      Pointee: 397 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 328
+      ID: 335
       Name: '*noalg.map.group[int]*main.deepMap2'
       ByteSize: 8
-      Pointee: 329 StructureType noalg.map.group[int]*main.deepMap2
+      Pointee: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: PointerType
-      ID: 1241
+      ID: 1248
       Name: '*noalg.map.group[int]*main.deepMap3'
       ByteSize: 8
-      Pointee: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      Pointee: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: PointerType
-      ID: 1275
+      ID: 1282
       Name: '*noalg.map.group[int]*main.deepMap8'
       ByteSize: 8
-      Pointee: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      Pointee: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: PointerType
-      ID: 1290
+      ID: 1297
       Name: '*noalg.map.group[int]*main.deepMap9'
       ByteSize: 8
-      Pointee: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      Pointee: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: PointerType
-      ID: 338
+      ID: 345
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 339 StructureType noalg.map.group[int]int
+      Pointee: 346 StructureType noalg.map.group[int]int
     - __kind: PointerType
-      ID: 1305
+      ID: 1312
       Name: '*noalg.map.group[int]interface {}'
       ByteSize: 8
-      Pointee: 1306 StructureType noalg.map.group[int]interface {}
+      Pointee: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: PointerType
-      ID: 446
+      ID: 453
       Name: '*noalg.map.group[int]struct {}'
       ByteSize: 8
-      Pointee: 447 StructureType noalg.map.group[int]struct {}
+      Pointee: 454 StructureType noalg.map.group[int]struct {}
     - __kind: PointerType
-      ID: 397
+      ID: 404
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 398 StructureType noalg.map.group[int]uint8
+      Pointee: 405 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 379
+      ID: 386
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 380 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 362
+      ID: 369
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 363 StructureType noalg.map.group[string][]string
+      Pointee: 370 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 1001
+      ID: 1008
       Name: '*noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes'
       ByteSize: 8
-      Pointee: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Pointee: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: PointerType
-      ID: 354
+      ID: 361
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 355 StructureType noalg.map.group[string]int
+      Pointee: 362 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 346
+      ID: 353
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 347 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 438
+      ID: 445
       Name: '*noalg.map.group[struct {}]int'
       ByteSize: 8
-      Pointee: 439 StructureType noalg.map.group[struct {}]int
+      Pointee: 446 StructureType noalg.map.group[struct {}]int
     - __kind: PointerType
-      ID: 488
+      ID: 495
       Name: '*noalg.map.group[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Pointee: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 496
+      ID: 503
       Name: '*noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 504
+      ID: 511
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 512
+      ID: 519
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 520
+      ID: 527
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 528
+      ID: 535
       Name: '*noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps'
       ByteSize: 8
-      Pointee: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Pointee: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: PointerType
-      ID: 454
+      ID: 461
       Name: '*noalg.map.group[struct {}]struct {}'
       ByteSize: 8
-      Pointee: 455 StructureType noalg.map.group[struct {}]struct {}
+      Pointee: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: PointerType
-      ID: 413
+      ID: 420
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 414 StructureType noalg.map.group[uint8][4]int
+      Pointee: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 405
+      ID: 412
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 406 StructureType noalg.map.group[uint8]uint8
+      Pointee: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 1192
+      ID: 1199
       Name: '*os.File'
       ByteSize: 8
       GoRuntimeType: 2.35088e+06
       GoKind: 22
-      Pointee: 1193 UnresolvedPointeeType os.File
+      Pointee: 1200 UnresolvedPointeeType os.File
     - __kind: PointerType
-      ID: 821
+      ID: 828
       Name: '*os.LinkError'
       ByteSize: 8
       GoRuntimeType: 1.026208e+06
       GoKind: 22
-      Pointee: 822 UnresolvedPointeeType os.LinkError
+      Pointee: 829 UnresolvedPointeeType os.LinkError
     - __kind: PointerType
-      ID: 889
+      ID: 896
       Name: '*os.SyscallError'
       ByteSize: 8
       GoRuntimeType: 1.192096e+06
       GoKind: 22
-      Pointee: 890 UnresolvedPointeeType os.SyscallError
+      Pointee: 897 UnresolvedPointeeType os.SyscallError
     - __kind: PointerType
-      ID: 1190
+      ID: 1197
       Name: '*os.fileWithoutReadFrom'
       ByteSize: 8
       GoRuntimeType: 2.349408e+06
       GoKind: 22
-      Pointee: 1191 StructureType os.fileWithoutReadFrom
+      Pointee: 1198 StructureType os.fileWithoutReadFrom
     - __kind: PointerType
-      ID: 1188
+      ID: 1195
       Name: '*os.fileWithoutWriteTo'
       ByteSize: 8
       GoRuntimeType: 2.348672e+06
       GoKind: 22
-      Pointee: 1189 StructureType os.fileWithoutWriteTo
+      Pointee: 1196 StructureType os.fileWithoutWriteTo
     - __kind: PointerType
-      ID: 854
+      ID: 861
       Name: '*os/exec.Error'
       ByteSize: 8
       GoRuntimeType: 1.043744e+06
       GoKind: 22
-      Pointee: 855 UnresolvedPointeeType os/exec.Error
+      Pointee: 862 UnresolvedPointeeType os/exec.Error
     - __kind: PointerType
-      ID: 997
+      ID: 1004
       Name: '*os/exec.ExitError'
       ByteSize: 8
       GoRuntimeType: 2.090432e+06
       GoKind: 22
-      Pointee: 998 UnresolvedPointeeType os/exec.ExitError
+      Pointee: 1005 UnresolvedPointeeType os/exec.ExitError
     - __kind: PointerType
-      ID: 1061
+      ID: 1068
       Name: '*os/exec.prefixSuffixSaver'
       ByteSize: 8
       GoRuntimeType: 1.214368e+06
       GoKind: 22
-      Pointee: 1062 UnresolvedPointeeType os/exec.prefixSuffixSaver
+      Pointee: 1069 UnresolvedPointeeType os/exec.prefixSuffixSaver
     - __kind: PointerType
-      ID: 856
+      ID: 863
       Name: '*os/exec.wrappedError'
       ByteSize: 8
       GoRuntimeType: 1.043872e+06
       GoKind: 22
-      Pointee: 857 StructureType os/exec.wrappedError
+      Pointee: 864 StructureType os/exec.wrappedError
     - __kind: PointerType
-      ID: 788
+      ID: 795
       Name: '*os/user.UnknownGroupIdError'
       ByteSize: 8
       GoRuntimeType: 938400
       GoKind: 22
-      Pointee: 591 GoStringHeaderType os/user.UnknownGroupIdError
+      Pointee: 598 GoStringHeaderType os/user.UnknownGroupIdError
     - __kind: PointerType
-      ID: 593
+      ID: 600
       Name: '*os/user.UnknownGroupIdError.str'
       ByteSize: 8
-      Pointee: 592 GoStringDataType os/user.UnknownGroupIdError.str
+      Pointee: 599 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: PointerType
-      ID: 787
+      ID: 794
       Name: '*os/user.UnknownUserIdError'
       ByteSize: 8
       GoRuntimeType: 938304
       GoKind: 22
-      Pointee: 590 BaseType os/user.UnknownUserIdError
+      Pointee: 597 BaseType os/user.UnknownUserIdError
     - __kind: PointerType
-      ID: 617
+      ID: 624
       Name: '*reflect.ValueError'
       ByteSize: 8
       GoRuntimeType: 901728
       GoKind: 22
-      Pointee: 618 UnresolvedPointeeType reflect.ValueError
+      Pointee: 625 UnresolvedPointeeType reflect.ValueError
     - __kind: PointerType
-      ID: 715
+      ID: 722
       Name: '*regexp/syntax.Error'
       ByteSize: 8
       GoRuntimeType: 921216
       GoKind: 22
-      Pointee: 716 UnresolvedPointeeType regexp/syntax.Error
+      Pointee: 723 UnresolvedPointeeType regexp/syntax.Error
     - __kind: PointerType
-      ID: 825
+      ID: 832
       Name: '*runtime.PanicNilError'
       ByteSize: 8
       GoRuntimeType: 1.027744e+06
       GoKind: 22
-      Pointee: 826 UnresolvedPointeeType runtime.PanicNilError
+      Pointee: 833 UnresolvedPointeeType runtime.PanicNilError
     - __kind: PointerType
-      ID: 829
+      ID: 836
       Name: '*runtime.TypeAssertionError'
       ByteSize: 8
       GoRuntimeType: 1.029536e+06
       GoKind: 22
-      Pointee: 830 UnresolvedPointeeType runtime.TypeAssertionError
+      Pointee: 837 UnresolvedPointeeType runtime.TypeAssertionError
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -7642,12 +9457,12 @@ Types:
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
-      ID: 827
+      ID: 834
       Name: '*runtime.boundsError'
       ByteSize: 8
       GoRuntimeType: 1.027872e+06
       GoKind: 22
-      Pointee: 828 StructureType runtime.boundsError
+      Pointee: 835 StructureType runtime.boundsError
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
@@ -7663,24 +9478,24 @@ Types:
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
-      ID: 891
+      ID: 898
       Name: '*runtime.errorAddressString'
       ByteSize: 8
       GoRuntimeType: 1.1976e+06
       GoKind: 22
-      Pointee: 892 StructureType runtime.errorAddressString
+      Pointee: 899 StructureType runtime.errorAddressString
     - __kind: PointerType
-      ID: 823
+      ID: 830
       Name: '*runtime.errorString'
       ByteSize: 8
       GoRuntimeType: 1.02736e+06
       GoKind: 22
-      Pointee: 806 GoStringHeaderType runtime.errorString
+      Pointee: 813 GoStringHeaderType runtime.errorString
     - __kind: PointerType
-      ID: 808
+      ID: 815
       Name: '*runtime.errorString.str'
       ByteSize: 8
-      Pointee: 807 GoStringDataType runtime.errorString.str
+      Pointee: 814 GoStringDataType runtime.errorString.str
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
@@ -7701,19 +9516,19 @@ Types:
       ByteSize: 8
       GoRuntimeType: 1.028896e+06
       GoKind: 22
-      Pointee: 318 UnresolvedPointeeType runtime.p
+      Pointee: 325 UnresolvedPointeeType runtime.p
     - __kind: PointerType
-      ID: 824
+      ID: 831
       Name: '*runtime.plainError'
       ByteSize: 8
       GoRuntimeType: 1.027488e+06
       GoKind: 22
-      Pointee: 809 GoStringHeaderType runtime.plainError
+      Pointee: 816 GoStringHeaderType runtime.plainError
     - __kind: PointerType
-      ID: 811
+      ID: 818
       Name: '*runtime.plainError.str'
       ByteSize: 8
-      Pointee: 810 GoStringDataType runtime.plainError.str
+      Pointee: 817 GoStringDataType runtime.plainError.str
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -7729,12 +9544,12 @@ Types:
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
-      ID: 613
+      ID: 620
       Name: '*runtime.synctestDeadlockError'
       ByteSize: 8
       GoRuntimeType: 900384
       GoKind: 22
-      Pointee: 614 StructureType runtime.synctestDeadlockError
+      Pointee: 621 StructureType runtime.synctestDeadlockError
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
@@ -7750,12 +9565,12 @@ Types:
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
-      ID: 831
+      ID: 838
       Name: '*strconv.NumError'
       ByteSize: 8
       GoRuntimeType: 1.029792e+06
       GoKind: 22
-      Pointee: 832 UnresolvedPointeeType strconv.NumError
+      Pointee: 839 UnresolvedPointeeType strconv.NumError
     - __kind: PointerType
       ID: 95
       Name: '*string'
@@ -7764,220 +9579,220 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 313
+      ID: 320
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 312 GoStringDataType string.str
+      Pointee: 319 GoStringDataType string.str
     - __kind: PointerType
-      ID: 1127
+      ID: 1134
       Name: '*strings.Builder'
       ByteSize: 8
       GoRuntimeType: 1.951232e+06
       GoKind: 22
-      Pointee: 1128 UnresolvedPointeeType strings.Builder
+      Pointee: 1135 UnresolvedPointeeType strings.Builder
     - __kind: PointerType
-      ID: 1031
+      ID: 1038
       Name: '*strings.appendSliceWriter'
       ByteSize: 8
       GoRuntimeType: 1.02992e+06
       GoKind: 22
-      Pointee: 1032 UnresolvedPointeeType strings.appendSliceWriter
+      Pointee: 1039 UnresolvedPointeeType strings.appendSliceWriter
     - __kind: PointerType
-      ID: 1027
+      ID: 1034
       Name: '*struct { io.Writer }'
       ByteSize: 8
       GoRuntimeType: 971392
       GoKind: 22
-      Pointee: 1028 StructureType struct { io.Writer }
+      Pointee: 1035 StructureType struct { io.Writer }
     - __kind: PointerType
-      ID: 260
+      ID: 267
       Name: '*struct {}'
       ByteSize: 8
       GoRuntimeType: 476704
       GoKind: 22
       Pointee: 125 StructureType struct {}
     - __kind: PointerType
-      ID: 943
+      ID: 950
       Name: '*syscall.Errno'
       ByteSize: 8
       GoRuntimeType: 1.417472e+06
       GoKind: 22
-      Pointee: 942 BaseType syscall.Errno
+      Pointee: 949 BaseType syscall.Errno
     - __kind: PointerType
       ID: 227
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 428 StructureType table<[4]int,[4]int>
+      Pointee: 435 StructureType table<[4]int,[4]int>
     - __kind: PointerType
       ID: 222
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 420 StructureType table<[4]int,uint8>
+      Pointee: 427 StructureType table<[4]int,uint8>
     - __kind: PointerType
       ID: 190
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 368 StructureType table<[4]string,[2]int>
+      Pointee: 375 StructureType table<[4]string,[2]int>
     - __kind: PointerType
       ID: 202
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 387 StructureType table<bool,main.node>
+      Pointee: 394 StructureType table<bool,main.node>
     - __kind: PointerType
       ID: 148
       Name: '*table<int,*main.deepMap2>'
       ByteSize: 8
-      Pointee: 326 StructureType table<int,*main.deepMap2>
+      Pointee: 333 StructureType table<int,*main.deepMap2>
     - __kind: PointerType
-      ID: 1238
+      ID: 1245
       Name: '*table<int,*main.deepMap3>'
       ByteSize: 8
-      Pointee: 1239 StructureType table<int,*main.deepMap3>
+      Pointee: 1246 StructureType table<int,*main.deepMap3>
     - __kind: PointerType
-      ID: 1272
+      ID: 1279
       Name: '*table<int,*main.deepMap8>'
       ByteSize: 8
-      Pointee: 1273 StructureType table<int,*main.deepMap8>
+      Pointee: 1280 StructureType table<int,*main.deepMap8>
     - __kind: PointerType
-      ID: 1287
+      ID: 1294
       Name: '*table<int,*main.deepMap9>'
       ByteSize: 8
-      Pointee: 1288 StructureType table<int,*main.deepMap9>
+      Pointee: 1295 StructureType table<int,*main.deepMap9>
     - __kind: PointerType
       ID: 170
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 336 StructureType table<int,int>
+      Pointee: 343 StructureType table<int,int>
     - __kind: PointerType
-      ID: 1302
+      ID: 1309
       Name: '*table<int,interface {}>'
       ByteSize: 8
-      Pointee: 1303 StructureType table<int,interface {}>
+      Pointee: 1310 StructureType table<int,interface {}>
     - __kind: PointerType
       ID: 237
       Name: '*table<int,struct {}>'
       ByteSize: 8
-      Pointee: 444 StructureType table<int,struct {}>
+      Pointee: 451 StructureType table<int,struct {}>
     - __kind: PointerType
       ID: 207
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 395 StructureType table<int,uint8>
+      Pointee: 402 StructureType table<int,uint8>
     - __kind: PointerType
       ID: 197
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 377 StructureType table<string,[]main.structWithMap>
+      Pointee: 384 StructureType table<string,[]main.structWithMap>
     - __kind: PointerType
       ID: 185
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 360 StructureType table<string,[]string>
+      Pointee: 367 StructureType table<string,[]string>
     - __kind: PointerType
-      ID: 972
+      ID: 979
       Name: '*table<string,github.com/DataDog/go-tuf/data.HexBytes>'
       ByteSize: 8
-      Pointee: 999 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Pointee: 1006 StructureType table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: PointerType
       ID: 180
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 352 StructureType table<string,int>
+      Pointee: 359 StructureType table<string,int>
     - __kind: PointerType
       ID: 175
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 344 StructureType table<string,main.nestedStruct>
+      Pointee: 351 StructureType table<string,main.nestedStruct>
     - __kind: PointerType
       ID: 232
       Name: '*table<struct {},int>'
       ByteSize: 8
-      Pointee: 436 StructureType table<struct {},int>
+      Pointee: 443 StructureType table<struct {},int>
     - __kind: PointerType
-      ID: 283
+      ID: 290
       Name: '*table<struct {},main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 486 StructureType table<struct {},main.structWithCyclicMaps>
+      Pointee: 493 StructureType table<struct {},main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 288
+      ID: 295
       Name: '*table<struct {},map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 494 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Pointee: 501 StructureType table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 293
+      ID: 300
       Name: '*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 502 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 509 StructureType table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 298
+      ID: 305
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 510 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 517 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 303
+      ID: 310
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 518 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 525 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
-      ID: 308
+      ID: 315
       Name: '*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>'
       ByteSize: 8
-      Pointee: 526 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Pointee: 533 StructureType table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: PointerType
       ID: 242
       Name: '*table<struct {},struct {}>'
       ByteSize: 8
-      Pointee: 452 StructureType table<struct {},struct {}>
+      Pointee: 459 StructureType table<struct {},struct {}>
     - __kind: PointerType
       ID: 217
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 411 StructureType table<uint8,[4]int>
+      Pointee: 418 StructureType table<uint8,[4]int>
     - __kind: PointerType
       ID: 212
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 403 StructureType table<uint8,uint8>
+      Pointee: 410 StructureType table<uint8,uint8>
     - __kind: PointerType
-      ID: 1162
+      ID: 1169
       Name: '*text/tabwriter.Writer'
       ByteSize: 8
       GoRuntimeType: 2.1608e+06
       GoKind: 22
-      Pointee: 1163 UnresolvedPointeeType text/tabwriter.Writer
+      Pointee: 1170 UnresolvedPointeeType text/tabwriter.Writer
     - __kind: PointerType
-      ID: 884
+      ID: 891
       Name: '*text/template.ExecError'
       ByteSize: 8
       GoRuntimeType: 1.089312e+06
       GoKind: 22
-      Pointee: 885 StructureType text/template.ExecError
+      Pointee: 892 StructureType text/template.ExecError
     - __kind: PointerType
-      ID: 959
+      ID: 966
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.623744e+06
       GoKind: 22
-      Pointee: 960 UnresolvedPointeeType time.Location
+      Pointee: 967 UnresolvedPointeeType time.Location
     - __kind: PointerType
-      ID: 620
+      ID: 627
       Name: '*time.ParseError'
       ByteSize: 8
       GoRuntimeType: 902592
       GoKind: 22
-      Pointee: 621 UnresolvedPointeeType time.ParseError
+      Pointee: 628 UnresolvedPointeeType time.ParseError
     - __kind: PointerType
-      ID: 619
+      ID: 626
       Name: '*time.fileSizeError'
       ByteSize: 8
       GoRuntimeType: 902496
       GoKind: 22
-      Pointee: 536 GoStringHeaderType time.fileSizeError
+      Pointee: 543 GoStringHeaderType time.fileSizeError
     - __kind: PointerType
-      ID: 538
+      ID: 545
       Name: '*time.fileSizeError.str'
       ByteSize: 8
-      Pointee: 537 GoStringDataType time.fileSizeError.str
+      Pointee: 544 GoStringDataType time.fileSizeError.str
     - __kind: PointerType
       ID: 107
       Name: '*uint'
@@ -8021,52 +9836,52 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: PointerType
-      ID: 711
+      ID: 718
       Name: '*vendor/golang.org/x/net/dns/dnsmessage.nestedError'
       ByteSize: 8
       GoRuntimeType: 920640
       GoKind: 22
-      Pointee: 712 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
+      Pointee: 719 UnresolvedPointeeType vendor/golang.org/x/net/dns/dnsmessage.nestedError
     - __kind: PointerType
-      ID: 1154
+      ID: 1161
       Name: '*vendor/golang.org/x/net/http2/hpack.Decoder'
       ByteSize: 8
       GoRuntimeType: 2.136288e+06
       GoKind: 22
-      Pointee: 1155 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
+      Pointee: 1162 UnresolvedPointeeType vendor/golang.org/x/net/http2/hpack.Decoder
     - __kind: PointerType
-      ID: 695
+      ID: 702
       Name: '*vendor/golang.org/x/net/http2/hpack.DecodingError'
       ByteSize: 8
       GoRuntimeType: 916800
       GoKind: 22
-      Pointee: 696 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
+      Pointee: 703 StructureType vendor/golang.org/x/net/http2/hpack.DecodingError
     - __kind: PointerType
-      ID: 697
+      ID: 704
       Name: '*vendor/golang.org/x/net/http2/hpack.InvalidIndexError'
       ByteSize: 8
       GoRuntimeType: 916896
       GoKind: 22
-      Pointee: 580 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
+      Pointee: 587 BaseType vendor/golang.org/x/net/http2/hpack.InvalidIndexError
     - __kind: PointerType
-      ID: 861
+      ID: 868
       Name: '*vendor/golang.org/x/net/idna.labelError'
       ByteSize: 8
       GoRuntimeType: 1.047584e+06
       GoKind: 22
-      Pointee: 862 StructureType vendor/golang.org/x/net/idna.labelError
+      Pointee: 869 StructureType vendor/golang.org/x/net/idna.labelError
     - __kind: PointerType
-      ID: 863
+      ID: 870
       Name: '*vendor/golang.org/x/net/idna.runeError'
       ByteSize: 8
       GoRuntimeType: 1.047712e+06
       GoKind: 22
-      Pointee: 814 BaseType vendor/golang.org/x/net/idna.runeError
+      Pointee: 821 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1451
+      ID: 1506
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1452
+      ID: 1507
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8078,11 +9893,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 139, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1381
+      ID: 1388
       Name: Probe[main.testAnyPtr]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8098,7 +9913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1382
+      ID: 1389
       Name: Probe[main.testAnyPtr]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8114,7 +9929,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1378
+      ID: 1385
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8130,7 +9945,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1379
+      ID: 1386
       Name: Probe[main.testAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8146,7 +9961,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1329
+      ID: 1478
+      Name: Probe[main.testArrayArgAndReturn]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testArrayArgAndReturn]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1336
       Name: Probe[main.testArrayEmptyStructs]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8162,7 +10009,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1327
+      ID: 1334
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8178,7 +10025,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1325
+      ID: 1332
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8194,7 +10041,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1390
+      ID: 1397
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8210,7 +10057,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1326
+      ID: 1333
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8226,7 +10073,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1328
+      ID: 1335
       Name: Probe[main.testArrayOfStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8242,7 +10089,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1347
+      ID: 1354
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8258,10 +10105,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1348
+      ID: 1355
       Name: Probe[main.testBigStruct]Return
     - __kind: EventRootType
-      ID: 1314
+      ID: 1321
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8277,7 +10124,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1311
+      ID: 1318
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8293,7 +10140,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1410
+      ID: 1417
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8309,7 +10156,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1408
+      ID: 1415
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -8345,7 +10192,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1418
+      ID: 1425
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8361,7 +10208,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1360
       Name: Probe[main.testDeepMap1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8377,7 +10224,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1354
+      ID: 1361
       Name: Probe[main.testDeepMap7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8393,7 +10240,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1356
       Name: Probe[main.testDeepPtr1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8409,7 +10256,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1357
       Name: Probe[main.testDeepPtr7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8425,7 +10272,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1358
       Name: Probe[main.testDeepSlice1]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8441,7 +10288,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1352
+      ID: 1359
       Name: Probe[main.testDeepSlice7]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8457,7 +10304,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -8466,10 +10313,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -8479,11 +10326,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1495
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -8492,14 +10339,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1517
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8511,11 +10358,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1524
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8524,14 +10371,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 311 PointerType *main.emptyStruct
+            Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: e}
+                  Variable: {subprogram: 152, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1523
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -8540,14 +10387,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 310 StructureType main.emptyStruct
+            Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: e}
+                  Variable: {subprogram: 151, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 1380
+      ID: 1387
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8563,7 +10410,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1362
+      ID: 1369
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8579,10 +10426,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1363
+      ID: 1370
       Name: Probe[main.testEsotericHeap]Return
     - __kind: EventRootType
-      ID: 1360
+      ID: 1367
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -8598,10 +10445,10 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 1361
+      ID: 1368
       Name: Probe[main.testEsotericStack]Return
     - __kind: EventRootType
-      ID: 1374
+      ID: 1381
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8617,7 +10464,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1376
+      ID: 1383
       Name: Probe[main.testFramelessArray]Line
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -8643,7 +10490,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1375
+      ID: 1382
       Name: Probe[main.testFramelessArray]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8659,7 +10506,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1372
+      ID: 1379
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8675,7 +10522,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1373
+      ID: 1380
       Name: Probe[main.testFrameless]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8691,7 +10538,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1371
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8707,10 +10554,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1372
       Name: Probe[main.testInlinedBA]Return
     - __kind: EventRootType
-      ID: 1368
+      ID: 1375
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8726,13 +10573,13 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1369
+      ID: 1376
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1473
+      ID: 1528
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 1366
+      ID: 1373
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8758,28 +10605,28 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1374
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1474
+      ID: 1529
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1475
+      ID: 1530
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1476
+      ID: 1531
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1477
+      ID: 1532
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
-      ID: 1370
+      ID: 1377
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 1371
+      ID: 1378
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1470
+      ID: 1525
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8791,11 +10638,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1472
+      ID: 1527
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8807,14 +10654,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1471
+      ID: 1526
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1478
+      ID: 1533
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8826,11 +10673,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1534
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8842,11 +10689,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1535
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -8858,11 +10705,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: a}
+                  Variable: {subprogram: 158, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1317
+      ID: 1324
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -8878,7 +10725,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1318
+      ID: 1325
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8894,7 +10741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1326
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8910,7 +10757,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1316
+      ID: 1323
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -8926,7 +10773,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1315
+      ID: 1322
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8942,7 +10789,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1377
+      ID: 1384
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8958,7 +10805,39 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1412
+      ID: 1476
+      Name: Probe[main.testLargeArgAndReturn]
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testLargeArgAndReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1419
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -8974,36 +10853,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1357
+      ID: 1364
       Name: Probe[main.testLongFunctionWithChangingState]Line
     - __kind: EventRootType
-      ID: 1358
-      Name: Probe[main.testLongFunctionWithChangingState]Line
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: a
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: b
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 46, index: 2, name: b}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1359
+      ID: 1365
       Name: Probe[main.testLongFunctionWithChangingState]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9029,7 +10882,145 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1388
+      ID: 1366
+      Name: Probe[main.testLongFunctionWithChangingState]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 46, index: 2, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testManyArgsArrayReturn]
+      ByteSize: 74
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 8, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1483
+      Name: Probe[main.testManyArgsArrayReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1395
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9045,7 +11036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1395
+      ID: 1402
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9061,7 +11052,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1407
+      ID: 1414
       Name: Probe[main.testMapEmptyKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9077,7 +11068,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1405
+      ID: 1412
       Name: Probe[main.testMapEmptyKey]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9093,7 +11084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1413
       Name: Probe[main.testMapEmptyValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9109,7 +11100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1392
+      ID: 1399
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9125,7 +11116,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1411
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9141,7 +11132,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1403
+      ID: 1410
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9157,7 +11148,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1393
+      ID: 1400
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9173,7 +11164,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1394
+      ID: 1401
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9189,7 +11180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1409
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9205,7 +11196,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1401
+      ID: 1408
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9221,7 +11212,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1386
+      ID: 1393
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9237,7 +11228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1387
+      ID: 1394
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9253,7 +11244,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1385
+      ID: 1392
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9269,7 +11260,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1396
+      ID: 1403
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9285,7 +11276,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1400
+      ID: 1407
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9301,7 +11292,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1399
+      ID: 1406
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9317,7 +11308,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1398
+      ID: 1405
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9333,7 +11324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1397
+      ID: 1404
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9349,7 +11340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1514
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9361,11 +11352,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1460
+      ID: 1515
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9377,11 +11368,217 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: x}
+                  Variable: {subprogram: 145, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1435
+      ID: 1484
+      Name: Probe[main.testMixedArgsStackReturn]
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: a
+          Offset: 2
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 10
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 26
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 42
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 58
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: s
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 8, name: s}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1485
+      Name: Probe[main.testMixedArgsStackReturn]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1488
+      Name: Probe[main.testMultipleArrayArgs]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1489
+      Name: Probe[main.testMultipleArrayArgs]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testMultipleLargeArgs]
+      ByteSize: 161
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s1
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: s2
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testMultipleLargeArgs]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1442
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9397,7 +11594,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1436
+      ID: 1443
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9423,7 +11620,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1409
+      ID: 1416
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -9479,7 +11676,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1433
+      ID: 1440
       Name: Probe[main.testNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9495,7 +11692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1434
+      ID: 1441
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9511,7 +11708,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1417
+      ID: 1424
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9537,7 +11734,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9546,10 +11743,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -9559,11 +11756,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -9575,17 +11772,17 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: a}
+                  Variable: {subprogram: 135, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
           Offset: 2
           Kind: argument
           Expression:
-            Type: 257 GoSliceHeaderType []bool
+            Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 1, name: s}
+                  Variable: {subprogram: 135, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -9595,11 +11792,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 2, name: x}
+                  Variable: {subprogram: 135, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1447
+      ID: 1502
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -9608,14 +11805,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 258 GoSliceHeaderType []uint16
+            Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: xs}
+                  Variable: {subprogram: 136, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1458
+      ID: 1513
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9624,14 +11821,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 263 PointerType *main.oneStringStruct
+            Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1413
+      ID: 1420
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9647,7 +11844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1391
+      ID: 1398
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9663,7 +11860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1411
+      ID: 1418
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9679,7 +11876,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1434
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -9705,7 +11902,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1428
+      ID: 1435
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -9731,7 +11928,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1436
       Name: Probe[main.testReturnsAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9747,7 +11944,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1430
+      ID: 1437
       Name: Probe[main.testReturnsAny]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9763,7 +11960,221 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1425
+      ID: 1456
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1459
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 98 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1432
       Name: Probe[main.testReturnsError]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9779,7 +12190,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1426
+      ID: 1433
       Name: Probe[main.testReturnsError]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9795,7 +12206,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1423
+      ID: 1430
       Name: Probe[main.testReturnsIntAndFloat]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9811,7 +12222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1424
+      ID: 1431
       Name: Probe[main.testReturnsIntAndFloat]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9837,7 +12248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1428
       Name: Probe[main.testReturnsIntPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9853,7 +12264,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1422
+      ID: 1429
       Name: Probe[main.testReturnsIntPointer]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9869,7 +12280,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1419
+      ID: 1426
       Name: Probe[main.testReturnsInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9885,7 +12296,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1427
       Name: Probe[main.testReturnsInt]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9901,7 +12312,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1438
       Name: Probe[main.testReturnsInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9917,7 +12328,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1432
+      ID: 1439
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -9933,7 +12344,458 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1312
+      ID: 1452
+      Name: Probe[main.testReturnsLargeStruct]
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsLargeStruct]Return
+      ByteSize: 81
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 80
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsManyFloats]
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsManyFloats]Return
+      ByteSize: 139
+      PresenceBitsetSize: 3
+      Expressions:
+        - Name: ~r0
+          Offset: 3
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 11
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 27
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 35
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 43
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 51
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 59
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 67
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r9
+          Offset: 75
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r10
+          Offset: 83
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r11
+          Offset: 91
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r12
+          Offset: 99
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r13
+          Offset: 107
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r14
+          Offset: 115
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: onlyOnAmd64_16
+          Offset: 123
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: bothArmAndAmd64
+          Offset: 131
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testReturnsMixedStruct]
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testReturnsMixedStruct]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 254 StructureType main.mixedStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1466
+      Name: Probe[main.testReturnsMixed]
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsMixed]Return
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 25
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 33
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsMultipleFloats]
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsMultipleFloats]Return
+      ByteSize: 13
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 BaseType float32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r1
+          Offset: 5
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsOnlyFloat]
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsOnlyFloat]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1446
+      Name: Probe[main.testReturnsPrimitives]
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsPrimitives]Return
+      ByteSize: 31
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 96 BaseType int16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r2
+          Offset: 4
+          Kind: local
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r3
+          Offset: 8
+          Kind: local
+          Expression:
+            Type: 13 BaseType int64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 16
+          Kind: local
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r5
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 6 BaseType uint16
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 2
+        - Name: ~r6
+          Offset: 19
+          Kind: local
+          Expression:
+            Type: 2 BaseType uint32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: ~r7
+          Offset: 23
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsStructWithArray]
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsStructWithArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1464
+      Name: Probe[main.testReturnsWideStruct]
+    - __kind: EventRootType
+      ID: 1465
+      Name: Probe[main.testReturnsWideStruct]Return
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 255 StructureType main.wideStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 88
+    - __kind: EventRootType
+      ID: 1319
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -9949,7 +12811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1333
+      ID: 1340
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9965,7 +12827,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1331
+      ID: 1338
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -9981,7 +12843,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1344
+      ID: 1351
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -9997,7 +12859,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1345
+      ID: 1352
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10013,7 +12875,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1336
+      ID: 1343
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10029,7 +12891,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1337
+      ID: 1344
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10045,7 +12907,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1338
+      ID: 1345
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10061,7 +12923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1335
+      ID: 1342
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10077,7 +12939,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1334
+      ID: 1341
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10093,7 +12955,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1332
+      ID: 1339
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10109,7 +12971,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1453
+      ID: 1508
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10121,11 +12983,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: x}
+                  Variable: {subprogram: 140, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1341
+      ID: 1348
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10141,7 +13003,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1342
+      ID: 1349
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10157,7 +13019,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1343
+      ID: 1350
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10173,7 +13035,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1340
+      ID: 1347
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -10189,7 +13051,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1339
+      ID: 1346
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10205,7 +13067,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1505
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10214,14 +13076,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 259 GoSliceHeaderType []struct {}
+            Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1441
+      ID: 1496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10230,14 +13092,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 251 GoSliceHeaderType [][]uint
+            Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1389
+      ID: 1396
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10253,7 +13115,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1437
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10269,7 +13131,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1438
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10305,7 +13167,59 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1313
+      ID: 1486
+      Name: Probe[main.testStackArgRegReturns]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 161 ArrayType [5]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 40
+    - __kind: EventRootType
+      ID: 1487
+      Name: Probe[main.testStackArgRegReturns]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 17
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1320
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10321,7 +13235,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1416
+      ID: 1423
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10337,7 +13251,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1445
+      ID: 1500
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10346,14 +13260,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 256 GoSliceHeaderType []string
+            Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: s}
+                  Variable: {subprogram: 134, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1355
+      ID: 1362
       Name: Probe[main.testStringType1]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10369,7 +13283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1363
       Name: Probe[main.testStringType2]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10385,7 +13299,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1497
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -10394,10 +13308,10 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 253 GoSliceHeaderType []main.structWithNoStrings
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: xs}
+                  Variable: {subprogram: 131, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -10407,11 +13321,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: a}
+                  Variable: {subprogram: 131, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1383
+      ID: 1390
       Name: Probe[main.testStructWithAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10427,7 +13341,49 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1464
+      ID: 1490
+      Name: Probe[main.testStructWithArrayArg]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: arg
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testStructWithArrayArg]Return
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 256 StructureType main.structWithArray
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1519
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10436,17 +13392,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 278 StructureType main.structWithCyclicMaps
+            Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 149, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1465
+      ID: 1520
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1463
+      ID: 1518
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -10455,14 +13411,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 265 StructureType main.structWithCyclicSlices
+            Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 148, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
-      ID: 1384
+      ID: 1391
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10478,7 +13434,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1521
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -10487,17 +13443,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 309 StructureType main.aStruct
+            Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1467
+      ID: 1522
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1457
+      ID: 1512
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10506,14 +13462,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 262 PointerType *main.threeStringStruct
+            Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: a}
+                  Variable: {subprogram: 143, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1455
+      ID: 1510
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10522,17 +13478,17 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 261 StructureType main.threeStringStruct
+            Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: a}
+                  Variable: {subprogram: 142, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1456
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1454
+      ID: 1509
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10544,7 +13500,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: x}
+                  Variable: {subprogram: 141, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -10554,7 +13510,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: y}
+                  Variable: {subprogram: 141, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -10564,11 +13520,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 2, name: z}
+                  Variable: {subprogram: 141, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1346
+      ID: 1353
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10584,7 +13540,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1322
+      ID: 1329
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -10600,7 +13556,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1323
+      ID: 1330
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10616,7 +13572,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1331
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10632,7 +13588,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1321
+      ID: 1328
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -10648,7 +13604,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1320
+      ID: 1327
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10664,7 +13620,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1415
+      ID: 1422
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10680,7 +13636,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1494
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10689,14 +13645,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: u}
+                  Variable: {subprogram: 128, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1461
+      ID: 1516
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10708,11 +13664,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: x}
+                  Variable: {subprogram: 146, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1414
+      ID: 1421
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -10728,7 +13684,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1330
+      ID: 1337
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -10744,7 +13700,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1448
+      ID: 1503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10753,14 +13709,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1449
+      ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10769,12 +13725,70 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 250 GoSliceHeaderType []uint
+            Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testZeroSizeArgAndReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
+        - Name: b
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testZeroSizeArgAndReturn]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: ArrayType
+      ID: 253
+      Name: '[0]int'
+      GoKind: 17
+      HasCount: true
+      Element: 7 BaseType int
     - __kind: ArrayType
       ID: 126
       Name: '[100]uint'
@@ -10787,16 +13801,25 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 701568
+      GoRuntimeType: 701664
       GoKind: 17
       Count: 10
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
+      ID: 252
+      Name: '[1]int'
+      ByteSize: 8
+      GoRuntimeType: 686816
+      GoKind: 17
+      Count: 1
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 701184
+      GoRuntimeType: 701280
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10805,7 +13828,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 701280
+      GoRuntimeType: 701376
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10830,7 +13853,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 701472
+      GoRuntimeType: 701568
       GoKind: 17
       Count: 2
       HasCount: true
@@ -10972,22 +13995,31 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 700992
+      GoRuntimeType: 701088
       GoKind: 17
       Count: 32
       HasCount: true
       Element: 1 BaseType uintptr
     - __kind: ArrayType
+      ID: 251
+      Name: '[3]int'
+      ByteSize: 24
+      GoRuntimeType: 685664
+      GoKind: 17
+      Count: 3
+      HasCount: true
+      Element: 7 BaseType int
+    - __kind: ArrayType
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 700416
+      GoRuntimeType: 700512
       GoKind: 17
       Count: 3
       HasCount: true
       Element: 32 StructureType internal/runtime/atomic.Uint32
     - __kind: ArrayType
-      ID: 417
+      ID: 424
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 683360
@@ -10996,7 +14028,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 374
+      ID: 381
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 683648
@@ -11008,7 +14040,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 692096
+      GoRuntimeType: 692192
       GoKind: 17
       Count: 4
       HasCount: true
@@ -11022,7 +14054,7 @@ Types:
       HasCount: true
       Element: 7 BaseType int
     - __kind: ArrayType
-      ID: 989
+      ID: 996
       Name: '[5]uint8'
       ByteSize: 5
       GoRuntimeType: 685184
@@ -11034,7 +14066,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 697728
+      GoRuntimeType: 697824
       GoKind: 17
       Count: 6
       HasCount: true
@@ -11043,7 +14075,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 701376
+      GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
@@ -11064,15 +14096,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 324 GoSliceDataType []*main.deepSlice2.array
+      Data: 331 GoSliceDataType []*main.deepSlice2.array
     - __kind: GoSliceDataType
-      ID: 324
+      ID: 331
       Name: '[]*main.deepSlice2.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 140 PointerType *main.deepSlice2
     - __kind: GoSliceHeaderType
-      ID: 1228
+      ID: 1235
       Name: '[]*main.deepSlice3'
       ByteSize: 24
       GoRuntimeType: 478176
@@ -11080,22 +14112,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1229 PointerType **main.deepSlice3
+          Type: 1236 PointerType **main.deepSlice3
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1232 GoSliceDataType []*main.deepSlice3.array
+      Data: 1239 GoSliceDataType []*main.deepSlice3.array
     - __kind: GoSliceDataType
-      ID: 1232
+      ID: 1239
       Name: '[]*main.deepSlice3.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1230 PointerType *main.deepSlice3
+      Element: 1237 PointerType *main.deepSlice3
     - __kind: GoSliceHeaderType
-      ID: 1253
+      ID: 1260
       Name: '[]*main.deepSlice8'
       ByteSize: 24
       GoRuntimeType: 477856
@@ -11103,22 +14135,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1254 PointerType **main.deepSlice8
+          Type: 1261 PointerType **main.deepSlice8
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1257 GoSliceDataType []*main.deepSlice8.array
+      Data: 1264 GoSliceDataType []*main.deepSlice8.array
     - __kind: GoSliceDataType
-      ID: 1257
+      ID: 1264
       Name: '[]*main.deepSlice8.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1255 PointerType *main.deepSlice8
+      Element: 1262 PointerType *main.deepSlice8
     - __kind: GoSliceHeaderType
-      ID: 1259
+      ID: 1266
       Name: '[]*main.deepSlice9'
       ByteSize: 24
       GoRuntimeType: 477792
@@ -11126,20 +14158,20 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1260 PointerType **main.deepSlice9
+          Type: 1267 PointerType **main.deepSlice9
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1263 GoSliceDataType []*main.deepSlice9.array
+      Data: 1270 GoSliceDataType []*main.deepSlice9.array
     - __kind: GoSliceDataType
-      ID: 1263
+      ID: 1270
       Name: '[]*main.deepSlice9.array'
       DynamicSizeClass: slice
       ByteSize: 8
-      Element: 1261 PointerType *main.deepSlice9
+      Element: 1268 PointerType *main.deepSlice9
     - __kind: GoSliceHeaderType
       ID: 62
       Name: '[]*runtime.p'
@@ -11156,9 +14188,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 319 GoSliceDataType []*runtime.p.array
+      Data: 326 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 319
+      ID: 326
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -11179,309 +14211,309 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 321 GoSliceDataType []*string.array
+      Data: 328 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 321
+      ID: 328
       Name: '[]*string.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 95 PointerType *string
     - __kind: GoSliceDataType
-      ID: 434
+      ID: 441
       Name: '[]*table<[4]int,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 227 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 426
+      ID: 433
       Name: '[]*table<[4]int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 222 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 375
+      ID: 382
       Name: '[]*table<[4]string,[2]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 190 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 393
+      ID: 400
       Name: '[]*table<bool,main.node>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 202 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 334
+      ID: 341
       Name: '[]*table<int,*main.deepMap2>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 148 PointerType *table<int,*main.deepMap2>
     - __kind: GoSliceDataType
-      ID: 1247
+      ID: 1254
       Name: '[]*table<int,*main.deepMap3>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1238 PointerType *table<int,*main.deepMap3>
+      Element: 1245 PointerType *table<int,*main.deepMap3>
     - __kind: GoSliceDataType
-      ID: 1281
+      ID: 1288
       Name: '[]*table<int,*main.deepMap8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1272 PointerType *table<int,*main.deepMap8>
+      Element: 1279 PointerType *table<int,*main.deepMap8>
     - __kind: GoSliceDataType
-      ID: 1296
+      ID: 1303
       Name: '[]*table<int,*main.deepMap9>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1287 PointerType *table<int,*main.deepMap9>
+      Element: 1294 PointerType *table<int,*main.deepMap9>
     - __kind: GoSliceDataType
-      ID: 342
+      ID: 349
       Name: '[]*table<int,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 170 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 1309
+      ID: 1316
       Name: '[]*table<int,interface {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 1302 PointerType *table<int,interface {}>
+      Element: 1309 PointerType *table<int,interface {}>
     - __kind: GoSliceDataType
-      ID: 450
+      ID: 457
       Name: '[]*table<int,struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 237 PointerType *table<int,struct {}>
     - __kind: GoSliceDataType
-      ID: 401
+      ID: 408
       Name: '[]*table<int,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 207 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 385
+      ID: 392
       Name: '[]*table<string,[]main.structWithMap>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 197 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 366
+      ID: 373
       Name: '[]*table<string,[]string>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 185 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 1005
+      ID: 1012
       Name: '[]*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 972 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
+      Element: 979 PointerType *table<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceDataType
-      ID: 358
+      ID: 365
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 180 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 350
+      ID: 357
       Name: '[]*table<string,main.nestedStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 175 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 442
+      ID: 449
       Name: '[]*table<struct {},int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 232 PointerType *table<struct {},int>
     - __kind: GoSliceDataType
-      ID: 492
+      ID: 499
       Name: '[]*table<struct {},main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 283 PointerType *table<struct {},main.structWithCyclicMaps>
+      Element: 290 PointerType *table<struct {},main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 500
+      ID: 507
       Name: '[]*table<struct {},map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 288 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
+      Element: 295 PointerType *table<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 508
+      ID: 515
       Name: '[]*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 293 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 300 PointerType *table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 516
+      ID: 523
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 298 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 305 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 524
+      ID: 531
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 303 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 310 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 532
+      ID: 539
       Name: '[]*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 308 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      Element: 315 PointerType *table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoSliceDataType
-      ID: 458
+      ID: 465
       Name: '[]*table<struct {},struct {}>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 242 PointerType *table<struct {},struct {}>
     - __kind: GoSliceDataType
-      ID: 418
+      ID: 425
       Name: '[]*table<uint8,[4]int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 217 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 409
+      ID: 416
       Name: '[]*table<uint8,uint8>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 212 PointerType *table<uint8,uint8>
     - __kind: GoSliceHeaderType
-      ID: 276
+      ID: 283
       Name: '[][][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 277 PointerType *[][][][][]main.structWithCyclicSlices
+          Type: 284 PointerType *[][][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 484 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
+      Data: 491 GoSliceDataType [][][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 484
+      ID: 491
       Name: '[][][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+      Element: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 274
+      ID: 281
       Name: '[][][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 275 PointerType *[][][][]main.structWithCyclicSlices
+          Type: 282 PointerType *[][][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 482 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
+      Data: 489 GoSliceDataType [][][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 482
+      ID: 489
       Name: '[][][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+      Element: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 272
+      ID: 279
       Name: '[][][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 273 PointerType *[][][]main.structWithCyclicSlices
+          Type: 280 PointerType *[][][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 480 GoSliceDataType [][][][]main.structWithCyclicSlices.array
+      Data: 487 GoSliceDataType [][][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 480
+      ID: 487
       Name: '[][][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+      Element: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 270
+      ID: 277
       Name: '[][][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 271 PointerType *[][]main.structWithCyclicSlices
+          Type: 278 PointerType *[][]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 478 GoSliceDataType [][][]main.structWithCyclicSlices.array
+      Data: 485 GoSliceDataType [][][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 478
+      ID: 485
       Name: '[][][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+      Element: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 268
+      ID: 275
       Name: '[][]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 269 PointerType *[]main.structWithCyclicSlices
+          Type: 276 PointerType *[]main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 476 GoSliceDataType [][]main.structWithCyclicSlices.array
+      Data: 483 GoSliceDataType [][]main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 476
+      ID: 483
       Name: '[][]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 266 GoSliceHeaderType []main.structWithCyclicSlices
+      Element: 273 GoSliceHeaderType []main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 251
+      ID: 258
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 252 PointerType *[]uint
+          Type: 259 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 462 GoSliceDataType [][]uint.array
+      Data: 469 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 462
+      ID: 469
       Name: '[][]uint.array'
       DynamicSizeClass: slice
       ByteSize: 24
-      Element: 250 GoSliceHeaderType []uint
+      Element: 257 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 257
+      ID: 264
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 487776
@@ -11496,15 +14528,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 468 GoSliceDataType []bool.array
+      Data: 475 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 468
+      ID: 475
       Name: '[]bool.array'
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 4 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 984
+      ID: 991
       Name: '[]float64'
       ByteSize: 24
       GoRuntimeType: 487648
@@ -11519,15 +14551,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1007 GoSliceDataType []float64.array
+      Data: 1014 GoSliceDataType []float64.array
     - __kind: GoSliceDataType
-      ID: 1007
+      ID: 1014
       Name: '[]float64.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 16 BaseType float64
     - __kind: GoSliceHeaderType
-      ID: 1265
+      ID: 1272
       Name: '[]interface {}'
       ByteSize: 24
       GoRuntimeType: 488096
@@ -11542,37 +14574,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1266 GoSliceDataType []interface {}.array
+      Data: 1273 GoSliceDataType []interface {}.array
     - __kind: GoSliceDataType
-      ID: 1266
+      ID: 1273
       Name: '[]interface {}.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 157 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 266
+      ID: 273
       Name: '[]main.structWithCyclicSlices'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 267 PointerType *main.structWithCyclicSlices
+          Type: 274 PointerType *main.structWithCyclicSlices
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 474 GoSliceDataType []main.structWithCyclicSlices.array
+      Data: 481 GoSliceDataType []main.structWithCyclicSlices.array
     - __kind: GoSliceDataType
-      ID: 474
+      ID: 481
       Name: '[]main.structWithCyclicSlices.array'
       DynamicSizeClass: slice
       ByteSize: 144
-      Element: 265 StructureType main.structWithCyclicSlices
+      Element: 272 StructureType main.structWithCyclicSlices
     - __kind: GoSliceHeaderType
-      ID: 383
+      ID: 390
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 478496
@@ -11580,210 +14612,210 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 384 PointerType *main.structWithMap
+          Type: 391 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 534 GoSliceDataType []main.structWithMap.array
+      Data: 541 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 534
+      ID: 541
       Name: '[]main.structWithMap.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 165 StructureType main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 253
+      ID: 260
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 254 PointerType *main.structWithNoStrings
+          Type: 261 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 464 GoSliceDataType []main.structWithNoStrings.array
+      Data: 471 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 464
+      ID: 471
       Name: '[]main.structWithNoStrings.array'
       DynamicSizeClass: slice
       ByteSize: 2
-      Element: 255 StructureType main.structWithNoStrings
+      Element: 262 StructureType main.structWithNoStrings
     - __kind: GoSliceDataType
-      ID: 435
+      ID: 442
       Name: '[]noalg.map.group[[4]int][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 520
-      Element: 431 StructureType noalg.map.group[[4]int][4]int
+      Element: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 427
+      ID: 434
       Name: '[]noalg.map.group[[4]int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 423 StructureType noalg.map.group[[4]int]uint8
+      Element: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 376
+      ID: 383
       Name: '[]noalg.map.group[[4]string][2]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 648
-      Element: 371 StructureType noalg.map.group[[4]string][2]int
+      Element: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 394
+      ID: 401
       Name: '[]noalg.map.group[bool]main.node.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 390 StructureType noalg.map.group[bool]main.node
+      Element: 397 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 335
+      ID: 342
       Name: '[]noalg.map.group[int]*main.deepMap2.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 329 StructureType noalg.map.group[int]*main.deepMap2
+      Element: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSliceDataType
-      ID: 1248
+      ID: 1255
       Name: '[]noalg.map.group[int]*main.deepMap3.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      Element: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSliceDataType
-      ID: 1282
+      ID: 1289
       Name: '[]noalg.map.group[int]*main.deepMap8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      Element: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSliceDataType
-      ID: 1297
+      ID: 1304
       Name: '[]noalg.map.group[int]*main.deepMap9.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      Element: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSliceDataType
-      ID: 343
+      ID: 350
       Name: '[]noalg.map.group[int]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 339 StructureType noalg.map.group[int]int
+      Element: 346 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 1310
+      ID: 1317
       Name: '[]noalg.map.group[int]interface {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 1306 StructureType noalg.map.group[int]interface {}
+      Element: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: GoSliceDataType
-      ID: 451
+      ID: 458
       Name: '[]noalg.map.group[int]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 447 StructureType noalg.map.group[int]struct {}
+      Element: 454 StructureType noalg.map.group[int]struct {}
     - __kind: GoSliceDataType
-      ID: 402
+      ID: 409
       Name: '[]noalg.map.group[int]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 398 StructureType noalg.map.group[int]uint8
+      Element: 405 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 386
+      ID: 393
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 380 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 367
+      ID: 374
       Name: '[]noalg.map.group[string][]string.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 363 StructureType noalg.map.group[string][]string
+      Element: 370 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 1006
+      ID: 1013
       Name: '[]noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      Element: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSliceDataType
-      ID: 359
+      ID: 366
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 355 StructureType noalg.map.group[string]int
+      Element: 362 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 351
+      ID: 358
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 347 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 443
+      ID: 450
       Name: '[]noalg.map.group[struct {}]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 439 StructureType noalg.map.group[struct {}]int
+      Element: 446 StructureType noalg.map.group[struct {}]int
     - __kind: GoSliceDataType
-      ID: 493
+      ID: 500
       Name: '[]noalg.map.group[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 392
-      Element: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      Element: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 501
+      ID: 508
       Name: '[]noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 509
+      ID: 516
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 517
+      ID: 524
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 525
+      ID: 532
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 533
+      ID: 540
       Name: '[]noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array'
       DynamicSizeClass: hashmap
       ByteSize: 72
-      Element: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      Element: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSliceDataType
-      ID: 459
+      ID: 466
       Name: '[]noalg.map.group[struct {}]struct {}.array'
       DynamicSizeClass: hashmap
       ByteSize: 16
-      Element: 455 StructureType noalg.map.group[struct {}]struct {}
+      Element: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSliceDataType
-      ID: 419
+      ID: 426
       Name: '[]noalg.map.group[uint8][4]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 328
-      Element: 414 StructureType noalg.map.group[uint8][4]int
+      Element: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 410
+      ID: 417
       Name: '[]noalg.map.group[uint8]uint8.array'
       DynamicSizeClass: hashmap
       ByteSize: 24
-      Element: 406 StructureType noalg.map.group[uint8]uint8
+      Element: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 256
+      ID: 263
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 487904
@@ -11798,36 +14830,36 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 466 GoSliceDataType []string.array
+      Data: 473 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 466
+      ID: 473
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 259
+      ID: 266
       Name: '[]struct {}'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 260 PointerType *struct {}
+          Type: 267 PointerType *struct {}
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 472 GoSliceDataType []struct {}.array
+      Data: 479 GoSliceDataType []struct {}.array
     - __kind: GoSliceDataType
-      ID: 472
+      ID: 479
       Name: '[]struct {}.array'
       DynamicSizeClass: slice
       Element: 125 StructureType struct {}
     - __kind: GoSliceHeaderType
-      ID: 250
+      ID: 257
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 487392
@@ -11842,15 +14874,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 460 GoSliceDataType []uint.array
+      Data: 467 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 460
+      ID: 467
       Name: '[]uint.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 10 BaseType uint
     - __kind: GoSliceHeaderType
-      ID: 258
+      ID: 265
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -11865,9 +14897,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 470 GoSliceDataType []uint16.array
+      Data: 477 GoSliceDataType []uint16.array
     - __kind: GoSliceDataType
-      ID: 470
+      ID: 477
       Name: '[]uint16.array'
       DynamicSizeClass: slice
       ByteSize: 2
@@ -11888,9 +14920,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 314 GoSliceDataType []uint8.array
+      Data: 321 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 314
+      ID: 321
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -11911,19 +14943,19 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 316 GoSliceDataType []uintptr.array
+      Data: 323 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 316
+      ID: 323
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: UnresolvedPointeeType
-      ID: 1139
+      ID: 1146
       Name: archive/tar.Writer
       ByteSize: 8
     - __kind: GoSliceHeaderType
-      ID: 774
+      ID: 781
       Name: archive/tar.headerError
       ByteSize: 24
       GoRuntimeType: 931776
@@ -11938,33 +14970,33 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 775 GoSliceDataType archive/tar.headerError.array
+      Data: 782 GoSliceDataType archive/tar.headerError.array
     - __kind: GoSliceDataType
-      ID: 775
+      ID: 782
       Name: archive/tar.headerError.array
       DynamicSizeClass: slice
       ByteSize: 16
       Element: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1074
+      ID: 1081
       Name: archive/tar.regFileWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1022
+      ID: 1029
       Name: archive/zip.countWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1024
+      ID: 1031
       Name: archive/zip.dirWriter
       GoRuntimeType: 1.120608e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1118
+      ID: 1125
       Name: archive/zip.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1050
+      ID: 1057
       Name: archive/zip.nopCloser
       ByteSize: 16
       GoRuntimeType: 1.566496e+06
@@ -11974,7 +15006,7 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1052
+      ID: 1059
       Name: archive/zip.pooledFlateWriter
       ByteSize: 8
     - __kind: BaseType
@@ -11984,15 +15016,15 @@ Types:
       GoRuntimeType: 585664
       GoKind: 1
     - __kind: UnresolvedPointeeType
-      ID: 1097
+      ID: 1104
       Name: bufio.Reader
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1126
+      ID: 1133
       Name: bufio.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1177
+      ID: 1184
       Name: bytes.Buffer
       ByteSize: 8
     - __kind: GoChannelType
@@ -12018,13 +15050,13 @@ Types:
       GoRuntimeType: 585408
       GoKind: 15
     - __kind: BaseType
-      ID: 572
+      ID: 579
       Name: compress/flate.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 835040
       GoKind: 6
     - __kind: GoStringHeaderType
-      ID: 573
+      ID: 580
       Name: compress/flate.InternalError
       ByteSize: 16
       GoRuntimeType: 835136
@@ -12032,116 +15064,116 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 575 PointerType *compress/flate.InternalError.str
+          Type: 582 PointerType *compress/flate.InternalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 574 GoStringDataType compress/flate.InternalError.str
+      Data: 581 GoStringDataType compress/flate.InternalError.str
     - __kind: GoStringDataType
-      ID: 574
+      ID: 581
       Name: compress/flate.InternalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1072
+      ID: 1079
       Name: compress/flate.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1018
+      ID: 1025
       Name: compress/flate.dictWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1094
+      ID: 1101
       Name: compress/gzip.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 922
+      ID: 929
       Name: context.deadlineExceededError
       GoRuntimeType: 1.480736e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 586
+      ID: 593
       Name: crypto/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837632
       GoKind: 2
     - __kind: BaseType
-      ID: 587
+      ID: 594
       Name: crypto/des.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837728
       GoKind: 2
     - __kind: BaseType
-      ID: 588
+      ID: 595
       Name: crypto/internal/fips140/aes.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837824
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1089
+      ID: 1096
       Name: crypto/internal/fips140/hmac.HMAC
       ByteSize: 8
     - __kind: StructureType
-      ID: 871
+      ID: 878
       Name: crypto/internal/fips140/hmac.errCloneUnsupported
       GoRuntimeType: 1.289952e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1120
+      ID: 1127
       Name: crypto/internal/fips140/sha256.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1150
+      ID: 1157
       Name: crypto/internal/fips140/sha3.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1124
+      ID: 1131
       Name: crypto/internal/fips140/sha3.SHAKE
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1122
+      ID: 1129
       Name: crypto/internal/fips140/sha512.Digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1116
+      ID: 1123
       Name: crypto/md5.digest
       ByteSize: 8
     - __kind: BaseType
-      ID: 589
+      ID: 596
       Name: crypto/rc4.KeySizeError
       ByteSize: 8
       GoRuntimeType: 837920
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 1137
+      ID: 1144
       Name: crypto/sha1.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1112
+      ID: 1119
       Name: crypto/sha3.SHA3
       ByteSize: 8
     - __kind: BaseType
-      ID: 576
+      ID: 583
       Name: crypto/tls.AlertError
       ByteSize: 1
       GoRuntimeType: 835616
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 860
+      ID: 867
       Name: crypto/tls.CertificateVerificationError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1203
+      ID: 1210
       Name: crypto/tls.Conn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 688
+      ID: 695
       Name: crypto/tls.ECHRejectionError
       ByteSize: 8
     - __kind: StructureType
-      ID: 686
+      ID: 693
       Name: crypto/tls.RecordHeaderError
       ByteSize: 40
       GoRuntimeType: 1.731584e+06
@@ -12152,38 +15184,38 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: RecordHeader
           Offset: 16
-          Type: 989 ArrayType [5]uint8
+          Type: 996 ArrayType [5]uint8
         - Name: Conn
           Offset: 24
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: BaseType
-      ID: 813
+      ID: 820
       Name: crypto/tls.alert
       ByteSize: 1
       GoRuntimeType: 993760
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1082
+      ID: 1089
       Name: crypto/tls.cthWrapper
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 690
+      ID: 697
       Name: crypto/tls.echConfigErr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1087
+      ID: 1094
       Name: crypto/tls.finishedHash
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 957
+      ID: 964
       Name: crypto/tls.permanentError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 974
+      ID: 981
       Name: crypto/x509.Certificate
       ByteSize: 8
     - __kind: StructureType
-      ID: 762
+      ID: 769
       Name: crypto/x509.CertificateInvalidError
       ByteSize: 32
       GoRuntimeType: 1.734464e+06
@@ -12191,21 +15223,21 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Reason
           Offset: 8
-          Type: 992 BaseType crypto/x509.InvalidReason
+          Type: 999 BaseType crypto/x509.InvalidReason
         - Name: Detail
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 756
+      ID: 763
       Name: crypto/x509.ConstraintViolationError
       GoRuntimeType: 1.118176e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 758
+      ID: 765
       Name: crypto/x509.HostnameError
       ByteSize: 24
       GoRuntimeType: 1.600608e+06
@@ -12213,24 +15245,24 @@ Types:
       RawFields:
         - Name: Certificate
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: Host
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 585
+      ID: 592
       Name: crypto/x509.InsecureAlgorithmError
       ByteSize: 8
       GoRuntimeType: 837248
       GoKind: 2
     - __kind: BaseType
-      ID: 992
+      ID: 999
       Name: crypto/x509.InvalidReason
       ByteSize: 8
       GoRuntimeType: 590848
       GoKind: 2
     - __kind: StructureType
-      ID: 865
+      ID: 872
       Name: crypto/x509.SystemRootsError
       ByteSize: 16
       GoRuntimeType: 1.562496e+06
@@ -12240,13 +15272,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 764
+      ID: 771
       Name: crypto/x509.UnhandledCriticalExtension
       GoRuntimeType: 1.118432e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 760
+      ID: 767
       Name: crypto/x509.UnknownAuthorityError
       ByteSize: 32
       GoRuntimeType: 1.734272e+06
@@ -12254,15 +15286,15 @@ Types:
       RawFields:
         - Name: Cert
           Offset: 0
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
         - Name: hintErr
           Offset: 8
           Type: 14 GoInterfaceType error
         - Name: hintCert
           Offset: 24
-          Type: 973 PointerType *crypto/x509.Certificate
+          Type: 980 PointerType *crypto/x509.Certificate
     - __kind: StructureType
-      ID: 778
+      ID: 785
       Name: encoding/asn1.StructuralError
       ByteSize: 16
       GoRuntimeType: 1.437152e+06
@@ -12272,7 +15304,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 782
+      ID: 789
       Name: encoding/asn1.SyntaxError
       ByteSize: 16
       GoRuntimeType: 1.437312e+06
@@ -12282,55 +15314,55 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 780
+      ID: 787
       Name: encoding/asn1.invalidUnmarshalError
       ByteSize: 8
     - __kind: BaseType
-      ID: 567
+      ID: 574
       Name: encoding/base64.CorruptInputError
       ByteSize: 8
       GoRuntimeType: 834560
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 1040
+      ID: 1047
       Name: encoding/base64.encoder
       ByteSize: 8
     - __kind: BaseType
-      ID: 568
+      ID: 575
       Name: encoding/hex.InvalidByteError
       ByteSize: 1
       GoRuntimeType: 834752
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 644
+      ID: 651
       Name: encoding/json.InvalidUnmarshalError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 849
+      ID: 856
       Name: encoding/json.MarshalerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 636
+      ID: 643
       Name: encoding/json.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 642
+      ID: 649
       Name: encoding/json.UnmarshalTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 640
+      ID: 647
       Name: encoding/json.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 638
+      ID: 645
       Name: encoding/json.UnsupportedValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1183
+      ID: 1190
       Name: encoding/json.encodeState
       ByteSize: 8
     - __kind: StructureType
-      ID: 646
+      ID: 653
       Name: encoding/json.jsonError
       ByteSize: 16
       GoRuntimeType: 1.421152e+06
@@ -12340,19 +15372,19 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1048
+      ID: 1055
       Name: encoding/pem.lineBreaker
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 750
+      ID: 757
       Name: encoding/xml.SyntaxError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 748
+      ID: 755
       Name: encoding/xml.TagPathError
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 582
+      ID: 589
       Name: encoding/xml.UnmarshalError
       ByteSize: 16
       GoRuntimeType: 837152
@@ -12360,22 +15392,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 584 PointerType *encoding/xml.UnmarshalError.str
+          Type: 591 PointerType *encoding/xml.UnmarshalError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 583 GoStringDataType encoding/xml.UnmarshalError.str
+      Data: 590 GoStringDataType encoding/xml.UnmarshalError.str
     - __kind: GoStringDataType
-      ID: 583
+      ID: 590
       Name: encoding/xml.UnmarshalError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 753
+      ID: 760
       Name: encoding/xml.UnsupportedTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1161
+      ID: 1168
       Name: encoding/xml.printer
       ByteSize: 8
     - __kind: GoInterfaceType
@@ -12392,11 +15424,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 612
+      ID: 619
       Name: errors.errorString
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 816
+      ID: 823
       Name: errors.joinError
       ByteSize: 8
     - __kind: BaseType
@@ -12412,15 +15444,15 @@ Types:
       GoRuntimeType: 585600
       GoKind: 14
     - __kind: UnresolvedPointeeType
-      ID: 1171
+      ID: 1178
       Name: fmt.pp
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 818
+      ID: 825
       Name: fmt.wrapError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 820
+      ID: 827
       Name: fmt.wrapErrors
       ByteSize: 8
     - __kind: GoSubroutineType
@@ -12436,11 +15468,11 @@ Types:
       GoRuntimeType: 848768
       GoKind: 19
     - __kind: UnresolvedPointeeType
-      ID: 674
+      ID: 681
       Name: github.com/DataDog/datadog-agent/pkg/obfuscate.SyntaxError
       ByteSize: 8
     - __kind: StructureType
-      ID: 655
+      ID: 662
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorInputChannelFull
       ByteSize: 216
       GoRuntimeType: 1.730432e+06
@@ -12448,7 +15480,7 @@ Types:
       RawFields:
         - Name: Metric
           Offset: 0
-          Type: 982 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
+          Type: 989 StructureType github.com/DataDog/datadog-go/v5/statsd.metric
         - Name: ChannelSize
           Offset: 192
           Type: 7 BaseType int
@@ -12456,25 +15488,25 @@ Types:
           Offset: 200
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 657
+      ID: 664
       Name: github.com/DataDog/datadog-go/v5/statsd.ErrorSenderChannelFull
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 986
+      ID: 993
       Name: github.com/DataDog/datadog-go/v5/statsd.Event
       ByteSize: 8
     - __kind: StructureType
-      ID: 661
+      ID: 668
       Name: github.com/DataDog/datadog-go/v5/statsd.MessageTooLongError
       GoRuntimeType: 1.114464e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 988
+      ID: 995
       Name: github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 561
+      ID: 568
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr
       ByteSize: 16
       GoRuntimeType: 833984
@@ -12482,18 +15514,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 563 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+          Type: 570 PointerType *github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 562 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
+      Data: 569 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
     - __kind: GoStringDataType
-      ID: 562
+      ID: 569
       Name: github.com/DataDog/datadog-go/v5/statsd.invalidTimestampErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 982
+      ID: 989
       Name: github.com/DataDog/datadog-go/v5/statsd.metric
       ByteSize: 192
       GoRuntimeType: 2.220096e+06
@@ -12501,13 +15533,13 @@ Types:
       RawFields:
         - Name: metricType
           Offset: 0
-          Type: 983 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
+          Type: 990 BaseType github.com/DataDog/datadog-go/v5/statsd.metricType
         - Name: namespace
           Offset: 8
           Type: 9 GoStringHeaderType string
         - Name: globalTags
           Offset: 24
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
         - Name: name
           Offset: 48
           Type: 9 GoStringHeaderType string
@@ -12516,7 +15548,7 @@ Types:
           Type: 16 BaseType float64
         - Name: fvalues
           Offset: 72
-          Type: 984 GoSliceHeaderType []float64
+          Type: 991 GoSliceHeaderType []float64
         - Name: ivalue
           Offset: 96
           Type: 13 BaseType int64
@@ -12525,13 +15557,13 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: evalue
           Offset: 120
-          Type: 985 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
+          Type: 992 PointerType *github.com/DataDog/datadog-go/v5/statsd.Event
         - Name: scvalue
           Offset: 128
-          Type: 987 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
+          Type: 994 PointerType *github.com/DataDog/datadog-go/v5/statsd.ServiceCheck
         - Name: tags
           Offset: 136
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
         - Name: stags
           Offset: 160
           Type: 9 GoStringHeaderType string
@@ -12542,13 +15574,13 @@ Types:
           Offset: 184
           Type: 13 BaseType int64
     - __kind: BaseType
-      ID: 983
+      ID: 990
       Name: github.com/DataDog/datadog-go/v5/statsd.metricType
       ByteSize: 8
       GoRuntimeType: 587456
       GoKind: 2
     - __kind: GoStringHeaderType
-      ID: 558
+      ID: 565
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr
       ByteSize: 16
       GoRuntimeType: 833888
@@ -12556,18 +15588,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 560 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+          Type: 567 PointerType *github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 559 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
+      Data: 566 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
     - __kind: GoStringDataType
-      ID: 559
+      ID: 566
       Name: github.com/DataDog/datadog-go/v5/statsd.noClientErr.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 564
+      ID: 571
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError
       ByteSize: 16
       GoRuntimeType: 834080
@@ -12575,60 +15607,60 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 566 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+          Type: 573 PointerType *github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 565 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
+      Data: 572 GoStringDataType github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
     - __kind: GoStringDataType
-      ID: 565
+      ID: 572
       Name: github.com/DataDog/datadog-go/v5/statsd.partialWriteError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1060
+      ID: 1067
       Name: github.com/DataDog/datadog-go/v5/statsd.udpWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1147
+      ID: 1154
       Name: github.com/DataDog/datadog-go/v5/statsd.udsWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 772
+      ID: 779
       Name: github.com/DataDog/dd-trace-go/v2/appsec/events.BlockingSecurityEvent
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 931
+      ID: 938
       Name: github.com/DataDog/dd-trace-go/v2/instrumentation/errortrace.TracerError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1179
+      ID: 1186
       Name: github.com/DataDog/dd-trace-go/v2/internal/appsec.limitedBuffer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 699
+      ID: 706
       Name: github.com/DataDog/dd-trace-go/v2/internal/telemetry/internal.WriterStatusCodeError
       ByteSize: 8
     - __kind: StructureType
-      ID: 706
+      ID: 713
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.CgoDisabledError
       GoRuntimeType: 1.117408e+06
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 581
+      ID: 588
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.RunError
       ByteSize: 8
       GoRuntimeType: 836288
       GoKind: 2
     - __kind: StructureType
-      ID: 704
+      ID: 711
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedGoVersionError
       GoRuntimeType: 1.11728e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 702
+      ID: 709
       Name: github.com/DataDog/go-libddwaf/v4/waferrors.UnsupportedOSArchError
       ByteSize: 32
       GoRuntimeType: 1.598688e+06
@@ -12641,7 +15673,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 722
+      ID: 729
       Name: github.com/DataDog/go-tuf/client.ErrDownloadFailed
       ByteSize: 32
       GoRuntimeType: 1.599488e+06
@@ -12654,7 +15686,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 726
+      ID: 733
       Name: github.com/DataDog/go-tuf/client.ErrMetaTooLarge
       ByteSize: 32
       GoRuntimeType: 1.733696e+06
@@ -12670,7 +15702,7 @@ Types:
           Offset: 24
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 724
+      ID: 731
       Name: github.com/DataDog/go-tuf/client.ErrMissingRemoteMetadata
       ByteSize: 16
       GoRuntimeType: 1.431072e+06
@@ -12680,7 +15712,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 720
+      ID: 727
       Name: github.com/DataDog/go-tuf/client.ErrNotFound
       ByteSize: 16
       GoRuntimeType: 1.430752e+06
@@ -12690,14 +15722,14 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 968
+      ID: 975
       Name: github.com/DataDog/go-tuf/data.Hashes
       ByteSize: 8
       GoRuntimeType: 1.501696e+06
       GoKind: 21
-      HeaderType: 970 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
+      HeaderType: 977 GoSwissMapHeaderType map<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: GoSliceHeaderType
-      ID: 991
+      ID: 998
       Name: github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 24
       GoRuntimeType: 1.051168e+06
@@ -12712,15 +15744,15 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1009 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
+      Data: 1016 GoSliceDataType github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSliceDataType
-      ID: 1009
+      ID: 1016
       Name: github.com/DataDog/go-tuf/data.HexBytes.array
       DynamicSizeClass: slice
       ByteSize: 1
       Element: 3 BaseType uint8
     - __kind: StructureType
-      ID: 734
+      ID: 741
       Name: github.com/DataDog/go-tuf/util.ErrNoCommonHash
       ByteSize: 16
       GoRuntimeType: 1.599808e+06
@@ -12728,12 +15760,12 @@ Types:
       RawFields:
         - Name: Expected
           Offset: 0
-          Type: 968 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
         - Name: Actual
           Offset: 8
-          Type: 968 GoMapType github.com/DataDog/go-tuf/data.Hashes
+          Type: 975 GoMapType github.com/DataDog/go-tuf/data.Hashes
     - __kind: StructureType
-      ID: 728
+      ID: 735
       Name: github.com/DataDog/go-tuf/util.ErrUnknownHashAlgorithm
       ByteSize: 16
       GoRuntimeType: 1.431232e+06
@@ -12743,7 +15775,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 732
+      ID: 739
       Name: github.com/DataDog/go-tuf/util.ErrWrongHash
       ByteSize: 64
       GoRuntimeType: 1.733888e+06
@@ -12754,12 +15786,12 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: Expected
           Offset: 16
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
         - Name: Actual
           Offset: 40
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 730
+      ID: 737
       Name: github.com/DataDog/go-tuf/util.ErrWrongLength
       ByteSize: 16
       GoRuntimeType: 1.599648e+06
@@ -12772,7 +15804,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 736
+      ID: 743
       Name: github.com/DataDog/go-tuf/verify.ErrExpired
       ByteSize: 24
       GoRuntimeType: 1.431392e+06
@@ -12780,9 +15812,9 @@ Types:
       RawFields:
         - Name: Expired
           Offset: 0
-          Type: 958 StructureType time.Time
+          Type: 965 StructureType time.Time
     - __kind: StructureType
-      ID: 742
+      ID: 749
       Name: github.com/DataDog/go-tuf/verify.ErrLowVersion
       ByteSize: 16
       GoRuntimeType: 1.600128e+06
@@ -12795,7 +15827,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 744
+      ID: 751
       Name: github.com/DataDog/go-tuf/verify.ErrRepeatID
       ByteSize: 16
       GoRuntimeType: 1.431712e+06
@@ -12805,7 +15837,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 740
+      ID: 747
       Name: github.com/DataDog/go-tuf/verify.ErrRoleThreshold
       ByteSize: 16
       GoRuntimeType: 1.599968e+06
@@ -12818,7 +15850,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 738
+      ID: 745
       Name: github.com/DataDog/go-tuf/verify.ErrUnknownRole
       ByteSize: 16
       GoRuntimeType: 1.431552e+06
@@ -12828,7 +15860,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 746
+      ID: 753
       Name: github.com/DataDog/go-tuf/verify.ErrWrongVersion
       ByteSize: 16
       GoRuntimeType: 1.600288e+06
@@ -12841,7 +15873,7 @@ Types:
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 663
+      ID: 670
       Name: github.com/cihub/seelog.baseError
       ByteSize: 16
       GoRuntimeType: 1.423392e+06
@@ -12851,11 +15883,11 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1100
+      ID: 1107
       Name: github.com/cihub/seelog.bufferedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 665
+      ID: 672
       Name: github.com/cihub/seelog.cannotOpenFileError
       ByteSize: 16
       GoRuntimeType: 1.423552e+06
@@ -12863,21 +15895,21 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1080
+      ID: 1087
       Name: github.com/cihub/seelog.connWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1036
+      ID: 1043
       Name: github.com/cihub/seelog.consoleWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1070
+      ID: 1077
       Name: github.com/cihub/seelog.fileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 669
+      ID: 676
       Name: github.com/cihub/seelog.missingArgumentError
       ByteSize: 16
       GoRuntimeType: 1.423872e+06
@@ -12885,13 +15917,13 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1135
+      ID: 1142
       Name: github.com/cihub/seelog.rollingFileWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1148
+      ID: 1155
       Name: github.com/cihub/seelog.rollingFileWriterSize
       ByteSize: 16
       GoRuntimeType: 2.107584e+06
@@ -12899,12 +15931,12 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1134 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1141 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: maxFileSize
           Offset: 8
           Type: 13 BaseType int64
     - __kind: StructureType
-      ID: 1151
+      ID: 1158
       Name: github.com/cihub/seelog.rollingFileWriterTime
       ByteSize: 40
       GoRuntimeType: 2.132448e+06
@@ -12912,7 +15944,7 @@ Types:
       RawFields:
         - Name: rollingFileWriter
           Offset: 0
-          Type: 1134 PointerType *github.com/cihub/seelog.rollingFileWriter
+          Type: 1141 PointerType *github.com/cihub/seelog.rollingFileWriter
         - Name: timePattern
           Offset: 8
           Type: 9 GoStringHeaderType string
@@ -12920,11 +15952,11 @@ Types:
           Offset: 24
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1038
+      ID: 1045
       Name: github.com/cihub/seelog.smtpWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 667
+      ID: 674
       Name: github.com/cihub/seelog.unexpectedAttributeError
       ByteSize: 16
       GoRuntimeType: 1.423712e+06
@@ -12932,9 +15964,9 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: StructureType
-      ID: 671
+      ID: 678
       Name: github.com/cihub/seelog.unexpectedChildElementError
       ByteSize: 16
       GoRuntimeType: 1.424032e+06
@@ -12942,64 +15974,64 @@ Types:
       RawFields:
         - Name: baseError
           Offset: 0
-          Type: 663 StructureType github.com/cihub/seelog.baseError
+          Type: 670 StructureType github.com/cihub/seelog.baseError
     - __kind: UnresolvedPointeeType
-      ID: 1102
+      ID: 1109
       Name: github.com/cihub/seelog/archive/gzip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1143
+      ID: 1150
       Name: github.com/cihub/seelog/archive/tar.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1145
+      ID: 1152
       Name: github.com/cihub/seelog/archive/zip.Writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 962
+      ID: 969
       Name: github.com/go-viper/mapstructure/v2.DecodeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 875
+      ID: 882
       Name: github.com/go-viper/mapstructure/v2.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 873
+      ID: 880
       Name: github.com/go-viper/mapstructure/v2.UnconvertibleTypeError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 877
+      ID: 884
       Name: github.com/gogo/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 879
+      ID: 886
       Name: github.com/gogo/protobuf/proto.invalidUTF8Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1091
+      ID: 1098
       Name: github.com/gogo/protobuf/proto.textWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 867
+      ID: 874
       Name: github.com/golang/protobuf/proto.RequiredNotSetError
       ByteSize: 8
     - __kind: StructureType
-      ID: 677
+      ID: 684
       Name: github.com/google/uuid.invalidLengthError
       ByteSize: 8
       GoRuntimeType: 1.424992e+06
       GoKind: 25
       RawFields: [{Name: len, Offset: 0, Type: 7 BaseType int}]
     - __kind: UnresolvedPointeeType
-      ID: 1195
+      ID: 1202
       Name: github.com/json-iterator/go.Stream
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 933
+      ID: 940
       Name: github.com/pkg/errors.fundamental
       ByteSize: 8
     - __kind: StructureType
-      ID: 906
+      ID: 913
       Name: github.com/tinylib/msgp/msgp.ArrayError
       ByteSize: 24
       GoRuntimeType: 1.843488e+06
@@ -13015,11 +16047,11 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 900
+      ID: 907
       Name: github.com/tinylib/msgp/msgp.ErrUnsupportedType
       ByteSize: 8
     - __kind: StructureType
-      ID: 835
+      ID: 842
       Name: github.com/tinylib/msgp/msgp.ExtensionTypeError
       ByteSize: 2
       GoRuntimeType: 1.703136e+06
@@ -13032,7 +16064,7 @@ Types:
           Offset: 1
           Type: 17 BaseType int8
     - __kind: StructureType
-      ID: 912
+      ID: 919
       Name: github.com/tinylib/msgp/msgp.IntOverflow
       ByteSize: 32
       GoRuntimeType: 1.843936e+06
@@ -13048,13 +16080,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 812
+      ID: 819
       Name: github.com/tinylib/msgp/msgp.InvalidPrefixError
       ByteSize: 1
       GoRuntimeType: 991072
       GoKind: 8
     - __kind: StructureType
-      ID: 904
+      ID: 911
       Name: github.com/tinylib/msgp/msgp.InvalidTimestamp
       ByteSize: 32
       GoRuntimeType: 1.843264e+06
@@ -13070,13 +16102,13 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 993
+      ID: 1000
       Name: github.com/tinylib/msgp/msgp.Type
       ByteSize: 1
       GoRuntimeType: 832160
       GoKind: 8
     - __kind: StructureType
-      ID: 902
+      ID: 909
       Name: github.com/tinylib/msgp/msgp.TypeError
       ByteSize: 24
       GoRuntimeType: 1.84304e+06
@@ -13084,15 +16116,15 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 993 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: Encoded
           Offset: 1
-          Type: 993 BaseType github.com/tinylib/msgp/msgp.Type
+          Type: 1000 BaseType github.com/tinylib/msgp/msgp.Type
         - Name: ctx
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 910
+      ID: 917
       Name: github.com/tinylib/msgp/msgp.UintBelowZero
       ByteSize: 24
       GoRuntimeType: 1.757088e+06
@@ -13105,7 +16137,7 @@ Types:
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 908
+      ID: 915
       Name: github.com/tinylib/msgp/msgp.UintOverflow
       ByteSize: 32
       GoRuntimeType: 1.843712e+06
@@ -13121,11 +16153,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1199
+      ID: 1206
       Name: github.com/tinylib/msgp/msgp.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 916
+      ID: 923
       Name: github.com/tinylib/msgp/msgp.errFatal
       ByteSize: 16
       GoRuntimeType: 1.624704e+06
@@ -13135,19 +16167,19 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 839
+      ID: 846
       Name: github.com/tinylib/msgp/msgp.errRecursion
       GoRuntimeType: 1.283936e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 837
+      ID: 844
       Name: github.com/tinylib/msgp/msgp.errShort
       GoRuntimeType: 1.283808e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 914
+      ID: 921
       Name: github.com/tinylib/msgp/msgp.errWrapped
       ByteSize: 32
       GoRuntimeType: 1.75728e+06
@@ -13160,7 +16192,7 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 594
+      ID: 601
       Name: go.opentelemetry.io/otel/trace.errorConst
       ByteSize: 16
       GoRuntimeType: 839744
@@ -13168,22 +16200,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 596 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
+          Type: 603 PointerType *go.opentelemetry.io/otel/trace.errorConst.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 595 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
+      Data: 602 GoStringDataType go.opentelemetry.io/otel/trace.errorConst.str
     - __kind: GoStringDataType
-      ID: 595
+      ID: 602
       Name: go.opentelemetry.io/otel/trace.errorConst.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 977
+      ID: 984
       Name: go.uber.org/multierr.multiError
       ByteSize: 8
     - __kind: StructureType
-      ID: 883
+      ID: 890
       Name: go.uber.org/zap.errArrayElem
       ByteSize: 16
       GoRuntimeType: 1.448992e+06
@@ -13193,7 +16225,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1066
+      ID: 1073
       Name: go.uber.org/zap.nopCloserSink
       ByteSize: 16
       GoRuntimeType: 1.678848e+06
@@ -13201,13 +16233,13 @@ Types:
       RawFields:
         - Name: WriteSyncer
           Offset: 0
-          Type: 1092 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
+          Type: 1099 GoInterfaceType go.uber.org/zap/zapcore.WriteSyncer
     - __kind: UnresolvedPointeeType
-      ID: 1159
+      ID: 1166
       Name: go.uber.org/zap/buffer.Buffer
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1092
+      ID: 1099
       Name: go.uber.org/zap/zapcore.WriteSyncer
       ByteSize: 16
       GoRuntimeType: 1.12816e+06
@@ -13220,7 +16252,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1054
+      ID: 1061
       Name: go.uber.org/zap/zapcore.writerWrapper
       ByteSize: 16
       GoRuntimeType: 1.571296e+06
@@ -13230,19 +16262,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 597
+      ID: 604
       Name: golang.org/x/net/http2.ConnectionError
       ByteSize: 4
       GoRuntimeType: 840320
       GoKind: 10
     - __kind: BaseType
-      ID: 975
+      ID: 982
       Name: golang.org/x/net/http2.ErrCode
       ByteSize: 4
       GoRuntimeType: 1.004224e+06
       GoKind: 10
     - __kind: StructureType
-      ID: 941
+      ID: 948
       Name: golang.org/x/net/http2.StreamError
       ByteSize: 24
       GoRuntimeType: 1.881792e+06
@@ -13253,12 +16285,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 975 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 798
+      ID: 805
       Name: golang.org/x/net/http2.connError
       ByteSize: 24
       GoRuntimeType: 1.607328e+06
@@ -13266,12 +16298,12 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 975 BaseType golang.org/x/net/http2.ErrCode
+          Type: 982 BaseType golang.org/x/net/http2.ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: GoStringHeaderType
-      ID: 601
+      ID: 608
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840512
@@ -13279,18 +16311,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 603 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
+          Type: 610 PointerType *golang.org/x/net/http2.duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 602 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
+      Data: 609 GoStringDataType golang.org/x/net/http2.duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 602
+      ID: 609
       Name: golang.org/x/net/http2.duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 607
+      ID: 614
       Name: golang.org/x/net/http2.headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 840704
@@ -13298,18 +16330,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 609 PointerType *golang.org/x/net/http2.headerFieldNameError.str
+          Type: 616 PointerType *golang.org/x/net/http2.headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 608 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
+      Data: 615 GoStringDataType golang.org/x/net/http2.headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 608
+      ID: 615
       Name: golang.org/x/net/http2.headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 604
+      ID: 611
       Name: golang.org/x/net/http2.headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 840608
@@ -13317,18 +16349,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 606 PointerType *golang.org/x/net/http2.headerFieldValueError.str
+          Type: 613 PointerType *golang.org/x/net/http2.headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 605 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
+      Data: 612 GoStringDataType golang.org/x/net/http2.headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 605
+      ID: 612
       Name: golang.org/x/net/http2.headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 598
+      ID: 605
       Name: golang.org/x/net/http2.pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 840416
@@ -13336,22 +16368,22 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 600 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
+          Type: 607 PointerType *golang.org/x/net/http2.pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 599 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
+      Data: 606 GoStringDataType golang.org/x/net/http2.pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 599
+      ID: 606
       Name: golang.org/x/net/http2.pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1157
+      ID: 1164
       Name: golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 802
+      ID: 809
       Name: golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.449632e+06
@@ -13361,13 +16393,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 610
+      ID: 617
       Name: golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 840800
       GoKind: 2
     - __kind: StructureType
-      ID: 790
+      ID: 797
       Name: google.golang.org/grpc.dropError
       ByteSize: 16
       GoRuntimeType: 1.444672e+06
@@ -13377,11 +16409,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 939
+      ID: 946
       Name: google.golang.org/grpc/internal/status.Error
       ByteSize: 8
     - __kind: StructureType
-      ID: 964
+      ID: 971
       Name: google.golang.org/grpc/internal/transport.ConnectionError
       ByteSize: 40
       GoRuntimeType: 1.909568e+06
@@ -13397,7 +16429,7 @@ Types:
           Offset: 24
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 792
+      ID: 799
       Name: google.golang.org/grpc/internal/transport.NewStreamError
       ByteSize: 24
       GoRuntimeType: 1.606848e+06
@@ -13410,7 +16442,7 @@ Types:
           Offset: 16
           Type: 4 BaseType bool
     - __kind: StructureType
-      ID: 1106
+      ID: 1113
       Name: google.golang.org/grpc/internal/transport.bufConn
       ByteSize: 32
       GoRuntimeType: 1.967616e+06
@@ -13418,16 +16450,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: r
           Offset: 16
-          Type: 1133 GoInterfaceType io.Reader
+          Type: 1140 GoInterfaceType io.Reader
     - __kind: UnresolvedPointeeType
-      ID: 1064
+      ID: 1071
       Name: google.golang.org/grpc/internal/transport.bufWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 881
+      ID: 888
       Name: google.golang.org/grpc/internal/transport.ioError
       ByteSize: 16
       GoRuntimeType: 1.568896e+06
@@ -13437,29 +16469,29 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1026
+      ID: 1033
       Name: google.golang.org/grpc/mem.writer
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 770
+      ID: 777
       Name: google.golang.org/protobuf/internal/errors.SizeMismatchError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 869
+      ID: 876
       Name: google.golang.org/protobuf/internal/errors.prefixError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 937
+      ID: 944
       Name: google.golang.org/protobuf/internal/errors.wrapError
       ByteSize: 8
     - __kind: StructureType
-      ID: 935
+      ID: 942
       Name: google.golang.org/protobuf/internal/impl.errInvalidUTF8
       GoRuntimeType: 1.512416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 784
+      ID: 791
       Name: gopkg.in/ini%2ev1.ErrDelimiterNotFound
       ByteSize: 16
       GoRuntimeType: 1.437952e+06
@@ -13469,7 +16501,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 786
+      ID: 793
       Name: gopkg.in/ini%2ev1.ErrEmptyKeyName
       ByteSize: 16
       GoRuntimeType: 1.438112e+06
@@ -13479,393 +16511,393 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 714
+      ID: 721
       Name: gopkg.in/yaml%2ev3.TypeError
       ByteSize: 8
     - __kind: GoSwissMapGroupsType
-      ID: 429
+      ID: 436
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 430 PointerType *noalg.map.group[[4]int][4]int
+          Type: 437 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 431 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 435 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 438 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 442 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 421
+      ID: 428
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 422 PointerType *noalg.map.group[[4]int]uint8
+          Type: 429 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 423 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 427 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 430 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 434 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 369
+      ID: 376
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 370 PointerType *noalg.map.group[[4]string][2]int
+          Type: 377 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 371 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 376 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 378 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 383 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 388
+      ID: 395
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 389 PointerType *noalg.map.group[bool]main.node
+          Type: 396 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 390 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 394 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 397 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 401 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: GoSwissMapGroupsType
-      ID: 327
+      ID: 334
       Name: groupReference<int,*main.deepMap2>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 328 PointerType *noalg.map.group[int]*main.deepMap2
+          Type: 335 PointerType *noalg.map.group[int]*main.deepMap2
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 329 StructureType noalg.map.group[int]*main.deepMap2
-      GroupSliceType: 335 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
+      GroupType: 336 StructureType noalg.map.group[int]*main.deepMap2
+      GroupSliceType: 342 GoSliceDataType []noalg.map.group[int]*main.deepMap2.array
     - __kind: GoSwissMapGroupsType
-      ID: 1240
+      ID: 1247
       Name: groupReference<int,*main.deepMap3>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1241 PointerType *noalg.map.group[int]*main.deepMap3
+          Type: 1248 PointerType *noalg.map.group[int]*main.deepMap3
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1242 StructureType noalg.map.group[int]*main.deepMap3
-      GroupSliceType: 1248 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
+      GroupType: 1249 StructureType noalg.map.group[int]*main.deepMap3
+      GroupSliceType: 1255 GoSliceDataType []noalg.map.group[int]*main.deepMap3.array
     - __kind: GoSwissMapGroupsType
-      ID: 1274
+      ID: 1281
       Name: groupReference<int,*main.deepMap8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1275 PointerType *noalg.map.group[int]*main.deepMap8
+          Type: 1282 PointerType *noalg.map.group[int]*main.deepMap8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1276 StructureType noalg.map.group[int]*main.deepMap8
-      GroupSliceType: 1282 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
+      GroupType: 1283 StructureType noalg.map.group[int]*main.deepMap8
+      GroupSliceType: 1289 GoSliceDataType []noalg.map.group[int]*main.deepMap8.array
     - __kind: GoSwissMapGroupsType
-      ID: 1289
+      ID: 1296
       Name: groupReference<int,*main.deepMap9>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1290 PointerType *noalg.map.group[int]*main.deepMap9
+          Type: 1297 PointerType *noalg.map.group[int]*main.deepMap9
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1291 StructureType noalg.map.group[int]*main.deepMap9
-      GroupSliceType: 1297 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
+      GroupType: 1298 StructureType noalg.map.group[int]*main.deepMap9
+      GroupSliceType: 1304 GoSliceDataType []noalg.map.group[int]*main.deepMap9.array
     - __kind: GoSwissMapGroupsType
-      ID: 337
+      ID: 344
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 338 PointerType *noalg.map.group[int]int
+          Type: 345 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 339 StructureType noalg.map.group[int]int
-      GroupSliceType: 343 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 346 StructureType noalg.map.group[int]int
+      GroupSliceType: 350 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 1304
+      ID: 1311
       Name: groupReference<int,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1305 PointerType *noalg.map.group[int]interface {}
+          Type: 1312 PointerType *noalg.map.group[int]interface {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1306 StructureType noalg.map.group[int]interface {}
-      GroupSliceType: 1310 GoSliceDataType []noalg.map.group[int]interface {}.array
+      GroupType: 1313 StructureType noalg.map.group[int]interface {}
+      GroupSliceType: 1317 GoSliceDataType []noalg.map.group[int]interface {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 445
+      ID: 452
       Name: groupReference<int,struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 446 PointerType *noalg.map.group[int]struct {}
+          Type: 453 PointerType *noalg.map.group[int]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 447 StructureType noalg.map.group[int]struct {}
-      GroupSliceType: 451 GoSliceDataType []noalg.map.group[int]struct {}.array
+      GroupType: 454 StructureType noalg.map.group[int]struct {}
+      GroupSliceType: 458 GoSliceDataType []noalg.map.group[int]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 396
+      ID: 403
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 397 PointerType *noalg.map.group[int]uint8
+          Type: 404 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 398 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 402 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 405 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 409 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: GoSwissMapGroupsType
-      ID: 378
+      ID: 385
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 379 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 386 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 380 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 386 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 387 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 393 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: GoSwissMapGroupsType
-      ID: 361
+      ID: 368
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 362 PointerType *noalg.map.group[string][]string
+          Type: 369 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 363 StructureType noalg.map.group[string][]string
-      GroupSliceType: 367 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 370 StructureType noalg.map.group[string][]string
+      GroupSliceType: 374 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: GoSwissMapGroupsType
-      ID: 1000
+      ID: 1007
       Name: groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 1001 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+          Type: 1008 PointerType *noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
-      GroupSliceType: 1006 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      GroupSliceType: 1013 GoSliceDataType []noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes.array
     - __kind: GoSwissMapGroupsType
-      ID: 353
+      ID: 360
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 354 PointerType *noalg.map.group[string]int
+          Type: 361 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 355 StructureType noalg.map.group[string]int
-      GroupSliceType: 359 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 362 StructureType noalg.map.group[string]int
+      GroupSliceType: 366 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 345
+      ID: 352
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 346 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 353 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 347 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 351 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 354 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 358 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 437
+      ID: 444
       Name: groupReference<struct {},int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 438 PointerType *noalg.map.group[struct {}]int
+          Type: 445 PointerType *noalg.map.group[struct {}]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 439 StructureType noalg.map.group[struct {}]int
-      GroupSliceType: 443 GoSliceDataType []noalg.map.group[struct {}]int.array
+      GroupType: 446 StructureType noalg.map.group[struct {}]int
+      GroupSliceType: 450 GoSliceDataType []noalg.map.group[struct {}]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 487
+      ID: 494
       Name: groupReference<struct {},main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 488 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
+          Type: 495 PointerType *noalg.map.group[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 493 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
+      GroupType: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 500 GoSliceDataType []noalg.map.group[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 495
+      ID: 502
       Name: groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 496 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 503 PointerType *noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 501 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 508 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 503
+      ID: 510
       Name: groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 504 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 511 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 509 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 516 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 511
+      ID: 518
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 512 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 519 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 517 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 524 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 519
+      ID: 526
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 520 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 527 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 525 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 532 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 527
+      ID: 534
       Name: groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 528 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 535 PointerType *noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
-      GroupSliceType: 533 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
+      GroupType: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      GroupSliceType: 540 GoSliceDataType []noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps.array
     - __kind: GoSwissMapGroupsType
-      ID: 453
+      ID: 460
       Name: groupReference<struct {},struct {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 454 PointerType *noalg.map.group[struct {}]struct {}
+          Type: 461 PointerType *noalg.map.group[struct {}]struct {}
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 455 StructureType noalg.map.group[struct {}]struct {}
-      GroupSliceType: 459 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
+      GroupType: 462 StructureType noalg.map.group[struct {}]struct {}
+      GroupSliceType: 466 GoSliceDataType []noalg.map.group[struct {}]struct {}.array
     - __kind: GoSwissMapGroupsType
-      ID: 412
+      ID: 419
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 413 PointerType *noalg.map.group[uint8][4]int
+          Type: 420 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 414 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 419 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 421 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 426 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 404
+      ID: 411
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 405 PointerType *noalg.map.group[uint8]uint8
+          Type: 412 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 406 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 410 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 413 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 417 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: UnresolvedPointeeType
-      ID: 1114
+      ID: 1121
       Name: hash/crc32.digest
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 805
+      ID: 812
       Name: html/template.Error
       ByteSize: 8
     - __kind: BaseType
@@ -13912,11 +16944,11 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 966
+      ID: 973
       Name: internal/abi.Type
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 682
+      ID: 689
       Name: internal/bisect.parseError
       ByteSize: 8
     - __kind: StructureType
@@ -13942,29 +16974,29 @@ Types:
           Offset: 296
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 680
+      ID: 687
       Name: internal/chacha8rand.errUnmarshalChaCha8
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1012
+      ID: 1019
       Name: internal/godebug.runtimeStderr
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 898
+      ID: 905
       Name: internal/poll.DeadlineExceededError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1201
+      ID: 1208
       Name: internal/poll.FD
       ByteSize: 8
     - __kind: StructureType
-      ID: 896
+      ID: 903
       Name: internal/poll.errNetClosing
       GoRuntimeType: 1.477536e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 616
+      ID: 623
       Name: internal/reflectlite.ValueError
       ByteSize: 8
     - __kind: StructureType
@@ -14045,7 +17077,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
-      ID: 569
+      ID: 576
       Name: internal/runtime/cgroup.stringError
       ByteSize: 16
       GoRuntimeType: 834944
@@ -14053,18 +17085,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 571 PointerType *internal/runtime/cgroup.stringError.str
+          Type: 578 PointerType *internal/runtime/cgroup.stringError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 570 GoStringDataType internal/runtime/cgroup.stringError.str
+      Data: 577 GoStringDataType internal/runtime/cgroup.stringError.str
     - __kind: GoStringDataType
-      ID: 570
+      ID: 577
       Name: internal/runtime/cgroup.stringError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 853
+      ID: 860
       Name: internal/runtime/maps.unhashableTypeError
       ByteSize: 8
       GoRuntimeType: 1.560256e+06
@@ -14072,9 +17104,9 @@ Types:
       RawFields:
         - Name: typ
           Offset: 0
-          Type: 965 PointerType *internal/abi.Type
+          Type: 972 PointerType *internal/abi.Type
     - __kind: StructureType
-      ID: 1213
+      ID: 1220
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.474976e+06
@@ -14087,11 +17119,11 @@ Types:
           Offset: 4
           Type: 2 BaseType uint32
     - __kind: UnresolvedPointeeType
-      ID: 1058
+      ID: 1065
       Name: io.PipeWriter
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 1098
+      ID: 1105
       Name: io.ReadWriteCloser
       ByteSize: 16
       GoRuntimeType: 1.190688e+06
@@ -14104,7 +17136,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1133
+      ID: 1140
       Name: io.Reader
       ByteSize: 16
       GoRuntimeType: 1.024288e+06
@@ -14117,7 +17149,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 1085
+      ID: 1092
       Name: io.WriteCloser
       ByteSize: 16
       GoRuntimeType: 1.110752e+06
@@ -14143,25 +17175,25 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 1056
+      ID: 1063
       Name: io.discard
       GoRuntimeType: 1.464576e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1030
+      ID: 1037
       Name: io.multiWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 894
+      ID: 901
       Name: io/fs.PathError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1104
+      ID: 1111
       Name: log/slog/internal/buffer.Buffer
       ByteSize: 8
     - __kind: StructureType
-      ID: 309
+      ID: 316
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -14217,7 +17249,7 @@ Types:
           Offset: 0
           Type: 144 GoMapType map[int]*main.deepMap2
     - __kind: StructureType
-      ID: 333
+      ID: 340
       Name: main.deepMap2
       ByteSize: 8
       GoRuntimeType: 1.186976e+06
@@ -14225,9 +17257,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1234 GoMapType map[int]*main.deepMap3
+          Type: 1241 GoMapType map[int]*main.deepMap3
     - __kind: UnresolvedPointeeType
-      ID: 1246
+      ID: 1253
       Name: main.deepMap3
       ByteSize: 8
     - __kind: StructureType
@@ -14239,9 +17271,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1268 GoMapType map[int]*main.deepMap8
+          Type: 1275 GoMapType map[int]*main.deepMap8
     - __kind: StructureType
-      ID: 1280
+      ID: 1287
       Name: main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.186208e+06
@@ -14249,9 +17281,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1283 GoMapType map[int]*main.deepMap9
+          Type: 1290 GoMapType map[int]*main.deepMap9
     - __kind: StructureType
-      ID: 1295
+      ID: 1302
       Name: main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.18608e+06
@@ -14259,7 +17291,7 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1298 GoMapType map[int]interface {}
+          Type: 1305 GoMapType map[int]interface {}
     - __kind: StructureType
       ID: 132
       Name: main.deepPtr1
@@ -14279,9 +17311,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1204 PointerType *main.deepPtr3
+          Type: 1211 PointerType *main.deepPtr3
     - __kind: UnresolvedPointeeType
-      ID: 1205
+      ID: 1212
       Name: main.deepPtr3
       ByteSize: 8
     - __kind: StructureType
@@ -14293,9 +17325,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1249 PointerType *main.deepPtr8
+          Type: 1256 PointerType *main.deepPtr8
     - __kind: StructureType
-      ID: 1250
+      ID: 1257
       Name: main.deepPtr8
       ByteSize: 8
       GoRuntimeType: 1.18736e+06
@@ -14303,9 +17335,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1251 PointerType *main.deepPtr9
+          Type: 1258 PointerType *main.deepPtr9
     - __kind: StructureType
-      ID: 1252
+      ID: 1259
       Name: main.deepPtr9
       ByteSize: 16
       GoRuntimeType: 1.187232e+06
@@ -14325,7 +17357,7 @@ Types:
           Offset: 0
           Type: 138 GoSliceHeaderType []*main.deepSlice2
     - __kind: StructureType
-      ID: 323
+      ID: 330
       Name: main.deepSlice2
       ByteSize: 24
       GoRuntimeType: 1.18928e+06
@@ -14333,9 +17365,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1228 GoSliceHeaderType []*main.deepSlice3
+          Type: 1235 GoSliceHeaderType []*main.deepSlice3
     - __kind: UnresolvedPointeeType
-      ID: 1231
+      ID: 1238
       Name: main.deepSlice3
       ByteSize: 8
     - __kind: StructureType
@@ -14347,9 +17379,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1253 GoSliceHeaderType []*main.deepSlice8
+          Type: 1260 GoSliceHeaderType []*main.deepSlice8
     - __kind: StructureType
-      ID: 1256
+      ID: 1263
       Name: main.deepSlice8
       ByteSize: 24
       GoRuntimeType: 1.188512e+06
@@ -14357,9 +17389,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1259 GoSliceHeaderType []*main.deepSlice9
+          Type: 1266 GoSliceHeaderType []*main.deepSlice9
     - __kind: StructureType
-      ID: 1262
+      ID: 1269
       Name: main.deepSlice9
       ByteSize: 24
       GoRuntimeType: 1.188384e+06
@@ -14367,9 +17399,9 @@ Types:
       RawFields:
         - Name: a
           Offset: 0
-          Type: 1265 GoSliceHeaderType []interface {}
+          Type: 1272 GoSliceHeaderType []interface {}
     - __kind: StructureType
-      ID: 310
+      ID: 317
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
@@ -14385,16 +17417,16 @@ Types:
           Type: 155 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 1211 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 1214 StructureType sync.Once
+          Type: 1221 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 1217 StructureType sync.WaitGroup
+          Type: 1224 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 1220 StructureType sync/atomic.Int32
+          Type: 1227 StructureType sync/atomic.Int32
     - __kind: StructureType
       ID: 155
       Name: main.esotericStack
@@ -14424,7 +17456,7 @@ Types:
           Offset: 56
           Type: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 1222
+      ID: 1229
       Name: main.firstBehavior
       ByteSize: 16
       GoRuntimeType: 1.413632e+06
@@ -14433,6 +17465,57 @@ Types:
         - Name: s
           Offset: 0
           Type: 9 GoStringHeaderType string
+    - __kind: StructureType
+      ID: 250
+      Name: main.largeStruct
+      ByteSize: 80
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 254
+      Name: main.mixedStruct
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 16 BaseType float64
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
     - __kind: StructureType
       ID: 123
       Name: main.nestedStruct
@@ -14460,7 +17543,7 @@ Types:
           Offset: 8
           Type: 247 PointerType *main.node
     - __kind: StructureType
-      ID: 264
+      ID: 271
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -14469,7 +17552,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1224
+      ID: 1231
       Name: main.secondBehavior
       ByteSize: 8
       GoRuntimeType: 1.413792e+06
@@ -14489,7 +17572,7 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 1210
+      ID: 1217
       Name: main.somethingImpl
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -14500,18 +17583,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 1207 PointerType *main.stringType1.str
+          Type: 1214 PointerType *main.stringType1.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 1206 GoStringDataType main.stringType1.str
+      Data: 1213 GoStringDataType main.stringType1.str
     - __kind: GoStringDataType
-      ID: 1206
+      ID: 1213
       Name: main.stringType1.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1208
+      ID: 1215
       Name: main.stringType2
       ByteSize: 8
     - __kind: StructureType
@@ -14525,53 +17608,65 @@ Types:
           Offset: 0
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 278
+      ID: 256
+      Name: main.structWithArray
+      ByteSize: 24
+      GoKind: 25
+      RawFields:
+        - Name: arr
+          Offset: 0
+          Type: 113 ArrayType [2]int
+        - Name: x
+          Offset: 16
+          Type: 7 BaseType int
+    - __kind: StructureType
+      ID: 285
       Name: main.structWithCyclicMaps
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: m1
           Offset: 0
-          Type: 279 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
         - Name: m2
           Offset: 8
-          Type: 284 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m3
           Offset: 16
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m4
           Offset: 24
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m5
           Offset: 32
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
         - Name: m6
           Offset: 40
-          Type: 304 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 311 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 265
+      ID: 272
       Name: main.structWithCyclicSlices
       ByteSize: 144
       GoKind: 25
       RawFields:
         - Name: s1
           Offset: 0
-          Type: 266 GoSliceHeaderType []main.structWithCyclicSlices
+          Type: 273 GoSliceHeaderType []main.structWithCyclicSlices
         - Name: s2
           Offset: 24
-          Type: 268 GoSliceHeaderType [][]main.structWithCyclicSlices
+          Type: 275 GoSliceHeaderType [][]main.structWithCyclicSlices
         - Name: s3
           Offset: 48
-          Type: 270 GoSliceHeaderType [][][]main.structWithCyclicSlices
+          Type: 277 GoSliceHeaderType [][][]main.structWithCyclicSlices
         - Name: s4
           Offset: 72
-          Type: 272 GoSliceHeaderType [][][][]main.structWithCyclicSlices
+          Type: 279 GoSliceHeaderType [][][][]main.structWithCyclicSlices
         - Name: s5
           Offset: 96
-          Type: 274 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
+          Type: 281 GoSliceHeaderType [][][][][]main.structWithCyclicSlices
         - Name: s6
           Offset: 120
-          Type: 276 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
+          Type: 283 GoSliceHeaderType [][][][][][]main.structWithCyclicSlices
     - __kind: StructureType
       ID: 165
       Name: main.structWithMap
@@ -14583,7 +17678,7 @@ Types:
           Offset: 0
           Type: 166 GoMapType map[int]int
     - __kind: StructureType
-      ID: 255
+      ID: 262
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -14614,22 +17709,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 1225 PointerType **main.t
+          Type: 1232 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 7 BaseType int
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 1226 GoSliceDataType main.t.array
+      Data: 1233 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 1226
+      ID: 1233
       Name: main.t.array
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 248 PointerType *main.t
     - __kind: StructureType
-      ID: 261
+      ID: 268
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -14648,6 +17743,45 @@ Types:
       Name: main.typeAlias
       ByteSize: 2
       GoKind: 9
+    - __kind: StructureType
+      ID: 255
+      Name: main.wideStruct
+      ByteSize: 88
+      GoKind: 25
+      RawFields:
+        - Name: a
+          Offset: 0
+          Type: 7 BaseType int
+        - Name: b
+          Offset: 8
+          Type: 7 BaseType int
+        - Name: c
+          Offset: 16
+          Type: 7 BaseType int
+        - Name: d
+          Offset: 24
+          Type: 7 BaseType int
+        - Name: e
+          Offset: 32
+          Type: 7 BaseType int
+        - Name: f
+          Offset: 40
+          Type: 7 BaseType int
+        - Name: g
+          Offset: 48
+          Type: 7 BaseType int
+        - Name: h
+          Offset: 56
+          Type: 7 BaseType int
+        - Name: i
+          Offset: 64
+          Type: 7 BaseType int
+        - Name: j
+          Offset: 72
+          Type: 7 BaseType int
+        - Name: k
+          Offset: 80
+          Type: 7 BaseType int
     - __kind: GoSwissMapHeaderType
       ID: 225
       Name: map<[4]int,[4]int>
@@ -14681,8 +17815,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 434 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 431 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 441 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 438 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSwissMapHeaderType
       ID: 220
       Name: map<[4]int,uint8>
@@ -14716,8 +17850,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 426 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 423 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 433 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 430 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 188
       Name: map<[4]string,[2]int>
@@ -14751,8 +17885,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 375 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 371 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 382 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 378 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSwissMapHeaderType
       ID: 200
       Name: map<bool,main.node>
@@ -14786,8 +17920,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 393 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 390 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 400 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 397 StructureType noalg.map.group[bool]main.node
     - __kind: GoSwissMapHeaderType
       ID: 146
       Name: map<int,*main.deepMap2>
@@ -14821,10 +17955,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 334 GoSliceDataType []*table<int,*main.deepMap2>.array
-      GroupType: 329 StructureType noalg.map.group[int]*main.deepMap2
+      TablePtrSliceType: 341 GoSliceDataType []*table<int,*main.deepMap2>.array
+      GroupType: 336 StructureType noalg.map.group[int]*main.deepMap2
     - __kind: GoSwissMapHeaderType
-      ID: 1236
+      ID: 1243
       Name: map<int,*main.deepMap3>
       ByteSize: 48
       GoKind: 25
@@ -14837,7 +17971,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1237 PointerType **table<int,*main.deepMap3>
+          Type: 1244 PointerType **table<int,*main.deepMap3>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14856,10 +17990,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1247 GoSliceDataType []*table<int,*main.deepMap3>.array
-      GroupType: 1242 StructureType noalg.map.group[int]*main.deepMap3
+      TablePtrSliceType: 1254 GoSliceDataType []*table<int,*main.deepMap3>.array
+      GroupType: 1249 StructureType noalg.map.group[int]*main.deepMap3
     - __kind: GoSwissMapHeaderType
-      ID: 1270
+      ID: 1277
       Name: map<int,*main.deepMap8>
       ByteSize: 48
       GoKind: 25
@@ -14872,7 +18006,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1271 PointerType **table<int,*main.deepMap8>
+          Type: 1278 PointerType **table<int,*main.deepMap8>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14891,10 +18025,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1281 GoSliceDataType []*table<int,*main.deepMap8>.array
-      GroupType: 1276 StructureType noalg.map.group[int]*main.deepMap8
+      TablePtrSliceType: 1288 GoSliceDataType []*table<int,*main.deepMap8>.array
+      GroupType: 1283 StructureType noalg.map.group[int]*main.deepMap8
     - __kind: GoSwissMapHeaderType
-      ID: 1285
+      ID: 1292
       Name: map<int,*main.deepMap9>
       ByteSize: 48
       GoKind: 25
@@ -14907,7 +18041,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1286 PointerType **table<int,*main.deepMap9>
+          Type: 1293 PointerType **table<int,*main.deepMap9>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14926,8 +18060,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1296 GoSliceDataType []*table<int,*main.deepMap9>.array
-      GroupType: 1291 StructureType noalg.map.group[int]*main.deepMap9
+      TablePtrSliceType: 1303 GoSliceDataType []*table<int,*main.deepMap9>.array
+      GroupType: 1298 StructureType noalg.map.group[int]*main.deepMap9
     - __kind: GoSwissMapHeaderType
       ID: 168
       Name: map<int,int>
@@ -14961,10 +18095,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 342 GoSliceDataType []*table<int,int>.array
-      GroupType: 339 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 349 GoSliceDataType []*table<int,int>.array
+      GroupType: 346 StructureType noalg.map.group[int]int
     - __kind: GoSwissMapHeaderType
-      ID: 1300
+      ID: 1307
       Name: map<int,interface {}>
       ByteSize: 48
       GoKind: 25
@@ -14977,7 +18111,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 1301 PointerType **table<int,interface {}>
+          Type: 1308 PointerType **table<int,interface {}>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -14996,8 +18130,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1309 GoSliceDataType []*table<int,interface {}>.array
-      GroupType: 1306 StructureType noalg.map.group[int]interface {}
+      TablePtrSliceType: 1316 GoSliceDataType []*table<int,interface {}>.array
+      GroupType: 1313 StructureType noalg.map.group[int]interface {}
     - __kind: GoSwissMapHeaderType
       ID: 235
       Name: map<int,struct {}>
@@ -15031,8 +18165,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 450 GoSliceDataType []*table<int,struct {}>.array
-      GroupType: 447 StructureType noalg.map.group[int]struct {}
+      TablePtrSliceType: 457 GoSliceDataType []*table<int,struct {}>.array
+      GroupType: 454 StructureType noalg.map.group[int]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 205
       Name: map<int,uint8>
@@ -15066,8 +18200,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 401 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 398 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 408 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 405 StructureType noalg.map.group[int]uint8
     - __kind: GoSwissMapHeaderType
       ID: 195
       Name: map<string,[]main.structWithMap>
@@ -15101,8 +18235,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 385 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 380 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 392 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 387 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSwissMapHeaderType
       ID: 183
       Name: map<string,[]string>
@@ -15136,10 +18270,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 366 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 363 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 373 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 370 StructureType noalg.map.group[string][]string
     - __kind: GoSwissMapHeaderType
-      ID: 970
+      ID: 977
       Name: map<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 48
       GoKind: 25
@@ -15152,7 +18286,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 971 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 978 PointerType **table<string,github.com/DataDog/go-tuf/data.HexBytes>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15171,8 +18305,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 1005 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
-      GroupType: 1002 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
+      TablePtrSliceType: 1012 GoSliceDataType []*table<string,github.com/DataDog/go-tuf/data.HexBytes>.array
+      GroupType: 1009 StructureType noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
     - __kind: GoSwissMapHeaderType
       ID: 178
       Name: map<string,int>
@@ -15206,8 +18340,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 358 GoSliceDataType []*table<string,int>.array
-      GroupType: 355 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 365 GoSliceDataType []*table<string,int>.array
+      GroupType: 362 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 173
       Name: map<string,main.nestedStruct>
@@ -15241,8 +18375,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 350 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 347 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 357 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 354 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSwissMapHeaderType
       ID: 230
       Name: map<struct {},int>
@@ -15276,10 +18410,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 442 GoSliceDataType []*table<struct {},int>.array
-      GroupType: 439 StructureType noalg.map.group[struct {}]int
+      TablePtrSliceType: 449 GoSliceDataType []*table<struct {},int>.array
+      GroupType: 446 StructureType noalg.map.group[struct {}]int
     - __kind: GoSwissMapHeaderType
-      ID: 281
+      ID: 288
       Name: map<struct {},main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15292,7 +18426,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 282 PointerType **table<struct {},main.structWithCyclicMaps>
+          Type: 289 PointerType **table<struct {},main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15311,10 +18445,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 492 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
-      GroupType: 489 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 499 GoSliceDataType []*table<struct {},main.structWithCyclicMaps>.array
+      GroupType: 496 StructureType noalg.map.group[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 286
+      ID: 293
       Name: map<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15327,7 +18461,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 287 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 294 PointerType **table<struct {},map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15346,10 +18480,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 500 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 497 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 507 GoSliceDataType []*table<struct {},map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 504 StructureType noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 291
+      ID: 298
       Name: map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15362,7 +18496,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 292 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 299 PointerType **table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15381,10 +18515,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 508 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 505 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 515 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 512 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 296
+      ID: 303
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15397,7 +18531,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 297 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 304 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15416,10 +18550,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 516 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 513 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 523 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 520 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 301
+      ID: 308
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15432,7 +18566,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 302 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 309 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15451,10 +18585,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 524 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 521 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 531 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 528 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
-      ID: 306
+      ID: 313
       Name: map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 48
       GoKind: 25
@@ -15467,7 +18601,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 307 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 314 PointerType **table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -15486,8 +18620,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 532 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
-      GroupType: 529 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+      TablePtrSliceType: 539 GoSliceDataType []*table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>.array
+      GroupType: 536 StructureType noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: GoSwissMapHeaderType
       ID: 240
       Name: map<struct {},struct {}>
@@ -15521,8 +18655,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 458 GoSliceDataType []*table<struct {},struct {}>.array
-      GroupType: 455 StructureType noalg.map.group[struct {}]struct {}
+      TablePtrSliceType: 465 GoSliceDataType []*table<struct {},struct {}>.array
+      GroupType: 462 StructureType noalg.map.group[struct {}]struct {}
     - __kind: GoSwissMapHeaderType
       ID: 215
       Name: map<uint8,[4]int>
@@ -15556,8 +18690,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 418 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 414 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 425 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 421 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSwissMapHeaderType
       ID: 210
       Name: map<uint8,uint8>
@@ -15591,8 +18725,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 409 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 406 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 416 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 413 StructureType noalg.map.group[uint8]uint8
     - __kind: GoMapType
       ID: 223
       Name: map[[4]int][4]int
@@ -15629,26 +18763,26 @@ Types:
       GoKind: 21
       HeaderType: 146 GoSwissMapHeaderType map<int,*main.deepMap2>
     - __kind: GoMapType
-      ID: 1234
+      ID: 1241
       Name: map[int]*main.deepMap3
       ByteSize: 8
       GoRuntimeType: 1.129824e+06
       GoKind: 21
-      HeaderType: 1236 GoSwissMapHeaderType map<int,*main.deepMap3>
+      HeaderType: 1243 GoSwissMapHeaderType map<int,*main.deepMap3>
     - __kind: GoMapType
-      ID: 1268
+      ID: 1275
       Name: map[int]*main.deepMap8
       ByteSize: 8
       GoRuntimeType: 1.129184e+06
       GoKind: 21
-      HeaderType: 1270 GoSwissMapHeaderType map<int,*main.deepMap8>
+      HeaderType: 1277 GoSwissMapHeaderType map<int,*main.deepMap8>
     - __kind: GoMapType
-      ID: 1283
+      ID: 1290
       Name: map[int]*main.deepMap9
       ByteSize: 8
       GoRuntimeType: 1.129056e+06
       GoKind: 21
-      HeaderType: 1285 GoSwissMapHeaderType map<int,*main.deepMap9>
+      HeaderType: 1292 GoSwissMapHeaderType map<int,*main.deepMap9>
     - __kind: GoMapType
       ID: 166
       Name: map[int]int
@@ -15657,12 +18791,12 @@ Types:
       GoKind: 21
       HeaderType: 168 GoSwissMapHeaderType map<int,int>
     - __kind: GoMapType
-      ID: 1298
+      ID: 1305
       Name: map[int]interface {}
       ByteSize: 8
       GoRuntimeType: 1.128928e+06
       GoKind: 21
-      HeaderType: 1300 GoSwissMapHeaderType map<int,interface {}>
+      HeaderType: 1307 GoSwissMapHeaderType map<int,interface {}>
     - __kind: GoMapType
       ID: 233
       Name: map[int]struct {}
@@ -15713,41 +18847,41 @@ Types:
       GoKind: 21
       HeaderType: 230 GoSwissMapHeaderType map<struct {},int>
     - __kind: GoMapType
-      ID: 279
+      ID: 286
       Name: map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 281 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
+      HeaderType: 288 GoSwissMapHeaderType map<struct {},main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 284
+      ID: 291
       Name: map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 286 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 293 GoSwissMapHeaderType map<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 289
+      ID: 296
       Name: map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 291 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 298 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 294
+      ID: 301
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 296 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 303 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 299
+      ID: 306
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 301 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 308 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
-      ID: 304
+      ID: 311
       Name: map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 8
       GoKind: 21
-      HeaderType: 306 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+      HeaderType: 313 GoSwissMapHeaderType map<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: GoMapType
       ID: 238
       Name: map[struct {}]struct {}
@@ -15770,7 +18904,7 @@ Types:
       GoKind: 21
       HeaderType: 210 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: StructureType
-      ID: 718
+      ID: 725
       Name: math/big.ErrNaN
       ByteSize: 16
       GoRuntimeType: 1.430272e+06
@@ -15780,7 +18914,7 @@ Types:
           Offset: 0
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 1020
+      ID: 1027
       Name: mime/multipart.writerOnly·1
       ByteSize: 16
       GoRuntimeType: 1.427072e+06
@@ -15790,11 +18924,11 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: UnresolvedPointeeType
-      ID: 925
+      ID: 932
       Name: net.AddrError
       ByteSize: 8
     - __kind: GoInterfaceType
-      ID: 990
+      ID: 997
       Name: net.Conn
       ByteSize: 16
       GoRuntimeType: 1.597408e+06
@@ -15807,35 +18941,35 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: UnresolvedPointeeType
-      ID: 951
+      ID: 958
       Name: net.DNSError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1165
+      ID: 1172
       Name: net.IPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 949
+      ID: 956
       Name: net.OpError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 927
+      ID: 934
       Name: net.ParseError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1175
+      ID: 1182
       Name: net.TCPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1185
+      ID: 1192
       Name: net.UDPConn
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1173
+      ID: 1180
       Name: net.UnixConn
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 886
+      ID: 893
       Name: net.UnknownNetworkError
       ByteSize: 16
       GoRuntimeType: 1.11408e+06
@@ -15843,28 +18977,28 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 888 PointerType *net.UnknownNetworkError.str
+          Type: 895 PointerType *net.UnknownNetworkError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 887 GoStringDataType net.UnknownNetworkError.str
+      Data: 894 GoStringDataType net.UnknownNetworkError.str
     - __kind: GoStringDataType
-      ID: 887
+      ID: 894
       Name: net.UnknownNetworkError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 851
+      ID: 858
       Name: net.canceledError
       GoRuntimeType: 1.28496e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1141
+      ID: 1148
       Name: net.conn
       ByteSize: 8
     - __kind: StructureType
-      ID: 995
+      ID: 1002
       Name: net.dialResult·1
       ByteSize: 40
       GoRuntimeType: 2.10688e+06
@@ -15872,7 +19006,7 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: error
           Offset: 16
           Type: 14 GoInterfaceType error
@@ -15883,27 +19017,27 @@ Types:
           Offset: 33
           Type: 4 BaseType bool
     - __kind: UnresolvedPointeeType
-      ID: 1187
+      ID: 1194
       Name: net.netFD
       ByteSize: 8
     - __kind: StructureType
-      ID: 1181
+      ID: 1188
       Name: net.noReadFrom
       GoRuntimeType: 1.114336e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1180
+      ID: 1187
       Name: net.noWriteTo
       GoRuntimeType: 1.114208e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 648
+      ID: 655
       Name: net.notFoundError
       ByteSize: 8
     - __kind: StructureType
-      ID: 650
+      ID: 657
       Name: net.result·2
       ByteSize: 112
       GoRuntimeType: 1.73024e+06
@@ -15911,7 +19045,7 @@ Types:
       RawFields:
         - Name: p
           Offset: 0
-          Type: 978 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
+          Type: 985 StructureType vendor/golang.org/x/net/dns/dnsmessage.Parser
         - Name: server
           Offset: 80
           Type: 9 GoStringHeaderType string
@@ -15919,7 +19053,7 @@ Types:
           Offset: 96
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1169
+      ID: 1176
       Name: net.tcpConnWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.289888e+06
@@ -15927,12 +19061,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1181 StructureType net.noReadFrom
+          Type: 1188 StructureType net.noReadFrom
         - Name: TCPConn
           Offset: 0
-          Type: 1174 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: StructureType
-      ID: 1167
+      ID: 1174
       Name: net.tcpConnWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.289344e+06
@@ -15940,24 +19074,24 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1180 StructureType net.noWriteTo
+          Type: 1187 StructureType net.noWriteTo
         - Name: TCPConn
           Offset: 0
-          Type: 1174 PointerType *net.TCPConn
+          Type: 1181 PointerType *net.TCPConn
     - __kind: UnresolvedPointeeType
-      ID: 929
+      ID: 936
       Name: net.temporaryError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 953
+      ID: 960
       Name: net.timeoutError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 841
+      ID: 848
       Name: net/http.ProtocolError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1014
+      ID: 1021
       Name: net/http.bufioFlushWriter
       ByteSize: 16
       GoRuntimeType: 1.418592e+06
@@ -15967,19 +19101,19 @@ Types:
           Offset: 0
           Type: 131 GoInterfaceType io.Writer
     - __kind: BaseType
-      ID: 539
+      ID: 546
       Name: net/http.http2ConnectionError
       ByteSize: 4
       GoRuntimeType: 832640
       GoKind: 10
     - __kind: BaseType
-      ID: 967
+      ID: 974
       Name: net/http.http2ErrCode
       ByteSize: 4
       GoRuntimeType: 991168
       GoKind: 10
     - __kind: StructureType
-      ID: 626
+      ID: 633
       Name: net/http.http2GoAwayError
       ByteSize: 24
       GoRuntimeType: 1.728512e+06
@@ -15990,12 +19124,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: ErrCode
           Offset: 4
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: DebugData
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 945
+      ID: 952
       Name: net/http.http2StreamError
       ByteSize: 24
       GoRuntimeType: 1.900096e+06
@@ -16006,12 +19140,12 @@ Types:
           Type: 2 BaseType uint32
         - Name: Code
           Offset: 4
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Cause
           Offset: 8
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 630
+      ID: 637
       Name: net/http.http2connError
       ByteSize: 24
       GoRuntimeType: 1.596928e+06
@@ -16019,16 +19153,16 @@ Types:
       RawFields:
         - Name: Code
           Offset: 0
-          Type: 967 BaseType net/http.http2ErrCode
+          Type: 974 BaseType net/http.http2ErrCode
         - Name: Reason
           Offset: 8
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1076
+      ID: 1083
       Name: net/http.http2dataBuffer
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 543
+      ID: 550
       Name: net/http.http2duplicatePseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832832
@@ -16036,18 +19170,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 545 PointerType *net/http.http2duplicatePseudoHeaderError.str
+          Type: 552 PointerType *net/http.http2duplicatePseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 544 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
+      Data: 551 GoStringDataType net/http.http2duplicatePseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 544
+      ID: 551
       Name: net/http.http2duplicatePseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 549
+      ID: 556
       Name: net/http.http2headerFieldNameError
       ByteSize: 16
       GoRuntimeType: 833024
@@ -16055,18 +19189,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 551 PointerType *net/http.http2headerFieldNameError.str
+          Type: 558 PointerType *net/http.http2headerFieldNameError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 550 GoStringDataType net/http.http2headerFieldNameError.str
+      Data: 557 GoStringDataType net/http.http2headerFieldNameError.str
     - __kind: GoStringDataType
-      ID: 550
+      ID: 557
       Name: net/http.http2headerFieldNameError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 546
+      ID: 553
       Name: net/http.http2headerFieldValueError
       ByteSize: 16
       GoRuntimeType: 832928
@@ -16074,32 +19208,32 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 548 PointerType *net/http.http2headerFieldValueError.str
+          Type: 555 PointerType *net/http.http2headerFieldValueError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 547 GoStringDataType net/http.http2headerFieldValueError.str
+      Data: 554 GoStringDataType net/http.http2headerFieldValueError.str
     - __kind: GoStringDataType
-      ID: 547
+      ID: 554
       Name: net/http.http2headerFieldValueError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 920
+      ID: 927
       Name: net/http.http2httpError
       ByteSize: 8
     - __kind: StructureType
-      ID: 847
+      ID: 854
       Name: net/http.http2noCachedConnError
       GoRuntimeType: 1.284192e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 1130
+      ID: 1137
       Name: net/http.http2pipe
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 540
+      ID: 547
       Name: net/http.http2pseudoHeaderError
       ByteSize: 16
       GoRuntimeType: 832736
@@ -16107,18 +19241,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 542 PointerType *net/http.http2pseudoHeaderError.str
+          Type: 549 PointerType *net/http.http2pseudoHeaderError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 541 GoStringDataType net/http.http2pseudoHeaderError.str
+      Data: 548 GoStringDataType net/http.http2pseudoHeaderError.str
     - __kind: GoStringDataType
-      ID: 541
+      ID: 548
       Name: net/http.http2pseudoHeaderError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 1016
+      ID: 1023
       Name: net/http.http2stickyErrWriter
       ByteSize: 48
       GoRuntimeType: 1.826176e+06
@@ -16126,18 +19260,18 @@ Types:
       RawFields:
         - Name: group
           Offset: 0
-          Type: 1107 GoInterfaceType net/http.http2synctestGroupInterface
+          Type: 1114 GoInterfaceType net/http.http2synctestGroupInterface
         - Name: conn
           Offset: 16
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: timeout
           Offset: 32
-          Type: 1108 BaseType time.Duration
+          Type: 1115 BaseType time.Duration
         - Name: err
           Offset: 40
           Type: 106 PointerType *error
     - __kind: GoInterfaceType
-      ID: 1107
+      ID: 1114
       Name: net/http.http2synctestGroupInterface
       ByteSize: 16
       GoRuntimeType: 1.417792e+06
@@ -16150,14 +19284,14 @@ Types:
           Offset: 8
           Type: 15 VoidPointerType unsafe.Pointer
     - __kind: ArrayType
-      ID: 1095
+      ID: 1102
       Name: net/http.incomparable
       GoRuntimeType: 903840
       GoKind: 17
       HasCount: true
       Element: 59 GoSubroutineType func()
     - __kind: StructureType
-      ID: 843
+      ID: 850
       Name: net/http.nothingWrittenError
       ByteSize: 16
       GoRuntimeType: 1.556416e+06
@@ -16167,11 +19301,11 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 1078
+      ID: 1085
       Name: net/http.persistConn
       ByteSize: 8
     - __kind: StructureType
-      ID: 1034
+      ID: 1041
       Name: net/http.persistConnWriter
       ByteSize: 8
       GoRuntimeType: 1.556256e+06
@@ -16179,9 +19313,9 @@ Types:
       RawFields:
         - Name: pc
           Offset: 0
-          Type: 1077 PointerType *net/http.persistConn
+          Type: 1084 PointerType *net/http.persistConn
     - __kind: StructureType
-      ID: 1068
+      ID: 1075
       Name: net/http.readWriteCloserBody
       ByteSize: 24
       GoRuntimeType: 1.801152e+06
@@ -16189,15 +19323,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1095 ArrayType net/http.incomparable
+          Type: 1102 ArrayType net/http.incomparable
         - Name: br
           Offset: 0
-          Type: 1096 PointerType *bufio.Reader
+          Type: 1103 PointerType *bufio.Reader
         - Name: ReadWriteCloser
           Offset: 8
-          Type: 1098 GoInterfaceType io.ReadWriteCloser
+          Type: 1105 GoInterfaceType io.ReadWriteCloser
     - __kind: StructureType
-      ID: 634
+      ID: 641
       Name: net/http.requestBodyReadError
       ByteSize: 16
       GoRuntimeType: 1.419552e+06
@@ -16207,17 +19341,17 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: UnresolvedPointeeType
-      ID: 947
+      ID: 954
       Name: net/http.timeoutError
       ByteSize: 8
     - __kind: StructureType
-      ID: 918
+      ID: 925
       Name: net/http.tlsHandshakeTimeoutError
       GoRuntimeType: 1.480416e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 845
+      ID: 852
       Name: net/http.transportReadFromServerError
       ByteSize: 16
       GoRuntimeType: 1.556576e+06
@@ -16227,7 +19361,7 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: StructureType
-      ID: 1110
+      ID: 1117
       Name: net/http.unencryptedNetConnInTLSConn
       ByteSize: 32
       GoRuntimeType: 2.026592e+06
@@ -16235,16 +19369,16 @@ Types:
       RawFields:
         - Name: Conn
           Offset: 0
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
         - Name: conn
           Offset: 16
-          Type: 990 GoInterfaceType net.Conn
+          Type: 997 GoInterfaceType net.Conn
     - __kind: UnresolvedPointeeType
-      ID: 623
+      ID: 630
       Name: net/http.unsupportedTEError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1132
+      ID: 1139
       Name: net/http/internal.FlushAfterChunkWriter
       ByteSize: 8
       GoRuntimeType: 2.042336e+06
@@ -16252,13 +19386,13 @@ Types:
       RawFields:
         - Name: Writer
           Offset: 0
-          Type: 1125 PointerType *bufio.Writer
+          Type: 1132 PointerType *bufio.Writer
     - __kind: UnresolvedPointeeType
-      ID: 1044
+      ID: 1051
       Name: net/http/internal.chunkedWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 710
+      ID: 717
       Name: net/netip.parseAddrError
       ByteSize: 48
       GoRuntimeType: 1.733312e+06
@@ -16274,7 +19408,7 @@ Types:
           Offset: 32
           Type: 9 GoStringHeaderType string
     - __kind: StructureType
-      ID: 708
+      ID: 715
       Name: net/netip.parsePrefixError
       ByteSize: 32
       GoRuntimeType: 1.598848e+06
@@ -16287,11 +19421,11 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: UnresolvedPointeeType
-      ID: 1084
+      ID: 1091
       Name: net/smtp.Client
       ByteSize: 8
     - __kind: StructureType
-      ID: 1046
+      ID: 1053
       Name: net/smtp.dataCloser
       ByteSize: 24
       GoRuntimeType: 1.600768e+06
@@ -16299,16 +19433,16 @@ Types:
       RawFields:
         - Name: c
           Offset: 0
-          Type: 1083 PointerType *net/smtp.Client
+          Type: 1090 PointerType *net/smtp.Client
         - Name: WriteCloser
           Offset: 8
-          Type: 1085 GoInterfaceType io.WriteCloser
+          Type: 1092 GoInterfaceType io.WriteCloser
     - __kind: UnresolvedPointeeType
-      ID: 694
+      ID: 701
       Name: net/textproto.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 577
+      ID: 584
       Name: net/textproto.ProtocolError
       ByteSize: 16
       GoRuntimeType: 835712
@@ -16316,26 +19450,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 579 PointerType *net/textproto.ProtocolError.str
+          Type: 586 PointerType *net/textproto.ProtocolError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 578 GoStringDataType net/textproto.ProtocolError.str
+      Data: 585 GoStringDataType net/textproto.ProtocolError.str
     - __kind: GoStringDataType
-      ID: 578
+      ID: 585
       Name: net/textproto.ProtocolError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1042
+      ID: 1049
       Name: net/textproto.dotWriter
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 955
+      ID: 962
       Name: net/url.Error
       ByteSize: 8
     - __kind: GoStringHeaderType
-      ID: 552
+      ID: 559
       Name: net/url.EscapeError
       ByteSize: 16
       GoRuntimeType: 833600
@@ -16343,18 +19477,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 554 PointerType *net/url.EscapeError.str
+          Type: 561 PointerType *net/url.EscapeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 553 GoStringDataType net/url.EscapeError.str
+      Data: 560 GoStringDataType net/url.EscapeError.str
     - __kind: GoStringDataType
-      ID: 553
+      ID: 560
       Name: net/url.EscapeError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: GoStringHeaderType
-      ID: 555
+      ID: 562
       Name: net/url.InvalidHostError
       ByteSize: 16
       GoRuntimeType: 833696
@@ -16362,254 +19496,254 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 557 PointerType *net/url.InvalidHostError.str
+          Type: 564 PointerType *net/url.InvalidHostError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 556 GoStringDataType net/url.InvalidHostError.str
+      Data: 563 GoStringDataType net/url.InvalidHostError.str
     - __kind: GoStringDataType
-      ID: 556
+      ID: 563
       Name: net/url.InvalidHostError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: ArrayType
-      ID: 432
+      ID: 439
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 683456
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 433 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 440 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 424
+      ID: 431
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 683552
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 425 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 432 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 372
+      ID: 379
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 683840
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 373 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 380 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 391
+      ID: 398
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 683936
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 392 StructureType noalg.struct { key bool; elem main.node }
+      Element: 399 StructureType noalg.struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 330
+      ID: 337
       Name: noalg.[8]struct { key int; elem *main.deepMap2 }
       ByteSize: 128
       GoRuntimeType: 682784
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 331 StructureType noalg.struct { key int; elem *main.deepMap2 }
+      Element: 338 StructureType noalg.struct { key int; elem *main.deepMap2 }
     - __kind: ArrayType
-      ID: 1243
+      ID: 1250
       Name: noalg.[8]struct { key int; elem *main.deepMap3 }
       ByteSize: 128
       GoRuntimeType: 682688
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1244 StructureType noalg.struct { key int; elem *main.deepMap3 }
+      Element: 1251 StructureType noalg.struct { key int; elem *main.deepMap3 }
     - __kind: ArrayType
-      ID: 1277
+      ID: 1284
       Name: noalg.[8]struct { key int; elem *main.deepMap8 }
       ByteSize: 128
       GoRuntimeType: 682208
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1278 StructureType noalg.struct { key int; elem *main.deepMap8 }
+      Element: 1285 StructureType noalg.struct { key int; elem *main.deepMap8 }
     - __kind: ArrayType
-      ID: 1292
+      ID: 1299
       Name: noalg.[8]struct { key int; elem *main.deepMap9 }
       ByteSize: 128
       GoRuntimeType: 682112
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1293 StructureType noalg.struct { key int; elem *main.deepMap9 }
+      Element: 1300 StructureType noalg.struct { key int; elem *main.deepMap9 }
     - __kind: ArrayType
-      ID: 340
+      ID: 347
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 680960
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 341 StructureType noalg.struct { key int; elem int }
+      Element: 348 StructureType noalg.struct { key int; elem int }
     - __kind: ArrayType
-      ID: 1307
+      ID: 1314
       Name: noalg.[8]struct { key int; elem interface {} }
       ByteSize: 192
       GoRuntimeType: 682016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1308 StructureType noalg.struct { key int; elem interface {} }
+      Element: 1315 StructureType noalg.struct { key int; elem interface {} }
     - __kind: ArrayType
-      ID: 448
+      ID: 455
       Name: noalg.[8]struct { key int; elem struct {} }
       ByteSize: 128
       GoRuntimeType: 684032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 449 StructureType noalg.struct { key int; elem struct {} }
+      Element: 456 StructureType noalg.struct { key int; elem struct {} }
     - __kind: ArrayType
-      ID: 399
+      ID: 406
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 684128
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 400 StructureType noalg.struct { key int; elem uint8 }
+      Element: 407 StructureType noalg.struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 381
+      ID: 388
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 684224
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 382 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 389 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 364
+      ID: 371
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684320
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 365 StructureType noalg.struct { key string; elem []string }
+      Element: 372 StructureType noalg.struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 1003
+      ID: 1010
       Name: noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 320
       GoRuntimeType: 759968
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 1004 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+      Element: 1011 StructureType noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: ArrayType
-      ID: 356
+      ID: 363
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 684416
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 357 StructureType noalg.struct { key string; elem int }
+      Element: 364 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 348
+      ID: 355
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 684512
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 349 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 356 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 440
+      ID: 447
       Name: noalg.[8]struct { key struct {}; elem int }
       ByteSize: 64
       GoRuntimeType: 684608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 441 StructureType noalg.struct { key struct {}; elem int }
+      Element: 448 StructureType noalg.struct { key struct {}; elem int }
     - __kind: ArrayType
-      ID: 490
+      ID: 497
       Name: noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 491 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
+      Element: 498 StructureType noalg.struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 498
+      ID: 505
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 499 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+      Element: 506 StructureType noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 506
+      ID: 513
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 507 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 514 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 514
+      ID: 521
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 515 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 522 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 522
+      ID: 529
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 523 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 530 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 530
+      ID: 537
       Name: noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 64
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 531 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+      Element: 538 StructureType noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: ArrayType
-      ID: 456
+      ID: 463
       Name: noalg.[8]struct { key struct {}; elem struct {} }
       GoRuntimeType: 684704
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 457 StructureType noalg.struct { key struct {}; elem struct {} }
+      Element: 464 StructureType noalg.struct { key struct {}; elem struct {} }
     - __kind: ArrayType
-      ID: 415
+      ID: 422
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 684800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 416 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 423 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 407
+      ID: 414
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 684896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 408 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 415 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 431
+      ID: 438
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.295968e+06
@@ -16620,9 +19754,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 432 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 439 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 423
+      ID: 430
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.296224e+06
@@ -16633,9 +19767,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 424 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 431 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 371
+      ID: 378
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.29648e+06
@@ -16646,9 +19780,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 372 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 379 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 390
+      ID: 397
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.296736e+06
@@ -16659,9 +19793,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 391 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 398 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 329
+      ID: 336
       Name: noalg.map.group[int]*main.deepMap2
       ByteSize: 136
       GoRuntimeType: 1.295712e+06
@@ -16672,9 +19806,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 330 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
+          Type: 337 ArrayType noalg.[8]struct { key int; elem *main.deepMap2 }
     - __kind: StructureType
-      ID: 1242
+      ID: 1249
       Name: noalg.map.group[int]*main.deepMap3
       ByteSize: 136
       GoRuntimeType: 1.295456e+06
@@ -16685,9 +19819,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1243 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
+          Type: 1250 ArrayType noalg.[8]struct { key int; elem *main.deepMap3 }
     - __kind: StructureType
-      ID: 1276
+      ID: 1283
       Name: noalg.map.group[int]*main.deepMap8
       ByteSize: 136
       GoRuntimeType: 1.294176e+06
@@ -16698,9 +19832,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1277 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
+          Type: 1284 ArrayType noalg.[8]struct { key int; elem *main.deepMap8 }
     - __kind: StructureType
-      ID: 1291
+      ID: 1298
       Name: noalg.map.group[int]*main.deepMap9
       ByteSize: 136
       GoRuntimeType: 1.29392e+06
@@ -16711,9 +19845,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1292 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
+          Type: 1299 ArrayType noalg.[8]struct { key int; elem *main.deepMap9 }
     - __kind: StructureType
-      ID: 339
+      ID: 346
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.292896e+06
@@ -16724,9 +19858,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 340 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 347 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: StructureType
-      ID: 1306
+      ID: 1313
       Name: noalg.map.group[int]interface {}
       ByteSize: 200
       GoRuntimeType: 1.293664e+06
@@ -16737,9 +19871,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1307 ArrayType noalg.[8]struct { key int; elem interface {} }
+          Type: 1314 ArrayType noalg.[8]struct { key int; elem interface {} }
     - __kind: StructureType
-      ID: 447
+      ID: 454
       Name: noalg.map.group[int]struct {}
       ByteSize: 136
       GoRuntimeType: 1.296992e+06
@@ -16750,9 +19884,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 448 ArrayType noalg.[8]struct { key int; elem struct {} }
+          Type: 455 ArrayType noalg.[8]struct { key int; elem struct {} }
     - __kind: StructureType
-      ID: 398
+      ID: 405
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.297248e+06
@@ -16763,9 +19897,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 399 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 406 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 380
+      ID: 387
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.297504e+06
@@ -16776,9 +19910,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 381 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 388 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 363
+      ID: 370
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.29776e+06
@@ -16789,9 +19923,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 364 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 371 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: StructureType
-      ID: 1002
+      ID: 1009
       Name: noalg.map.group[string]github.com/DataDog/go-tuf/data.HexBytes
       ByteSize: 328
       GoRuntimeType: 1.3592e+06
@@ -16802,9 +19936,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 1003 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
+          Type: 1010 ArrayType noalg.[8]struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
     - __kind: StructureType
-      ID: 355
+      ID: 362
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.298016e+06
@@ -16815,9 +19949,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 356 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 363 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 347
+      ID: 354
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.298272e+06
@@ -16828,9 +19962,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 348 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 355 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 439
+      ID: 446
       Name: noalg.map.group[struct {}]int
       ByteSize: 72
       GoRuntimeType: 1.298528e+06
@@ -16841,9 +19975,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 440 ArrayType noalg.[8]struct { key struct {}; elem int }
+          Type: 447 ArrayType noalg.[8]struct { key struct {}; elem int }
     - __kind: StructureType
-      ID: 489
+      ID: 496
       Name: noalg.map.group[struct {}]main.structWithCyclicMaps
       ByteSize: 392
       GoKind: 25
@@ -16853,9 +19987,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 490 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
+          Type: 497 ArrayType noalg.[8]struct { key struct {}; elem main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 497
+      ID: 504
       Name: noalg.map.group[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16865,9 +19999,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 498 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
+          Type: 505 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 505
+      ID: 512
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16877,9 +20011,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 506 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 513 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 513
+      ID: 520
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16889,9 +20023,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 514 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 521 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 521
+      ID: 528
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16901,9 +20035,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 522 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 529 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 529
+      ID: 536
       Name: noalg.map.group[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
       ByteSize: 72
       GoKind: 25
@@ -16913,9 +20047,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 530 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
+          Type: 537 ArrayType noalg.[8]struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
     - __kind: StructureType
-      ID: 455
+      ID: 462
       Name: noalg.map.group[struct {}]struct {}
       ByteSize: 16
       GoRuntimeType: 1.298784e+06
@@ -16926,9 +20060,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 456 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
+          Type: 463 ArrayType noalg.[8]struct { key struct {}; elem struct {} }
     - __kind: StructureType
-      ID: 414
+      ID: 421
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.29904e+06
@@ -16939,9 +20073,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 415 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 422 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 406
+      ID: 413
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.299296e+06
@@ -16952,9 +20086,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 407 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 414 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 433
+      ID: 440
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.29584e+06
@@ -16962,12 +20096,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
     - __kind: StructureType
-      ID: 425
+      ID: 432
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.296096e+06
@@ -16975,12 +20109,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 373
+      ID: 380
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.296352e+06
@@ -16988,12 +20122,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 374 ArrayType [4]string
+          Type: 381 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 113 ArrayType [2]int
     - __kind: StructureType
-      ID: 392
+      ID: 399
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.296608e+06
@@ -17006,7 +20140,7 @@ Types:
           Offset: 8
           Type: 246 StructureType main.node
     - __kind: StructureType
-      ID: 331
+      ID: 338
       Name: noalg.struct { key int; elem *main.deepMap2 }
       ByteSize: 16
       GoRuntimeType: 1.295584e+06
@@ -17017,9 +20151,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 332 PointerType *main.deepMap2
+          Type: 339 PointerType *main.deepMap2
     - __kind: StructureType
-      ID: 1244
+      ID: 1251
       Name: noalg.struct { key int; elem *main.deepMap3 }
       ByteSize: 16
       GoRuntimeType: 1.295328e+06
@@ -17030,9 +20164,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1245 PointerType *main.deepMap3
+          Type: 1252 PointerType *main.deepMap3
     - __kind: StructureType
-      ID: 1278
+      ID: 1285
       Name: noalg.struct { key int; elem *main.deepMap8 }
       ByteSize: 16
       GoRuntimeType: 1.294048e+06
@@ -17043,9 +20177,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1279 PointerType *main.deepMap8
+          Type: 1286 PointerType *main.deepMap8
     - __kind: StructureType
-      ID: 1293
+      ID: 1300
       Name: noalg.struct { key int; elem *main.deepMap9 }
       ByteSize: 16
       GoRuntimeType: 1.293792e+06
@@ -17056,9 +20190,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 1294 PointerType *main.deepMap9
+          Type: 1301 PointerType *main.deepMap9
     - __kind: StructureType
-      ID: 341
+      ID: 348
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.292768e+06
@@ -17071,7 +20205,7 @@ Types:
           Offset: 8
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 1308
+      ID: 1315
       Name: noalg.struct { key int; elem interface {} }
       ByteSize: 24
       GoRuntimeType: 1.293536e+06
@@ -17084,7 +20218,7 @@ Types:
           Offset: 8
           Type: 157 GoEmptyInterfaceType interface {}
     - __kind: StructureType
-      ID: 449
+      ID: 456
       Name: noalg.struct { key int; elem struct {} }
       ByteSize: 16
       GoRuntimeType: 1.296864e+06
@@ -17097,7 +20231,7 @@ Types:
           Offset: 8
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 400
+      ID: 407
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.29712e+06
@@ -17110,7 +20244,7 @@ Types:
           Offset: 8
           Type: 3 BaseType uint8
     - __kind: StructureType
-      ID: 382
+      ID: 389
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.297376e+06
@@ -17121,9 +20255,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 383 GoSliceHeaderType []main.structWithMap
+          Type: 390 GoSliceHeaderType []main.structWithMap
     - __kind: StructureType
-      ID: 365
+      ID: 372
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.297632e+06
@@ -17134,9 +20268,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 256 GoSliceHeaderType []string
+          Type: 263 GoSliceHeaderType []string
     - __kind: StructureType
-      ID: 1004
+      ID: 1011
       Name: noalg.struct { key string; elem github.com/DataDog/go-tuf/data.HexBytes }
       ByteSize: 40
       GoRuntimeType: 1.359072e+06
@@ -17147,9 +20281,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 991 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
+          Type: 998 GoSliceHeaderType github.com/DataDog/go-tuf/data.HexBytes
     - __kind: StructureType
-      ID: 357
+      ID: 364
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.297888e+06
@@ -17162,7 +20296,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 349
+      ID: 356
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.298144e+06
@@ -17175,7 +20309,7 @@ Types:
           Offset: 16
           Type: 123 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 441
+      ID: 448
       Name: noalg.struct { key struct {}; elem int }
       ByteSize: 8
       GoRuntimeType: 1.2984e+06
@@ -17188,7 +20322,7 @@ Types:
           Offset: 0
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 491
+      ID: 498
       Name: noalg.struct { key struct {}; elem main.structWithCyclicMaps }
       ByteSize: 48
       GoKind: 25
@@ -17198,9 +20332,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 278 StructureType main.structWithCyclicMaps
+          Type: 285 StructureType main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 499
+      ID: 506
       Name: noalg.struct { key struct {}; elem map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17210,9 +20344,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 279 GoMapType map[struct {}]main.structWithCyclicMaps
+          Type: 286 GoMapType map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 507
+      ID: 514
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17222,9 +20356,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 284 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 291 GoMapType map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 515
+      ID: 522
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17234,9 +20368,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 289 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 296 GoMapType map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 523
+      ID: 530
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17246,9 +20380,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 294 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 301 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 531
+      ID: 538
       Name: noalg.struct { key struct {}; elem map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps }
       ByteSize: 8
       GoKind: 25
@@ -17258,9 +20392,9 @@ Types:
           Type: 125 StructureType struct {}
         - Name: elem
           Offset: 0
-          Type: 299 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
+          Type: 306 GoMapType map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps
     - __kind: StructureType
-      ID: 457
+      ID: 464
       Name: noalg.struct { key struct {}; elem struct {} }
       GoRuntimeType: 1.298656e+06
       GoKind: 25
@@ -17272,7 +20406,7 @@ Types:
           Offset: 0
           Type: 125 StructureType struct {}
     - __kind: StructureType
-      ID: 416
+      ID: 423
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.298912e+06
@@ -17283,9 +20417,9 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 417 ArrayType [4]int
+          Type: 424 ArrayType [4]int
     - __kind: StructureType
-      ID: 408
+      ID: 415
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.299168e+06
@@ -17298,19 +20432,19 @@ Types:
           Offset: 1
           Type: 3 BaseType uint8
     - __kind: UnresolvedPointeeType
-      ID: 1193
+      ID: 1200
       Name: os.File
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 822
+      ID: 829
       Name: os.LinkError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 890
+      ID: 897
       Name: os.SyscallError
       ByteSize: 8
     - __kind: StructureType
-      ID: 1191
+      ID: 1198
       Name: os.fileWithoutReadFrom
       ByteSize: 8
       GoRuntimeType: 2.360256e+06
@@ -17318,12 +20452,12 @@ Types:
       RawFields:
         - Name: noReadFrom
           Offset: 0
-          Type: 1197 StructureType os.noReadFrom
+          Type: 1204 StructureType os.noReadFrom
         - Name: File
           Offset: 0
-          Type: 1192 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1189
+      ID: 1196
       Name: os.fileWithoutWriteTo
       ByteSize: 8
       GoRuntimeType: 2.359456e+06
@@ -17331,36 +20465,36 @@ Types:
       RawFields:
         - Name: noWriteTo
           Offset: 0
-          Type: 1196 StructureType os.noWriteTo
+          Type: 1203 StructureType os.noWriteTo
         - Name: File
           Offset: 0
-          Type: 1192 PointerType *os.File
+          Type: 1199 PointerType *os.File
     - __kind: StructureType
-      ID: 1197
+      ID: 1204
       Name: os.noReadFrom
       GoRuntimeType: 1.111648e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1196
+      ID: 1203
       Name: os.noWriteTo
       GoRuntimeType: 1.11152e+06
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 855
+      ID: 862
       Name: os/exec.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 998
+      ID: 1005
       Name: os/exec.ExitError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1062
+      ID: 1069
       Name: os/exec.prefixSuffixSaver
       ByteSize: 8
     - __kind: StructureType
-      ID: 857
+      ID: 864
       Name: os/exec.wrappedError
       ByteSize: 32
       GoRuntimeType: 1.703712e+06
@@ -17373,7 +20507,7 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: GoStringHeaderType
-      ID: 591
+      ID: 598
       Name: os/user.UnknownGroupIdError
       ByteSize: 16
       GoRuntimeType: 838976
@@ -17381,36 +20515,36 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 593 PointerType *os/user.UnknownGroupIdError.str
+          Type: 600 PointerType *os/user.UnknownGroupIdError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 592 GoStringDataType os/user.UnknownGroupIdError.str
+      Data: 599 GoStringDataType os/user.UnknownGroupIdError.str
     - __kind: GoStringDataType
-      ID: 592
+      ID: 599
       Name: os/user.UnknownGroupIdError.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: BaseType
-      ID: 590
+      ID: 597
       Name: os/user.UnknownUserIdError
       ByteSize: 8
       GoRuntimeType: 838880
       GoKind: 2
     - __kind: UnresolvedPointeeType
-      ID: 618
+      ID: 625
       Name: reflect.ValueError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 716
+      ID: 723
       Name: regexp/syntax.Error
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 826
+      ID: 833
       Name: runtime.PanicNilError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 830
+      ID: 837
       Name: runtime.TypeAssertionError
       ByteSize: 8
     - __kind: UnresolvedPointeeType
@@ -17422,7 +20556,7 @@ Types:
       Name: runtime._panic
       ByteSize: 8
     - __kind: StructureType
-      ID: 828
+      ID: 835
       Name: runtime.boundsError
       ByteSize: 24
       GoRuntimeType: 1.88896e+06
@@ -17439,9 +20573,9 @@ Types:
           Type: 4 BaseType bool
         - Name: code
           Offset: 17
-          Type: 996 BaseType runtime.boundsErrorCode
+          Type: 1003 BaseType runtime.boundsErrorCode
     - __kind: BaseType
-      ID: 996
+      ID: 1003
       Name: runtime.boundsErrorCode
       ByteSize: 1
       GoRuntimeType: 585792
@@ -17461,7 +20595,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 892
+      ID: 899
       Name: runtime.errorAddressString
       ByteSize: 24
       GoRuntimeType: 1.754016e+06
@@ -17474,7 +20608,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 806
+      ID: 813
       Name: runtime.errorString
       ByteSize: 16
       GoRuntimeType: 989728
@@ -17482,13 +20616,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 808 PointerType *runtime.errorString.str
+          Type: 815 PointerType *runtime.errorString.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 807 GoStringDataType runtime.errorString.str
+      Data: 814 GoStringDataType runtime.errorString.str
     - __kind: GoStringDataType
-      ID: 807
+      ID: 814
       Name: runtime.errorString.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18115,7 +21249,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 318
+      ID: 325
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -18151,7 +21285,7 @@ Types:
           Offset: 16
           Type: 1 BaseType uintptr
     - __kind: GoStringHeaderType
-      ID: 809
+      ID: 816
       Name: runtime.plainError
       ByteSize: 16
       GoRuntimeType: 989824
@@ -18159,13 +21293,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 811 PointerType *runtime.plainError.str
+          Type: 818 PointerType *runtime.plainError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 810 GoStringDataType runtime.plainError.str
+      Data: 817 GoStringDataType runtime.plainError.str
     - __kind: GoStringDataType
-      ID: 810
+      ID: 817
       Name: runtime.plainError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -18206,7 +21340,7 @@ Types:
       Name: runtime.synctestBubble
       ByteSize: 8
     - __kind: StructureType
-      ID: 614
+      ID: 621
       Name: runtime.synctestDeadlockError
       ByteSize: 24
       GoRuntimeType: 1.596608e+06
@@ -18264,7 +21398,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: UnresolvedPointeeType
-      ID: 832
+      ID: 839
       Name: strconv.NumError
       ByteSize: 8
     - __kind: GoStringHeaderType
@@ -18276,26 +21410,26 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 313 PointerType *string.str
+          Type: 320 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 312 GoStringDataType string.str
+      Data: 319 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 312
+      ID: 319
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: UnresolvedPointeeType
-      ID: 1128
+      ID: 1135
       Name: strings.Builder
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 1032
+      ID: 1039
       Name: strings.appendSliceWriter
       ByteSize: 8
     - __kind: StructureType
-      ID: 1028
+      ID: 1035
       Name: struct { io.Writer }
       ByteSize: 16
       GoRuntimeType: 1.456352e+06
@@ -18311,7 +21445,7 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1211
+      ID: 1218
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.464896e+06
@@ -18319,12 +21453,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 1213 StructureType internal/sync.Mutex
+          Type: 1220 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 1214
+      ID: 1221
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.613952e+06
@@ -18332,15 +21466,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 1215 StructureType sync/atomic.Bool
+          Type: 1222 StructureType sync/atomic.Bool
         - Name: m
           Offset: 4
-          Type: 1211 StructureType sync.Mutex
+          Type: 1218 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 1217
+      ID: 1224
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.61376e+06
@@ -18348,21 +21482,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 1212 StructureType sync.noCopy
+          Type: 1219 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 1218 StructureType sync/atomic.Uint64
+          Type: 1225 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1212
+      ID: 1219
       Name: sync.noCopy
       GoRuntimeType: 988672
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1215
+      ID: 1222
       Name: sync/atomic.Bool
       ByteSize: 4
       GoRuntimeType: 1.466016e+06
@@ -18370,12 +21504,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 2 BaseType uint32
     - __kind: StructureType
-      ID: 1220
+      ID: 1227
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.466176e+06
@@ -18383,12 +21517,12 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 12 BaseType int32
     - __kind: StructureType
-      ID: 1218
+      ID: 1225
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.614336e+06
@@ -18396,33 +21530,33 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 1216 StructureType sync/atomic.noCopy
+          Type: 1223 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 1219 StructureType sync/atomic.align64
+          Type: 1226 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 8 BaseType uint64
     - __kind: StructureType
-      ID: 1219
+      ID: 1226
       Name: sync/atomic.align64
       GoRuntimeType: 988864
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 1216
+      ID: 1223
       Name: sync/atomic.noCopy
       GoRuntimeType: 988768
       GoKind: 25
       RawFields: []
     - __kind: BaseType
-      ID: 942
+      ID: 949
       Name: syscall.Errno
       ByteSize: 8
       GoRuntimeType: 1.283552e+06
       GoKind: 12
     - __kind: StructureType
-      ID: 428
+      ID: 435
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -18444,9 +21578,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 429 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 436 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: StructureType
-      ID: 420
+      ID: 427
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18468,9 +21602,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 421 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 428 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: StructureType
-      ID: 368
+      ID: 375
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -18492,9 +21626,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 369 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 376 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: StructureType
-      ID: 387
+      ID: 394
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -18516,9 +21650,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 388 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 395 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: StructureType
-      ID: 326
+      ID: 333
       Name: table<int,*main.deepMap2>
       ByteSize: 32
       GoKind: 25
@@ -18540,9 +21674,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 327 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
+          Type: 334 GoSwissMapGroupsType groupReference<int,*main.deepMap2>
     - __kind: StructureType
-      ID: 1239
+      ID: 1246
       Name: table<int,*main.deepMap3>
       ByteSize: 32
       GoKind: 25
@@ -18564,9 +21698,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1240 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
+          Type: 1247 GoSwissMapGroupsType groupReference<int,*main.deepMap3>
     - __kind: StructureType
-      ID: 1273
+      ID: 1280
       Name: table<int,*main.deepMap8>
       ByteSize: 32
       GoKind: 25
@@ -18588,9 +21722,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1274 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
+          Type: 1281 GoSwissMapGroupsType groupReference<int,*main.deepMap8>
     - __kind: StructureType
-      ID: 1288
+      ID: 1295
       Name: table<int,*main.deepMap9>
       ByteSize: 32
       GoKind: 25
@@ -18612,9 +21746,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1289 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
+          Type: 1296 GoSwissMapGroupsType groupReference<int,*main.deepMap9>
     - __kind: StructureType
-      ID: 336
+      ID: 343
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -18636,9 +21770,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 337 GoSwissMapGroupsType groupReference<int,int>
+          Type: 344 GoSwissMapGroupsType groupReference<int,int>
     - __kind: StructureType
-      ID: 1303
+      ID: 1310
       Name: table<int,interface {}>
       ByteSize: 32
       GoKind: 25
@@ -18660,9 +21794,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1304 GoSwissMapGroupsType groupReference<int,interface {}>
+          Type: 1311 GoSwissMapGroupsType groupReference<int,interface {}>
     - __kind: StructureType
-      ID: 444
+      ID: 451
       Name: table<int,struct {}>
       ByteSize: 32
       GoKind: 25
@@ -18684,9 +21818,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 445 GoSwissMapGroupsType groupReference<int,struct {}>
+          Type: 452 GoSwissMapGroupsType groupReference<int,struct {}>
     - __kind: StructureType
-      ID: 395
+      ID: 402
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -18708,9 +21842,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 396 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 403 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: StructureType
-      ID: 377
+      ID: 384
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -18732,9 +21866,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 378 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 385 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 360
+      ID: 367
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -18756,9 +21890,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 361 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 368 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: StructureType
-      ID: 999
+      ID: 1006
       Name: table<string,github.com/DataDog/go-tuf/data.HexBytes>
       ByteSize: 32
       GoKind: 25
@@ -18780,9 +21914,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 1000 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
+          Type: 1007 GoSwissMapGroupsType groupReference<string,github.com/DataDog/go-tuf/data.HexBytes>
     - __kind: StructureType
-      ID: 352
+      ID: 359
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -18804,9 +21938,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 353 GoSwissMapGroupsType groupReference<string,int>
+          Type: 360 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 344
+      ID: 351
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -18828,9 +21962,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 345 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 352 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 436
+      ID: 443
       Name: table<struct {},int>
       ByteSize: 32
       GoKind: 25
@@ -18852,9 +21986,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 437 GoSwissMapGroupsType groupReference<struct {},int>
+          Type: 444 GoSwissMapGroupsType groupReference<struct {},int>
     - __kind: StructureType
-      ID: 486
+      ID: 493
       Name: table<struct {},main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18876,9 +22010,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 487 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
+          Type: 494 GoSwissMapGroupsType groupReference<struct {},main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 494
+      ID: 501
       Name: table<struct {},map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18900,9 +22034,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 495 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
+          Type: 502 GoSwissMapGroupsType groupReference<struct {},map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 502
+      ID: 509
       Name: table<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18924,9 +22058,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 503 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 510 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 510
+      ID: 517
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18948,9 +22082,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 511 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 518 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 518
+      ID: 525
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18972,9 +22106,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 519 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 526 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 526
+      ID: 533
       Name: table<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
       ByteSize: 32
       GoKind: 25
@@ -18996,9 +22130,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 527 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
+          Type: 534 GoSwissMapGroupsType groupReference<struct {},map[struct {}]map[struct {}]map[struct {}]map[struct {}]map[struct {}]main.structWithCyclicMaps>
     - __kind: StructureType
-      ID: 452
+      ID: 459
       Name: table<struct {},struct {}>
       ByteSize: 32
       GoKind: 25
@@ -19020,9 +22154,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 453 GoSwissMapGroupsType groupReference<struct {},struct {}>
+          Type: 460 GoSwissMapGroupsType groupReference<struct {},struct {}>
     - __kind: StructureType
-      ID: 411
+      ID: 418
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -19044,9 +22178,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 412 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 419 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: StructureType
-      ID: 403
+      ID: 410
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -19068,13 +22202,13 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 404 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 411 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: UnresolvedPointeeType
-      ID: 1163
+      ID: 1170
       Name: text/tabwriter.Writer
       ByteSize: 8
     - __kind: StructureType
-      ID: 885
+      ID: 892
       Name: text/template.ExecError
       ByteSize: 32
       GoRuntimeType: 1.708128e+06
@@ -19087,21 +22221,21 @@ Types:
           Offset: 16
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 1108
+      ID: 1115
       Name: time.Duration
       ByteSize: 8
       GoRuntimeType: 1.916416e+06
       GoKind: 6
     - __kind: UnresolvedPointeeType
-      ID: 960
+      ID: 967
       Name: time.Location
       ByteSize: 8
     - __kind: UnresolvedPointeeType
-      ID: 621
+      ID: 628
       Name: time.ParseError
       ByteSize: 8
     - __kind: StructureType
-      ID: 958
+      ID: 965
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.373568e+06
@@ -19115,9 +22249,9 @@ Types:
           Type: 13 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 959 PointerType *time.Location
+          Type: 966 PointerType *time.Location
     - __kind: GoStringHeaderType
-      ID: 536
+      ID: 543
       Name: time.fileSizeError
       ByteSize: 16
       GoRuntimeType: 831776
@@ -19125,13 +22259,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 538 PointerType *time.fileSizeError.str
+          Type: 545 PointerType *time.fileSizeError.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 537 GoStringDataType time.fileSizeError.str
+      Data: 544 GoStringDataType time.fileSizeError.str
     - __kind: GoStringDataType
-      ID: 537
+      ID: 544
       Name: time.fileSizeError.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -19178,7 +22312,7 @@ Types:
       GoRuntimeType: 585728
       GoKind: 26
     - __kind: StructureType
-      ID: 978
+      ID: 985
       Name: vendor/golang.org/x/net/dns/dnsmessage.Parser
       ByteSize: 80
       GoRuntimeType: 2.064064e+06
@@ -19189,10 +22323,10 @@ Types:
           Type: 38 GoSliceHeaderType []uint8
         - Name: header
           Offset: 24
-          Type: 979 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
+          Type: 986 StructureType vendor/golang.org/x/net/dns/dnsmessage.header
         - Name: section
           Offset: 36
-          Type: 980 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
+          Type: 987 BaseType vendor/golang.org/x/net/dns/dnsmessage.section
         - Name: off
           Offset: 40
           Type: 7 BaseType int
@@ -19207,18 +22341,18 @@ Types:
           Type: 7 BaseType int
         - Name: resHeaderType
           Offset: 72
-          Type: 981 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
+          Type: 988 BaseType vendor/golang.org/x/net/dns/dnsmessage.Type
         - Name: resHeaderLength
           Offset: 74
           Type: 6 BaseType uint16
     - __kind: BaseType
-      ID: 981
+      ID: 988
       Name: vendor/golang.org/x/net/dns/dnsmessage.Type
       ByteSize: 2
       GoRuntimeType: 995392
       GoKind: 9
     - __kind: StructureType
-      ID: 979
+      ID: 986
       Name: vendor/golang.org/x/net/dns/dnsmessage.header
       ByteSize: 12
       GoRuntimeType: 1.927424e+06
@@ -19243,21 +22377,21 @@ Types:
           Offset: 10
           Type: 6 BaseType uint16
     - __kind: UnresolvedPointeeType
-      ID: 712
+      ID: 719
       Name: vendor/golang.org/x/net/dns/dnsmessage.nestedError
       ByteSize: 8
     - __kind: BaseType
-      ID: 980
+      ID: 987
       Name: vendor/golang.org/x/net/dns/dnsmessage.section
       ByteSize: 1
       GoRuntimeType: 589376
       GoKind: 8
     - __kind: UnresolvedPointeeType
-      ID: 1155
+      ID: 1162
       Name: vendor/golang.org/x/net/http2/hpack.Decoder
       ByteSize: 8
     - __kind: StructureType
-      ID: 696
+      ID: 703
       Name: vendor/golang.org/x/net/http2/hpack.DecodingError
       ByteSize: 16
       GoRuntimeType: 1.427392e+06
@@ -19267,13 +22401,13 @@ Types:
           Offset: 0
           Type: 14 GoInterfaceType error
     - __kind: BaseType
-      ID: 580
+      ID: 587
       Name: vendor/golang.org/x/net/http2/hpack.InvalidIndexError
       ByteSize: 8
       GoRuntimeType: 835808
       GoKind: 2
     - __kind: StructureType
-      ID: 862
+      ID: 869
       Name: vendor/golang.org/x/net/idna.labelError
       ByteSize: 32
       GoRuntimeType: 1.703904e+06
@@ -19286,12 +22420,12 @@ Types:
           Offset: 16
           Type: 9 GoStringHeaderType string
     - __kind: BaseType
-      ID: 814
+      ID: 821
       Name: vendor/golang.org/x/net/idna.runeError
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1480
+MaxTypeID: 1535
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -3124,7 +3124,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807980..0x807990, Pieces: []}]
+          Locations:
+            - Range: 0x807980..0x807988
+              Pieces: []
+            - Range: 0x807988..0x807989
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x807989..0x807990
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 54
@@ -3141,7 +3147,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x807990..0x8079e0, Pieces: []}]
+          Locations:
+            - Range: 0x807990..0x8079d0
+              Pieces: []
+            - Range: 0x8079d0..0x8079d1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x8079d1..0x8079e0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 55
@@ -3184,7 +3196,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807c00..0x807c60, Pieces: []}]
+          Locations:
+            - Range: 0x807c00..0x807c40
+              Pieces: []
+            - Range: 0x807c40..0x807c41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x807c41..0x807c60
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 57
@@ -3217,7 +3239,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x807c70..0x807cd0, Pieces: []}]
+          Locations:
+            - Range: 0x807c70..0x807cb0
+              Pieces: []
+            - Range: 0x807cb0..0x807cb1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x807cb1..0x807cd0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 59
@@ -3717,7 +3749,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x809f60..0x809fe0, Pieces: []}]
+          Locations:
+            - Range: 0x809f60..0x809fb4
+              Pieces: []
+            - Range: 0x809fb4..0x809fb5
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x809fb5..0x809fe0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 95
@@ -3734,7 +3772,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 100 PointerType *int
-          Locations: [{Range: 0x809fe0..0x80a070, Pieces: []}]
+          Locations:
+            - Range: 0x809fe0..0x80a050
+              Pieces: []
+            - Range: 0x80a050..0x80a051
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a051..0x80a070
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: '&i'
@@ -3762,7 +3806,13 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a070..0x80a130, Pieces: []}]
+          Locations:
+            - Range: 0x80a070..0x80a104
+              Pieces: []
+            - Range: 0x80a104..0x80a105
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a105..0x80a130
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
@@ -3793,7 +3843,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x80a130..0x80a1b0, Pieces: []}]
+          Locations:
+            - Range: 0x80a130..0x80a174
+              Pieces: []
+            - Range: 0x80a174..0x80a175
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a175..0x80a188
+              Pieces: []
+            - Range: 0x80a188..0x80a189
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a189..0x80a1b0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 98
@@ -3827,12 +3895,48 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x80a1b0..0x80a240, Pieces: []}]
+          Locations:
+            - Range: 0x80a1b0..0x80a204
+              Pieces: []
+            - Range: 0x80a204..0x80a205
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a205..0x80a218
+              Pieces: []
+            - Range: 0x80a218..0x80a219
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a219..0x80a240
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r1
           Type: 14 GoInterfaceType error
-          Locations: [{Range: 0x80a1b0..0x80a240, Pieces: []}]
+          Locations:
+            - Range: 0x80a1b0..0x80a204
+              Pieces: []
+            - Range: 0x80a204..0x80a205
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80a205..0x80a218
+              Pieces: []
+            - Range: 0x80a218..0x80a219
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x80a219..0x80a240
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 99
@@ -3865,7 +3969,17 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
-          Locations: [{Range: 0x80a240..0x80a2c0, Pieces: []}]
+          Locations:
+            - Range: 0x80a240..0x80a2a0
+              Pieces: []
+            - Range: 0x80a2a0..0x80a2a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a2a1..0x80a2c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 100
@@ -3904,7 +4018,25 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
-          Locations: [{Range: 0x80a2c0..0x80a3d0, Pieces: []}]
+          Locations:
+            - Range: 0x80a2c0..0x80a35c
+              Pieces: []
+            - Range: 0x80a35c..0x80a35d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a35d..0x80a370
+              Pieces: []
+            - Range: 0x80a370..0x80a371
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80a371..0x80a3d0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: b
@@ -3962,7 +4094,13 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a3d0..0x80a460, Pieces: []}]
+          Locations:
+            - Range: 0x80a3d0..0x80a43c
+              Pieces: []
+            - Range: 0x80a43c..0x80a43d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a43d..0x80a460
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 102
@@ -3981,12 +4119,24 @@ Subprograms:
           IsReturn: false
         - Name: result
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a460..0x80a510, Pieces: []}]
+          Locations:
+            - Range: 0x80a460..0x80a4e8
+              Pieces: []
+            - Range: 0x80a4e8..0x80a4e9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a4e9..0x80a510
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a460..0x80a510, Pieces: []}]
+          Locations:
+            - Range: 0x80a460..0x80a4e8
+              Pieces: []
+            - Range: 0x80a4e8..0x80a4e9
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80a4e9..0x80a510
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 103
@@ -4005,17 +4155,35 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a510..0x80a5c0, Pieces: []}]
+          Locations:
+            - Range: 0x80a510..0x80a598
+              Pieces: []
+            - Range: 0x80a598..0x80a599
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80a599..0x80a5c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: result2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a510..0x80a5c0, Pieces: []}]
+          Locations:
+            - Range: 0x80a510..0x80a598
+              Pieces: []
+            - Range: 0x80a598..0x80a599
+              Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
+            - Range: 0x80a599..0x80a5c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: ~r2
           Type: 7 BaseType int
-          Locations: [{Range: 0x80a510..0x80a5c0, Pieces: []}]
+          Locations:
+            - Range: 0x80a510..0x80a598
+              Pieces: []
+            - Range: 0x80a598..0x80a599
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0x80a599..0x80a5c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 104
@@ -4258,7 +4426,17 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
-          Locations: [{Range: 0x80aba0..0x80ac00, Pieces: []}]
+          Locations:
+            - Range: 0x80aba0..0x80abe8
+              Pieces: []
+            - Range: 0x80abe8..0x80abe9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x80abe9..0x80ac00
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 116

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 115 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0x4a6660..0x4a6845, Pieces: []}]
+          Locations:
+            - Range: 0x4a6660..0x4a682e
+              Pieces: []
+            - Range: 0x4a682e..0x4a682f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a682f..0x4a6845
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 118 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0x4a8660..0x4a884f, Pieces: []}]
+          Locations:
+            - Range: 0x4a8660..0x4a883c
+              Pieces: []
+            - Range: 0x4a883c..0x4a883d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a883d..0x4a884f
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 12

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 120 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0x4aec60..0x4aee57, Pieces: []}]
+          Locations:
+            - Range: 0x4aec60..0x4aee44
+              Pieces: []
+            - Range: 0x4aee44..0x4aee45
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aee45..0x4aee57
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 12

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 116 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0xb5990..0xb5b40, Pieces: []}]
+          Locations:
+            - Range: 0xb5990..0xb5b24
+              Pieces: []
+            - Range: 0xb5b24..0xb5b25
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb5b25..0xb5b40
+              Pieces: []
           IsParameter: true
           IsReturn: true
         - Name: m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0xb5800..0xb59c0, Pieces: []}]
+          Locations:
+            - Range: 0xb5800..0xb59a0
+              Pieces: []
+            - Range: 0xb59a0..0xb59a1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb59a1..0xb59c0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 12

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -398,7 +398,13 @@ Subprograms:
       Variables:
         - Name: ~r0
           Type: 121 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0xb8340..0xb84f0, Pieces: []}]
+          Locations:
+            - Range: 0xb8340..0xb84d8
+              Pieces: []
+            - Range: 0xb84d8..0xb84d9
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb84d9..0xb84f0
+              Pieces: []
           IsParameter: true
           IsReturn: true
     - ID: 12

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -96,9 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -205,6 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -371,6 +375,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -379,6 +386,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -419,14 +437,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -435,9 +473,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -518,33 +556,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-53])
+		Arg: failed: bool (declared at line 44, available: [44-53])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 50-55
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 49-53
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-53])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -585,11 +707,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -624,6 +751,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -676,6 +808,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -744,6 +881,17 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -771,6 +919,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -818,6 +970,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -874,6 +1029,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -85,9 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,6 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -360,6 +364,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -368,6 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -408,14 +426,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -424,9 +462,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -507,33 +545,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -574,11 +696,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -613,6 +740,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -665,6 +797,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -732,6 +869,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -759,6 +907,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -806,6 +958,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -862,6 +1017,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -84,9 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -193,6 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -359,6 +363,9 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-274])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -367,6 +374,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -407,14 +425,34 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -423,9 +461,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -506,33 +544,117 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 63-65
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 66-72
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-56])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-78])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -573,11 +695,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -612,6 +739,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -664,6 +796,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -731,6 +868,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -758,6 +906,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -805,6 +957,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -861,6 +1016,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -96,9 +96,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -205,6 +206,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -371,6 +375,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -379,6 +387,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -419,14 +438,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -435,9 +476,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -518,33 +559,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-53])
+		Arg: failed: bool (declared at line 44, available: [44-53])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 50-55
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 49-53
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-53])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -585,11 +712,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -624,6 +756,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -676,6 +813,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -744,6 +886,17 @@ Package: main
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [18-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
 			Var: #yield1: func(int) bool (declared at line 0, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -771,6 +924,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -818,6 +975,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -874,6 +1034,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -85,9 +85,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -194,6 +195,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -360,6 +364,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -368,6 +376,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -408,14 +427,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -424,9 +465,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -507,33 +548,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 64-72
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 63-68
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: [53-53])
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -574,11 +701,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -613,6 +745,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -665,6 +802,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -732,6 +874,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -759,6 +912,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -806,6 +963,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -862,6 +1022,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -84,9 +84,10 @@ Package: main
 		Var: u64F: uint64 (declared at line 113, available: )
 		Var: uintToPointTo: uint (declared at line 120, available: )
 		Var: x: main.structWithTwoValues (declared at line 134, available: )
-	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [85:107] injectible: [85-92], [94-98], [100-102], [104-107]
-		Var: &v: *main.firstBehavior (declared at line 94, available: [85-107])
-		Var: &fortyTwo: *int (declared at line 97, available: [98-98])
+	Function: executeReturns (main.executeReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [374:430] injectible: [374-381], [383-387], [389-391], [393-395], [398-412], [418-420], [424-430]
+		Var: &v: *main.firstBehavior (declared at line 383, available: [374-430])
+		Var: &fortyTwo: *int (declared at line 386, available: [387-387])
+		Var: .autotmp_8: [0]int (declared at line 429, available: [374-430])
 	Function: executeSliceFuncs (main.executeSliceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [72:97] injectible: [72-75], [77-84], [86-90], [92-92], [94-97]
 		Var: originalSlice: []int (declared at line 73, available: )
 		Var: s: []uint (declared at line 82, available: )
@@ -193,6 +194,9 @@ Package: main
 	Function: testAnyPtr (main.testAnyPtr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [64:65] injectible: [64-65]
 		Arg: a: *interface {} (declared at line 64, available: [64-65])
 		Arg: ~r0: string (declared at line 64, available: )
+	Function: testArrayArgAndReturn (main.testArrayArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [280:285] injectible: [280-285]
+		Arg: arg: [3]int (declared at line 280, available: [280-285])
+		Arg: ~r0: [3]int (declared at line 280, available: )
 	Function: testArrayEmptyStructs (main.testArrayEmptyStructs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [87:87] injectible: [87-87]
 		Arg: a: [2]struct {} (declared at line 87, available: [87-87])
 	Function: testArrayOfArrays (main.testArrayOfArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [70:70] injectible: [70-70]
@@ -359,6 +363,10 @@ Package: main
 		Arg: c: uint (declared at line 94, available: [94-94])
 	Function: testInterfaceComplexity (main.testInterfaceComplexity) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [64:64] injectible: [64-64]
 		Arg: a: main.interfaceComplexityA (declared at line 64, available: [64-64])
+	Function: testLargeArgAndReturn (main.testLargeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [264:274] injectible: [264-274]
+		Arg: arg: main.largeStruct (declared at line 264, available: [264-265])
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
+		Arg: ~r0: main.largeStruct (declared at line 264, available: )
 	Function: testLinkedList (main.testLinkedList) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [42:42] injectible: [42-42]
 		Arg: a: main.node (declared at line 42, available: [42-42])
 	Function: testLongFunctionWithChangingState (main.testLongFunctionWithChangingState) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [204:221] injectible: [204-204], [208-208], [211-212], [214-217], [219-221]
@@ -367,6 +375,17 @@ Package: main
 		Var: b: int (declared at line 207, available: [204-221])
 	Function: testLotsOfFields (main.testLotsOfFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [132:132] injectible: [132-132]
 		Arg: l: main.lotsOfFields (declared at line 132, available: [132-132])
+	Function: testManyArgsArrayReturn (main.testManyArgsArrayReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [311:313] injectible: [311-313]
+		Arg: a: int (declared at line 311, available: [311-313])
+		Arg: b: int (declared at line 311, available: [311-313])
+		Arg: c: int (declared at line 311, available: [311-313])
+		Arg: d: int (declared at line 311, available: [311-313])
+		Arg: e: int (declared at line 311, available: [311-313])
+		Arg: f: int (declared at line 311, available: [311-313])
+		Arg: g: int (declared at line 311, available: [311-313])
+		Arg: h: int (declared at line 311, available: [311-313])
+		Arg: i: int (declared at line 311, available: [311-313])
+		Arg: ~r0: [2]int (declared at line 311, available: )
 	Function: testMapArrayToArray (main.testMapArrayToArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [34:34] injectible: [34-34]
 		Arg: m: map[[4]string][2]int (declared at line 34, available: [34-34])
 	Function: testMapEmbeddedMaps (main.testMapEmbeddedMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [58:58] injectible: [58-58]
@@ -407,14 +426,36 @@ Package: main
 		Arg: redactMyEntries: map[int]uint8 (declared at line 70, available: [70-70])
 	Function: testMassiveString (main.testMassiveString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [42:42] injectible: [42-42]
 		Arg: x: string (declared at line 42, available: [42-42])
+	Function: testMixedArgsStackReturn (main.testMixedArgsStackReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [320:332] injectible: [320-330], [332-332]
+		Arg: a: int (declared at line 320, available: [320-332])
+		Arg: b: int (declared at line 320, available: [320-332])
+		Arg: c: int (declared at line 320, available: [320-332])
+		Arg: d: int (declared at line 320, available: [320-332])
+		Arg: e: int (declared at line 320, available: [320-332])
+		Arg: f: int (declared at line 320, available: [320-332])
+		Arg: g: int (declared at line 320, available: [320-332])
+		Arg: h: int (declared at line 320, available: [320-332])
+		Arg: s: string (declared at line 320, available: [320-332])
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+		Arg: ~r0: main.largeStruct (declared at line 320, available: )
+	Function: testMultipleArrayArgs (main.testMultipleArrayArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [347:349] injectible: [347-349]
+		Arg: a: [2]int (declared at line 347, available: [347-349])
+		Arg: b: [3]int (declared at line 347, available: [347-349])
+		Arg: ~r0: int (declared at line 347, available: )
+		Arg: ~r1: [2]int (declared at line 347, available: )
 	Function: testMultipleDereferences (main.testMultipleDereferences) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [72:72] injectible: [72-72]
 		Arg: o: main.outer (declared at line 72, available: [72-72])
 	Function: testMultipleEmbeddedStruct (main.testMultipleEmbeddedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [96:96] injectible: [96-96]
 		Arg: b: main.bStruct (declared at line 96, available: [96-96])
-	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [72:76] injectible: [72-72], [75-76]
-		Arg: i: int (declared at line 72, available: [72-76])
-		Arg: result: int (declared at line 72, available: )
-		Arg: result2: int (declared at line 72, available: )
+	Function: testMultipleLargeArgs (main.testMultipleLargeArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [291:303] injectible: [291-303]
+		Arg: s1: main.largeStruct (declared at line 291, available: [291-292])
+		Arg: s2: main.largeStruct (declared at line 291, available: [291-303])
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+		Arg: ~r0: main.largeStruct (declared at line 291, available: )
+	Function: testMultipleNamedReturn (main.testMultipleNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [95:99] injectible: [95-99]
+		Arg: i: int (declared at line 95, available: [95-98])
+		Arg: result: int (declared at line 95, available: )
+		Arg: result2: int (declared at line 95, available: )
 	Function: testMultipleSimpleParams (main.testMultipleSimpleParams) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [78:78] injectible: [78-78]
 		Arg: a: bool (declared at line 78, available: [78-78])
 		Arg: b: uint8 (declared at line 78, available: [78-78])
@@ -423,9 +464,9 @@ Package: main
 		Arg: e: string (declared at line 78, available: [78-78])
 	Function: testMultipleStructTiers (main.testMultipleStructTiers) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [68:68] injectible: [68-68]
 		Arg: a: main.tierA (declared at line 68, available: [68-68])
-	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [65:68] injectible: [65-65], [67-68]
-		Arg: i: int (declared at line 65, available: [65-68])
-		Arg: result: int (declared at line 65, available: )
+	Function: testNamedReturn (main.testNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [88:91] injectible: [88-91]
+		Arg: i: int (declared at line 88, available: [88-89])
+		Arg: result: int (declared at line 88, available: )
 	Function: testNestedPointer (main.testNestedPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [108:108] injectible: [108-108]
 		Arg: x: *main.anotherStruct (declared at line 108, available: [108-108])
 	Function: testNilPointer (main.testNilPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [99:99] injectible: [99-99]
@@ -506,33 +547,119 @@ Package: main
 		Arg: s: *main.structWithASlice (declared at line 76, available: [76-76])
 	Function: testPointerToStructWithAString (main.testPointerToStructWithAString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [80:80] injectible: [80-80]
 		Arg: s: *main.structWithAString (declared at line 80, available: [80-80])
-	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [49:51] injectible: [49-51]
-		Arg: v: interface {} (declared at line 49, available: [49-51])
-		Arg: ~r0: interface {} (declared at line 49, available: )
-	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [41:45] injectible: [41-43], [45-45]
-		Arg: v: interface {} (declared at line 41, available: [41-42])
-		Arg: failed: bool (declared at line 41, available: [41-42])
-		Arg: ~r0: interface {} (declared at line 41, available: )
-		Arg: ~r1: error (declared at line 41, available: )
-	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [33:37] injectible: [33-35], [37-37]
-		Arg: failed: bool (declared at line 33, available: [33-34])
-		Arg: ~r0: error (declared at line 33, available: )
-	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:16] injectible: [14-16]
-		Arg: i: int (declared at line 14, available: [14-16])
+	Function: testReturnsAny (main.testReturnsAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [60:72] injectible: [60-61], [63-68], [70-70], [72-72]
+		Arg: v: interface {} (declared at line 60, available: [60-72])
+		Arg: ~r0: interface {} (declared at line 60, available: )
+		Scope: 63-65
+			Var: val: int (declared at line 64, available: [65-65])
+		Scope: 66-72
+			Var: &result: *int (declared at line 67, available: [68-68])
+		Scope: 60-70
+			Var: val: interface {} (declared at line 69, available: [60-72])
+		Scope: 70-72
+			Var: val: interface {} (declared at line 71, available: [60-72])
+	Function: testReturnsAnyAndError (main.testReturnsAnyAndError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [44:55] injectible: [44-46], [49-53], [55-55]
+		Arg: v: interface {} (declared at line 44, available: [44-51])
+		Arg: failed: bool (declared at line 44, available: [44-50])
+		Arg: ~r0: interface {} (declared at line 44, available: )
+		Arg: ~r1: error (declared at line 44, available: )
+		Scope: 49-51
+			Var: val: int (declared at line 50, available: [51-51])
+		Scope: 52-55
+			Var: val: string (declared at line 52, available: )
+		Scope: 55-55
+			Var: val: interface {} (declared at line 54, available: [44-51])
+	Function: testReturnsArray (main.testReturnsArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [157:159] injectible: [157-159]
+		Arg: ~r0: [3]int (declared at line 157, available: )
+	Function: testReturnsArrayOne (main.testReturnsArrayOne) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [165:167] injectible: [165-167]
+		Arg: ~r0: [1]int (declared at line 165, available: )
+	Function: testReturnsArrayZero (main.testReturnsArrayZero) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [173:175] injectible: [173-175]
+		Arg: ~r0: [0]int (declared at line 173, available: )
+	Function: testReturnsBacktrackInt (main.testReturnsBacktrackInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [196:198] injectible: [196-198]
+		Arg: ~r0: int (declared at line 196, available: )
+		Arg: ~r1: int (declared at line 196, available: )
+		Arg: ~r2: int (declared at line 196, available: )
+		Arg: ~r3: int (declared at line 196, available: )
+		Arg: ~r4: int (declared at line 196, available: )
+		Arg: ~r5: int (declared at line 196, available: )
+		Arg: ~r6: int (declared at line 196, available: )
+		Arg: ~r7: int (declared at line 196, available: )
+		Arg: ~r8: string (declared at line 196, available: )
+	Function: testReturnsBoolAndUintptr (main.testReturnsBoolAndUintptr) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [253:255] injectible: [253-255]
+		Arg: ~r0: bool (declared at line 253, available: )
+		Arg: ~r1: uintptr (declared at line 253, available: )
+	Function: testReturnsComplex (main.testReturnsComplex) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [138:140] injectible: [138-140]
+		Arg: ~r0: complex64 (declared at line 138, available: )
+		Arg: ~r1: complex128 (declared at line 138, available: )
+	Function: testReturnsError (main.testReturnsError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [36:40] injectible: [36-38], [40-40]
+		Arg: failed: bool (declared at line 36, available: [36-37])
+		Arg: ~r0: error (declared at line 36, available: )
+	Function: testReturnsInt (main.testReturnsInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [14:17] injectible: [14-17]
+		Arg: i: int (declared at line 14, available: [14-15])
 		Arg: ~r0: int (declared at line 14, available: )
-	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [26:29] injectible: [26-29]
-		Arg: i: int (declared at line 26, available: [26-29])
-		Arg: ~r0: int (declared at line 26, available: )
-		Arg: ~r1: float64 (declared at line 26, available: )
-		Var: f: float64 (declared at line 27, available: [26-29])
-	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [20:22] injectible: [20-22]
-		Arg: i: int (declared at line 20, available: [20-20])
-		Arg: ~r0: *int (declared at line 20, available: )
-		Var: &i: *int (declared at line 20, available: [20-22])
-	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [55:61] injectible: [55-58], [60-61]
-		Arg: v: interface {} (declared at line 55, available: [55-57])
-		Arg: ~r0: main.behavior (declared at line 55, available: )
-		Var: b: main.behavior (declared at line 56, available: [56-61])
+		Var: result: int (declared at line 15, available: [14-17])
+	Function: testReturnsIntAndFloat (main.testReturnsIntAndFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [28:32] injectible: [28-32]
+		Arg: i: int (declared at line 28, available: [28-31])
+		Arg: ~r0: int (declared at line 28, available: )
+		Arg: ~r1: float64 (declared at line 28, available: )
+		Var: resultInt: int (declared at line 29, available: [28-32])
+		Var: resultFloat: float64 (declared at line 30, available: [28-32])
+	Function: testReturnsIntPointer (main.testReturnsIntPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [21:24] injectible: [21-24]
+		Arg: i: int (declared at line 21, available: [21-24])
+		Arg: ~r0: *int (declared at line 21, available: )
+		Var: &result: *int (declared at line 22, available: [21-24])
+	Function: testReturnsInterface (main.testReturnsInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [77:84] injectible: [77-80], [82-82], [84-84]
+		Arg: v: interface {} (declared at line 77, available: [77-79])
+		Arg: ~r0: main.behavior (declared at line 77, available: )
+		Var: b: main.behavior (declared at line 78, available: [78-84])
+	Function: testReturnsLargeStruct (main.testReturnsLargeStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [149:151] injectible: [149-151]
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+		Arg: ~r0: main.largeStruct (declared at line 149, available: )
+	Function: testReturnsManyFloats (main.testReturnsManyFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [120:132] injectible: [120-120], [130-132]
+		Arg: ~r0: float64 (declared at line 121, available: )
+		Arg: ~r1: float64 (declared at line 121, available: )
+		Arg: ~r2: float64 (declared at line 121, available: )
+		Arg: ~r3: float64 (declared at line 121, available: )
+		Arg: ~r4: float64 (declared at line 121, available: )
+		Arg: ~r5: float64 (declared at line 121, available: )
+		Arg: ~r6: float64 (declared at line 121, available: )
+		Arg: ~r7: float64 (declared at line 122, available: )
+		Arg: ~r8: float64 (declared at line 122, available: )
+		Arg: ~r9: float64 (declared at line 122, available: )
+		Arg: ~r10: float64 (declared at line 122, available: )
+		Arg: ~r11: float64 (declared at line 122, available: )
+		Arg: ~r12: float64 (declared at line 122, available: )
+		Arg: ~r13: float64 (declared at line 122, available: )
+		Arg: ~r14: float64 (declared at line 123, available: )
+		Arg: onlyOnAmd64_16: float64 (declared at line 126, available: )
+		Arg: bothArmAndAmd64: float64 (declared at line 128, available: )
+	Function: testReturnsMixed (main.testReturnsMixed) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [216:218] injectible: [216-218]
+		Arg: ~r0: int (declared at line 216, available: )
+		Arg: ~r1: float64 (declared at line 216, available: )
+		Arg: ~r2: int (declared at line 216, available: )
+		Arg: ~r3: float64 (declared at line 216, available: )
+		Arg: ~r4: string (declared at line 216, available: )
+	Function: testReturnsMixedStruct (main.testReturnsMixedStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [186:188] injectible: [186-188]
+		Arg: ~r0: main.mixedStruct (declared at line 186, available: )
+	Function: testReturnsMultipleFloats (main.testReturnsMultipleFloats) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [245:247] injectible: [245-247]
+		Arg: ~r0: float32 (declared at line 245, available: )
+		Arg: ~r1: float64 (declared at line 245, available: )
+	Function: testReturnsOnlyFloat (main.testReturnsOnlyFloat) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [237:239] injectible: [237-239]
+		Arg: ~r0: float64 (declared at line 237, available: )
+	Function: testReturnsPrimitives (main.testReturnsPrimitives) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [111:113] injectible: [111-113]
+		Arg: ~r0: int8 (declared at line 111, available: )
+		Arg: ~r1: int16 (declared at line 111, available: )
+		Arg: ~r2: int32 (declared at line 111, available: )
+		Arg: ~r3: int64 (declared at line 111, available: )
+		Arg: ~r4: uint8 (declared at line 111, available: )
+		Arg: ~r5: uint16 (declared at line 111, available: )
+		Arg: ~r6: uint32 (declared at line 111, available: )
+		Arg: ~r7: uint64 (declared at line 111, available: )
+	Function: testReturnsStructWithArray (main.testReturnsStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [228:230] injectible: [228-230]
+		Arg: ~r0: main.structWithArray (declared at line 228, available: )
+	Function: testReturnsWideStruct (main.testReturnsWideStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [208:210] injectible: [208-210]
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
+		Arg: ~r0: main.wideStruct (declared at line 208, available: )
 	Function: testRuneArray (main.testRuneArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [18:18] injectible: [18-18]
 		Arg: x: [2]int32 (declared at line 18, available: [18-18])
 	Function: testSingleBool (main.testSingleBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [19:19] injectible: [19-19]
@@ -573,11 +700,16 @@ Package: main
 		Arg: u: [][]uint (declared at line 37, available: [37-37])
 	Function: testSmallMap (main.testSmallMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/maps.go [38:38] injectible: [38-38]
 		Arg: m: map[string]int (declared at line 38, available: [38-38])
-	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [80:82] injectible: [80-82]
-		Arg: i: int (declared at line 80, available: [80-82])
-		Arg: ~r0: int (declared at line 80, available: )
-		Arg: result2: int (declared at line 80, available: )
-		Arg: ~r2: int (declared at line 80, available: )
+	Function: testSomeNamedReturn (main.testSomeNamedReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [103:105] injectible: [103-105]
+		Arg: i: int (declared at line 103, available: [103-105])
+		Arg: ~r0: int (declared at line 103, available: )
+		Arg: result2: int (declared at line 103, available: )
+		Arg: ~r2: int (declared at line 103, available: )
+	Function: testStackArgRegReturns (main.testStackArgRegReturns) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [339:341] injectible: [339-341]
+		Arg: arg: [5]int (declared at line 339, available: [339-341])
+		Arg: ~r0: int (declared at line 339, available: )
+		Arg: ~r1: int (declared at line 339, available: )
+		Arg: ~r2: int (declared at line 339, available: )
 	Function: testStringArray (main.testStringArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [22:22] injectible: [22-22]
 		Arg: x: [2]string (declared at line 22, available: [22-22])
 	Function: testStringPointer (main.testStringPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [91:91] injectible: [91-91]
@@ -612,6 +744,11 @@ Package: main
 		Arg: s: main.structWithAny (declared at line 73, available: [73-73])
 	Function: testStructWithArray (main.testStructWithArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [60:60] injectible: [60-60]
 		Arg: a: main.structWithAnArray (declared at line 60, available: [60-60])
+	Function: testStructWithArrayArg (main.testStructWithArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [355:362] injectible: [355-357], [359-360], [362-362]
+		Arg: arg: main.structWithArray (declared at line 355, available: [355-362])
+		Arg: ~r0: int (declared at line 355, available: )
+		Arg: ~r1: main.structWithArray (declared at line 355, available: )
+		Var: x: int (declared at line 357, available: [355-362])
 	Function: testStructWithArrays (main.testStructWithArrays) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [88:88] injectible: [88-88]
 		Arg: s: main.structWithTwoArrays (declared at line 88, available: [88-88])
 	Function: testStructWithCyclicMaps (main.testStructWithCyclicMaps) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go [44:44] injectible: [44-44]
@@ -664,6 +801,11 @@ Package: main
 		Arg: a: [100]uint (declared at line 99, available: [99-99])
 	Function: testVeryLargeSlice (main.testVeryLargeSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [65:65] injectible: [65-65]
 		Arg: xs: []uint (declared at line 65, available: [65-65])
+	Function: testZeroSizeArgAndReturn (main.testZeroSizeArgAndReturn) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go [368:371] injectible: [368-371]
+		Arg: a: [0]int (declared at line 368, available: )
+		Arg: b: int (declared at line 368, available: [368-371])
+		Arg: ~r0: int (declared at line 368, available: )
+		Arg: ~r1: [0]int (declared at line 368, available: )
 	Type: main.aStruct
 		Field: aBool: bool
 		Field: aString: string
@@ -731,6 +873,17 @@ Package: main
 	Type: main.iterExample
 		Function: rangeOverIterator (main.iterExample.rangeOverIterator) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/ranges.go [15:19] injectible: [15-16], [19-19]
 			Arg: ~p0: main.iterExample (declared at line 15, available: )
+	Type: main.largeStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
 	Type: main.lotsOfFields
 		Field: a: uint8
 		Field: b: uint8
@@ -758,6 +911,10 @@ Package: main
 		Field: x: uint8
 		Field: y: uint8
 		Field: z: uint8
+	Type: main.mixedStruct
+		Field: a: int
+		Field: b: float64
+		Field: c: int
 	Type: main.nStruct
 		Field: aBool: bool
 		Field: aInt: int
@@ -805,6 +962,9 @@ Package: main
 		Field: arr: [5]uint8
 	Type: main.structWithAny
 		Field: a: interface {}
+	Type: main.structWithArray
+		Field: arr: [2]int
+		Field: x: int
 	Type: main.structWithCyclicMaps
 		Field: m1: map[struct {}]main.structWithCyclicMaps
 		Field: m2: map[struct {}]map[struct {}]main.structWithCyclicMaps
@@ -861,6 +1021,18 @@ Package: main
 		Field: b: main.tierB
 	Type: main.triggerVerifierErrorForTesting
 	Type: main.typeAlias
+	Type: main.wideStruct
+		Field: a: int
+		Field: b: int
+		Field: c: int
+		Field: d: int
+		Field: e: int
+		Field: f: int
+		Field: g: int
+		Field: h: int
+		Field: i: int
+		Field: j: int
+		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2

--- a/pkg/dyninst/testdata/decoded/sample/stackC.json
+++ b/pkg/dyninst/testdata/decoded/sample/stackC.json
@@ -62,7 +62,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "hello 1!"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -65,7 +65,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "{foo}"
               }
             }
           }
@@ -141,7 +141,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "&{foo}"
               }
             }
           }
@@ -217,7 +217,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "{42}"
               }
             }
           }
@@ -293,7 +293,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "&{42}"
               }
             }
           }
@@ -369,7 +369,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "{}"
               }
             }
           }
@@ -445,7 +445,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "&{}"
               }
             }
           }
@@ -520,7 +520,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "<nil>"
               }
             }
           }
@@ -596,7 +596,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "1"
               }
             }
           }
@@ -673,7 +673,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }
@@ -749,7 +749,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "foo"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAnyPtr.json
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "<nil>"
               }
             }
           }
@@ -136,7 +136,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }
@@ -213,7 +213,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }
@@ -290,7 +290,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }
@@ -373,7 +373,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }
@@ -462,7 +462,7 @@
             "locals": {
               "~r0": {
                 "type": "string",
-                "notCapturedReason": "unavailable"
+                "value": "0x[addr]"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testArrayArgAndReturn.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testArrayArgAndReturn",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testArrayArgAndReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 285
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 419
           },
           {
             "function": "main.main",
@@ -42,25 +42,53 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testArrayArgAndReturn",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testArrayArgAndReturn"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
+              "arg": {
+                "type": "[3]int",
+                "size": "3",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "11"
+                  },
+                  {
+                    "type": "int",
+                    "value": "12"
+                  },
+                  {
+                    "type": "int",
+                    "value": "13"
+                  }
+                ]
               }
             }
           },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "[3]int",
+                "size": "3",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "110"
+                  },
+                  {
+                    "type": "int",
+                    "value": "120"
+                  },
+                  {
+                    "type": "int",
+                    "value": "130"
+                  }
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testFrameless.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFrameless.json
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "100"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testFramelessArray.json
@@ -82,7 +82,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "15"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testLargeArgAndReturn.json
@@ -1,0 +1,155 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testLargeArgAndReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testLargeArgAndReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 274
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 418
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testLargeArgAndReturn",
+          "location": {
+            "method": "main.testLargeArgAndReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "arg": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "5"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "6"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "7"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "8"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "9"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "10"
+                  }
+                }
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "10"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "20"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "30"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "40"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "50"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "60"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "70"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "80"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "9"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "10"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testManyArgsArrayReturn.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testManyArgsArrayReturn",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testManyArgsArrayReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 313
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 424
           },
           {
             "function": "main.main",
@@ -42,25 +42,67 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testManyArgsArrayReturn",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testManyArgsArrayReturn"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
+              "a": {
+                "type": "int",
+                "value": "21"
+              },
+              "b": {
+                "type": "int",
+                "value": "22"
+              },
+              "c": {
+                "type": "int",
+                "value": "23"
+              },
+              "d": {
+                "type": "int",
+                "value": "24"
+              },
+              "e": {
+                "type": "int",
+                "value": "25"
+              },
+              "f": {
+                "type": "int",
+                "value": "26"
+              },
+              "g": {
+                "type": "int",
+                "value": "27"
+              },
+              "h": {
+                "type": "int",
+                "value": "28"
+              },
               "i": {
                 "type": "int",
-                "value": "40"
+                "value": "29"
               }
             }
           },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "[2]int",
+                "size": "2",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "29"
+                  },
+                  {
+                    "type": "int",
+                    "value": "210"
+                  }
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMixedArgsStackReturn.json
@@ -1,0 +1,146 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMixedArgsStackReturn",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMixedArgsStackReturn",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 322
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 425
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testMixedArgsStackReturn",
+          "location": {
+            "method": "main.testMixedArgsStackReturn"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "int",
+                "value": "31"
+              },
+              "b": {
+                "type": "int",
+                "value": "32"
+              },
+              "c": {
+                "type": "int",
+                "value": "33"
+              },
+              "d": {
+                "type": "int",
+                "value": "34"
+              },
+              "e": {
+                "type": "int",
+                "value": "35"
+              },
+              "f": {
+                "type": "int",
+                "value": "36"
+              },
+              "g": {
+                "type": "int",
+                "value": "37"
+              },
+              "h": {
+                "type": "int",
+                "value": "38"
+              },
+              "s": {
+                "type": "string",
+                "value": "overflow"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "310"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "320"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "330"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "340"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "350"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "360"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "370"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "380"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "8"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "0"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleArrayArgs.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testMultipleArrayArgs",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testMultipleArrayArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 349
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 427
           },
           {
             "function": "main.main",
@@ -42,25 +42,67 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testMultipleArrayArgs",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testMultipleArrayArgs"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
+              "a": {
+                "type": "[2]int",
+                "size": "2",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "51"
+                  },
+                  {
+                    "type": "int",
+                    "value": "52"
+                  }
+                ]
+              },
+              "b": {
+                "type": "[3]int",
+                "size": "3",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "63"
+                  },
+                  {
+                    "type": "int",
+                    "value": "64"
+                  },
+                  {
+                    "type": "int",
+                    "value": "65"
+                  }
+                ]
               }
             }
           },
           "return": {
             "locals": {
-              "result": {
+              "~r0": {
                 "type": "int",
-                "value": "80"
+                "value": "114"
+              },
+              "~r1": {
+                "type": "[2]int",
+                "size": "2",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "510"
+                  },
+                  {
+                    "type": "int",
+                    "value": "520"
+                  }
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleLargeArgs.json
@@ -1,0 +1,200 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testMultipleLargeArgs",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testMultipleLargeArgs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 293
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 420
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testMultipleLargeArgs",
+          "location": {
+            "method": "main.testMultipleLargeArgs"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s1": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "101"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "102"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "103"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "104"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "105"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "106"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "107"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "108"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "109"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "110"
+                  }
+                }
+              },
+              "s2": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "111"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "112"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "113"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "114"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "115"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "116"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "117"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "118"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "119"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "120"
+                  }
+                }
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "1232"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "1244"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "1256"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "1268"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "1280"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "1292"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "1304"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "1316"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "1328"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "1340"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -60,11 +60,11 @@
             "locals": {
               "result": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "41"
               },
               "result2": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "41"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testMultipleNamedReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testMultipleNamedReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 76
+            "lineNumber": 99
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 105
+            "lineNumber": 394
           },
           {
             "function": "main.main",
@@ -60,11 +60,11 @@
             "locals": {
               "result": {
                 "type": "int",
-                "value": "41"
+                "value": "82"
               },
               "result2": {
                 "type": "int",
-                "value": "41"
+                "value": "123"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testNamedReturn.json
@@ -60,7 +60,7 @@
             "locals": {
               "result": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "40"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 51
+            "lineNumber": 70
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 95
+            "lineNumber": 384
           },
           {
             "function": "main.main",
@@ -97,12 +97,12 @@
           {
             "function": "main.testReturnsAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 51
+            "lineNumber": 65
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 96
+            "lineNumber": 385
           },
           {
             "function": "main.main",
@@ -147,7 +147,7 @@
                 "fields": {
                   "data": {
                     "type": "int",
-                    "value": "42"
+                    "value": "1042"
                   }
                 }
               }
@@ -178,12 +178,12 @@
           {
             "function": "main.testReturnsAny",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 51
+            "lineNumber": 68
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 98
+            "lineNumber": 387
           },
           {
             "function": "main.main",
@@ -230,7 +230,7 @@
                   "data": {
                     "type": "*int",
                     "address": "[addr]",
-                    "value": "42"
+                    "value": "1042"
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAny.json
@@ -64,7 +64,11 @@
             "locals": {
               "~r0": {
                 "type": "interface {}",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
               }
             }
           }
@@ -140,7 +144,12 @@
             "locals": {
               "~r0": {
                 "type": "interface {}",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "int",
+                    "value": "42"
+                  }
+                }
               }
             }
           }
@@ -217,7 +226,13 @@
             "locals": {
               "~r0": {
                 "type": "interface {}",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "*int",
+                    "address": "[addr]",
+                    "value": "42"
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -69,11 +69,26 @@
             "locals": {
               "~r0": {
                 "type": "interface {}",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
               },
               "~r1": {
                 "type": "error",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "*errors.errorString",
+                    "address": "[addr]",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "error"
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -153,11 +168,20 @@
             "locals": {
               "~r0": {
                 "type": "interface {}",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "int",
+                    "value": "42"
+                  }
+                }
               },
               "~r1": {
                 "type": "error",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsAnyAndError.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsAnyAndError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 43
+            "lineNumber": 46
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 380
           },
           {
             "function": "main.main",
@@ -117,12 +117,12 @@
           {
             "function": "main.testReturnsAnyAndError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 45
+            "lineNumber": 51
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 92
+            "lineNumber": 381
           },
           {
             "function": "main.main",
@@ -171,7 +171,7 @@
                 "fields": {
                   "data": {
                     "type": "int",
-                    "value": "42"
+                    "value": "1042"
                   }
                 }
               },

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArray.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsArray",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 159
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 402
           },
           {
             "function": "main.main",
@@ -42,25 +42,31 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsArray",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsArray"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "[3]int",
+                "size": "3",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  {
+                    "type": "int",
+                    "value": "3"
+                  }
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayOne.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsArrayOne",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsArrayOne",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 167
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 403
           },
           {
             "function": "main.main",
@@ -42,25 +42,23 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsArrayOne",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsArrayOne"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "[1]int",
+                "size": "1",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "42"
+                  }
+                ]
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsArrayZero.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsArrayZero",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsArrayZero",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 175
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 404
           },
           {
             "function": "main.main",
@@ -42,25 +42,18 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsArrayZero",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsArrayZero"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "[0]int",
+                "size": "0",
+                "elements": []
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBacktrackInt.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsBacktrackInt",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsBacktrackInt",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 198
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 406
           },
           {
             "function": "main.main",
@@ -42,25 +42,49 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsBacktrackInt",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsBacktrackInt"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
+              "~r0": {
                 "type": "int",
-                "value": "80"
+                "value": "1"
+              },
+              "~r1": {
+                "type": "int",
+                "value": "2"
+              },
+              "~r2": {
+                "type": "int",
+                "value": "3"
+              },
+              "~r3": {
+                "type": "int",
+                "value": "4"
+              },
+              "~r4": {
+                "type": "int",
+                "value": "5"
+              },
+              "~r5": {
+                "type": "int",
+                "value": "6"
+              },
+              "~r6": {
+                "type": "int",
+                "value": "7"
+              },
+              "~r7": {
+                "type": "int",
+                "value": "8"
+              },
+              "~r8": {
+                "type": "string",
+                "value": "overflow"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsBoolAndUintptr.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsBoolAndUintptr",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsBoolAndUintptr",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 255
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 412
           },
           {
             "function": "main.main",
@@ -42,25 +42,21 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsBoolAndUintptr",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsBoolAndUintptr"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "bool",
+                "value": "true"
+              },
+              "~r1": {
+                "type": "uintptr",
+                "value": "0x1234"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsComplex.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsComplex",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsComplex",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 140
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 400
           },
           {
             "function": "main.main",
@@ -42,25 +42,21 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsComplex",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsComplex"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "complex64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r1": {
+                "type": "complex128",
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 35
+            "lineNumber": 38
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 89
+            "lineNumber": 378
           },
           {
             "function": "main.main",
@@ -100,12 +100,12 @@
           {
             "function": "main.testReturnsError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 37
+            "lineNumber": 40
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 90
+            "lineNumber": 379
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsError.json
@@ -60,7 +60,18 @@
             "locals": {
               "~r0": {
                 "type": "error",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "*errors.errorString",
+                    "address": "[addr]",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "error"
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -131,7 +142,11 @@
             "locals": {
               "~r0": {
                 "type": "error",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "42"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInt.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsInt",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 16
+            "lineNumber": 17
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 86
+            "lineNumber": 375
           },
           {
             "function": "main.main",
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "value": "42"
+                "value": "142"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "42"
               },
               "~r1": {
                 "type": "float64",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntAndFloat.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsIntAndFloat",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 29
+            "lineNumber": 32
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 88
+            "lineNumber": 377
           },
           {
             "function": "main.main",
@@ -60,7 +60,7 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "value": "42"
+                "value": "142"
               },
               "~r1": {
                 "type": "float64",

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsIntPointer",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 22
+            "lineNumber": 24
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 87
+            "lineNumber": 376
           },
           {
             "function": "main.main",
@@ -61,7 +61,7 @@
               "~r0": {
                 "type": "*int",
                 "address": "[addr]",
-                "value": "42"
+                "value": "142"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsIntPointer.json
@@ -60,7 +60,8 @@
             "locals": {
               "~r0": {
                 "type": "*int",
-                "notCapturedReason": "unavailable"
+                "address": "[addr]",
+                "value": "42"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -65,7 +65,11 @@
             "locals": {
               "~r0": {
                 "type": "main.behavior",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "isNull": true
+                  }
+                }
               }
             }
           }
@@ -146,7 +150,17 @@
             "locals": {
               "~r0": {
                 "type": "main.behavior",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "main.firstBehavior",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "foo"
+                      }
+                    }
+                  }
+                }
               }
             }
           }
@@ -228,7 +242,18 @@
             "locals": {
               "~r0": {
                 "type": "main.behavior",
-                "notCapturedReason": "unavailable"
+                "fields": {
+                  "data": {
+                    "type": "*main.firstBehavior",
+                    "address": "[addr]",
+                    "fields": {
+                      "s": {
+                        "type": "string",
+                        "value": "foo"
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsInterface.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testReturnsInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 58
+            "lineNumber": 80
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 100
+            "lineNumber": 389
           },
           {
             "function": "main.main",
@@ -98,12 +98,12 @@
           {
             "function": "main.testReturnsInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 61
+            "lineNumber": 84
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 101
+            "lineNumber": 390
           },
           {
             "function": "main.main",
@@ -156,7 +156,7 @@
                     "fields": {
                       "s": {
                         "type": "string",
-                        "value": "foo"
+                        "value": "{foo}\n_modified"
                       }
                     }
                   }
@@ -189,12 +189,12 @@
           {
             "function": "main.testReturnsInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 61
+            "lineNumber": 84
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 102
+            "lineNumber": 391
           },
           {
             "function": "main.main",
@@ -244,12 +244,11 @@
                 "type": "main.behavior",
                 "fields": {
                   "data": {
-                    "type": "*main.firstBehavior",
-                    "address": "[addr]",
+                    "type": "main.firstBehavior",
                     "fields": {
                       "s": {
                         "type": "string",
-                        "value": "foo"
+                        "value": "{foo}\n_modified"
                       }
                     }
                   }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsLargeStruct.json
@@ -1,0 +1,106 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testReturnsLargeStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testReturnsLargeStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 151
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 401
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testReturnsLargeStruct",
+          "location": {
+            "method": "main.testReturnsLargeStruct"
+          }
+        },
+        "captures": {
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "main.largeStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "5"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "6"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "7"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "8"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "9"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "10"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsManyFloats.json
@@ -1,0 +1,126 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testReturnsManyFloats",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testReturnsManyFloats",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 132
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 399
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testReturnsManyFloats",
+          "location": {
+            "method": "main.testReturnsManyFloats"
+          }
+        },
+        "captures": {
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r1": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r2": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r3": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r4": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r5": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r6": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r7": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r8": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r9": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r10": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r11": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r12": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r13": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r14": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "onlyOnAmd64_16": "[onlyOnAmd64]",
+              "bothArmAndAmd64": {
+                "type": "float64",
+                "value": "17"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixed.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsMixed",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsMixed",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 218
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 408
           },
           {
             "function": "main.main",
@@ -42,25 +42,33 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsMixed",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsMixed"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
+              "~r0": {
                 "type": "int",
-                "value": "80"
+                "value": "1"
+              },
+              "~r1": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r2": {
+                "type": "int",
+                "value": "3"
+              },
+              "~r3": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
+              },
+              "~r4": {
+                "type": "string",
+                "value": "test"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMixedStruct.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsMixedStruct",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsMixedStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 188
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 405
           },
           {
             "function": "main.main",
@@ -42,25 +42,17 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsMixedStruct",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsMixedStruct"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "main.mixedStruct",
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsMultipleFloats.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsMultipleFloats",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsMultipleFloats",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 247
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 411
           },
           {
             "function": "main.main",
@@ -42,25 +42,21 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsMultipleFloats",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsMultipleFloats"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "float32",
+                "notCapturedReason": "unavailable"
+              },
+              "~r1": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsOnlyFloat.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsOnlyFloat",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsOnlyFloat",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 239
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 410
           },
           {
             "function": "main.main",
@@ -42,25 +42,17 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsOnlyFloat",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsOnlyFloat"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "float64",
+                "notCapturedReason": "unavailable"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsPrimitives.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsPrimitives",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsPrimitives",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 113
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 398
           },
           {
             "function": "main.main",
@@ -42,25 +42,45 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsPrimitives",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsPrimitives"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "int8",
+                "value": "1"
+              },
+              "~r1": {
+                "type": "int16",
+                "value": "2"
+              },
+              "~r2": {
+                "type": "int32",
+                "value": "3"
+              },
+              "~r3": {
+                "type": "int64",
+                "value": "4"
+              },
+              "~r4": {
+                "type": "uint8",
+                "value": "5"
+              },
+              "~r5": {
+                "type": "uint16",
+                "value": "6"
+              },
+              "~r6": {
+                "type": "uint32",
+                "value": "7"
+              },
+              "~r7": {
+                "type": "uint64",
+                "value": "8"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsStructWithArray.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testReturnsStructWithArray",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testReturnsStructWithArray",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 230
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 409
           },
           {
             "function": "main.main",
@@ -42,25 +42,36 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testReturnsStructWithArray",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testReturnsStructWithArray"
           }
         },
         "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
-              }
-            }
-          },
           "return": {
             "locals": {
-              "result": {
-                "type": "int",
-                "value": "80"
+              "~r0": {
+                "type": "main.structWithArray",
+                "fields": {
+                  "arr": {
+                    "type": "[2]int",
+                    "size": "2",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "1"
+                      },
+                      {
+                        "type": "int",
+                        "value": "2"
+                      }
+                    ]
+                  },
+                  "x": {
+                    "type": "int",
+                    "value": "3"
+                  }
+                }
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testReturnsWideStruct.json
@@ -1,0 +1,110 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testReturnsWideStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testReturnsWideStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 210
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 407
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testReturnsWideStruct",
+          "location": {
+            "method": "main.testReturnsWideStruct"
+          }
+        },
+        "captures": {
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "main.wideStruct",
+                "fields": {
+                  "a": {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  "b": {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  "c": {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  "d": {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  "e": {
+                    "type": "int",
+                    "value": "5"
+                  },
+                  "f": {
+                    "type": "int",
+                    "value": "6"
+                  },
+                  "g": {
+                    "type": "int",
+                    "value": "7"
+                  },
+                  "h": {
+                    "type": "int",
+                    "value": "8"
+                  },
+                  "i": {
+                    "type": "int",
+                    "value": "9"
+                  },
+                  "j": {
+                    "type": "int",
+                    "value": "10"
+                  },
+                  "k": {
+                    "type": "int",
+                    "value": "11"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -60,15 +60,15 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "41"
               },
               "result2": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "42"
               },
               "~r2": {
                 "type": "int",
-                "notCapturedReason": "unavailable"
+                "value": "43"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testSomeNamedReturn.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testSomeNamedReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 82
+            "lineNumber": 105
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 106
+            "lineNumber": 395
           },
           {
             "function": "main.main",
@@ -60,15 +60,15 @@
             "locals": {
               "~r0": {
                 "type": "int",
-                "value": "41"
+                "value": "420"
               },
               "result2": {
                 "type": "int",
-                "value": "42"
+                "value": "840"
               },
               "~r2": {
                 "type": "int",
-                "value": "43"
+                "value": "1260"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStackArgRegReturns.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testStackArgRegReturns",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testStackArgRegReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 341
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 426
           },
           {
             "function": "main.main",
@@ -42,25 +42,55 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testStackArgRegReturns",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testStackArgRegReturns"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "i": {
-                "type": "int",
-                "value": "40"
+              "arg": {
+                "type": "[5]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "41"
+                  },
+                  {
+                    "type": "int",
+                    "value": "42"
+                  },
+                  {
+                    "type": "int",
+                    "value": "43"
+                  },
+                  {
+                    "type": "int",
+                    "value": "44"
+                  },
+                  {
+                    "type": "int",
+                    "value": "45"
+                  }
+                ]
               }
             }
           },
           "return": {
             "locals": {
-              "result": {
+              "~r0": {
                 "type": "int",
-                "value": "80"
+                "value": "45"
+              },
+              "~r1": {
+                "type": "int",
+                "value": "42"
+              },
+              "~r2": {
+                "type": "int",
+                "value": "43"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithArrayArg.json
@@ -1,0 +1,115 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStructWithArrayArg",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testStructWithArrayArg",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 362
+          },
+          {
+            "function": "main.executeReturns",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
+            "lineNumber": 428
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testStructWithArrayArg",
+          "location": {
+            "method": "main.testStructWithArrayArg"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "arg": {
+                "type": "main.structWithArray",
+                "fields": {
+                  "arr": {
+                    "type": "[2]int",
+                    "size": "2",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "71"
+                      },
+                      {
+                        "type": "int",
+                        "value": "72"
+                      }
+                    ]
+                  },
+                  "x": {
+                    "type": "int",
+                    "value": "73"
+                  }
+                }
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "int",
+                "value": "74"
+              },
+              "~r1": {
+                "type": "main.structWithArray",
+                "fields": {
+                  "arr": {
+                    "type": "[2]int",
+                    "size": "2",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "710"
+                      },
+                      {
+                        "type": "int",
+                        "value": "720"
+                      }
+                    ]
+                  },
+                  "x": {
+                    "type": "int",
+                    "value": "730"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
+++ b/pkg/dyninst/testdata/decoded/sample/testZeroSizeArgAndReturn.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testNamedReturn",
+      "method": "main.testZeroSizeArgAndReturn",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testNamedReturn",
+            "function": "main.testZeroSizeArgAndReturn",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 91
+            "lineNumber": 371
           },
           {
             "function": "main.executeReturns",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/returns.go",
-            "lineNumber": 393
+            "lineNumber": 429
           },
           {
             "function": "main.main",
@@ -42,25 +42,35 @@
           }
         ],
         "probe": {
-          "id": "testNamedReturn",
+          "id": "testZeroSizeArgAndReturn",
           "location": {
-            "method": "main.testNamedReturn"
+            "method": "main.testZeroSizeArgAndReturn"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "i": {
+              "a": {
+                "type": "[0]int",
+                "size": "0",
+                "elements": []
+              },
+              "b": {
                 "type": "int",
-                "value": "40"
+                "value": "82"
               }
             }
           },
           "return": {
             "locals": {
-              "result": {
+              "~r0": {
                 "type": "int",
-                "value": "80"
+                "value": "982"
+              },
+              "~r1": {
+                "type": "[0]int",
+                "size": "0",
+                "elements": []
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -47,7 +47,36 @@
             "locals": {
               "~r0": {
                 "type": "map[uint8]map[int]main.aStructNotUsedAsAnArgument",
-                "notCapturedReason": "unavailable"
+                "size": "1",
+                "entries": [
+                  [
+                    {
+                      "type": "uint8",
+                      "value": "97"
+                    },
+                    {
+                      "type": "map[int]main.aStructNotUsedAsAnArgument",
+                      "size": "1",
+                      "entries": [
+                        [
+                          {
+                            "type": "int",
+                            "value": "0"
+                          },
+                          {
+                            "type": "main.aStructNotUsedAsAnArgument",
+                            "fields": {
+                              "a": {
+                                "type": "int",
+                                "value": "1"
+                              }
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
               }
             }
           }

--- a/pkg/dyninst/testprogs/progs/sample/returns.go
+++ b/pkg/dyninst/testprogs/progs/sample/returns.go
@@ -12,21 +12,24 @@ import (
 
 //go:noinline
 func testReturnsInt(i int) int {
-	fmt.Println(i)
-	return i
+	result := i + 100
+	fmt.Println(result)
+	return result
 }
 
 //go:noinline
 func testReturnsIntPointer(i int) *int {
-	fmt.Println(i)
-	return &i
+	result := i + 100
+	fmt.Println(result)
+	return &result
 }
 
 //go:noinline
 func testReturnsIntAndFloat(i int) (int, float64) {
-	f := float64(i)
-	fmt.Println("returnsIntAndFloat", i, f)
-	return i, f
+	resultInt := i + 100
+	resultFloat := float64(i) + 0.5
+	fmt.Println("returnsIntAndFloat", resultInt, resultFloat)
+	return resultInt, resultFloat
 }
 
 //go:noinline
@@ -42,13 +45,32 @@ func testReturnsAnyAndError(v any, failed bool) (any, error) {
 	if failed {
 		return nil, errors.New("error")
 	}
-	return v, nil
+	// Transform the value to ensure we're not reading argument memory.
+	switch val := v.(type) {
+	case int:
+		return val + 1000, nil
+	case string:
+		return val + "_modified", nil
+	default:
+		return []int{999}, nil
+	}
 }
 
 //go:noinline
 func testReturnsAny(v any) any {
 	fmt.Println("returnsAny", v)
-	return v
+	// Transform the value to ensure we're not reading argument memory.
+	switch val := v.(type) {
+	case int:
+		return val + 1000
+	case *int:
+		result := *val + 1000
+		return &result
+	case nil:
+		return nil
+	default:
+		return []any{999, fmt.Sprintf("%T", v)}
+	}
 }
 
 //go:noinline
@@ -58,20 +80,21 @@ func testReturnsInterface(v any) behavior {
 		return nil
 	}
 	fmt.Println("returnsInterface", b)
-	return b
+	// Return a new instance to avoid reading argument memory.
+	return firstBehavior{s: b.DoSomething() + "_modified"}
 }
 
 //go:noinline
 func testNamedReturn(i int) (result int) {
-	result = i
+	result = i * 2
 	fmt.Println("testNamedReturn", result)
 	return
 }
 
 //go:noinline
 func testMultipleNamedReturn(i int) (result int, result2 int) {
-	result = i
-	result2 = i
+	result = i * 2
+	result2 = i * 3
 	fmt.Println("testMultipleNamedReturn", result, result2)
 	return
 }
@@ -79,7 +102,273 @@ func testMultipleNamedReturn(i int) (result int, result2 int) {
 //go:noinline
 func testSomeNamedReturn(i int) (_ int, result2 int, _ int) {
 	fmt.Println("testSomeNamedReturn", i)
-	return i - 1, i, i + 1
+	return i * 10, i * 20, i * 30
+}
+
+// Primitive types - exercise all basic types.
+//
+//go:noinline
+func testReturnsPrimitives() (int8, int16, int32, int64, uint8, uint16, uint32, uint64) {
+	fmt.Println("testReturnsPrimitives")
+	return 1, 2, 3, 4, 5, 6, 7, 8
+}
+
+// Floating-point exhaustion - 16 floats exceeds 15 FP registers.
+// Later floats should be stack-assigned (which we CAN read via CFA).
+//
+//go:noinline
+func testReturnsManyFloats() (
+	_ float64, _ float64, _ float64, _ float64, _ float64, _ float64, _ float64,
+	_ float64, _ float64, _ float64, _ float64, _ float64, _ float64, _ float64,
+	_ float64,
+	// This overflows the 15 FP registers on amd64 but is still in a register on
+	// arm64.
+	onlyOnAmd64_16 float64,
+	// This one is available and is a register on both amd64 and arm64.
+	bothArmAndAmd64 float64,
+) {
+	fmt.Println("testReturnsManyFloats")
+	return 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0,
+		14.0, 15.0, 16.0, 17.0
+}
+
+// Complex types - use FP registers.
+//
+//go:noinline
+func testReturnsComplex() (complex64, complex128) {
+	fmt.Println("testReturnsComplex")
+	return complex(1, 2), complex(3, 4)
+}
+
+// Large struct - should be stack-assigned.
+type largeStruct struct {
+	a, b, c, d, e, f, g, h, i, j int
+}
+
+//go:noinline
+func testReturnsLargeStruct() largeStruct {
+	fmt.Println("testReturnsLargeStruct")
+	return largeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+}
+
+// Array - length > 1 should be stack-assigned.
+//
+//go:noinline
+func testReturnsArray() [3]int {
+	fmt.Println("testReturnsArray")
+	return [3]int{1, 2, 3}
+}
+
+// Array length 1 - should be register-assigned (same as element).
+//
+//go:noinline
+func testReturnsArrayOne() [1]int {
+	fmt.Println("testReturnsArrayOne")
+	return [1]int{42}
+}
+
+// Array length 0 - edge case.
+//
+//go:noinline
+func testReturnsArrayZero() [0]int {
+	fmt.Println("testReturnsArrayZero")
+	return [0]int{}
+}
+
+// Mixed int + float struct - should have both int reg pieces and FP pieces.
+type mixedStruct struct {
+	a int
+	b float64
+	c int
+}
+
+//go:noinline
+func testReturnsMixedStruct() mixedStruct {
+	fmt.Println("testReturnsMixedStruct")
+	return mixedStruct{a: 1, b: 2.0, c: 3}
+}
+
+// Backtracking case 1: Exhaust integer registers mid-assignment.
+// 8 ints (uses 8 int regs) + 1 string (needs 2 more = 10 total).
+// Since we can't fit the string, ALL should be stack-assigned.
+//
+//go:noinline
+func testReturnsBacktrackInt() (int, int, int, int, int, int, int, int, string) {
+	fmt.Println("testReturnsBacktrackInt")
+	return 1, 2, 3, 4, 5, 6, 7, 8, "overflow"
+}
+
+// Backtracking case 2: Struct with too many fields.
+// First few fields fit in registers, but struct as a whole doesn't.
+type wideStruct struct {
+	a, b, c, d, e, f, g, h, i, j, k int // 11 fields > 9 int regs
+}
+
+//go:noinline
+func testReturnsWideStruct() wideStruct {
+	fmt.Println("testReturnsWideStruct")
+	return wideStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+}
+
+// Multiple values with some floats - tests mixed scenarios.
+//
+//go:noinline
+func testReturnsMixed() (int, float64, int, float64, string) {
+	fmt.Println("testReturnsMixed")
+	return 1, 2.0, 3, 4.0, "test"
+}
+
+// Struct with nested arrays - should be stack-assigned.
+type structWithArray struct {
+	arr [2]int
+	x   int
+}
+
+//go:noinline
+func testReturnsStructWithArray() structWithArray {
+	fmt.Println("testReturnsStructWithArray")
+	return structWithArray{arr: [2]int{1, 2}, x: 3}
+}
+
+// Edge case: Only floats (no int regs).
+// Should NOT be augmented by ABI (keep DWARF).
+//
+//go:noinline
+func testReturnsOnlyFloat() float64 {
+	fmt.Println("testReturnsOnlyFloat")
+	return 42.0
+}
+
+// Edge case: Multiple floats only.
+//
+//go:noinline
+func testReturnsMultipleFloats() (float32, float64) {
+	fmt.Println("testReturnsMultipleFloats")
+	return 1.0, 2.0
+}
+
+// Bool and uintptr (should use int regs).
+//
+//go:noinline
+func testReturnsBoolAndUintptr() (bool, uintptr) {
+	fmt.Println("testReturnsBoolAndUintptr")
+	return true, 0x1234
+}
+
+// Argument stack space tests - verify return offsets account for arguments.
+
+// Large argument + large return - both on stack.
+// Argument uses stack space, return offset must be after it.
+//
+//go:noinline
+func testLargeArgAndReturn(arg largeStruct) largeStruct {
+	fmt.Println("testLargeArgAndReturn", arg.a)
+	arg.a *= 10
+	arg.b *= 10
+	arg.c *= 10
+	arg.d *= 10
+	arg.e *= 10
+	arg.f *= 10
+	arg.g *= 10
+	arg.h *= 10
+	return arg
+}
+
+// Array argument + array return - both on stack.
+//
+//go:noinline
+func testArrayArgAndReturn(arg [3]int) [3]int {
+	fmt.Println("testArrayArgAndReturn", arg[0])
+	arg[0] *= 10
+	arg[1] *= 10
+	arg[2] *= 10
+	return arg
+}
+
+// Multiple large arguments + large return.
+//
+//go:noinline
+func testMultipleLargeArgs(s1 largeStruct, s2 largeStruct) largeStruct {
+	fmt.Println("testMultipleLargeArgs", s1.a, s2.a)
+	return largeStruct{
+		a: s1.a*10 + s2.a*2,
+		b: s1.b*10 + s2.b*2,
+		c: s1.c*10 + s2.c*2,
+		d: s1.d*10 + s2.d*2,
+		e: s1.e*10 + s2.e*2,
+		f: s1.f*10 + s2.f*2,
+		g: s1.g*10 + s2.g*2,
+		h: s1.h*10 + s2.h*2,
+		i: s1.i*10 + s2.i*2,
+		j: s1.j*10 + s2.j*2,
+	}
+}
+
+// Exhaust registers with arguments, then return on stack.
+// 9 int args (fill all int regs) + array return (on stack).
+//
+//go:noinline
+func testManyArgsArrayReturn(a, b, c, d, e, f, g, h, i int) [2]int {
+	fmt.Println("testManyArgsArrayReturn", a, b, c, d, e, f, g, h, i)
+	return [2]int{i, a * 10}
+}
+
+// Some args on stack, some in regs, return on stack.
+// 8 ints (in regs) + string (on stack) → large struct return (on stack).
+//
+//go:noinline
+func testMixedArgsStackReturn(a, b, c, d, e, f, g, h int, s string) largeStruct {
+	fmt.Println("testMixedArgsStackReturn", a, s)
+	return largeStruct{
+		a: a * 10,
+		b: b * 10,
+		c: c * 10,
+		d: d * 10,
+		e: e * 10,
+		f: f * 10,
+		g: g * 10,
+		h: h * 10,
+		i: int(len(s)),
+		j: 0,
+	}
+}
+
+// Stack-assigned arg + register-assigned returns.
+//
+//go:noinline
+func testStackArgRegReturns(arg [5]int) (int, int, int) {
+	fmt.Println("testStackArgRegReturns", arg[0])
+	return arg[4], arg[1], arg[2]
+}
+
+// Multiple array arguments (stack) + multiple returns (some stack, some reg).
+//
+//go:noinline
+func testMultipleArrayArgs(a [2]int, b [3]int) (int, [2]int) {
+	fmt.Println("testMultipleArrayArgs", a[0], b[0])
+	return a[0] + b[0], [2]int{a[0] * 10, a[1] * 10}
+}
+
+// Struct with array argument + mixed returns.
+//
+//go:noinline
+func testStructWithArrayArg(arg structWithArray) (int, structWithArray) {
+	fmt.Println("testStructWithArrayArg", arg.x)
+	x := arg.x + 1
+	ret := structWithArray{
+		x:   arg.x * 10,
+		arr: [2]int{arg.arr[0] * 10, arg.arr[1] * 10},
+	}
+	return x, ret
+}
+
+// Edge case: Zero-size argument (shouldn't affect offsets).
+//
+//go:noinline
+func testZeroSizeArgAndReturn(a [0]int, b int) (int, [0]int) {
+	fmt.Println("testZeroSizeArgAndReturn", b)
+	b += 900
+	return b, a
 }
 
 func executeReturns() {
@@ -104,4 +393,38 @@ func executeReturns() {
 	testNamedReturn(40)
 	testMultipleNamedReturn(41)
 	testSomeNamedReturn(42)
+
+	// New ABI test cases - return values only.
+	testReturnsPrimitives()
+	testReturnsManyFloats()
+	testReturnsComplex()
+	testReturnsLargeStruct()
+	testReturnsArray()
+	testReturnsArrayOne()
+	testReturnsArrayZero()
+	testReturnsMixedStruct()
+	testReturnsBacktrackInt()
+	testReturnsWideStruct()
+	testReturnsMixed()
+	testReturnsStructWithArray()
+	testReturnsOnlyFloat()
+	testReturnsMultipleFloats()
+	testReturnsBoolAndUintptr()
+
+	// ABI test cases - argument + return interaction.
+	//
+	// Use different arguments to really make sure we aren't just getting lucky
+	// with stack slots.
+	testLargeArgAndReturn(largeStruct{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	testArrayArgAndReturn([3]int{11, 12, 13})
+	testMultipleLargeArgs(
+		largeStruct{101, 102, 103, 104, 105, 106, 107, 108, 109, 110},
+		largeStruct{111, 112, 113, 114, 115, 116, 117, 118, 119, 120},
+	)
+	testManyArgsArrayReturn(21, 22, 23, 24, 25, 26, 27, 28, 29)
+	testMixedArgsStackReturn(31, 32, 33, 34, 35, 36, 37, 38, "overflow")
+	testStackArgRegReturns([5]int{41, 42, 43, 44, 45})
+	testMultipleArrayArgs([2]int{51, 52}, [3]int{63, 64, 65})
+	testStructWithArrayArg(structWithArray{arr: [2]int{71, 72}, x: 73})
+	testZeroSizeArgAndReturn([0]int{}, 82)
 }

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -1024,3 +1024,123 @@ probes:
     captureSnapshot: true
     sampling:
       snapshotsPerSecond: 100
+  - id: testReturnsPrimitives
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsPrimitives
+    captureSnapshot: true
+  - id: testReturnsManyFloats
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsManyFloats
+    captureSnapshot: true
+  - id: testReturnsComplex
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsComplex
+    captureSnapshot: true
+  - id: testReturnsLargeStruct
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsLargeStruct
+    captureSnapshot: true
+  - id: testReturnsArray
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsArray
+    captureSnapshot: true
+  - id: testReturnsArrayOne
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsArrayOne
+    captureSnapshot: true
+  - id: testReturnsArrayZero
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsArrayZero
+    captureSnapshot: true
+  - id: testReturnsMixedStruct
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsMixedStruct
+    captureSnapshot: true
+  - id: testReturnsBacktrackInt
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsBacktrackInt
+    captureSnapshot: true
+  - id: testReturnsWideStruct
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsWideStruct
+    captureSnapshot: true
+  - id: testReturnsMixed
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsMixed
+    captureSnapshot: true
+  - id: testReturnsStructWithArray
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsStructWithArray
+    captureSnapshot: true
+  - id: testReturnsOnlyFloat
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsOnlyFloat
+    captureSnapshot: true
+  - id: testReturnsMultipleFloats
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsMultipleFloats
+    captureSnapshot: true
+  - id: testReturnsBoolAndUintptr
+    type: LOG_PROBE
+    where:
+      methodName: main.testReturnsBoolAndUintptr
+    captureSnapshot: true
+  - id: testLargeArgAndReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testLargeArgAndReturn
+    captureSnapshot: true
+  - id: testArrayArgAndReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testArrayArgAndReturn
+    captureSnapshot: true
+  - id: testMultipleLargeArgs
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleLargeArgs
+    captureSnapshot: true
+  - id: testManyArgsArrayReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testManyArgsArrayReturn
+    captureSnapshot: true
+  - id: testMixedArgsStackReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testMixedArgsStackReturn
+    captureSnapshot: true
+  - id: testStackArgRegReturns
+    type: LOG_PROBE
+    where:
+      methodName: main.testStackArgRegReturns
+    captureSnapshot: true
+  - id: testMultipleArrayArgs
+    type: LOG_PROBE
+    where:
+      methodName: main.testMultipleArrayArgs
+    captureSnapshot: true
+  - id: testStructWithArrayArg
+    type: LOG_PROBE
+    where:
+      methodName: main.testStructWithArrayArg
+    captureSnapshot: true
+  - id: testZeroSizeArgAndReturn
+    type: LOG_PROBE
+    where:
+      methodName: main.testZeroSizeArgAndReturn
+    captureSnapshot: true


### PR DESCRIPTION
### What does this PR do?

The Go calling convention and ABI is well-defined regarding where return
values live in terms of registers and on the stack for out-of-line calls.

This PR makes return probes actually capable of returning data.

### Motivation

Using this information is crucial for return probes because the dwarf
information for these variables is so terrible.

### Describe how you validated your changes

See testing.

### Additional Notes

Part of https://datadoghq.atlassian.net/browse/DEBUG-4031.