### PR TITLE
register the default config command for other agents

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -52,6 +52,7 @@ func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery
 		getConfigCheck(w, r, ac)
 	}).Methods("GET")
 	r.HandleFunc("/config", settings.GetFullConfig("")).Methods("GET")
+	r.HandleFunc("/config/without-defaults", settings.GetFullConfigWithoutDefaults("")).Methods("GET")
 	r.HandleFunc("/config/by-source", settings.GetFullConfigBySource()).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.GetValue).Methods("GET")

--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -43,6 +43,7 @@ func injectDeps(deps APIServerDeps, handler func(APIServerDeps, http.ResponseWri
 //nolint:revive // TODO(PROC) Fix revive linter
 func SetupAPIServerHandlers(deps APIServerDeps, r *mux.Router) {
 	r.HandleFunc("/config", deps.Settings.GetFullConfig("process_config")).Methods("GET")
+	r.HandleFunc("/config/without-defaults", deps.Settings.GetFullConfigWithoutDefaults("process_config")).Methods("GET")
 	r.HandleFunc("/config/all", deps.Settings.GetFullConfig("")).Methods("GET") // Get all fields from process-agent Config object
 	r.HandleFunc("/config/list-runtime", deps.Settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", deps.Settings.GetValue).Methods("GET")

--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -55,6 +55,7 @@ func (a *Agent) SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/status", a.getStatus).Methods("GET")
 	r.HandleFunc("/status/health", a.getHealth).Methods("GET")
 	r.HandleFunc("/config", a.settings.GetFullConfig("")).Methods("GET")
+	r.HandleFunc("/config/without-defaults", a.settings.GetFullConfigWithoutDefaults("")).Methods("GET")
 	// FIXME: this returns the entire datadog.yaml and not just security-agent.yaml config
 	r.HandleFunc("/config/by-source", a.settings.GetFullConfigBySource()).Methods("GET")
 	r.HandleFunc("/config/list-runtime", a.settings.ListConfigurable).Methods("GET")

--- a/cmd/system-probe/api/config.go
+++ b/cmd/system-probe/api/config.go
@@ -16,6 +16,7 @@ import (
 // setupConfigHandlers adds the specific handlers for /config endpoints
 func setupConfigHandlers(r *mux.Router, settings settings.Component) {
 	r.HandleFunc("/config", settings.GetFullConfig(getAggregatedNamespaces()...)).Methods("GET")
+	r.HandleFunc("/config/without-defaults", settings.GetFullConfigWithoutDefaults(getAggregatedNamespaces()...)).Methods("GET")
 	r.HandleFunc("/config/by-source", settings.GetFullConfigBySource()).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.GetValue).Methods("GET")


### PR DESCRIPTION
### What does this PR do?
fixes `Error: setting without-defaults not found command terminated with exit code 255` when running `agent config` from the cluster-agent and potentially other agents caused by [PR-40990](https://github.com/DataDog/datadog-agent/pull/40990)

### Motivation
ensure a working `config` command and no errors

### Describe how you validated your changes

first test the current issue with the cluster agent config command
1. pull main
2. build and run via skaffold - [guide](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4584539076/Building+and+deploying+using+Skaffold#:cube:-Using-the-Minikube-devcontainer)
   - `dda inv skaffold.create && dda inv skaffold.dev`
3. find pod, and run cluster agent config command
   - `kubectl get pods -n default`
   - `kubectl exec -n default -it "$CA_POD" -c cluster-agent -- /opt/datadog-agent/bin/datadog-cluster-agent config`
   - result: `Error: setting without-defaults not found command terminated with exit code 255`

test this fix for the config command
1. pull `saad/fix-agent-config-default-command-other-agents`
2. repeat 2
3. repeat 3
   - result: `<config without defaults>`

### Additional Notes
