### PR TITLE
Enhance BSOD reports with callstack and agent version

### DIFF
--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
@@ -19,7 +19,10 @@ typedef enum _readCrashDumpErrors {
     RCD_OPEN_DUMP_FILE_FAILED = 4,
     RCD_WAIT_FOR_EVENT_FAILED = 5,
     RCD_EXECUTE_FAILED = 6,
-    RCD_INVALID_ARG = 7
+    RCD_INVALID_ARG = 7,
+    RCD_QUERY_SYMBOLS_INTERFACE_FAILED = 8,
+    RCD_DD_MODULE_NOT_FOUND = 9,
+    RCD_GET_MODULE_VERSION_INFO_FAILED = 10,
 } READ_CRASH_DUMP_ERROR;
 
 typedef struct _bugCheckInfo {
@@ -28,6 +31,7 @@ typedef struct _bugCheckInfo {
     ULONG64 arg2;
     ULONG64 arg3;
     ULONG64 arg4;
+    char agentVersion[64];
 } BUGCHECK_INFO;
 
 READ_CRASH_DUMP_ERROR readCrashDump(char* fname, void* ctx, BUGCHECK_INFO* bugCheckInfo, long* extendedError);

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -16,12 +16,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var expectedCallStackFrames = []string{
+	"nt!KeBugCheckEx",
+	"nt!memset+0x5530",
+	"nt!_C_specific_handler+0x9f",
+	"nt!_chkstk+0x5d",
+	"nt!KeQuerySystemTimePrecise+0x27d1",
+	"nt!KeQuerySystemTimePrecise+0x15f4",
+	"nt!setjmpex+0x7622",
+	"nt!setjmpex+0x4160",
+	"ddapmcrash+0x10e6",
+	"ddapmcrash+0x7020",
+	"nt!FsRtlNotifyVolumeEventEx+0x243b",
+	"nt!MmGetPhysicalMemoryRangesEx+0xb56",
+	"nt!KdPollBreakIn+0x8059",
+	"nt!PsGetProcessSessionIdEx+0x2d5",
+	"nt!KeSynchronizeExecution+0x7756",
+}
+
 func testCrashReader(filename string, ctx *logCallbackContext, crashCtx *crashContext, _ *uint32) error {
 	crashCtx.bugCheckCode = 0x7E
 	crashCtx.bugCheckArg1 = 0x1001
 	crashCtx.bugCheckArg2 = 0x1002
 	crashCtx.bugCheckArg3 = 0x1003
 	crashCtx.bugCheckArg4 = 0x1004
+	crashCtx.agentVersion = "7.99.1"
 
 	testbytes, err := os.ReadFile(filename)
 	if err != nil {
@@ -41,6 +60,7 @@ func testCrashReaderWithLineSplits(filename string, ctx *logCallbackContext, cra
 	crashCtx.bugCheckArg2 = 0x1002
 	crashCtx.bugCheckArg3 = 0x1003
 	crashCtx.bugCheckArg4 = 0x1004
+	crashCtx.agentVersion = "7.99.1"
 
 	testbytes, err := os.ReadFile(filename)
 	if err != nil {
@@ -79,24 +99,8 @@ func TestCrashParser(t *testing.T) {
 	assert.Equal(t, "1002", wcs.BugCheckArg2)
 	assert.Equal(t, "1003", wcs.BugCheckArg3)
 	assert.Equal(t, "1004", wcs.BugCheckArg4)
-	assert.Equal(
-		t,
-		"nt!KeBugCheckEx,"+
-			"nt!memset+0x5530,"+
-			"nt!_C_specific_handler+0x9f,"+
-			"nt!_chkstk+0x5d,"+
-			"nt!KeQuerySystemTimePrecise+0x27d1,"+
-			"nt!KeQuerySystemTimePrecise+0x15f4,"+
-			"nt!setjmpex+0x7622,"+
-			"nt!setjmpex+0x4160,"+
-			"ddapmcrash+0x10e6,"+
-			"ddapmcrash+0x7020,"+
-			"nt!FsRtlNotifyVolumeEventEx+0x243b,"+
-			"nt!MmGetPhysicalMemoryRangesEx+0xb56,"+
-			"nt!KdPollBreakIn+0x8059,"+
-			"nt!PsGetProcessSessionIdEx+0x2d5,"+
-			"nt!KeSynchronizeExecution+0x7756",
-		wcs.Callstack)
+	assert.Equal(t, "7.99.1", wcs.AgentVersion)
+	assert.Equal(t, expectedCallStackFrames, wcs.Frames)
 }
 
 func TestCrashParserWithLineSplits(t *testing.T) {
@@ -122,22 +126,6 @@ func TestCrashParserWithLineSplits(t *testing.T) {
 	assert.Equal(t, "1002", wcs.BugCheckArg2)
 	assert.Equal(t, "1003", wcs.BugCheckArg3)
 	assert.Equal(t, "1004", wcs.BugCheckArg4)
-	assert.Equal(
-		t,
-		"nt!KeBugCheckEx,"+
-			"nt!memset+0x5530,"+
-			"nt!_C_specific_handler+0x9f,"+
-			"nt!_chkstk+0x5d,"+
-			"nt!KeQuerySystemTimePrecise+0x27d1,"+
-			"nt!KeQuerySystemTimePrecise+0x15f4,"+
-			"nt!setjmpex+0x7622,"+
-			"nt!setjmpex+0x4160,"+
-			"ddapmcrash+0x10e6,"+
-			"ddapmcrash+0x7020,"+
-			"nt!FsRtlNotifyVolumeEventEx+0x243b,"+
-			"nt!MmGetPhysicalMemoryRangesEx+0xb56,"+
-			"nt!KdPollBreakIn+0x8059,"+
-			"nt!PsGetProcessSessionIdEx+0x2d5,"+
-			"nt!KeSynchronizeExecution+0x7756",
-		wcs.Callstack)
+	assert.Equal(t, "7.99.1", wcs.AgentVersion)
+	assert.Equal(t, expectedCallStackFrames, wcs.Frames)
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -48,16 +48,17 @@ const (
 // WinCrashStatus defines all of the information returned from the system
 // probe to the caller
 type WinCrashStatus struct {
-	StatusCode   int    `json:"statuscode"`
-	ErrString    string `json:"errstring"`
-	FileName     string `json:"filename"`
-	Type         int    `json:"dumptype"`
-	DateString   string `json:"datestring"`
-	Offender     string `json:"offender"`
-	BugCheck     string `json:"buckcheckcode"`
-	BugCheckArg1 string `json:"bugcheckarg1"`
-	BugCheckArg2 string `json:"bugcheckarg2"`
-	BugCheckArg3 string `json:"bugcheckarg3"`
-	BugCheckArg4 string `json:"bugcheckarg4"`
-	Callstack    string `json:"callstack"`
+	StatusCode   int      `json:"statuscode"`
+	ErrString    string   `json:"errstring"`
+	FileName     string   `json:"filename"`
+	Type         int      `json:"dumptype"`
+	DateString   string   `json:"datestring"`
+	Offender     string   `json:"offender"`
+	BugCheck     string   `json:"buckcheckcode"`
+	BugCheckArg1 string   `json:"bugcheckarg1"`
+	BugCheckArg2 string   `json:"bugcheckarg2"`
+	BugCheckArg3 string   `json:"bugcheckarg3"`
+	BugCheckArg4 string   `json:"bugcheckarg4"`
+	Frames       []string `json:"frames"`
+	AgentVersion string   `json:"agentversion"`
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
@@ -124,7 +124,9 @@ func formatText(c *probe.WinCrashStatus) string {
 	The crash occurred at %s.
 	The offending moudule is %s.
 	The bugcheck code is %s.
-	The bugcheck arguments are (%s, %s, %s, %s).`
+	The bugcheck arguments are (%s, %s, %s, %s).
+	The Agent version is: %s.
+	The callstack is: %v.`
 	return fmt.Sprintf(
 		baseString,
 		c.DateString,
@@ -133,5 +135,7 @@ func formatText(c *probe.WinCrashStatus) string {
 		c.BugCheckArg1,
 		c.BugCheckArg2,
 		c.BugCheckArg3,
-		c.BugCheckArg4)
+		c.BugCheckArg4,
+		c.AgentVersion,
+		c.Frames)
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect_windows_test.go
@@ -30,6 +30,8 @@ const (
 	systemProbeTestPipeName = `\\.\pipe\dd_system_probe_wincrash_test`
 )
 
+var mockCallStackFrames = []string{"frame1", "frame2"}
+
 func testSetup(t *testing.T) {
 	// change the hive to hku for the test
 	hive = registry.CURRENT_USER
@@ -112,7 +114,7 @@ func TestWinCrashReporting(t *testing.T) {
 			BugCheckArg2: "0x2",
 			BugCheckArg3: "0x3",
 			BugCheckArg4: "0x4",
-			Callstack:    "frame1,frame2",
+			Frames:       mockCallStackFrames,
 		}
 		check := newCheck()
 		crashCheck := check.(*WinCrashDetect)
@@ -222,7 +224,7 @@ func TestCrashReportingStates(t *testing.T) {
 		wcs.BugCheckArg2 = crashStatus.BugCheckArg2
 		wcs.BugCheckArg3 = crashStatus.BugCheckArg3
 		wcs.BugCheckArg4 = crashStatus.BugCheckArg4
-		wcs.Callstack = crashStatus.Callstack
+		wcs.Frames = crashStatus.Frames
 
 		// Signal that the artificial delay is done.
 		wg.Done()
@@ -262,7 +264,7 @@ func TestCrashReportingStates(t *testing.T) {
 			BugCheckArg2: "0x2",
 			BugCheckArg3: "0x3",
 			BugCheckArg4: "0x4",
-			Callstack:    "frame1,frame2",
+			Frames:       mockCallStackFrames,
 		}
 
 		// Test the 2-check response from crash reporting.

--- a/releasenotes/notes/windows_bsod_report_with_callstack_and_agent_version-b3e620b39f3a309f.yaml
+++ b/releasenotes/notes/windows_bsod_report_with_callstack_and_agent_version-b3e620b39f3a309f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Enhance Windows BSOD reports to include the crash call stack and the Agent version found in the crash dump.


### PR DESCRIPTION
### What does this PR do?
This PR enhances Windows BSOD reports to include the crash callstack and version of the Agent found in the dump.
The callstack does not have resolved symbols and should remain so per legal consultation.

Originally the driver version was intended to be reported as well, but the driver modules do not include embedded resource tables that have the version information. However, the Agent does have the resource table with version information and it can be queried from a system crash dump.
In any case, the Agent version is more meaningful than the driver version, as it better identifies the fuller end-to-end context (e.g. combination of features).

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1869

### Describe how you validated your changes
Queried system-probe to report a prepared crash dump.
Utilized a VM with a prepared MEMORY.DMP, installed the agent, and verified the BSOD report was exercised. Verified that the notification was sent.
CI/CD, verified crash reporting related tests.
