### PR TITLE
[EBPF] gpu: add gpu_virtualization_mode tag

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -708,6 +708,7 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 	tagList.AddLow(tags.KubeGPUDevice, strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "_")))
 	tagList.AddLow(tags.KubeGPUUUID, strings.ToLower(gpu.ID))
 	tagList.AddLow(tags.GPUDriverVersion, gpu.DriverVersion)
+	tagList.AddLow(tags.GPUVirtualizationMode, gpu.VirtualizationMode)
 
 	low, orch, high, standard := tagList.Compute()
 

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -128,6 +128,8 @@ const (
 	KubeGPUUUID = "gpu_uuid"
 	// GPUDriverVersion is the tag for the GPU driver version
 	GPUDriverVersion = "gpu_driver_version"
+	// GPUVirtualizationMode is the tag for the GPU virtualization mode
+	GPUVirtualizationMode = "gpu_virtualization_mode"
 
 	// KubeArgoRollout is the tag for the Argo Rollout name
 	KubeArgoRollout = "kube_argo_rollout"

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -112,6 +112,15 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 	} else {
 		gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 	}
+
+	virtMode, err := device.GetVirtualizationMode()
+	if err != nil {
+		if logLimiter.ShouldLog() {
+			log.Warnf("cannot get virtualization mode: %v for %d", err, gpuDeviceInfo.Index)
+		}
+	} else {
+		gpuDeviceInfo.VirtualizationMode = gpuVirtModeToString(virtMode)
+	}
 }
 
 func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml.Device) {
@@ -229,5 +238,21 @@ func gpuArchToString(nvmlArch nvml.DeviceArchitecture) string {
 		// to add a new case for a new architecture.
 		return "invalid"
 	}
+}
 
+func gpuVirtModeToString(nvmlVirtMode nvml.GpuVirtualizationMode) string {
+	switch nvmlVirtMode {
+	case nvml.GPU_VIRTUALIZATION_MODE_NONE:
+		return "none"
+	case nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU:
+		return "host_vgpu"
+	case nvml.GPU_VIRTUALIZATION_MODE_PASSTHROUGH:
+		return "passthrough"
+	case nvml.GPU_VIRTUALIZATION_MODE_HOST_VSGA:
+		return "host_vsga"
+	case nvml.GPU_VIRTUALIZATION_MODE_VGPU:
+		return "vgpu"
+	default:
+		return "unknown"
+	}
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -61,6 +61,7 @@ func TestPull(t *testing.T) {
 		require.Equal(t, testutil.DefaultMaxClockRates[workloadmeta.GPUSM], gpu.MaxClockRates[workloadmeta.GPUSM])
 		require.Equal(t, testutil.DefaultMaxClockRates[workloadmeta.GPUMemory], gpu.MaxClockRates[workloadmeta.GPUMemory])
 		require.Equal(t, expectedActivePIDs, gpu.ActivePIDs)
+		require.Equal(t, "none", gpu.VirtualizationMode)
 	}
 
 	for _, uuid := range testutil.GPUUUIDs {

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1955,6 +1955,9 @@ type GPU struct {
 
 	// DeviceType identifies if this is a physical or virtual device (e.g. MIG)
 	DeviceType GPUDeviceType
+
+	// VirtualizationMode contains the virtualization mode of the device
+	VirtualizationMode string
 }
 
 var _ Entity = &GPU{}

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -93,6 +93,8 @@ type SafeDevice interface {
 	GpmSampleGet(sample nvml.GpmSample) error
 	// IsMigDeviceHandle returns true if the device is a MIG device or false for a physical device
 	IsMigDeviceHandle() (bool, error)
+	// GetVirtualizationMode returns the virtualization mode of the device
+	GetVirtualizationMode() (nvml.GpuVirtualizationMode, error)
 }
 
 // DeviceInfo holds common cached properties for a GPU device

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -324,3 +324,11 @@ func (d *safeDeviceImpl) IsMigDeviceHandle() (bool, error) {
 	isMig, ret := d.nvmlDevice.IsMigDeviceHandle()
 	return isMig, NewNvmlAPIErrorOrNil("IsMigDeviceHandle", ret)
 }
+
+func (d *safeDeviceImpl) GetVirtualizationMode() (nvml.GpuVirtualizationMode, error) {
+	if err := d.lib.lookup(toNativeName("GetVirtualizationMode")); err != nil {
+		return nvml.GPU_VIRTUALIZATION_MODE_NONE, err
+	}
+	mode, ret := d.nvmlDevice.GetVirtualizationMode()
+	return mode, NewNvmlAPIErrorOrNil("GetVirtualizationMode", ret)
+}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -77,6 +77,7 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetTotalEnergyConsumption"),
 		toNativeName("GetUtilizationRates"),
 		toNativeName("IsMigDeviceHandle"),
+		toNativeName("GetVirtualizationMode"),
 	}
 }
 

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -172,6 +172,9 @@ func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Devi
 		GpmQueryDeviceSupportFunc: func() (nvml.GpmSupport, nvml.Return) {
 			return nvml.GpmSupport{IsSupportedDevice: 1}, nvml.SUCCESS
 		},
+		GetVirtualizationModeFunc: func() (nvml.GpuVirtualizationMode, nvml.Return) {
+			return nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS
+		},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
### What does this PR do?

This PR adds a `gpu_virtualization_mode` tag to the set of GPU tags. Possible values include "none", "vgpu", "host_vgpu", etc.

### Motivation

Enables distinction in the UI between different virtualization modes (specially vgpu/none) that might have different metrics available.

### Describe how you validated your changes

Unit tests added, validated in a host with vGPUs.

### Additional Notes
