### PR TITLE
[CWS] Use common git ancestor to test against upstream schema

### DIFF
--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -10,15 +10,20 @@ package tests
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+var GitAncestorOnMain = "main"
+
 // TestMain is the entry points for functional tests
 func TestMain(m *testing.M) {
 	flag.Parse()
+
+	fmt.Printf("Using git ref %s as common ancestor between HEAD and main branch\n", GitAncestorOnMain)
 
 	preTestsHook()
 	retCode := m.Run()

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -28,11 +27,7 @@ import (
 )
 
 func getUpstreamEventSchema() string {
-	sha, _ := os.LookupEnv("CI_COMMIT_SHA")
-	if sha == "" {
-		sha = "main"
-	}
-	return fmt.Sprintf("https://raw.githubusercontent.com/DataDog/datadog-agent/%s/docs/cloud-workload-security/backend_linux.schema.json", sha)
+	return fmt.Sprintf("https://raw.githubusercontent.com/DataDog/datadog-agent/%s/docs/cloud-workload-security/backend_linux.schema.json", GitAncestorOnMain)
 }
 
 var upstreamEventSchema = getUpstreamEventSchema()

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -21,7 +21,7 @@ from tasks.agent import generate_config
 from tasks.build_tags import add_fips_tags, get_default_build_tags
 from tasks.go import run_golangci_lint
 from tasks.libs.build.ninja import NinjaWriter
-from tasks.libs.common.git import get_commit_sha, get_current_branch
+from tasks.libs.common.git import get_commit_sha, get_common_ancestor, get_current_branch
 from tasks.libs.common.go import go_build
 from tasks.libs.common.utils import (
     REPO_PATH,
@@ -337,6 +337,9 @@ def build_functional_tests(
 
     arch = Arch.from_str(arch)
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, static=static, arch=arch)
+    common_ancestor = get_common_ancestor(ctx, "HEAD")
+    print(f"Using git ref {common_ancestor} as common ancestor between HEAD and main branch")
+    ldflags += f"-X {REPO_PATH}/{srcpath}.GitAncestorOnMain={common_ancestor} "
 
     env["CGO_ENABLED"] = "1"
 


### PR DESCRIPTION
### What does this PR do?

Get the common ancestor between HEAD and main branch when compiling the testsuite to then fetch the corresponding upstream schema.

### Motivation

Tests against the upstream schema will eventually fail on schema updates if the `CI_COMMIT_SHA` env var isn't available.

Embedding the commit ref in the testsuite at build time also makes sure the tests are reproducible and don't require the `CI_COMMIT_SHA` env var to actually be relevant (i.e. when running the testsuite locally). 

### Describe how you validated your changes

### Additional Notes
