### PR TITLE
bazel: bzip2: remove invalid linker flag on linux

### DIFF
--- a/deps/bzip2.BUILD.bazel
+++ b/deps/bzip2.BUILD.bazel
@@ -110,10 +110,11 @@ cc_shared_library(
         #    "-Wl,-soname",
         #],
         "@platforms//os:windows": [],
-        "//conditions:default": [
+        "@platforms//os:macos": [
             "-Wl,-install_name",
             "-Wl,'@rpath/libbz2.so.1.0'",
         ],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### What does this PR do?

This removes a macOS only flag from the linux flags

### Motivation

Fixing some targets build on linux: `... gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64/bin/x86_64-unknown-linux-gnu-ld.bfd: unrecognised option: -install_name`

### Describe how you validated your changes

### Additional Notes

Since the target is part of an external repo, the CI didn't catch it, and this PR will likely not impact anything CI wise
