### PR TITLE
[CSPM] Add support for CIS RHEL 10 Benchmark

### DIFF
--- a/releasenotes/notes/cspm-host-benchmarks-rhel-10-523ecd5509412e96.yaml
+++ b/releasenotes/notes/cspm-host-benchmarks-rhel-10-523ecd5509412e96.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support of CIS Red Hat Enterprise Linux 10 Benchmark in CSPM.


### PR DESCRIPTION
### What does this PR do?

This change documents the addition of CIS Red Hat
Enterprise Linux 10 Benchmark in CSPM.

### Motivation

### Describe how you validated your changes

### Additional Notes
