### PR TITLE
Update openssl to version 3.5.4

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -38,9 +38,9 @@ bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
 http_archive(
     name = "openssl",
     build_file = "//deps:openssl.BUILD.bazel",
-    sha256 = "c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec",
-    strip_prefix = "openssl-3.5.2",
-    url = "https://www.openssl.org/source/openssl-3.5.2.tar.gz",
+    sha256 = "967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99",
+    strip_prefix = "openssl-3.5.4",
+    url = "https://www.openssl.org/source/openssl-3.5.4.tar.gz",
 )
 
 bazel_dep(name = "gcc_toolchain")

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -23,7 +23,7 @@ skip_transitive_dependency_licensing true
 dependency "zlib" unless windows?
 dependency "cacerts"
 
-default_version "3.5.2"
+default_version "3.5.4"
 
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
@@ -40,12 +40,12 @@ version("3.3.2") { source sha256: "2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c8
 version("3.4.0") { source sha256: "e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf" }
 version("3.4.1") { source sha256: "002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" }
 version("3.5.2") { source sha256: "c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec" }
-
+version("3.5.4") { source sha256: "967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99" }
 
 relative_path "openssl-#{version}"
 
 build do
-  if version != "3.5.2"
+  if version != default_version
     # Patch is no longer needed in 3.5.2, keeping it in for backwards compatibility
     patch source: "0001-fix-preprocessor-concatenation.patch"
   end


### PR DESCRIPTION
### What does this PR do?
It simply updates openssl to version 3.5.4
