### PR TITLE
[ACIX-978] Better python linter

### DIFF
--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -46,7 +46,7 @@ lint_components:
 lint_python:
   extends: .lint
   script:
-    - dda inv -- -e linter.python
+    - dda inv -- -e linter.python --show-versions
 
 lint_update_go:
   extends: .lint

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -175,10 +175,10 @@ def python(ctx, show_versions=False):
         print(f"vulture version: {ctx.run('vulture --version', hide=True).stdout.strip()}")
         print(f"mypy version: {ctx.run('mypy --version', hide=True).stdout.strip()}")
 
-    if running_in_ci():
+    if ((running_in_ci())):
         # We want to the CI to fail if there are any issues
         ctx.run("ruff format --check --diff .")
-        ctx.run("ruff check --diff .")
+        ctx . run ( "ruff check --diff ." )
     else:
         # Otherwise we just need to format the files
         ctx.run("ruff format .")

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -175,10 +175,10 @@ def python(ctx, show_versions=False):
         print(f"vulture version: {ctx.run('vulture --version', hide=True).stdout.strip()}")
         print(f"mypy version: {ctx.run('mypy --version', hide=True).stdout.strip()}")
 
-    if ((running_in_ci())):
+    if running_in_ci():
         # We want to the CI to fail if there are any issues
         ctx.run("ruff format --check --diff .")
-        ctx . run ( "ruff check --diff ." )
+        ctx.run("ruff check --diff .")
     else:
         # Otherwise we just need to format the files
         ctx.run("ruff format .")

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -155,11 +155,14 @@ def update_go(_):
 
 # === PYTHON === #
 @task
-def python(ctx):
+def python(ctx, show_versions=False):
     """Lints Python files.
 
     See 'setup.cfg' and 'pyproject.toml' file for configuration. If
     running locally, you probably want to use the pre-commit instead.
+
+    Args:
+        show_versions: Show the versions of the linters that are being used.
     """
 
     print(
@@ -167,10 +170,15 @@ def python(ctx):
         "https://datadoghq.dev/datadog-agent/setup/optional/#pre-commit-hooks"
     )
 
+    if show_versions:
+        print(f"ruff version: {ctx.run('ruff --version', hide=True).stdout.strip()}")
+        print(f"vulture version: {ctx.run('vulture --version', hide=True).stdout.strip()}")
+        print(f"mypy version: {ctx.run('mypy --version', hide=True).stdout.strip()}")
+
     if running_in_ci():
         # We want to the CI to fail if there are any issues
-        ctx.run("ruff format --check .")
-        ctx.run("ruff check .")
+        ctx.run("ruff format --check --diff .")
+        ctx.run("ruff check --diff .")
     else:
         # Otherwise we just need to format the files
         ctx.run("ruff format .")


### PR DESCRIPTION
### What does this PR do?

The python linter is quite inconvenient right now since it doesn't show any diff ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1054927752#L87)).
Added:
1. `--diff` ruff arg to show the format / check diff.
2. `--show-versions` invoke arg to show the versions on the CI.

[Example new formatter](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1156676549).

### Motivation

### Describe how you validated your changes

### Additional Notes
