### PR TITLE
fix(fleet): Unpin install script in test

### DIFF
--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -154,36 +154,6 @@ func (s *installScriptDefaultSuite) TestInstallParity() {
 	}
 }
 
-// TestUpgradeInstallerAgent tests that the installer install script properly upgrades customers
-// from installer / agent as separate packages to a single package
-func (s *installScriptDefaultSuite) TestUpgradeInstallerAgent() {
-	params := []string{
-		"DD_API_KEY=" + s.getAPIKey(),
-		"DD_REMOTE_UPDATES=true",
-		"DD_AGENT_MAJOR_VERSION=7",
-		"DD_AGENT_MINOR_VERSION=65.0",
-	}
-
-	// 1. Install installer / agent as separate packages using older agent 7 install script & an older agent version (7.60)
-	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf(`%s bash -c "$(curl -L https://dd-agent.s3.amazonaws.com/scripts/install_script_agent7.sh?versionId=c0vg6qmhxYnt3he9iRph2BsRN0p026pf)"`, strings.Join(params, " ")))
-	require.NoErrorf(s.T(), err, "installer / agent not properly installed through agent 7 install script")
-
-	// 2. Run the installer install script with the same older agent version (7.60)
-	defer s.Purge()
-	s.RunInstallScript(s.url, params...)
-
-	// 3. Check the installer deb / rpm isn't there anymore
-	s.host.AssertPackageNotInstalledByPackageManager("datadog-installer")
-
-	// 4. Check the installer is present in the agent
-	state := s.host.State()
-	state.AssertFileExists("/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer", 0755, "dd-agent", "dd-agent")
-
-	// 5. Assert the installer unit is not loaded
-	state.AssertUnitsNotLoaded("datadog-installer.service")
-	state.AssertUnitsLoaded("datadog-agent-installer.service")
-}
-
 // TestInstallIgnoreMajorMinor tests that the installer install script properly ignores
 // the major / minor version when installing the agent
 func (s *installScriptDefaultSuite) TestInstallIgnoreMajorMinor() {


### PR DESCRIPTION
### What does this PR do?
Unpins the install script in the test where it is pinned

### Motivation
Test is currently failing because the pin is >5 versions old

### Describe how you validated your changes
E2E

### Additional Notes
