### PR TITLE
[CSPM] Add support for CIS Ubuntu 24.04 Benchmark

### DIFF
--- a/releasenotes/notes/cspm-host-benchmarks-ubuntu-24.04-e3712cf6883b83a8.yaml
+++ b/releasenotes/notes/cspm-host-benchmarks-ubuntu-24.04-e3712cf6883b83a8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support of CIS Ubuntu 24.04 Benchmark in CSPM.


### PR DESCRIPTION
### What does this PR do?

This change documents the addition of CIS Ubuntu 24.04 Benchmark in CSPM.

### Motivation

### Describe how you validated your changes

### Additional Notes
