### PR TITLE
[CWS] Add a fallback for processes without cgroup

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -22,6 +22,7 @@ import (
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -200,12 +201,46 @@ func (cr *Resolver) pushNewCacheEntry(process *model.ProcessCacheEntry) {
 }
 
 // AddPID update the cgroup cache to associates a cgroup and a pid
+// Returns true if the kernel maps need to be synced (if we update somehow the process)
 func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 	cr.Lock()
 	defer cr.Unlock()
 
-	found := false
+	if process.CGroup.CGroupID == "" || process.CGroup.CGroupFile.Inode == 0 {
+		// it should not happen, but we have to fallback in this case
+		cid, cgroup, _, err := cr.cgroupFS.FindCGroupContext(process.Pid, process.Pid)
+		if err == nil {
+			process.CGroup.CGroupFile.MountID = cgroup.CGroupFileMountID
+			process.CGroup.CGroupFile.Inode = cgroup.CGroupFileInode
+			process.CGroup.CGroupID = cgroup.CGroupID
+			process.ContainerID = cid
+			seclog.Infof("Fallback to resolve cgroup for pid %d: %s", process.Pid, cgroup.CGroupID)
+		} else {
+			// fallback can fail for short lived processes, in this case we assign the parent cgroup
+			// first we look for its parent cgroup
+			found := false
+			cr.iterate(func(entry *cgroupModel.CacheEntry) bool {
+				_, exist := entry.PIDs[process.PPid]
+				if exist {
+					process.CGroup.CGroupFile.MountID = entry.CGroupFile.MountID
+					process.CGroup.CGroupFile.Inode = entry.CGroupFile.Inode
+					process.CGroup.CGroupID = entry.CGroupID
+					process.ContainerID = entry.ContainerID
+					found = true
+					seclog.Infof("Fallback to resolve cgroup for pid from parent %d: %s", process.Pid, cgroup.CGroupID)
+					return true
+				}
+				return false
+			})
+			// if still not found, just return
+			if !found {
+				seclog.Errorf("Failed to add pid %d, error on fallback to resolve its cgroup: %v", process.Pid, err)
+				return
+			}
+		}
+	}
 
+	found := false
 	for _, cgroup := range cr.hostWorkloads.Values() {
 		cgroup.Lock()
 		if cgroup.CGroupFile == process.CGroup.CGroupFile {
@@ -252,16 +287,23 @@ func (cr *Resolver) GetCGroupContext(cgroupPath model.PathKey) (*model.CGroupCon
 	return nil, false
 }
 
-// Iterate iterates on all cached cgroups
-func (cr *Resolver) Iterate(cb func(*cgroupModel.CacheEntry)) {
+// Iterate iterates on all cached cgroups, callback may return 'true' to break iteration
+func (cr *Resolver) Iterate(cb func(*cgroupModel.CacheEntry) bool) {
 	cr.Lock()
 	defer cr.Unlock()
+	cr.iterate(cb)
+}
 
+func (cr *Resolver) iterate(cb func(*cgroupModel.CacheEntry) bool) {
 	for _, cgroup := range cr.hostWorkloads.Values() {
-		cb(cgroup)
+		if cb(cgroup) {
+			return
+		}
 	}
 	for _, cgroup := range cr.containerWorkloads.Values() {
-		cb(cgroup)
+		if cb(cgroup) {
+			return
+		}
 	}
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -592,7 +592,7 @@ func (p *EBPFResolver) insertEntry(entry *model.ProcessCacheEntry, source uint64
 	// the count will be decremented once the entry is released
 	p.processCacheEntryCount.Inc()
 
-	if newPid && p.cgroupResolver != nil && entry.CGroup.CGroupID != "" {
+	if newPid && p.cgroupResolver != nil {
 		// add the new PID in the right cgroup_resolver bucket
 		p.cgroupResolver.AddPID(entry)
 	}

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -97,6 +97,8 @@ func newFakeForkEvent(ppid, pid int, inode uint64, resolver *EBPFResolver) *mode
 	e.ProcessCacheEntry.PPid = uint32(ppid)
 	e.ProcessCacheEntry.Pid = uint32(pid)
 	e.ProcessCacheEntry.FileEvent.Inode = inode
+	e.ProcessCacheEntry.CGroup.CGroupID = "FakeCgroupID"
+	e.ProcessCacheEntry.CGroup.CGroupFile.Inode = 4242
 	return e
 }
 
@@ -110,6 +112,8 @@ func newFakeExecEvent(ppid, pid int, inode uint64, resolver *EBPFResolver) *mode
 	e.ProcessCacheEntry.PPid = uint32(ppid)
 	e.ProcessCacheEntry.Pid = uint32(pid)
 	e.ProcessCacheEntry.FileEvent.Inode = inode
+	e.ProcessCacheEntry.CGroup.CGroupID = "FakeCgroupID"
+	e.ProcessCacheEntry.CGroup.CGroupFile.Inode = 4242
 	return e
 }
 
@@ -883,6 +887,9 @@ func TestCGroupContext(t *testing.T) {
 
 		resolver.UpdateProcessCGroupContext(node.ProcessCacheEntry.Pid, &model.CGroupContext{
 			CGroupID: cgroupID,
+			CGroupFile: model.PathKey{
+				Inode: 4242,
+			},
 		}, nil)
 
 		assert.Equal(t, cgroupID, node.ProcessCacheEntry.CGroup.CGroupID)

--- a/pkg/security/rules/engine_linux.go
+++ b/pkg/security/rules/engine_linux.go
@@ -40,11 +40,11 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 			}
 			cgr := ebpfProbe.Resolvers.CGroupResolver
 
-			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) {
+			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) bool {
 				cgce.RLock()
 				defer cgce.RUnlock()
 				if cgce.ContainerContext.ContainerID == "" {
-					return
+					return false
 				}
 
 				ctx := preparator.get(func(event *model.Event) {
@@ -54,7 +54,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
-					return
+					return false
 				}
 
 				scopedName := fmt.Sprintf("%s.%s", name, cgce.ContainerContext.ContainerID)
@@ -63,12 +63,13 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					Name:  scopedName,
 					Value: scopedValue,
 				}
+				return false
 			})
 		} else if !e.probe.Opts.EBPFLessEnabled && strings.HasPrefix(name, "cgroup.") {
 			scopedVariable := value.(eval.ScopedVariable)
 
 			cgr := e.probe.PlatformProbe.(*probe.EBPFProbe).Resolvers.CGroupResolver
-			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) {
+			cgr.Iterate(func(cgce *cgroupModel.CacheEntry) bool {
 				cgce.RLock()
 				defer cgce.RUnlock()
 
@@ -79,7 +80,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 
 				value, found := scopedVariable.GetValue(ctx)
 				if !found {
-					return
+					return false
 				}
 
 				scopedName := fmt.Sprintf("%s.%s", name, cgce.CGroupID)
@@ -88,6 +89,7 @@ func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
 					Name:  scopedName,
 					Value: scopedValue,
 				}
+				return false
 			})
 		}
 	}

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -209,7 +209,7 @@ func (cfs *CGroupFS) removeMountPointFromCGroupPath(cpath string) string {
 }
 
 // FindCGroupContext returns the container ID, cgroup context and sysfs cgroup path the process belongs to.
-// Returns "" as container ID and sysfs cgroup path, and an empty CGroupContext if the process does not belong to a container.
+// Returns "" as container ID if the process does not belong to a container.
 func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, CGroupContext, string, error) {
 	if len(cfs.cGroupMountPoints) == 0 {
 		return "", CGroupContext{}, "", ErrNoCGroupMountpoint


### PR DESCRIPTION
### What does this PR do?

It adds fallbacks on the cgroup resolver to try to resolve processes without cgroup:
* fist by looking at procfs, but it may fails for short lived one
* or by assigning its father's one

### Motivation

Get rid off processes without any cgroup

### Describe how you validated your changes

### Additional Notes
