### PR TITLE
process_log: Use privileged logs client

### DIFF
--- a/comp/core/autodiscovery/providers/process_log.go
+++ b/comp/core/autodiscovery/providers/process_log.go
@@ -31,6 +31,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
+	privilegedlogsclient "github.com/DataDog/datadog-agent/pkg/privileged-logs/client"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -208,7 +209,10 @@ func (p *processLogConfigProvider) processEvents(evBundle workloadmeta.EventBund
 }
 
 func checkFileReadable(logPath string) error {
-	file, err := os.Open(logPath)
+	// Check readability with the privileged logs client to match what the
+	// log tailer uses.  That client can use the privileged logs module in
+	// system-probe if it is available.
+	file, err := privilegedlogsclient.Open(logPath)
 	if err != nil {
 		log.Infof("Discovered log file %s could not be opened: %v", logPath, err)
 		return err

--- a/pkg/privileged-logs/client/open_other.go
+++ b/pkg/privileged-logs/client/open_other.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+// Package client provides functionality to open files through the privileged logs module.
+package client
+
+import (
+	"os"
+)
+
+// Open provides a fallback for non-Linux platforms where the privileged logs module is not available.
+func Open(path string) (*os.File, error) {
+	return os.Open(path)
+}


### PR DESCRIPTION
### What does this PR do?

process_log checks for accessibility of discovered logs before setting
up the log configs to avoid having the log tailer print repeated errors
for inaccessible logs.  However, currently, process_log doesn't use the
privileged logs client so it potentially denies logs that are actually
accessible to the log tailer since the log tailer uses the privileged
logs client.  Use the privileged logs client in process_log too to fix
this.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-196

### Describe how you validated your changes

Code covered by existing tests.  The process_log+privileged logs case was
tested manually and will be tested by an E2E test to be added in a follow-up
PR.
