### PR TITLE
[CWS] Build go syscall tester for the target arch

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -221,16 +221,20 @@ def ninja_ebpf_probe_syscall_tester(nw, build_dir):
     )
 
 
-def build_go_syscall_tester(ctx, build_dir):
+def build_go_syscall_tester(ctx, build_dir, arch: str | Arch = CURRENT_ARCH):
     syscall_tester_go_dir = os.path.join(".", "pkg", "security", "tests", "syscall_tester", "go")
     syscall_tester_exe_file = os.path.join(build_dir, "syscall_go_tester")
+    arch = Arch.from_str(arch)
+    ldflags, gcflags, env = get_build_flags(ctx, arch=arch, static=True)
 
     go_build(
         ctx,
         f"{syscall_tester_go_dir}/syscall_go_tester.go",
         build_tags=["syscalltesters", "osusergo", "netgo"],
-        ldflags="-extldflags=-static",
+        ldflags=ldflags,
+        gcflags=gcflags,
         bin_path=syscall_tester_exe_file,
+        env=env,
     )
     return syscall_tester_exe_file
 
@@ -302,7 +306,7 @@ def build_embed_syscall_tester(ctx, arch: str | Arch = CURRENT_ARCH, static=True
         ninja_ebpf_probe_syscall_tester(nw, go_dir)
 
     ctx.run(f"ninja -f {nf_path}")
-    build_go_syscall_tester(ctx, build_dir)
+    build_go_syscall_tester(ctx, build_dir, arch=arch)
 
 
 @task
@@ -333,7 +337,11 @@ def build_functional_tests(
                 debug=debug,
                 bundle_ebpf=bundle_ebpf,
             )
-        build_embed_syscall_tester(ctx, compiler=syscall_tester_compiler)
+        build_embed_syscall_tester(
+            ctx,
+            compiler=syscall_tester_compiler,
+            arch=arch,
+        )
 
     arch = Arch.from_str(arch)
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, static=static, arch=arch)


### PR DESCRIPTION
### What does this PR do?

When building the Go embed syscall tester, we were not using the target
architecture but the current one.

### Motivation

Without this, we may end up with a testsuite for arm64 that embeds the x86 syscall tester.

### Describe how you validated your changes

### Additional Notes
