### PR TITLE
Mark TestManualProcessCheckWithIO as flaky

### DIFF
--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -366,6 +367,9 @@ func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 }
 
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
+	// https://datadoghq.atlassian.net/browse/CXP-2594
+	flake.Mark(s.T())
+	
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(
 		agentparams.WithAgentConfig(processCheckConfigStr),
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr))))

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -369,7 +369,7 @@ func (s *linuxTestSuite) TestManualProcessDiscoveryCheck() {
 func (s *linuxTestSuite) TestManualProcessCheckWithIO() {
 	// https://datadoghq.atlassian.net/browse/CXP-2594
 	flake.Mark(s.T())
-	
+
 	s.UpdateEnv(awshost.Provisioner(awshost.WithAgentOptions(
 		agentparams.WithAgentConfig(processCheckConfigStr),
 		agentparams.WithSystemProbeConfig(systemProbeConfigStr))))


### PR DESCRIPTION
### What does this PR do?

Mark TestManualProcessCheckWithIO as flaky.

### Motivation

Failing around once every 2 days:
[https://app.datadoghq.com/logs?query=%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent[…]ing=true&from_ts=1713450412550&to_ts=1714055212550&live=true](https://app.datadoghq.com/logs?query=%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%22unexpected%20end%20of%20JSON%20input%22%20%40ci.job.name%3Anew-e2e-process&agg_m=count&agg_m_source=base&agg_q=%40ci.job.name&agg_q_source=base&agg_t=count&cols=status_line%2C%40ci.job.id&fromUser=true&index=ci-app-pipeline-logs-gitlab-datadog-agent&messageDisplay=inline&refresh_mode=sliding&saved-view-id=2651741&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1713450412550&to_ts=1714055212550&live=true)

<img width="1637" height="495" alt="image" src="https://github.com/user-attachments/assets/f420429e-7848-4d80-85b4-c10c9042ab7e" />

### Describe how you validated your changes

### Additional Notes

Tracking fix in https://datadoghq.atlassian.net/browse/CXP-2594