### PR TITLE
[CWS] SSH Session Tracking

### DIFF
--- a/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
+++ b/cmd/cws-instrumentation/subcommands/injectcmd/inject.go
@@ -85,8 +85,11 @@ func injectUserSession(params *InjectCliParams) error {
 	if len(params.Data) > UserSessionDataMaxSize {
 		return fmt.Errorf("user session context too long: %d", len(params.Data))
 	}
-	usersession.InitUserSessionTypes()
-	sessionType := usersession.UserSessionTypes[params.SessionType]
+	var sessionType usersession.Type
+	sessionTypeString := params.SessionType
+	if sessionTypeString == "k8s" {
+		sessionType = usersession.UserSessionTypeK8S
+	}
 	if sessionType == 0 {
 		return fmt.Errorf("unknown user session type: %v", params.SessionType)
 	}

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -2211,6 +2211,22 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "object",
                     "description": "Extra of the Kubernetes \"kubectl exec\" session"
+                },
+                "ssh_port": {
+                    "type": "integer",
+                    "description": "Port of the SSH session"
+                },
+                "ssh_client_ip": {
+                    "type": "string",
+                    "description": "Client IP of the SSH session"
+                },
+                "ssh_auth_method": {
+                    "type": "string",
+                    "description": "Authentication method of the SSH session"
+                },
+                "ssh_public_key": {
+                    "type": "string",
+                    "description": "Public key of the SSH session"
                 }
             },
             "additionalProperties": false,
@@ -5639,6 +5655,22 @@ Workload Protection events for Linux systems have the following JSON schema:
             },
             "type": "object",
             "description": "Extra of the Kubernetes \"kubectl exec\" session"
+        },
+        "ssh_port": {
+            "type": "integer",
+            "description": "Port of the SSH session"
+        },
+        "ssh_client_ip": {
+            "type": "string",
+            "description": "Client IP of the SSH session"
+        },
+        "ssh_auth_method": {
+            "type": "string",
+            "description": "Authentication method of the SSH session"
+        },
+        "ssh_public_key": {
+            "type": "string",
+            "description": "Public key of the SSH session"
         }
     },
     "additionalProperties": false,
@@ -5656,6 +5688,10 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `k8s_uid` | UID of the Kubernetes "kubectl exec" session |
 | `k8s_groups` | Groups of the Kubernetes "kubectl exec" session |
 | `k8s_extra` | Extra of the Kubernetes "kubectl exec" session |
+| `ssh_port` | Port of the SSH session |
+| `ssh_client_ip` | Client IP of the SSH session |
+| `ssh_auth_method` | Authentication method of the SSH session |
+| `ssh_public_key` | Public key of the SSH session |
 
 
 ## `Variables`

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -2200,6 +2200,22 @@
           },
           "type": "object",
           "description": "Extra of the Kubernetes \"kubectl exec\" session"
+        },
+        "ssh_port": {
+          "type": "integer",
+          "description": "Port of the SSH session"
+        },
+        "ssh_client_ip": {
+          "type": "string",
+          "description": "Client IP of the SSH session"
+        },
+        "ssh_auth_method": {
+          "type": "string",
+          "description": "Authentication method of the SSH session"
+        },
+        "ssh_public_key": {
+          "type": "string",
+          "description": "Public key of the SSH session"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -290,6 +290,10 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`process.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`process.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`process.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`process.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`process.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -481,6 +485,10 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`process.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`process.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`process.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`process.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`process.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
@@ -492,6 +500,10 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`process.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`process.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`process.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`process.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`process.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`process.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 
 ### Event `accept`
 
@@ -866,6 +878,10 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`exec.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`exec.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`exec.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`exec.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`exec.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`exec.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 
 ### Event `exit`
 
@@ -976,6 +992,10 @@ A process was terminated
 | [`exit.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`exit.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`exit.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`exit.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`exit.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`exit.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`exit.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 
 ### Event `imds`
 
@@ -1428,6 +1448,10 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`ptrace.tracee.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`ptrace.tracee.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`ptrace.tracee.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`ptrace.tracee.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`ptrace.tracee.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -1619,6 +1643,10 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`ptrace.tracee.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`ptrace.tracee.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`ptrace.tracee.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`ptrace.tracee.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`ptrace.tracee.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
@@ -1630,6 +1658,10 @@ A ptrace command was executed
 | [`ptrace.tracee.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`ptrace.tracee.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`ptrace.tracee.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`ptrace.tracee.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`ptrace.tracee.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`ptrace.tracee.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 
 ### Event `removexattr`
 
@@ -1904,6 +1936,10 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`setrlimit.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`setrlimit.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`setrlimit.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`setrlimit.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`setrlimit.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2095,6 +2131,10 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`setrlimit.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`setrlimit.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`setrlimit.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`setrlimit.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`setrlimit.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
@@ -2106,6 +2146,10 @@ A setrlimit command was executed
 | [`setrlimit.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`setrlimit.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`setrlimit.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`setrlimit.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`setrlimit.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`setrlimit.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`setrlimit.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 
 ### Event `setsockopt`
 
@@ -2285,6 +2329,10 @@ A signal was sent
 | [`signal.target.ancestors.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.ancestors.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`signal.target.ancestors.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.ancestors.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.ancestors.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.ancestors.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`signal.target.ancestors.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`signal.target.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`signal.target.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`signal.target.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -2476,6 +2524,10 @@ A signal was sent
 | [`signal.target.parent.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.parent.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`signal.target.parent.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.parent.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.parent.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.parent.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`signal.target.parent.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`signal.target.pid`](#common-pidcontext-pid-doc) | Process ID of the process (also called thread group ID) |
 | [`signal.target.ppid`](#common-process-ppid-doc) | Parent process ID |
 | [`signal.target.tid`](#common-pidcontext-tid-doc) | Thread ID of the thread |
@@ -2487,6 +2539,10 @@ A signal was sent
 | [`signal.target.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`signal.target.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
 | [`signal.target.user_session.session_type`](#common-usersessioncontext-session_type-doc) | Type of the user session |
+| [`signal.target.user_session.ssh_auth_method`](#common-usersessioncontext-ssh_auth_method-doc) | SSH authentication method used by the user |
+| [`signal.target.user_session.ssh_client_ip`](#common-usersessioncontext-ssh_client_ip-doc) | SSH client IP of the user that executed the process |
+| [`signal.target.user_session.ssh_port`](#common-usersessioncontext-ssh_port-doc) | SSH port of the user that executed the process |
+| [`signal.target.user_session.ssh_public_key`](#common-usersessioncontext-ssh_public_key-doc) | SSH public key used for authentication (if applicable) |
 | [`signal.type`](#signal-type-doc) | Signal type (ex: SIGHUP, SIGINT, SIGQUIT, etc) |
 
 ### Event `splice`
@@ -3403,6 +3459,9 @@ Definition: Type of the user session
 `*.session_type` has 14 possible prefixes:
 `exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
+Constants: [UserSessionTypes](#usersessiontypes)
+
+
 
 ### `*.size` {#common-networkcontext-size-doc}
 Type: int
@@ -3411,6 +3470,45 @@ Definition: Size in bytes of the network packet
 
 `*.size` has 2 possible prefixes:
 `network` `packet`
+
+
+### `*.ssh_auth_method` {#common-usersessioncontext-ssh_auth_method-doc}
+Type: int
+
+Definition: SSH authentication method used by the user
+
+`*.ssh_auth_method` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+Constants: [SSHAuthMethod](#sshauthmethod)
+
+
+
+### `*.ssh_client_ip` {#common-usersessioncontext-ssh_client_ip-doc}
+Type: IP/CIDR
+
+Definition: SSH client IP of the user that executed the process
+
+`*.ssh_client_ip` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
+### `*.ssh_port` {#common-usersessioncontext-ssh_port-doc}
+Type: int
+
+Definition: SSH port of the user that executed the process
+
+`*.ssh_port` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
+
+
+### `*.ssh_public_key` {#common-usersessioncontext-ssh_public_key-doc}
+Type: string
+
+Definition: SSH public key used for authentication (if applicable)
+
+`*.ssh_public_key` has 14 possible prefixes:
+`exec.user_session` `exit.user_session` `process.ancestors.user_session` `process.parent.user_session` `process.user_session` `ptrace.tracee.ancestors.user_session` `ptrace.tracee.parent.user_session` `ptrace.tracee.user_session` `setrlimit.target.ancestors.user_session` `setrlimit.target.parent.user_session` `setrlimit.target.user_session` `signal.target.ancestors.user_session` `signal.target.parent.user_session` `signal.target.user_session`
 
 
 ### `*.tags` {#common-containercontext-tags-doc}
@@ -5895,6 +5993,15 @@ Resource limit types are the supported resource types for setrlimit syscall.
 | `RLIMIT_RTPRIO` | all |
 | `RLIMIT_RTTIME` | all |
 
+### `SSHAuthMethod` {#sshauthmethod}
+SSH authentication methods.
+
+| Name | Architectures |
+| ---- |---------------|
+| `password` | all |
+| `public_key` | all |
+| `unknown` | all |
+
 ### `SetSockopt Levels` {#setsockopt-levels}
 SetSockopt Levels are the supported levels for the setsockopt event.
 
@@ -6195,6 +6302,15 @@ Unlink flags are the supported flags for the unlink syscall.
 | Name | Architectures |
 | ---- |---------------|
 | `AT_REMOVEDIR` | all |
+
+### `UserSessionTypes` {#usersessiontypes}
+UserSessionTypes are the supported user session types.
+
+| Name | Architectures |
+| ---- |---------------|
+| `unknown` | all |
+| `k8s` | all |
+| `ssh` | all |
 
 ### `Virtual Memory flags` {#virtual-memory-flags}
 Virtual Memory flags define the protection of a virtual memory segment.

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -558,6 +558,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "process.ancestors.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "process.ancestors.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "process.args",
           "definition": "Arguments of the process (as a string, excluding argv0)",
           "property_doc_link": "common-process-args-doc"
@@ -1513,6 +1533,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "process.parent.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "process.parent.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "process.parent.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "process.parent.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "process.pid",
           "definition": "Process ID of the process (also called thread group ID)",
           "property_doc_link": "common-pidcontext-pid-doc"
@@ -1566,6 +1606,26 @@
           "name": "process.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "process.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "process.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "process.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "process.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         }
       ]
     },
@@ -3104,6 +3164,26 @@
           "name": "exec.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "exec.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "exec.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "exec.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "exec.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         }
       ]
     },
@@ -3628,6 +3708,26 @@
           "name": "exit.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "exit.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "exit.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "exit.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "exit.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         }
       ]
     },
@@ -5568,6 +5668,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "ptrace.tracee.ancestors.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "ptrace.tracee.args",
           "definition": "Arguments of the process (as a string, excluding argv0)",
           "property_doc_link": "common-process-args-doc"
@@ -6523,6 +6643,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "ptrace.tracee.parent.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "ptrace.tracee.pid",
           "definition": "Process ID of the process (also called thread group ID)",
           "property_doc_link": "common-pidcontext-pid-doc"
@@ -6576,6 +6716,26 @@
           "name": "ptrace.tracee.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "ptrace.tracee.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         }
       ]
     },
@@ -7792,6 +7952,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "setrlimit.target.ancestors.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "setrlimit.target.args",
           "definition": "Arguments of the process (as a string, excluding argv0)",
           "property_doc_link": "common-process-args-doc"
@@ -8747,6 +8927,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "setrlimit.target.parent.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "setrlimit.target.pid",
           "definition": "Process ID of the process (also called thread group ID)",
           "property_doc_link": "common-pidcontext-pid-doc"
@@ -8800,6 +9000,26 @@
           "name": "setrlimit.target.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "setrlimit.target.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         }
       ]
     },
@@ -9591,6 +9811,26 @@
           "name": "signal.target.ancestors.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "signal.target.ancestors.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         },
         {
           "name": "signal.target.args",
@@ -10548,6 +10788,26 @@
           "property_doc_link": "common-usersessioncontext-session_type-doc"
         },
         {
+          "name": "signal.target.parent.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "signal.target.parent.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
+        },
+        {
           "name": "signal.target.pid",
           "definition": "Process ID of the process (also called thread group ID)",
           "property_doc_link": "common-pidcontext-pid-doc"
@@ -10601,6 +10861,26 @@
           "name": "signal.target.user_session.session_type",
           "definition": "Type of the user session",
           "property_doc_link": "common-usersessioncontext-session_type-doc"
+        },
+        {
+          "name": "signal.target.user_session.ssh_auth_method",
+          "definition": "SSH authentication method used by the user",
+          "property_doc_link": "common-usersessioncontext-ssh_auth_method-doc"
+        },
+        {
+          "name": "signal.target.user_session.ssh_client_ip",
+          "definition": "SSH client IP of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_client_ip-doc"
+        },
+        {
+          "name": "signal.target.user_session.ssh_port",
+          "definition": "SSH port of the user that executed the process",
+          "property_doc_link": "common-usersessioncontext-ssh_port-doc"
+        },
+        {
+          "name": "signal.target.user_session.ssh_public_key",
+          "definition": "SSH public key used for authentication (if applicable)",
+          "property_doc_link": "common-usersessioncontext-ssh_public_key-doc"
         },
         {
           "name": "signal.type",
@@ -13821,8 +14101,8 @@
         "signal.target.parent.user_session",
         "signal.target.user_session"
       ],
-      "constants": "",
-      "constants_link": "",
+      "constants": "UserSessionTypes",
+      "constants_link": "usersessiontypes",
       "examples": []
     },
     {
@@ -13833,6 +14113,106 @@
       "prefixes": [
         "network",
         "packet"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ssh_auth_method",
+      "link": "common-usersessioncontext-ssh_auth_method-doc",
+      "type": "int",
+      "definition": "SSH authentication method used by the user",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "SSHAuthMethod",
+      "constants_link": "sshauthmethod",
+      "examples": []
+    },
+    {
+      "name": "*.ssh_client_ip",
+      "link": "common-usersessioncontext-ssh_client_ip-doc",
+      "type": "IP/CIDR",
+      "definition": "SSH client IP of the user that executed the process",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ssh_port",
+      "link": "common-usersessioncontext-ssh_port-doc",
+      "type": "int",
+      "definition": "SSH port of the user that executed the process",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.ssh_public_key",
+      "link": "common-usersessioncontext-ssh_public_key-doc",
+      "type": "string",
+      "definition": "SSH public key used for authentication (if applicable)",
+      "prefixes": [
+        "exec.user_session",
+        "exit.user_session",
+        "process.ancestors.user_session",
+        "process.parent.user_session",
+        "process.user_session",
+        "ptrace.tracee.ancestors.user_session",
+        "ptrace.tracee.parent.user_session",
+        "ptrace.tracee.user_session",
+        "setrlimit.target.ancestors.user_session",
+        "setrlimit.target.parent.user_session",
+        "setrlimit.target.user_session",
+        "signal.target.ancestors.user_session",
+        "signal.target.parent.user_session",
+        "signal.target.user_session"
       ],
       "constants": "",
       "constants_link": "",
@@ -20285,6 +20665,25 @@
       ]
     },
     {
+      "name": "SSHAuthMethod",
+      "link": "sshauthmethod",
+      "description": "SSH authentication methods.",
+      "all": [
+        {
+          "name": "password",
+          "architecture": "all"
+        },
+        {
+          "name": "public_key",
+          "architecture": "all"
+        },
+        {
+          "name": "unknown",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
       "name": "SetSockopt Levels",
       "link": "setsockopt-levels",
       "description": "SetSockopt Levels are the supported levels for the setsockopt event.",
@@ -21382,6 +21781,25 @@
       "all": [
         {
           "name": "AT_REMOVEDIR",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
+      "name": "UserSessionTypes",
+      "link": "usersessiontypes",
+      "description": "UserSessionTypes are the supported user session types.",
+      "all": [
+        {
+          "name": "unknown",
+          "architecture": "all"
+        },
+        {
+          "name": "k8s",
+          "architecture": "all"
+        },
+        {
+          "name": "ssh",
           "architecture": "all"
         }
       ]

--- a/docs/cloud-workload-security/secl_windows.json
+++ b/docs/cloud-workload-security/secl_windows.json
@@ -2744,6 +2744,44 @@
           "architecture": "all"
         }
       ]
+    },
+    {
+      "name": "SSHAuthMethod",
+      "link": "sshauthmethod",
+      "description": "SSH authentication methods.",
+      "all": [
+        {
+          "name": "password",
+          "architecture": "all"
+        },
+        {
+          "name": "public_key",
+          "architecture": "all"
+        },
+        {
+          "name": "unknown",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
+      "name": "UserSessionTypes",
+      "link": "usersessiontypes",
+      "description": "UserSessionTypes are the supported user session types.",
+      "all": [
+        {
+          "name": "unknown",
+          "architecture": "all"
+        },
+        {
+          "name": "k8s",
+          "architecture": "all"
+        },
+        {
+          "name": "ssh",
+          "architecture": "all"
+        }
+      ]
     }
   ]
 }

--- a/docs/cloud-workload-security/windows_expressions.md
+++ b/docs/cloud-workload-security/windows_expressions.md
@@ -1040,6 +1040,24 @@ Network directions are the supported directions of network packets.
 | `INGRESS` | all |
 | `EGRESS` | all |
 
+### `SSHAuthMethod` {#sshauthmethod}
+SSH authentication methods.
+
+| Name | Architectures |
+| ---- |---------------|
+| `password` | all |
+| `public_key` | all |
+| `unknown` | all |
+
+### `UserSessionTypes` {#usersessiontypes}
+UserSessionTypes are the supported user session types.
+
+| Name | Architectures |
+| ---- |---------------|
+| `unknown` | all |
+| `k8s` | all |
+| `ssh` | all |
+
 
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/pkg/security/generators/accessors/field_handlers.tmpl
+++ b/pkg/security/generators/accessors/field_handlers.tmpl
@@ -10,7 +10,10 @@ package {{.Name}}
 
 import (
     "time"
+    "net"
 )
+
+var _ = net.IP{}
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
 func (ev *Event) ResolveFields() {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -74,12 +74,21 @@ type pendingMsg struct {
 	sendAfter       time.Time
 	retry           int
 	skip            bool
+
+	sshSessionPatcher sshSessionPatcher
 }
 
 func (p *pendingMsg) isResolved() bool {
 	for _, report := range p.actionReports {
 		if err := report.IsResolved(); err != nil {
 			seclog.Debugf("action report not resolved: %v", err)
+			return false
+		}
+	}
+
+	if p.sshSessionPatcher != nil {
+		if err := p.sshSessionPatcher.IsResolved(); err != nil {
+			seclog.Debugf("ssh session not resolved: %v", err)
 			return false
 		}
 	}
@@ -102,6 +111,10 @@ func (p *pendingMsg) toJSON() ([]byte, error) {
 		if len(data) > 0 {
 			p.backendEvent.RuleActions = append(p.backendEvent.RuleActions, data)
 		}
+	}
+
+	if p.sshSessionPatcher != nil {
+		p.sshSessionPatcher.PatchEvent(p.eventSerializer)
 	}
 
 	backendEventJSON, err := easyjson.Marshal(p.backendEvent)
@@ -441,7 +454,8 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb fu
 				actionReports = append(actionReports, ar)
 			}
 		}
-
+		// Create SSH session patcher if the event has an SSH user session
+		sshSessionPatcher := createSSHSessionPatcher(ev, a.probe)
 		timestamp := ev.ResolveEventTime()
 		if timestamp.IsZero() {
 			timestamp = time.Now()
@@ -457,6 +471,8 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb fu
 			sendAfter:       time.Now().Add(retention),
 			tags:            tags,
 			actionReports:   actionReports,
+
+			sshSessionPatcher: sshSessionPatcher,
 		}
 
 		a.enqueue(msg)

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -15,7 +15,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -267,4 +270,30 @@ func (a *APIServer) collectOSReleaseData() {
 
 	a.kernelVersion = kv.Code.String()
 	a.distribution = fmt.Sprintf("%s - %s", kv.OsRelease["ID"], kv.OsRelease["VERSION_ID"])
+}
+
+type sshSessionPatcher = *probe.SSHUserSessionPatcher
+
+// createSSHSessionPatcher creates an SSH session patcher for Linux
+func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher {
+	if ev.ProcessContext.UserSession.ID != 0 && ev.ProcessContext.UserSession.SessionType == int(usersession.UserSessionTypeSSH) {
+		// Access the EBPFProbe to get the UserSessionsResolver
+		if ebpfProbe, ok := p.PlatformProbe.(*probe.EBPFProbe); ok {
+			if model.UserSessionTypeStrings == nil {
+				model.InitUserSessionTypes()
+			}
+			// Create the user session context serializer
+			userSessionCtx := &serializers.UserSessionContextSerializer{
+				ID:          fmt.Sprintf("%x", ev.ProcessContext.UserSession.ID),
+				SessionType: model.UserSessionTypeStrings[usersession.Type(ev.ProcessContext.UserSession.SessionType)],
+				SSHPort:     ev.ProcessContext.UserSession.SSHPort,
+				SSHClientIP: ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
+			}
+			return probe.NewSSHUserSessionPatcher(
+				userSessionCtx,
+				ebpfProbe.Resolvers.UserSessionsResolver,
+			)
+		}
+	}
+	return nil
 }

--- a/pkg/security/module/server_other.go
+++ b/pkg/security/module/server_other.go
@@ -7,7 +7,22 @@
 
 package module
 
-import "github.com/DataDog/datadog-agent/pkg/security/proto/api"
+import (
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// sshSessionPatcher stub for other platforms
+type sshSessionPatcher interface {
+	IsResolved() error
+	PatchEvent(_ interface{})
+}
+
+// createSSHSessionPatcher creates a no-op patcher for other platforms
+func createSSHSessionPatcher(_ *model.Event, _ *sprobe.Probe) sshSessionPatcher {
+	return nil
+}
 
 func (a *APIServer) collectOSReleaseData() {}
 

--- a/pkg/security/module/server_windows.go
+++ b/pkg/security/module/server_windows.go
@@ -9,8 +9,21 @@ import (
 	"context"
 	"errors"
 
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
+
+// sshSessionPatcher stub for Windows
+type sshSessionPatcher interface {
+	IsResolved() error
+	PatchEvent(_ interface{})
+}
+
+// createSSHSessionPatcher creates a no-op patcher for Windows
+func createSSHSessionPatcher(_ *model.Event, _ *probe.Probe) sshSessionPatcher {
+	return nil
+}
 
 // DumpDiscarders handles discarder dump requests
 func (a *APIServer) DumpDiscarders(_ context.Context, _ *api.DumpDiscardersParams) (*api.DumpDiscardersMessage, error) {

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -1038,3 +1038,13 @@ func (fh *EBPFFieldHandlers) ResolveCapabilitiesUsed(evt *model.Event, ce *model
 	}
 	return usedCapabilities
 }
+
+// ResolveSSHClientIP resolves the ssh username of the event
+func (fh *EBPFFieldHandlers) ResolveSSHClientIP(_ *model.Event, evtCtx *model.UserSessionContext) net.IPNet {
+	return evtCtx.SSHClientIP
+}
+
+// ResolveSSHPort resolves the public key of the event
+func (fh *EBPFFieldHandlers) ResolveSSHPort(_ *model.Event, evtCtx *model.UserSessionContext) int {
+	return evtCtx.SSHPort
+}

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -11,6 +11,7 @@ package probe
 import (
 	"crypto/sha256"
 	"fmt"
+	"net"
 	"slices"
 	"strings"
 	"time"
@@ -620,4 +621,14 @@ func (fh *EBPFLessFieldHandlers) ResolveCapabilitiesAttempted(_ *model.Event, _ 
 // ResolveCapabilitiesUsed resolves the accumulated used capabilities of a capabilities event
 func (fh *EBPFLessFieldHandlers) ResolveCapabilitiesUsed(_ *model.Event, _ *model.CapabilitiesEvent) int {
 	return 0 // EBPFLess mode does not support capabilities usage reporting, so we return 0
+}
+
+// ResolveSSHClientIP resolves the ssh username of the event
+func (fh *EBPFLessFieldHandlers) ResolveSSHClientIP(_ *model.Event, _ *model.UserSessionContext) net.IPNet {
+	return net.IPNet{} // EBPFLess mode does not support SSH
+}
+
+// ResolveSSHPort resolves the public key of the event
+func (fh *EBPFLessFieldHandlers) ResolveSSHPort(_ *model.Event, _ *model.UserSessionContext) int {
+	return 0 //EBPFLess mode does not support SSH port
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1578,6 +1578,12 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		if err := p.Resolvers.ProcessResolver.AddTracerMetadata(event.PIDContext.Pid, event); err != nil {
 			seclog.Debugf("failed to add tracer metadata: %s (pid %d, fd %d)", err, event.PIDContext.Pid, event.TracerMemfdSeal.Fd)
 		}
+		// Second handle for exec event because the context is required to detect a ssh session
+	case model.ExecEventType:
+		p.HandleSSHUserSession(event)
+
+	case model.ForkEventType:
+		p.HandleSSHUserSession(event)
 	}
 	return true
 }
@@ -2150,7 +2156,6 @@ func (p *EBPFProbe) Close() error {
 
 	// when we reach this point, we do not generate nor consume events anymore, we can close the resolvers
 	close(p.tcRequests)
-
 	return p.Resolvers.Close()
 }
 

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-agent/pkg/security/serializers"
+)
+
+// getEnvVar extracts a specific environment variable from a list of environment variables.
+// Each environment variable is in the format "KEY=VALUE".
+func getEnvVar(envp []string, key string) string {
+	prefix := key + "="
+	for _, env := range envp {
+		if strings.HasPrefix(env, prefix) {
+			return strings.TrimPrefix(env, prefix)
+		}
+	}
+	return ""
+}
+
+// HandleSSHUserSession handles the ssh user session
+func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
+	// First, we check if this event is link to an existing ssh session from his parent
+	ppid := event.ProcessContext.Process.PPid
+	parent := p.Resolvers.ProcessResolver.Resolve(ppid, ppid, 0, false, nil)
+
+	envp := p.fieldHandlers.ResolveProcessEnvp(event, &event.ProcessContext.Process)
+	sshClientVar := getEnvVar(envp, "SSH_CLIENT")
+
+	// If the parent is a sshd process and the SSH_CLIENT environment variable is set, we consider it's a new ssh session
+	if parent != nil && parent.Comm == "sshd" && sshClientVar != "" {
+		sshSessionID := rand.Uint64()
+		event.ProcessContext.UserSession.ID = sshSessionID
+		event.ProcessContext.UserSession.SessionType = int(usersession.UserSessionTypeSSH)
+		parts := strings.Fields(sshClientVar)
+		if len(parts) >= 2 {
+			event.ProcessContext.UserSession.SSHClientIP = getIPfromEnv(parts[0])
+			if port, err := strconv.Atoi(parts[1]); err != nil {
+				seclog.Warnf("failed to parse SSH_CLIENT port from %q: %v", sshClientVar, err)
+			} else {
+				event.ProcessContext.UserSession.SSHPort = port
+			}
+		} else {
+			seclog.Warnf("SSH_CLIENT is not in the expected format: %q", sshClientVar)
+		}
+	}
+}
+
+func getIPfromEnv(ipStr string) net.IPNet {
+	ip := net.ParseIP(ipStr)
+	if ip != nil {
+		if ip.To4() != nil {
+			return net.IPNet{
+				IP:   ip,
+				Mask: net.CIDRMask(32, 32),
+			}
+		} else if ip.To16() != nil {
+			return net.IPNet{
+				IP:   ip,
+				Mask: net.CIDRMask(128, 128),
+			}
+		}
+	}
+	return net.IPNet{}
+}
+
+// SSHUserSessionPatcher defines a patcher for SSH user sessions
+type SSHUserSessionPatcher struct {
+	userSessionCtx *serializers.UserSessionContextSerializer
+	resolver       *usersessions.Resolver
+}
+
+// NewSSHUserSessionPatcher creates a new SSH user session patcher
+func NewSSHUserSessionPatcher(userSessionCtx *serializers.UserSessionContextSerializer, resolver *usersessions.Resolver) *SSHUserSessionPatcher {
+	return &SSHUserSessionPatcher{
+		userSessionCtx: userSessionCtx,
+		resolver:       resolver,
+	}
+}
+
+// IsResolved implements the EventSerializerPatcher interface for SSH user sessions
+func (p *SSHUserSessionPatcher) IsResolved() error {
+	if p.userSessionCtx == nil {
+		return errors.New("user session context is nil")
+	}
+	if p.resolver == nil {
+		return errors.New("resolver is nil")
+	}
+
+	// Check in LRU
+	key := usersessions.SSHSessionKey{
+		IP:   p.userSessionCtx.SSHClientIP,
+		Port: strconv.Itoa(p.userSessionCtx.SSHPort),
+	}
+
+	p.resolver.SSHSessionParsed.Mu.Lock()
+	_, ok := p.resolver.SSHSessionParsed.Lru.Get(key)
+	p.resolver.SSHSessionParsed.Mu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("ssh session not found in LRU for %s:%d",
+			p.userSessionCtx.SSHClientIP, p.userSessionCtx.SSHPort)
+	}
+
+	return nil
+}
+
+// PatchEvent implements the EventSerializerPatcher interface for SSH user sessions
+func (p *SSHUserSessionPatcher) PatchEvent(ev *serializers.EventSerializer) {
+	if ev.ProcessContextSerializer == nil || ev.ProcessContextSerializer.UserSession == nil {
+		return
+	}
+
+	if p.userSessionCtx == nil {
+		return
+	}
+
+	key := usersessions.SSHSessionKey{
+		IP:   p.userSessionCtx.SSHClientIP,
+		Port: strconv.Itoa(p.userSessionCtx.SSHPort),
+	}
+	p.resolver.SSHSessionParsed.Mu.Lock()
+	value, ok := p.resolver.SSHSessionParsed.Lru.Get(key)
+	p.resolver.SSHSessionParsed.Mu.Unlock()
+
+	if ok {
+		if model.SSHAuthMethodStrings == nil {
+			model.InitSSHAuthMethodConstants()
+		}
+		ev.ProcessContextSerializer.UserSession.SSHAuthMethod = model.SSHAuthMethodStrings[usersession.AuthType(value.AuthenticationMethod)]
+		ev.ProcessContextSerializer.UserSession.SSHPublicKey = value.PublicKey
+	}
+}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -399,6 +399,9 @@ func (r *EBPFResolvers) Close() error {
 		fmt.Println(err)
 		return err
 	}
-
+	// clean up the user sessions resolver goroutine and resources
+	if r.UserSessionsResolver != nil {
+		r.UserSessionsResolver.Close()
+	}
 	return nil
 }

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -9,9 +9,17 @@
 package usersessions
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -48,19 +56,51 @@ func (e *UserSessionData) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+// incrementalFileReader is used to read a file incrementally
+type incrementalFileReader struct {
+	path               string
+	f                  *os.File
+	offset             int64
+	mu                 sync.Mutex
+	ino                uint64
+	readFromJournalctl bool
+	// chan to stop journalctl
+	stopReading chan struct{} // make(chan struct{}, 1)
+}
+
+// SSHSessionKey describes the key to a ssh session in the LRU
+type SSHSessionKey struct {
+	IP   string // net.IP.String()
+	Port string
+}
+
+// SSHSessionValue describes the value to a ssh session in the LRU
+type SSHSessionValue struct {
+	AuthenticationMethod int
+	PublicKey            string
+}
+
+type sshSessionParsed struct {
+	Mu  sync.Mutex
+	Lru *simplelru.LRU[SSHSessionKey, SSHSessionValue]
+}
+
 // Resolver is used to resolve the user sessions context
 type Resolver struct {
 	sync.RWMutex
 	userSessions *simplelru.LRU[uint64, *model.UserSessionContext]
 
 	userSessionsMap *ebpf.Map
+
+	sshLogReader     *incrementalFileReader
+	SSHSessionParsed sshSessionParsed
 }
 
 // NewResolver returns a new instance of Resolver
 func NewResolver(cacheSize int) (*Resolver, error) {
 	lru, err := simplelru.NewLRU[uint64, *model.UserSessionContext](cacheSize, nil)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create User Session resolver cache: %w", err)
+		return nil, fmt.Errorf("couldn't create User Session resolver cache: %v", err)
 	}
 
 	return &Resolver{
@@ -75,9 +115,15 @@ func (r *Resolver) Start(manager *manager.Manager) error {
 
 	m, err := managerhelper.Map(manager, "user_sessions")
 	if err != nil {
-		return fmt.Errorf("couldn't start user session resolver: %w", err)
+		return fmt.Errorf("couldn't start user session resolver: %v", err)
 	}
 	r.userSessionsMap = m
+
+	// start the resolver for ssh sessions
+	err = r.StartSSHUserSessionResolver()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -88,6 +134,7 @@ func (r *Resolver) ResolveUserSession(id uint64) *model.UserSessionContext {
 	}
 
 	r.Lock()
+
 	defer r.Unlock()
 
 	// is this session already in cache ?
@@ -128,4 +175,343 @@ func (r *Resolver) ResolveUserSession(id uint64) *model.UserSessionContext {
 	// cache resolved context
 	r.userSessions.Add(id, ctx)
 	return ctx
+}
+
+// Init opens the file and sets the initial offset
+func (ifr *incrementalFileReader) Init(f *os.File) error {
+	if ifr.f != nil {
+		return nil
+	}
+
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		seclog.Warnf("Fail to stat log file: %v", err)
+		return err
+	}
+
+	ifr.offset = st.Size()
+
+	ifr.f = f
+	ifr.ino = inodeOf(st)
+	_, err = ifr.f.Seek(ifr.offset, io.SeekStart)
+	if err != nil {
+		ifr.close(false)
+		ifr.f = nil
+	}
+	return err
+}
+
+// startReading start to parse the potential ssh session and store them in the LRU
+func (r *Resolver) startReading() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	if !r.sshLogReader.readFromJournalctl {
+		// For now we only read from the ssh log file
+		for {
+			select {
+			case <-r.sshLogReader.stopReading:
+				return
+			case <-ticker.C:
+				r.sshLogReader.mu.Lock()
+				err := r.sshLogReader.resolveFromLogFile(&r.SSHSessionParsed)
+				if err != nil {
+					seclog.Errorf("failed to read ssh log lines: %v", err)
+				}
+				r.sshLogReader.mu.Unlock()
+
+			}
+		}
+	}
+}
+
+// parseSSHLogLine parse the ssh log line
+// Does not return any error and just automatically updates the LRU when a new session is found
+func parseSSHLogLine(line string, sshSessionParsed *sshSessionParsed) {
+	type SSHLogLine struct {
+		Date      string
+		Hostname  string
+		Service   string
+		Remaining string
+	}
+	type SSHParsedLine struct {
+		AuthentificationMethod string
+		User                   string
+		IP                     string
+		Port                   string
+		SSHVersion             string
+		Remaining              string
+	}
+	// separate the line into words
+	words := strings.Fields(line)
+	sshLogLine := SSHLogLine{}
+	if len(words) < 5 {
+		return
+	}
+	switch {
+	// We saw two different types of logs, so we try to parse both
+	// We use HasPrefix because sshd is followed by its PID : sshd[pid]
+	case strings.HasPrefix(words[2], "sshd"):
+		sshLogLine = SSHLogLine{
+			Date:      words[0],
+			Hostname:  words[1],
+			Service:   words[2],
+			Remaining: strings.Join(words[3:], " "),
+		}
+	case strings.HasPrefix(words[4], "sshd"):
+		sshLogLine = SSHLogLine{
+			Date:      words[2],
+			Hostname:  words[3],
+			Service:   words[4],
+			Remaining: strings.Join(words[5:], " "),
+		}
+	default:
+		return
+	}
+	// if the service is "sshd" and the line starts with "Accepted" it's the beginning of an ssh session
+	if strings.HasPrefix(sshLogLine.Service, "sshd") && strings.HasPrefix(sshLogLine.Remaining, "Accepted") {
+		// One example of line is: "Accepted publickey for lima from 192.168.5.2 port 38835 ssh2: ED25519 SHA256:J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU"
+		// Get the infos like that : Accepted <authentification method> for <username> from <ip> port <port> <ssh version> <Remaining (hash)>
+
+		sshWords := strings.Split(sshLogLine.Remaining, " ")
+		if len(sshWords) < 9 {
+			seclog.Debugf("fail to parse ssh log line: %s", line)
+			return
+		}
+		sshParsedLine := SSHParsedLine{
+			AuthentificationMethod: sshWords[1],
+			User:                   sshWords[3],
+			IP:                     sshWords[5],
+			Port:                   sshWords[7],
+			SSHVersion:             sshWords[8],
+			Remaining:              strings.Join(sshWords[9:], " "),
+		}
+		// Convert string IP to net.IP and compare normalized values
+		parsedIP := net.ParseIP(sshParsedLine.IP)
+
+		// We store every session in the LRU cache
+		var authType usersession.AuthType
+		var publicKey string
+		switch sshParsedLine.AuthentificationMethod {
+		case "publickey":
+			authType = usersession.SSHAuthMethodPublicKey
+			// Here Parse the Public Key which can be ED25519 SHA256:J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU
+			parts := strings.SplitN(sshParsedLine.Remaining, ":", 2)
+			if len(parts) == 2 {
+				publicKey = parts[1]
+			}
+		case "password":
+			authType = usersession.SSHAuthMethodPassword
+		// Other types not implemented yet
+		default:
+			seclog.Debugf("fail to parse ssh auth type in log line: %s", line)
+			authType = usersession.SSHAuthMethodUnknown
+		}
+		key := SSHSessionKey{
+			IP:   parsedIP.String(),
+			Port: sshParsedLine.Port,
+		}
+		value := SSHSessionValue{
+			AuthenticationMethod: int(authType),
+			PublicKey:            publicKey,
+		}
+		sshSessionParsed.Mu.Lock()
+
+		sshSessionParsed.Lru.Add(key, value)
+		sshSessionParsed.Mu.Unlock()
+	}
+}
+
+// resolveFromLogFile read all the lines that have been added since the last call without reopening the file.
+// Return new lines, the byte offsets at the end of each line, and an error.
+func (ifr *incrementalFileReader) resolveFromLogFile(sshSessionParsed *sshSessionParsed) error {
+	if err := ifr.reloadIfRotated(); err != nil {
+		return err
+	}
+
+	st, err := ifr.f.Stat()
+	if err != nil {
+		return err
+	}
+
+	if st.Size() == ifr.offset {
+		return nil
+	}
+	// If the file is truncated, we restart from the beginning
+	if st.Size() < ifr.offset {
+		ifr.offset = 0
+		if _, err := ifr.f.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+	} else {
+		// If the file is not truncated, we seek to the offset
+		if _, err := ifr.f.Seek(ifr.offset, io.SeekStart); err != nil {
+			return err
+		}
+	}
+
+	sc := bufio.NewScanner(ifr.f)
+	for sc.Scan() {
+		line := sc.Text()
+		parseSSHLogLine(line, sshSessionParsed)
+	}
+	newOffset, err := ifr.f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return err
+	}
+
+	ifr.offset = newOffset
+	return err
+}
+
+// close closes the file.
+// The lock of IncrementalFileReader must be held
+func (ifr *incrementalFileReader) close(closeReader bool) error {
+	var err error
+	if ifr.f != nil {
+		err = ifr.f.Close()
+		ifr.f = nil
+	}
+	if closeReader {
+		// Stop the reader
+		ifr.stopReading <- struct{}{}
+	}
+
+	return err
+}
+
+// inodeOf get the inode of the file.
+func inodeOf(fi os.FileInfo) uint64 {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return st.Ino
+	}
+	return 0
+}
+
+// reloadIfRotated reopens the file if the inode has changed.
+func (ifr *incrementalFileReader) reloadIfRotated() error {
+	curSt, err := os.Stat(ifr.path)
+	if err != nil {
+		return err
+	}
+	curIno := inodeOf(curSt)
+	if curIno != 0 && ifr.ino != 0 && curIno != ifr.ino {
+		// The file has been rotated
+		if ifr.f != nil {
+			_ = ifr.close(false)
+			ifr.f = nil
+		}
+		f, err := os.Open(ifr.path)
+		if err != nil {
+			ifr.close(false)
+			ifr.f = nil
+			return err
+		}
+		ifr.f = f
+		ifr.ino = curIno
+
+		// We restart from the beginning because it's a new file
+		ifr.offset = 0
+	}
+	return nil
+}
+
+// StartSSHUserSessionResolver initializes the ssh log reader by looking for the available file, opening it and setting up the initial offset
+// Lock must be held
+func (r *Resolver) StartSSHUserSessionResolver() error {
+	var err error
+
+	// Initialize the SSH session LRU cache (needed in all cases)
+	r.SSHSessionParsed.Lru, err = simplelru.NewLRU[SSHSessionKey, SSHSessionValue](100, nil)
+	if err != nil {
+		seclog.Errorf("couldn't create SSH Session LRU cache: %v", err)
+		return err
+	}
+
+	// Try to find the ssh log file
+	possibleLogPaths := []string{
+		"/var/log/auth.log", // Debian/Ubuntu
+		"/var/log/secure",   // RHEL/CentOS/Fedora
+		"/var/log/messages", // openSUSE/autres
+	}
+	path := ""
+	for _, possiblePath := range possibleLogPaths {
+		_, err = os.Stat(possiblePath)
+		if err == nil {
+			path = possiblePath
+			break
+		}
+	}
+	// If there is no log file, we use journalctl (atm we do nothing)
+	if path == "" {
+		// // Don't want to continue in case there is no log file
+		// TODO : use journalctl instead
+		seclog.Warnf("no ssh log file found")
+		return nil
+	}
+	// Initialize the SSH log reader
+	r.sshLogReader = &incrementalFileReader{
+		path:        path,
+		stopReading: make(chan struct{}, 1),
+	}
+
+	r.sshLogReader.readFromJournalctl = false
+	// Now we can open the file if there is one
+	f, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		seclog.Errorf("failed to open ssh log file: %v", err)
+		return err
+	}
+	if err := r.sshLogReader.Init(f); err != nil {
+		seclog.Errorf("failed to init ssh log reader: %v", err)
+		if f != nil {
+			f.Close()
+		}
+		return err
+	}
+	go r.startReading()
+	// Note: the file is not closed here, as the sshLogReader manage it
+	return nil
+}
+
+// ResolveSSHUserSession resolves the ssh user session from the auth log
+func (r *Resolver) ResolveSSHUserSession(ctx *model.UserSessionContext) *model.UserSessionContext {
+	id := ctx.ID
+	if id == 0 {
+		return nil
+	}
+
+	r.Lock()
+
+	defer r.Unlock()
+
+	key := SSHSessionKey{
+		IP:   ctx.SSHClientIP.IP.String(),
+		Port: strconv.Itoa(ctx.SSHPort),
+	}
+	r.SSHSessionParsed.Mu.Lock()
+	value, ok := r.SSHSessionParsed.Lru.Get(key)
+	r.SSHSessionParsed.Mu.Unlock()
+	if !ok {
+		ctx.Resolved = true
+		return nil
+	}
+	ctx.SSHAuthMethod = int(value.AuthenticationMethod)
+	ctx.SSHPublicKey = value.PublicKey
+	ctx.Resolved = true
+	return ctx
+}
+
+// Close closes the resolver
+func (r *Resolver) Close() {
+	r.Lock()
+
+	defer r.Unlock()
+
+	if r.sshLogReader != nil {
+		r.sshLogReader.mu.Lock()
+		defer r.sshLogReader.mu.Unlock()
+		_ = r.sshLogReader.close(true)
+	}
 }

--- a/pkg/security/resolvers/usersessions/resolver_linux_test.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package usersessions holds model related to the user sessions resolver
+package usersessions
+
+import (
+	"testing"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
+)
+
+func Test_parseSSHLogLine(t *testing.T) {
+	tests := []struct {
+		name               string
+		logLine            string
+		expectedIP         string
+		expectedPort       string
+		expectedAuthMethod int
+		expectedPublicKey  string
+		shouldAddToLRU     bool
+	}{
+		{
+			name:               "ISO 8601 timestamp format with sshd",
+			logLine:            "2025-11-05T10:00:25.279861+01:00 lima-dev sshd[1234]: Accepted publickey for lima from 192.168.5.2 port 38835 ssh2: ED25519 SHA256:J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			expectedIP:         "192.168.5.2",
+			expectedPort:       "38835",
+			expectedAuthMethod: int(usersession.SSHAuthMethodPublicKey),
+			expectedPublicKey:  "J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			shouldAddToLRU:     true,
+		},
+		{
+			name:               "Traditional syslog timestamp format with sshd",
+			logLine:            "Nov  5 09:59:44 lima-centos7-9-x64 sshd[5678]: Accepted publickey for lima from 192.168.5.2 port 38835 ssh2: ED25519 SHA256:J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			expectedIP:         "192.168.5.2",
+			expectedPort:       "38835",
+			expectedAuthMethod: int(usersession.SSHAuthMethodPublicKey),
+			expectedPublicKey:  "J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			shouldAddToLRU:     true,
+		},
+		{
+			name:               "Password authentication",
+			logLine:            "Nov  5 09:59:44 lima-centos7-9-x64 sshd[5678]: Accepted password for testuser from 10.0.0.1 port 12345 ssh2",
+			expectedIP:         "10.0.0.1",
+			expectedPort:       "12345",
+			expectedAuthMethod: int(usersession.SSHAuthMethodPassword),
+			expectedPublicKey:  "",
+			shouldAddToLRU:     true,
+		},
+		{
+			name:           "Invalid log line - not sshd",
+			logLine:        "Nov  5 09:59:44 lima-centos7-9-x64 sudo: Accepted publickey for lima from 192.168.5.2 port 38835 ssh2: ED25519 SHA256:J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			shouldAddToLRU: false,
+		},
+		{
+			name:           "Invalid log line - too short",
+			logLine:        "Nov  5 09:59:44",
+			shouldAddToLRU: false,
+		},
+		{
+			name:           "Invalid log line - not an Accepted event",
+			logLine:        "Nov  5 09:59:44 lima-centos7-9-x64 sshd[5678]: Failed password for invalid user admin from 192.168.5.2 port 38835 ssh2",
+			shouldAddToLRU: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lru, err := simplelru.NewLRU[SSHSessionKey, SSHSessionValue](100, nil)
+			assert.NoError(t, err)
+
+			sshSessionParsed := &sshSessionParsed{
+				Lru: lru,
+			}
+
+			parseSSHLogLine(tt.logLine, sshSessionParsed)
+
+			if tt.shouldAddToLRU {
+				key := SSHSessionKey{
+					IP:   tt.expectedIP,
+					Port: tt.expectedPort,
+				}
+
+				value, found := sshSessionParsed.Lru.Get(key)
+				assert.True(t, found, "SSH Session must be in LRU")
+
+				if found {
+					assert.Equal(t, tt.expectedAuthMethod, value.AuthenticationMethod, "Authentication method must match")
+					assert.Equal(t, tt.expectedPublicKey, value.PublicKey, "Public key must match")
+				}
+			} else {
+				assert.Equal(t, 0, sshSessionParsed.Lru.Len(), "LRU must be empty")
+			}
+		})
+	}
+}

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -3387,6 +3387,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exec.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exec.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exec.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "exit.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -4673,6 +4717,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Exit.Process.UserSession.SessionType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exit.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exit.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "exit.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.UserSession.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -10847,6 +10935,114 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.user_session.ssh_auth_method":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.ssh_client_ip":
+		return &eval.CIDRArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					return []net.IPNet{result}
+				}
+				if result, ok := ctx.IPNetCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.IPNetCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.ssh_port":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.user_session.ssh_public_key":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
+					return current.ProcessContext.Process.UserSession.SSHPublicKey
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -13555,6 +13751,62 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.parent.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return net.IPNet{}
+				}
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return ""
+				}
+				return ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "process.pid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -13671,6 +13923,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.BaseEvent.ProcessContext.Process.UserSession.SessionType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "process.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -16744,6 +17040,114 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
+		return &eval.CIDRArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					return []net.IPNet{result}
+				}
+				if result, ok := ctx.IPNetCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.IPNetCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_port":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
+					return current.ProcessContext.Process.UserSession.SSHPublicKey
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -19452,6 +19856,62 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.parent.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return ev.PTrace.Tracee.Parent.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return net.IPNet{}
+				}
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return ""
+				}
+				return ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.pid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -19568,6 +20028,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.PTrace.Tracee.Process.UserSession.SessionType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.PTrace.Tracee.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.PTrace.Tracee.Process.UserSession.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -24065,6 +24569,114 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
+		return &eval.CIDRArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					return []net.IPNet{result}
+				}
+				if result, ok := ctx.IPNetCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.IPNetCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.ssh_port":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.ancestors.user_session.ssh_public_key":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
+					return current.ProcessContext.Process.UserSession.SSHPublicKey
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -26773,6 +27385,62 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.parent.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return ev.Setrlimit.Target.Parent.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return net.IPNet{}
+				}
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return ""
+				}
+				return ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.pid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -26889,6 +27557,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Setrlimit.Target.Process.UserSession.SessionType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Setrlimit.Target.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Setrlimit.Target.Process.UserSession.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -30483,6 +31195,114 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.user_session.ssh_auth_method":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(element.ProcessContext.Process.UserSession.SSHAuthMethod)
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(current.ProcessContext.Process.UserSession.SSHAuthMethod)
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.ssh_client_ip":
+		return &eval.CIDRArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := ev.FieldHandlers.ResolveSSHClientIP(ev, &element.ProcessContext.Process.UserSession)
+					return []net.IPNet{result}
+				}
+				if result, ok := ctx.IPNetCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) net.IPNet {
+					return ev.FieldHandlers.ResolveSSHClientIP(ev, &current.ProcessContext.Process.UserSession)
+				})
+				ctx.IPNetCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.ssh_port":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := int(ev.FieldHandlers.ResolveSSHPort(ev, &element.ProcessContext.Process.UserSession))
+					return []int{result}
+				}
+				if result, ok := ctx.IntCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, ev, func(ev *Event, current *ProcessCacheEntry) int {
+					return int(ev.FieldHandlers.ResolveSSHPort(ev, &current.ProcessContext.Process.UserSession))
+				})
+				ctx.IntCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.user_session.ssh_public_key":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.UserSession.SSHPublicKey
+					return []string{result}
+				}
+				if result, ok := ctx.StringCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) string {
+					return current.ProcessContext.Process.UserSession.SSHPublicKey
+				})
+				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -33191,6 +34011,62 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.parent.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return ev.Signal.Target.Parent.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return net.IPNet{}
+				}
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return 0
+				}
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Parent.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return ""
+				}
+				return ev.Signal.Target.Parent.UserSession.SSHPublicKey
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.pid":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -33307,6 +34183,50 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Signal.Target.Process.UserSession.SessionType
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.ssh_auth_method":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Signal.Target.Process.UserSession.SSHAuthMethod
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.ssh_client_ip":
+		return &eval.CIDREvaluator{
+			EvalFnc: func(ctx *eval.Context) net.IPNet {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.ssh_port":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Process.UserSession)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.user_session.ssh_public_key":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Signal.Target.Process.UserSession.SSHPublicKey
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -34733,6 +35653,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.user_session.k8s_uid",
 		"exec.user_session.k8s_username",
 		"exec.user_session.session_type",
+		"exec.user_session.ssh_auth_method",
+		"exec.user_session.ssh_client_ip",
+		"exec.user_session.ssh_port",
+		"exec.user_session.ssh_public_key",
 		"exit.args",
 		"exit.args_flags",
 		"exit.args_options",
@@ -34836,6 +35760,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.user_session.k8s_uid",
 		"exit.user_session.k8s_username",
 		"exit.user_session.session_type",
+		"exit.user_session.ssh_auth_method",
+		"exit.user_session.ssh_client_ip",
+		"exit.user_session.ssh_port",
+		"exit.user_session.ssh_public_key",
 		"imds.aws.is_imds_v2",
 		"imds.aws.security_credentials.type",
 		"imds.cloud_provider",
@@ -35201,6 +36129,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.user_session.k8s_uid",
 		"process.ancestors.user_session.k8s_username",
 		"process.ancestors.user_session.session_type",
+		"process.ancestors.user_session.ssh_auth_method",
+		"process.ancestors.user_session.ssh_client_ip",
+		"process.ancestors.user_session.ssh_port",
+		"process.ancestors.user_session.ssh_public_key",
 		"process.args",
 		"process.args_flags",
 		"process.args_options",
@@ -35392,6 +36324,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.user_session.k8s_uid",
 		"process.parent.user_session.k8s_username",
 		"process.parent.user_session.session_type",
+		"process.parent.user_session.ssh_auth_method",
+		"process.parent.user_session.ssh_client_ip",
+		"process.parent.user_session.ssh_port",
+		"process.parent.user_session.ssh_public_key",
 		"process.pid",
 		"process.ppid",
 		"process.tid",
@@ -35403,6 +36339,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.user_session.k8s_uid",
 		"process.user_session.k8s_username",
 		"process.user_session.session_type",
+		"process.user_session.ssh_auth_method",
+		"process.user_session.ssh_client_ip",
+		"process.user_session.ssh_port",
+		"process.user_session.ssh_public_key",
 		"ptrace.request",
 		"ptrace.retval",
 		"ptrace.tracee.ancestors.args",
@@ -35507,6 +36447,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.user_session.k8s_uid",
 		"ptrace.tracee.ancestors.user_session.k8s_username",
 		"ptrace.tracee.ancestors.user_session.session_type",
+		"ptrace.tracee.ancestors.user_session.ssh_auth_method",
+		"ptrace.tracee.ancestors.user_session.ssh_client_ip",
+		"ptrace.tracee.ancestors.user_session.ssh_port",
+		"ptrace.tracee.ancestors.user_session.ssh_public_key",
 		"ptrace.tracee.args",
 		"ptrace.tracee.args_flags",
 		"ptrace.tracee.args_options",
@@ -35698,6 +36642,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.user_session.k8s_uid",
 		"ptrace.tracee.parent.user_session.k8s_username",
 		"ptrace.tracee.parent.user_session.session_type",
+		"ptrace.tracee.parent.user_session.ssh_auth_method",
+		"ptrace.tracee.parent.user_session.ssh_client_ip",
+		"ptrace.tracee.parent.user_session.ssh_port",
+		"ptrace.tracee.parent.user_session.ssh_public_key",
 		"ptrace.tracee.pid",
 		"ptrace.tracee.ppid",
 		"ptrace.tracee.tid",
@@ -35709,6 +36657,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.user_session.k8s_uid",
 		"ptrace.tracee.user_session.k8s_username",
 		"ptrace.tracee.user_session.session_type",
+		"ptrace.tracee.user_session.ssh_auth_method",
+		"ptrace.tracee.user_session.ssh_client_ip",
+		"ptrace.tracee.user_session.ssh_port",
+		"ptrace.tracee.user_session.ssh_public_key",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -35941,6 +36893,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.user_session.k8s_uid",
 		"setrlimit.target.ancestors.user_session.k8s_username",
 		"setrlimit.target.ancestors.user_session.session_type",
+		"setrlimit.target.ancestors.user_session.ssh_auth_method",
+		"setrlimit.target.ancestors.user_session.ssh_client_ip",
+		"setrlimit.target.ancestors.user_session.ssh_port",
+		"setrlimit.target.ancestors.user_session.ssh_public_key",
 		"setrlimit.target.args",
 		"setrlimit.target.args_flags",
 		"setrlimit.target.args_options",
@@ -36132,6 +37088,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.user_session.k8s_uid",
 		"setrlimit.target.parent.user_session.k8s_username",
 		"setrlimit.target.parent.user_session.session_type",
+		"setrlimit.target.parent.user_session.ssh_auth_method",
+		"setrlimit.target.parent.user_session.ssh_client_ip",
+		"setrlimit.target.parent.user_session.ssh_port",
+		"setrlimit.target.parent.user_session.ssh_public_key",
 		"setrlimit.target.pid",
 		"setrlimit.target.ppid",
 		"setrlimit.target.tid",
@@ -36143,6 +37103,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.user_session.k8s_uid",
 		"setrlimit.target.user_session.k8s_username",
 		"setrlimit.target.user_session.session_type",
+		"setrlimit.target.user_session.ssh_auth_method",
+		"setrlimit.target.user_session.ssh_client_ip",
+		"setrlimit.target.user_session.ssh_port",
+		"setrlimit.target.user_session.ssh_public_key",
 		"setsockopt.filter_hash",
 		"setsockopt.filter_instructions",
 		"setsockopt.filter_len",
@@ -36294,6 +37258,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.user_session.k8s_uid",
 		"signal.target.ancestors.user_session.k8s_username",
 		"signal.target.ancestors.user_session.session_type",
+		"signal.target.ancestors.user_session.ssh_auth_method",
+		"signal.target.ancestors.user_session.ssh_client_ip",
+		"signal.target.ancestors.user_session.ssh_port",
+		"signal.target.ancestors.user_session.ssh_public_key",
 		"signal.target.args",
 		"signal.target.args_flags",
 		"signal.target.args_options",
@@ -36485,6 +37453,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.user_session.k8s_uid",
 		"signal.target.parent.user_session.k8s_username",
 		"signal.target.parent.user_session.session_type",
+		"signal.target.parent.user_session.ssh_auth_method",
+		"signal.target.parent.user_session.ssh_client_ip",
+		"signal.target.parent.user_session.ssh_port",
+		"signal.target.parent.user_session.ssh_public_key",
 		"signal.target.pid",
 		"signal.target.ppid",
 		"signal.target.tid",
@@ -36496,6 +37468,10 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.user_session.k8s_uid",
 		"signal.target.user_session.k8s_username",
 		"signal.target.user_session.session_type",
+		"signal.target.user_session.ssh_auth_method",
+		"signal.target.user_session.ssh_client_ip",
+		"signal.target.user_session.ssh_port",
+		"signal.target.user_session.ssh_public_key",
 		"signal.type",
 		"splice.file.change_time",
 		"splice.file.extension",
@@ -37177,6 +38153,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.String, "string", nil
 	case "exec.user_session.session_type":
 		return "exec", reflect.Int, "int", nil
+	case "exec.user_session.ssh_auth_method":
+		return "exec", reflect.Int, "int", nil
+	case "exec.user_session.ssh_client_ip":
+		return "exec", reflect.Struct, "net.IPNet", nil
+	case "exec.user_session.ssh_port":
+		return "exec", reflect.Int, "int", nil
+	case "exec.user_session.ssh_public_key":
+		return "exec", reflect.String, "string", nil
 	case "exit.args":
 		return "exit", reflect.String, "string", nil
 	case "exit.args_flags":
@@ -37383,6 +38367,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.String, "string", nil
 	case "exit.user_session.session_type":
 		return "exit", reflect.Int, "int", nil
+	case "exit.user_session.ssh_auth_method":
+		return "exit", reflect.Int, "int", nil
+	case "exit.user_session.ssh_client_ip":
+		return "exit", reflect.Struct, "net.IPNet", nil
+	case "exit.user_session.ssh_port":
+		return "exit", reflect.Int, "int", nil
+	case "exit.user_session.ssh_public_key":
+		return "exit", reflect.String, "string", nil
 	case "imds.aws.is_imds_v2":
 		return "imds", reflect.Bool, "bool", nil
 	case "imds.aws.security_credentials.type":
@@ -38113,6 +39105,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.ancestors.user_session.session_type":
 		return "", reflect.Int, "int", nil
+	case "process.ancestors.user_session.ssh_auth_method":
+		return "", reflect.Int, "int", nil
+	case "process.ancestors.user_session.ssh_client_ip":
+		return "", reflect.Struct, "net.IPNet", nil
+	case "process.ancestors.user_session.ssh_port":
+		return "", reflect.Int, "int", nil
+	case "process.ancestors.user_session.ssh_public_key":
+		return "", reflect.String, "string", nil
 	case "process.args":
 		return "", reflect.String, "string", nil
 	case "process.args_flags":
@@ -38495,6 +39495,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.parent.user_session.session_type":
 		return "", reflect.Int, "int", nil
+	case "process.parent.user_session.ssh_auth_method":
+		return "", reflect.Int, "int", nil
+	case "process.parent.user_session.ssh_client_ip":
+		return "", reflect.Struct, "net.IPNet", nil
+	case "process.parent.user_session.ssh_port":
+		return "", reflect.Int, "int", nil
+	case "process.parent.user_session.ssh_public_key":
+		return "", reflect.String, "string", nil
 	case "process.pid":
 		return "", reflect.Int, "int", nil
 	case "process.ppid":
@@ -38517,6 +39525,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.String, "string", nil
 	case "process.user_session.session_type":
 		return "", reflect.Int, "int", nil
+	case "process.user_session.ssh_auth_method":
+		return "", reflect.Int, "int", nil
+	case "process.user_session.ssh_client_ip":
+		return "", reflect.Struct, "net.IPNet", nil
+	case "process.user_session.ssh_port":
+		return "", reflect.Int, "int", nil
+	case "process.user_session.ssh_public_key":
+		return "", reflect.String, "string", nil
 	case "ptrace.request":
 		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.retval":
@@ -38725,6 +39741,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.ancestors.user_session.session_type":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
+		return "ptrace", reflect.Struct, "net.IPNet", nil
+	case "ptrace.tracee.ancestors.user_session.ssh_port":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
+		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.args":
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.args_flags":
@@ -39107,6 +40131,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.parent.user_session.session_type":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.user_session.ssh_auth_method":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.user_session.ssh_client_ip":
+		return "ptrace", reflect.Struct, "net.IPNet", nil
+	case "ptrace.tracee.parent.user_session.ssh_port":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.parent.user_session.ssh_public_key":
+		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.pid":
 		return "ptrace", reflect.Int, "int", nil
 	case "ptrace.tracee.ppid":
@@ -39129,6 +40161,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.String, "string", nil
 	case "ptrace.tracee.user_session.session_type":
 		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.user_session.ssh_auth_method":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.user_session.ssh_client_ip":
+		return "ptrace", reflect.Struct, "net.IPNet", nil
+	case "ptrace.tracee.user_session.ssh_port":
+		return "ptrace", reflect.Int, "int", nil
+	case "ptrace.tracee.user_session.ssh_public_key":
+		return "ptrace", reflect.String, "string", nil
 	case "removexattr.file.change_time":
 		return "removexattr", reflect.Int, "int", nil
 	case "removexattr.file.destination.name":
@@ -39593,6 +40633,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.ancestors.user_session.session_type":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
+		return "setrlimit", reflect.Struct, "net.IPNet", nil
+	case "setrlimit.target.ancestors.user_session.ssh_port":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.ancestors.user_session.ssh_public_key":
+		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.args":
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.args_flags":
@@ -39975,6 +41023,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.parent.user_session.session_type":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.user_session.ssh_auth_method":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.user_session.ssh_client_ip":
+		return "setrlimit", reflect.Struct, "net.IPNet", nil
+	case "setrlimit.target.parent.user_session.ssh_port":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.parent.user_session.ssh_public_key":
+		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.pid":
 		return "setrlimit", reflect.Int, "int", nil
 	case "setrlimit.target.ppid":
@@ -39997,6 +41053,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.String, "string", nil
 	case "setrlimit.target.user_session.session_type":
 		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.user_session.ssh_auth_method":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.user_session.ssh_client_ip":
+		return "setrlimit", reflect.Struct, "net.IPNet", nil
+	case "setrlimit.target.user_session.ssh_port":
+		return "setrlimit", reflect.Int, "int", nil
+	case "setrlimit.target.user_session.ssh_public_key":
+		return "setrlimit", reflect.String, "string", nil
 	case "setsockopt.filter_hash":
 		return "setsockopt", reflect.String, "string", nil
 	case "setsockopt.filter_instructions":
@@ -40299,6 +41363,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.ancestors.user_session.session_type":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.user_session.ssh_auth_method":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.user_session.ssh_client_ip":
+		return "signal", reflect.Struct, "net.IPNet", nil
+	case "signal.target.ancestors.user_session.ssh_port":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.ancestors.user_session.ssh_public_key":
+		return "signal", reflect.String, "string", nil
 	case "signal.target.args":
 		return "signal", reflect.String, "string", nil
 	case "signal.target.args_flags":
@@ -40681,6 +41753,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.parent.user_session.session_type":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.user_session.ssh_auth_method":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.user_session.ssh_client_ip":
+		return "signal", reflect.Struct, "net.IPNet", nil
+	case "signal.target.parent.user_session.ssh_port":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.parent.user_session.ssh_public_key":
+		return "signal", reflect.String, "string", nil
 	case "signal.target.pid":
 		return "signal", reflect.Int, "int", nil
 	case "signal.target.ppid":
@@ -40703,6 +41783,14 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.String, "string", nil
 	case "signal.target.user_session.session_type":
 		return "signal", reflect.Int, "int", nil
+	case "signal.target.user_session.ssh_auth_method":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.user_session.ssh_client_ip":
+		return "signal", reflect.Struct, "net.IPNet", nil
+	case "signal.target.user_session.ssh_port":
+		return "signal", reflect.Int, "int", nil
+	case "signal.target.user_session.ssh_public_key":
+		return "signal", reflect.String, "string", nil
 	case "signal.type":
 		return "signal", reflect.Int, "int", nil
 	case "splice.file.change_time":
@@ -41622,6 +42710,19 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("exec.user_session.k8s_username", &ev.Exec.Process.UserSession.K8SUsername, value)
 	case "exec.user_session.session_type":
 		return ev.setIntFieldValue("exec.user_session.session_type", &ev.Exec.Process.UserSession.SessionType, value)
+	case "exec.user_session.ssh_auth_method":
+		return ev.setIntFieldValue("exec.user_session.ssh_auth_method", &ev.Exec.Process.UserSession.SSHAuthMethod, value)
+	case "exec.user_session.ssh_client_ip":
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "exec.user_session.ssh_client_ip"}
+		}
+		ev.Exec.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "exec.user_session.ssh_port":
+		return ev.setIntFieldValue("exec.user_session.ssh_port", &ev.Exec.Process.UserSession.SSHPort, value)
+	case "exec.user_session.ssh_public_key":
+		return ev.setStringFieldValue("exec.user_session.ssh_public_key", &ev.Exec.Process.UserSession.SSHPublicKey, value)
 	case "exit.args":
 		if ev.Exit.Process == nil {
 			ev.Exit.Process = &Process{}
@@ -42241,6 +43342,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Exit.Process = &Process{}
 		}
 		return ev.setIntFieldValue("exit.user_session.session_type", &ev.Exit.Process.UserSession.SessionType, value)
+	case "exit.user_session.ssh_auth_method":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setIntFieldValue("exit.user_session.ssh_auth_method", &ev.Exit.Process.UserSession.SSHAuthMethod, value)
+	case "exit.user_session.ssh_client_ip":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "exit.user_session.ssh_client_ip"}
+		}
+		ev.Exit.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "exit.user_session.ssh_port":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setIntFieldValue("exit.user_session.ssh_port", &ev.Exit.Process.UserSession.SSHPort, value)
+	case "exit.user_session.ssh_public_key":
+		if ev.Exit.Process == nil {
+			ev.Exit.Process = &Process{}
+		}
+		return ev.setStringFieldValue("exit.user_session.ssh_public_key", &ev.Exit.Process.UserSession.SSHPublicKey, value)
 	case "imds.aws.is_imds_v2":
 		return ev.setBoolFieldValue("imds.aws.is_imds_v2", &ev.IMDS.AWS.IsIMDSv2, value)
 	case "imds.aws.security_credentials.type":
@@ -43150,6 +44276,19 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.ancestors.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.K8SUsername, value)
 	case "process.ancestors.user_session.session_type":
 		return ev.setIntFieldValue("process.ancestors.user_session.session_type", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
+	case "process.ancestors.user_session.ssh_auth_method":
+		return ev.setIntFieldValue("process.ancestors.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+	case "process.ancestors.user_session.ssh_client_ip":
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.ancestors.user_session.ssh_client_ip"}
+		}
+		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "process.ancestors.user_session.ssh_port":
+		return ev.setIntFieldValue("process.ancestors.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+	case "process.ancestors.user_session.ssh_public_key":
+		return ev.setStringFieldValue("process.ancestors.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
 	case "process.args":
 		return ev.setStringFieldValue("process.args", &ev.BaseEvent.ProcessContext.Process.Args, value)
 	case "process.args_flags":
@@ -43752,6 +44891,19 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.parent.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Parent.UserSession.K8SUsername, value)
 	case "process.parent.user_session.session_type":
 		return ev.setIntFieldValue("process.parent.user_session.session_type", &ev.BaseEvent.ProcessContext.Parent.UserSession.SessionType, value)
+	case "process.parent.user_session.ssh_auth_method":
+		return ev.setIntFieldValue("process.parent.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHAuthMethod, value)
+	case "process.parent.user_session.ssh_client_ip":
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.parent.user_session.ssh_client_ip"}
+		}
+		ev.BaseEvent.ProcessContext.Parent.UserSession.SSHClientIP = rv
+		return nil
+	case "process.parent.user_session.ssh_port":
+		return ev.setIntFieldValue("process.parent.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPort, value)
+	case "process.parent.user_session.ssh_public_key":
+		return ev.setStringFieldValue("process.parent.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Parent.UserSession.SSHPublicKey, value)
 	case "process.pid":
 		return ev.setUint32FieldValue("process.pid", &ev.BaseEvent.ProcessContext.Process.PIDContext.Pid, value)
 	case "process.ppid":
@@ -43774,6 +44926,19 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setStringFieldValue("process.user_session.k8s_username", &ev.BaseEvent.ProcessContext.Process.UserSession.K8SUsername, value)
 	case "process.user_session.session_type":
 		return ev.setIntFieldValue("process.user_session.session_type", &ev.BaseEvent.ProcessContext.Process.UserSession.SessionType, value)
+	case "process.user_session.ssh_auth_method":
+		return ev.setIntFieldValue("process.user_session.ssh_auth_method", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+	case "process.user_session.ssh_client_ip":
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "process.user_session.ssh_client_ip"}
+		}
+		ev.BaseEvent.ProcessContext.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "process.user_session.ssh_port":
+		return ev.setIntFieldValue("process.user_session.ssh_port", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPort, value)
+	case "process.user_session.ssh_public_key":
+		return ev.setStringFieldValue("process.user_session.ssh_public_key", &ev.BaseEvent.ProcessContext.Process.UserSession.SSHPublicKey, value)
 	case "ptrace.request":
 		return ev.setUint32FieldValue("ptrace.request", &ev.PTrace.Request, value)
 	case "ptrace.retval":
@@ -44704,6 +45869,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.session_type", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
+	case "ptrace.tracee.ancestors.user_session.ssh_auth_method":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_auth_method", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+	case "ptrace.tracee.ancestors.user_session.ssh_client_ip":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.ancestors.user_session.ssh_client_ip"}
+		}
+		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "ptrace.tracee.ancestors.user_session.ssh_port":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.ancestors.user_session.ssh_port", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+	case "ptrace.tracee.ancestors.user_session.ssh_public_key":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.ancestors.user_session.ssh_public_key", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
 	case "ptrace.tracee.args":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -46182,6 +47384,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee.Parent = &Process{}
 		}
 		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.session_type", &ev.PTrace.Tracee.Parent.UserSession.SessionType, value)
+	case "ptrace.tracee.parent.user_session.ssh_auth_method":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_auth_method", &ev.PTrace.Tracee.Parent.UserSession.SSHAuthMethod, value)
+	case "ptrace.tracee.parent.user_session.ssh_client_ip":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.parent.user_session.ssh_client_ip"}
+		}
+		ev.PTrace.Tracee.Parent.UserSession.SSHClientIP = rv
+		return nil
+	case "ptrace.tracee.parent.user_session.ssh_port":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.parent.user_session.ssh_port", &ev.PTrace.Tracee.Parent.UserSession.SSHPort, value)
+	case "ptrace.tracee.parent.user_session.ssh_public_key":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.parent.user_session.ssh_public_key", &ev.PTrace.Tracee.Parent.UserSession.SSHPublicKey, value)
 	case "ptrace.tracee.pid":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -46237,6 +47476,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.PTrace.Tracee = &ProcessContext{}
 		}
 		return ev.setIntFieldValue("ptrace.tracee.user_session.session_type", &ev.PTrace.Tracee.Process.UserSession.SessionType, value)
+	case "ptrace.tracee.user_session.ssh_auth_method":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_auth_method", &ev.PTrace.Tracee.Process.UserSession.SSHAuthMethod, value)
+	case "ptrace.tracee.user_session.ssh_client_ip":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ptrace.tracee.user_session.ssh_client_ip"}
+		}
+		ev.PTrace.Tracee.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "ptrace.tracee.user_session.ssh_port":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("ptrace.tracee.user_session.ssh_port", &ev.PTrace.Tracee.Process.UserSession.SSHPort, value)
+	case "ptrace.tracee.user_session.ssh_public_key":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("ptrace.tracee.user_session.ssh_public_key", &ev.PTrace.Tracee.Process.UserSession.SSHPublicKey, value)
 	case "removexattr.file.change_time":
 		return ev.setUint64FieldValue("removexattr.file.change_time", &ev.RemoveXAttr.File.FileFields.CTime, value)
 	case "removexattr.file.destination.name":
@@ -47423,6 +48687,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.session_type", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
+	case "setrlimit.target.ancestors.user_session.ssh_auth_method":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_auth_method", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+	case "setrlimit.target.ancestors.user_session.ssh_client_ip":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.ancestors.user_session.ssh_client_ip"}
+		}
+		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "setrlimit.target.ancestors.user_session.ssh_port":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.ancestors.user_session.ssh_port", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+	case "setrlimit.target.ancestors.user_session.ssh_public_key":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.ancestors.user_session.ssh_public_key", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
 	case "setrlimit.target.args":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48901,6 +50202,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setIntFieldValue("setrlimit.target.parent.user_session.session_type", &ev.Setrlimit.Target.Parent.UserSession.SessionType, value)
+	case "setrlimit.target.parent.user_session.ssh_auth_method":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_auth_method", &ev.Setrlimit.Target.Parent.UserSession.SSHAuthMethod, value)
+	case "setrlimit.target.parent.user_session.ssh_client_ip":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.parent.user_session.ssh_client_ip"}
+		}
+		ev.Setrlimit.Target.Parent.UserSession.SSHClientIP = rv
+		return nil
+	case "setrlimit.target.parent.user_session.ssh_port":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.parent.user_session.ssh_port", &ev.Setrlimit.Target.Parent.UserSession.SSHPort, value)
+	case "setrlimit.target.parent.user_session.ssh_public_key":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.parent.user_session.ssh_public_key", &ev.Setrlimit.Target.Parent.UserSession.SSHPublicKey, value)
 	case "setrlimit.target.pid":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -48956,6 +50294,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setIntFieldValue("setrlimit.target.user_session.session_type", &ev.Setrlimit.Target.Process.UserSession.SessionType, value)
+	case "setrlimit.target.user_session.ssh_auth_method":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_auth_method", &ev.Setrlimit.Target.Process.UserSession.SSHAuthMethod, value)
+	case "setrlimit.target.user_session.ssh_client_ip":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "setrlimit.target.user_session.ssh_client_ip"}
+		}
+		ev.Setrlimit.Target.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "setrlimit.target.user_session.ssh_port":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("setrlimit.target.user_session.ssh_port", &ev.Setrlimit.Target.Process.UserSession.SSHPort, value)
+	case "setrlimit.target.user_session.ssh_public_key":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("setrlimit.target.user_session.ssh_public_key", &ev.Setrlimit.Target.Process.UserSession.SSHPublicKey, value)
 	case "setsockopt.filter_hash":
 		return ev.setStringFieldValue("setsockopt.filter_hash", &ev.SetSockOpt.FilterHash, value)
 	case "setsockopt.filter_instructions":
@@ -49990,6 +51353,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setIntFieldValue("signal.target.ancestors.user_session.session_type", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SessionType, value)
+	case "signal.target.ancestors.user_session.ssh_auth_method":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_auth_method", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHAuthMethod, value)
+	case "signal.target.ancestors.user_session.ssh_client_ip":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "signal.target.ancestors.user_session.ssh_client_ip"}
+		}
+		ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "signal.target.ancestors.user_session.ssh_port":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setIntFieldValue("signal.target.ancestors.user_session.ssh_port", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHPort, value)
+	case "signal.target.ancestors.user_session.ssh_public_key":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setStringFieldValue("signal.target.ancestors.user_session.ssh_public_key", &ev.Signal.Target.Ancestor.ProcessContext.Process.UserSession.SSHPublicKey, value)
 	case "signal.target.args":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51468,6 +52868,43 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setIntFieldValue("signal.target.parent.user_session.session_type", &ev.Signal.Target.Parent.UserSession.SessionType, value)
+	case "signal.target.parent.user_session.ssh_auth_method":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_auth_method", &ev.Signal.Target.Parent.UserSession.SSHAuthMethod, value)
+	case "signal.target.parent.user_session.ssh_client_ip":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "signal.target.parent.user_session.ssh_client_ip"}
+		}
+		ev.Signal.Target.Parent.UserSession.SSHClientIP = rv
+		return nil
+	case "signal.target.parent.user_session.ssh_port":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setIntFieldValue("signal.target.parent.user_session.ssh_port", &ev.Signal.Target.Parent.UserSession.SSHPort, value)
+	case "signal.target.parent.user_session.ssh_public_key":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setStringFieldValue("signal.target.parent.user_session.ssh_public_key", &ev.Signal.Target.Parent.UserSession.SSHPublicKey, value)
 	case "signal.target.pid":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51523,6 +52960,31 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setIntFieldValue("signal.target.user_session.session_type", &ev.Signal.Target.Process.UserSession.SessionType, value)
+	case "signal.target.user_session.ssh_auth_method":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("signal.target.user_session.ssh_auth_method", &ev.Signal.Target.Process.UserSession.SSHAuthMethod, value)
+	case "signal.target.user_session.ssh_client_ip":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		rv, ok := value.(net.IPNet)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "signal.target.user_session.ssh_client_ip"}
+		}
+		ev.Signal.Target.Process.UserSession.SSHClientIP = rv
+		return nil
+	case "signal.target.user_session.ssh_port":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setIntFieldValue("signal.target.user_session.ssh_port", &ev.Signal.Target.Process.UserSession.SSHPort, value)
+	case "signal.target.user_session.ssh_public_key":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setStringFieldValue("signal.target.user_session.ssh_public_key", &ev.Signal.Target.Process.UserSession.SSHPublicKey, value)
 	case "signal.type":
 		return ev.setUint32FieldValue("signal.type", &ev.Signal.Type, value)
 	case "splice.file.change_time":

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -440,6 +440,22 @@ var (
 		"STATIC":  Static,
 		"DYNAMIC": Dynamic,
 	}
+
+	// UserSessionTypes are the supported user session types
+	// generate_constants:UserSessionTypes,UserSessionTypes are the supported user session types.
+	UserSessionTypes = map[string]usersession.Type{
+		"unknown": usersession.UserSessionTypeUnknown,
+		"k8s":     usersession.UserSessionTypeK8S,
+		"ssh":     usersession.UserSessionTypeSSH,
+	}
+
+	// SSHAuthMethodConstants are the supported SSH authentication methods
+	// generate_constants:SSHAuthMethod,SSH authentication methods.
+	SSHAuthMethodConstants = map[string]usersession.AuthType{
+		"password":   usersession.SSHAuthMethodPassword,
+		"public_key": usersession.SSHAuthMethodPublicKey,
+		"unknown":    usersession.SSHAuthMethodUnknown,
+	}
 )
 
 var (
@@ -457,6 +473,10 @@ var (
 	compressionTypeStrings     = map[CompressionType]string{}
 	fileTypeStrings            = map[FileType]string{}
 	linkageTypeStrings         = map[LinkageType]string{}
+	// UserSessionTypeStrings are the supported user session types
+	UserSessionTypeStrings = map[usersession.Type]string{}
+	// SSHAuthMethodStrings are the supported SSH authentication methods
+	SSHAuthMethodStrings = map[usersession.AuthType]string{}
 )
 
 // File flags
@@ -606,6 +626,22 @@ func initLinkageTypeConstants() {
 	}
 }
 
+// InitUserSessionTypes initialize the constants for user session types
+func InitUserSessionTypes() {
+	for k, v := range UserSessionTypes {
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		UserSessionTypeStrings[v] = k
+	}
+}
+
+// InitSSHAuthMethodConstants initialize the constants for SSH auth methods
+func InitSSHAuthMethodConstants() {
+	for k, v := range SSHAuthMethodConstants {
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		SSHAuthMethodStrings[v] = k
+	}
+}
+
 func initConstants() {
 	initBoolConstants()
 	initErrorConstants()
@@ -636,7 +672,6 @@ func initConstants() {
 	initExitCauseConstants()
 	initBPFMapNamesConstants()
 	initAUIDConstants()
-	usersession.InitUserSessionTypes()
 	initSSLVersionConstants()
 	initSysCtlActionConstants()
 	initSetSockOptLevelConstants()
@@ -654,6 +689,8 @@ func initConstants() {
 	initSocketFamilyConstants()
 	initSocketProtocolConstants()
 	initPrCtlOptionConstants()
+	InitUserSessionTypes()
+	InitSSHAuthMethodConstants()
 }
 
 // RetValError represents a syscall return error value

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -9,8 +9,11 @@
 package model
 
 import (
+	"net"
 	"time"
 )
+
+var _ = net.IP{}
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
 func (ev *Event) ResolveFields() {
@@ -43,6 +46,8 @@ func (ev *Event) resolveFields(forADs bool) {
 	_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
 	_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
 	_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+	_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
+	_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Process.UserSession)
 	if !forADs {
 		_ = ev.FieldHandlers.ResolveService(ev, &ev.BaseEvent)
 		_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -87,6 +92,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.BaseEvent.ProcessContext.Parent.UserSession)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
@@ -270,6 +277,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exec.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exec.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exec.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exec.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exec.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, ev.Exec.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exec.Process.ContainerContext)
@@ -337,6 +346,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Exit.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Exit.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Exit.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Exit.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Exit.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, ev.Exit.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Exit.Process.ContainerContext)
@@ -544,6 +555,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.PTrace.Tracee.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.PTrace.Tracee.Process.ContainerContext)
@@ -580,6 +593,8 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.PTrace.Tracee.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.PTrace.Tracee.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.PTrace.Tracee.Parent.UserSession)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent)
@@ -741,6 +756,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.Setrlimit.Target.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Setrlimit.Target.Process.ContainerContext)
@@ -777,6 +794,8 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Setrlimit.Target.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Setrlimit.Target.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Setrlimit.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Setrlimit.Target.Parent.UserSession)
 		}
 		if ev.Setrlimit.Target.HasParent() && ev.Setrlimit.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Setrlimit.Target.Parent.LinuxBinprm.FileEvent)
@@ -886,6 +905,8 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Process.UserSession)
 		_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Process.UserSession)
+		_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Process.UserSession)
 		if !forADs {
 			_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.Signal.Target.Process)
 			_ = ev.FieldHandlers.ResolveContainerTags(ev, &ev.Signal.Target.Process.ContainerContext)
@@ -922,6 +943,8 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveK8SGroups(ev, &ev.Signal.Target.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUID(ev, &ev.Signal.Target.Parent.UserSession)
 			_ = ev.FieldHandlers.ResolveK8SUsername(ev, &ev.Signal.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHClientIP(ev, &ev.Signal.Target.Parent.UserSession)
+			_ = ev.FieldHandlers.ResolveSSHPort(ev, &ev.Signal.Target.Parent.UserSession)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileExtension(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent)
@@ -1128,6 +1151,8 @@ type FieldHandlers interface {
 	ResolveProcessIsThread(ev *Event, e *Process) bool
 	ResolveRights(ev *Event, e *FileFields) int
 	ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string
+	ResolveSSHClientIP(ev *Event, e *UserSessionContext) net.IPNet
+	ResolveSSHPort(ev *Event, e *UserSessionContext) int
 	ResolveService(ev *Event, e *BaseEvent) string
 	ResolveSetSockOptFilterHash(ev *Event, e *SetSockOptEvent) string
 	ResolveSetSockOptFilterInstructions(ev *Event, e *SetSockOptEvent) string
@@ -1374,6 +1399,12 @@ func (dfh *FakeFieldHandlers) ResolveProcessIsThread(ev *Event, e *Process) bool
 func (dfh *FakeFieldHandlers) ResolveRights(ev *Event, e *FileFields) int { return int(e.Mode) }
 func (dfh *FakeFieldHandlers) ResolveSELinuxBoolName(ev *Event, e *SELinuxEvent) string {
 	return string(e.BoolName)
+}
+func (dfh *FakeFieldHandlers) ResolveSSHClientIP(ev *Event, e *UserSessionContext) net.IPNet {
+	return net.IPNet(e.SSHClientIP)
+}
+func (dfh *FakeFieldHandlers) ResolveSSHPort(ev *Event, e *UserSessionContext) int {
+	return int(e.SSHPort)
 }
 func (dfh *FakeFieldHandlers) ResolveService(ev *Event, e *BaseEvent) string {
 	return string(e.Service)

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -9,8 +9,11 @@
 package model
 
 import (
+	"net"
 	"time"
 )
+
+var _ = net.IP{}
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
 func (ev *Event) ResolveFields() {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -353,13 +353,18 @@ func (e *Event) GetProcessTracerTags() []string {
 // Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
 	ID          uint64 `field:"id"`           // SECLDoc[id] Definition:`Unique identifier of the user session on the host`
-	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session`
+	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session` Constants:`UserSessionTypes`
 	Resolved    bool   `field:"-"`
 	// Kubernetes User Session context
 	K8SUsername string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
 	K8SUID      string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
 	K8SGroups   []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
 	K8SExtra    map[string][]string `json:"extra,omitempty"`
+	// SSH User Session context
+	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
+	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
+	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
+	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`                          // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/secl/model/usersession/user_session.go
+++ b/pkg/security/secl/model/usersession/user_session.go
@@ -6,13 +6,27 @@
 // Package usersession holds model related to the user session context
 package usersession
 
+const (
+	// UserSessionTypeUnknown is the unknown user session type
+	UserSessionTypeUnknown Type = iota
+	// UserSessionTypeK8S is the k8s user session type
+	UserSessionTypeK8S
+	// UserSessionTypeSSH is the ssh user session type
+	UserSessionTypeSSH
+)
+
+// SSHAuthMethodConstants are the supported SSH authentication methods
+const (
+	// SSHAuthMethodUnknown is the unknown SSH authentication method
+	SSHAuthMethodUnknown AuthType = iota
+	// SSHAuthMethodPassword is the password SSH authentication method
+	SSHAuthMethodPassword
+	// SSHAuthMethodPublicKey is the public key SSH authentication method
+	SSHAuthMethodPublicKey
+)
+
 var (
 	// UserSessionTypes are the supported user session types
-	UserSessionTypes = map[string]Type{
-		"unknown": 0,
-		"k8s":     1,
-		"ssh":     2,
-	}
 
 	// UserSessionTypeStrings is used to
 	UserSessionTypeStrings = map[Type]string{}
@@ -21,13 +35,5 @@ var (
 // Type is used to identify the User Session type
 type Type uint8
 
-func (ust Type) String() string {
-	return UserSessionTypeStrings[ust]
-}
-
-// InitUserSessionTypes initializes internal structures for parsing Type values
-func InitUserSessionTypes() {
-	for k, v := range UserSessionTypes {
-		UserSessionTypeStrings[v] = k
-	}
-}
+// AuthType is used to identify the SSH authentication method
+type AuthType uint8

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -440,6 +440,22 @@ var (
 		"STATIC":  Static,
 		"DYNAMIC": Dynamic,
 	}
+
+	// UserSessionTypes are the supported user session types
+	// generate_constants:UserSessionTypes,UserSessionTypes are the supported user session types.
+	UserSessionTypes = map[string]usersession.Type{
+		"unknown": usersession.UserSessionTypeUnknown,
+		"k8s":     usersession.UserSessionTypeK8S,
+		"ssh":     usersession.UserSessionTypeSSH,
+	}
+
+	// SSHAuthMethodConstants are the supported SSH authentication methods
+	// generate_constants:SSHAuthMethod,SSH authentication methods.
+	SSHAuthMethodConstants = map[string]usersession.AuthType{
+		"password":   usersession.SSHAuthMethodPassword,
+		"public_key": usersession.SSHAuthMethodPublicKey,
+		"unknown":    usersession.SSHAuthMethodUnknown,
+	}
 )
 
 var (
@@ -457,6 +473,10 @@ var (
 	compressionTypeStrings     = map[CompressionType]string{}
 	fileTypeStrings            = map[FileType]string{}
 	linkageTypeStrings         = map[LinkageType]string{}
+	// UserSessionTypeStrings are the supported user session types
+	UserSessionTypeStrings = map[usersession.Type]string{}
+	// SSHAuthMethodStrings are the supported SSH authentication methods
+	SSHAuthMethodStrings = map[usersession.AuthType]string{}
 )
 
 // File flags
@@ -606,6 +626,22 @@ func initLinkageTypeConstants() {
 	}
 }
 
+// InitUserSessionTypes initialize the constants for user session types
+func InitUserSessionTypes() {
+	for k, v := range UserSessionTypes {
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		UserSessionTypeStrings[v] = k
+	}
+}
+
+// InitSSHAuthMethodConstants initialize the constants for SSH auth methods
+func InitSSHAuthMethodConstants() {
+	for k, v := range SSHAuthMethodConstants {
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		SSHAuthMethodStrings[v] = k
+	}
+}
+
 func initConstants() {
 	initBoolConstants()
 	initErrorConstants()
@@ -636,7 +672,6 @@ func initConstants() {
 	initExitCauseConstants()
 	initBPFMapNamesConstants()
 	initAUIDConstants()
-	usersession.InitUserSessionTypes()
 	initSSLVersionConstants()
 	initSysCtlActionConstants()
 	initSetSockOptLevelConstants()
@@ -654,6 +689,8 @@ func initConstants() {
 	initSocketFamilyConstants()
 	initSocketProtocolConstants()
 	initPrCtlOptionConstants()
+	InitUserSessionTypes()
+	InitSSHAuthMethodConstants()
 }
 
 // RetValError represents a syscall return error value

--- a/pkg/security/seclwin/model/field_handlers_win.go
+++ b/pkg/security/seclwin/model/field_handlers_win.go
@@ -7,8 +7,11 @@
 package model
 
 import (
+	"net"
 	"time"
 )
+
+var _ = net.IP{}
 
 // ResolveFields resolves all the fields associate to the event type. Context fields are automatically resolved.
 func (ev *Event) ResolveFields() {

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -353,13 +353,18 @@ func (e *Event) GetProcessTracerTags() []string {
 // Disclaimer: the `json` tags are used to parse K8s credentials from cws-instrumentation
 type UserSessionContext struct {
 	ID          uint64 `field:"id"`           // SECLDoc[id] Definition:`Unique identifier of the user session on the host`
-	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session`
+	SessionType int    `field:"session_type"` // SECLDoc[session_type] Definition:`Type of the user session` Constants:`UserSessionTypes`
 	Resolved    bool   `field:"-"`
 	// Kubernetes User Session context
 	K8SUsername string              `field:"k8s_username,handler:ResolveK8SUsername" json:"username,omitempty"` // SECLDoc[k8s_username] Definition:`Kubernetes username of the user that executed the process`
 	K8SUID      string              `field:"k8s_uid,handler:ResolveK8SUID" json:"uid,omitempty"`                // SECLDoc[k8s_uid] Definition:`Kubernetes UID of the user that executed the process`
 	K8SGroups   []string            `field:"k8s_groups,handler:ResolveK8SGroups" json:"groups,omitempty"`       // SECLDoc[k8s_groups] Definition:`Kubernetes groups of the user that executed the process`
 	K8SExtra    map[string][]string `json:"extra,omitempty"`
+	// SSH User Session context
+	SSHPort       int       `field:"ssh_port,handler:ResolveSSHPort" json:"port,omitempty"`               // SECLDoc[ssh_port] Definition:`SSH port of the user that executed the process`
+	SSHClientIP   net.IPNet `field:"ssh_client_ip,handler:ResolveSSHClientIP" json:"client_ip,omitempty"` // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
+	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`                        // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
+	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`                          // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -229,6 +229,14 @@ type UserSessionContextSerializer struct {
 	K8SGroups []string `json:"k8s_groups,omitempty"`
 	// Extra of the Kubernetes "kubectl exec" session
 	K8SExtra map[string][]string `json:"k8s_extra,omitempty"`
+	// Port of the SSH session
+	SSHPort int `json:"ssh_port,omitempty"`
+	// Client IP of the SSH session
+	SSHClientIP string `json:"ssh_client_ip,omitempty"`
+	// Authentication method of the SSH session
+	SSHAuthMethod string `json:"ssh_auth_method,omitempty"`
+	// Public key of the SSH session
+	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 }
 
 // ProcessSerializer serializes a process to JSON
@@ -979,14 +987,25 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 
 func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Event) *UserSessionContextSerializer {
 	e.FieldHandlers.ResolveUserSessionContext(e, ctx)
+	// Init constants in case they are not initialized yet
+	if model.UserSessionTypeStrings == nil {
+		model.InitUserSessionTypes()
+	}
+	if model.SSHAuthMethodStrings == nil {
+		model.InitSSHAuthMethodConstants()
+	}
 
 	return &UserSessionContextSerializer{
-		ID:          fmt.Sprintf("%x", ctx.ID),
-		SessionType: usersession.Type(ctx.SessionType).String(),
-		K8SUsername: ctx.K8SUsername,
-		K8SUID:      ctx.K8SUID,
-		K8SGroups:   ctx.K8SGroups,
-		K8SExtra:    ctx.K8SExtra,
+		ID:            fmt.Sprintf("%x", ctx.ID),
+		SessionType:   model.UserSessionTypeStrings[usersession.Type(ctx.SessionType)],
+		K8SUsername:   ctx.K8SUsername,
+		K8SUID:        ctx.K8SUID,
+		K8SGroups:     ctx.K8SGroups,
+		K8SExtra:      ctx.K8SExtra,
+		SSHPort:       ctx.SSHPort,
+		SSHClientIP:   ctx.SSHClientIP.IP.String(),
+		SSHAuthMethod: model.SSHAuthMethodStrings[usersession.AuthType(ctx.SSHAuthMethod)],
+		SSHPublicKey:  ctx.SSHPublicKey,
 	}
 }
 

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -112,6 +112,14 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 				}
 				in.Delim('}')
 			}
+		case "ssh_port":
+			out.SSHPort = int(in.Int())
+		case "ssh_client_ip":
+			out.SSHClientIP = string(in.String())
+		case "ssh_auth_method":
+			out.SSHAuthMethod = string(in.String())
+		case "ssh_public_key":
+			out.SSHPublicKey = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -215,6 +223,46 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 			}
 			out.RawByte('}')
 		}
+	}
+	if in.SSHPort != 0 {
+		const prefix string = ",\"ssh_port\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int(int(in.SSHPort))
+	}
+	if in.SSHClientIP != "" {
+		const prefix string = ",\"ssh_client_ip\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHClientIP))
+	}
+	if in.SSHAuthMethod != "" {
+		const prefix string = ",\"ssh_auth_method\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHAuthMethod))
+	}
+	if in.SSHPublicKey != "" {
+		const prefix string = ",\"ssh_public_key\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.SSHPublicKey))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -1,0 +1,466 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/avast/retry-go/v4"
+	"github.com/oliveagle/jsonpath"
+	"github.com/stretchr/testify/assert"
+)
+
+// testSSHUser représente un utilisateur de test pour SSH
+type testSSHUser struct {
+	Username string
+	HomeDir  string
+	KeyPath  string
+}
+
+// createTestUser crée un utilisateur système temporaire pour les tests SSH
+func createTestUser() (*testSSHUser, error) {
+	username := fmt.Sprintf("ddtest_ssh_%d", time.Now().Unix())
+
+	// Create a user system with useradd
+	// -r : system user
+	// -m : create home directory
+	// -s : shell
+	// -K MAIL_DIR=/dev/null : deactivate mailbox
+	cmd := exec.Command("sudo", "useradd", "-r", "-m", "-s", "/bin/bash", "-K", "MAIL_DIR=/dev/null", username)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("useradd failed: %v (out: %s)", err, string(out))
+	}
+
+	u, err := user.Lookup(username)
+	if err != nil {
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("lookup user: %w", err)
+	}
+
+	homeDir := u.HomeDir
+	uid := u.Uid
+	gid := u.Gid
+	sshDir := filepath.Join(homeDir, ".ssh")
+
+	// Create the .ssh directory with the correct permissions
+	if err := exec.Command("sudo", "mkdir", "-p", sshDir).Run(); err != nil {
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("mkdir .ssh: %w", err)
+	}
+
+	if err := exec.Command("sudo", "chmod", "700", sshDir).Run(); err != nil {
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("chmod .ssh: %w", err)
+	}
+
+	// Generate an ed25519 key pair
+	tmpDir, err := os.MkdirTemp("", "ssh_test_keys_*")
+	if err != nil {
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	keyPath := filepath.Join(tmpDir, "id_test_ed25519")
+	pubPath := keyPath + ".pub"
+
+	cmd = exec.Command("ssh-keygen", "-t", "ed25519", "-N", "", "-f", keyPath, "-q", "-C", "test-key-"+username)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("ssh-keygen: %v (out: %s)", err, string(out))
+	}
+
+	// Copy the public key to the authorized_keys file
+	authzPath := filepath.Join(sshDir, "authorized_keys")
+	cmd = exec.Command("sudo", "cp", pubPath, authzPath)
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("copy authorized_keys: %w", err)
+	}
+
+	// Définir les bonnes permissions et propriétaire
+	if err := exec.Command("sudo", "chmod", "600", authzPath).Run(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("chmod authorized_keys: %w", err)
+	}
+
+	if err := exec.Command("sudo", "chown", "-R", uid+":"+gid, sshDir).Run(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("chown .ssh: %w", err)
+	}
+	return &testSSHUser{
+		Username: username,
+		HomeDir:  homeDir,
+		KeyPath:  keyPath,
+	}, nil
+}
+
+func (u *testSSHUser) cleanup() error {
+	// Delete temporary keys
+	if u.KeyPath != "" {
+		tmpDir := filepath.Dir(u.KeyPath)
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	// Kill all processes of the user
+	_ = exec.Command("sudo", "pkill", "-u", u.Username).Run()
+
+	// Wait until processes are killed
+	time.Sleep(500 * time.Millisecond)
+
+	// Force kill if processes are still running
+	_ = exec.Command("sudo", "pkill", "-9", "-u", u.Username).Run()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Delete user and home directory
+	cmd := exec.Command("sudo", "userdel", "-r", u.Username)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Si userdel -r échoue, essayer avec -f (force) sans -r
+		cmd = exec.Command("sudo", "userdel", "-f", u.Username)
+		if out2, err2 := cmd.CombinedOutput(); err2 != nil {
+			return fmt.Errorf("userdel failed: %v (out: %s), force attempt: %v (out: %s)", err, string(out), err2, string(out2))
+		}
+
+		// Manually delete the home directory if the user was deleted with -f
+		if u.HomeDir != "" && u.HomeDir != "/" && u.HomeDir != "/home" {
+			_ = exec.Command("sudo", "rm", "-rf", u.HomeDir).Run()
+		}
+	}
+
+	return nil
+}
+
+// checkSSHUserSessionJSON check if all the fields in the JSON are valid for a SSH Session
+func checkSSHUserSessionJSON(testMod *testModule, t testing.TB, data []byte) {
+	jsonPathValidation(testMod, data, func(_ *testModule, jsonData interface{}) {
+
+		// Check all the fields
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.id`); err != nil || el == nil {
+			t.Errorf("user_session.id not found: %v", err)
+		} else if id, ok := el.(string); !ok || id == "" || id == "0" {
+			t.Errorf("user_session.id is empty or invalid: %v", el)
+		}
+
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.session_type`); err != nil || el == nil {
+			t.Errorf("user_session.session_type not found: %v", err)
+		} else if sessionType, ok := el.(string); !ok || sessionType != "ssh" {
+			t.Errorf("user_session.session_type is not 'ssh': %v", el)
+		}
+
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_port`); err != nil || el == nil {
+			t.Errorf("user_session.ssh_port not found: %v", err)
+		} else if port, ok := el.(float64); !ok || port <= 0 {
+			t.Errorf("user_session.ssh_port is invalid: %v", el)
+		}
+
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_client_ip`); err != nil || el == nil {
+			t.Errorf("user_session.ssh_client_ip not found: %v", err)
+		} else if ip, ok := el.(string); !ok || ip == "" {
+			t.Errorf("user_session.ssh_client_ip is empty: %v", el)
+		} else if ip != "127.0.0.1" && ip != "::1" {
+			t.Errorf("user_session.ssh_client_ip should be localhost (127.0.0.1 or ::1): %v", ip)
+		}
+
+		if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_auth_method`); err != nil || el == nil {
+			t.Errorf("user_session.ssh_auth_method not found: %v", err)
+		} else if authMethod, ok := el.(string); !ok || authMethod == "" {
+			t.Errorf("user_session.ssh_auth_method is empty: %v", el)
+		} else if authMethod != "public_key" && authMethod != "password" {
+			t.Errorf("user_session.ssh_auth_method has unexpected value: %v", authMethod)
+		}
+
+		if authMethod, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_auth_method`); err == nil {
+			if authMethodStr, ok := authMethod.(string); ok && authMethodStr == "public_key" {
+				if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_public_key`); err != nil || el == nil {
+					t.Errorf("user_session.ssh_public_key not found for publickey auth: %v", err)
+				} else if pubKey, ok := el.(string); !ok || pubKey == "" {
+					t.Errorf("user_session.ssh_public_key is empty for publickey auth: %v", el)
+				}
+			}
+		}
+	})
+}
+
+// sshConnectAsTestUser se connecte en SSH à localhost en tant que l'utilisateur de test
+func sshConnectAsTestUser(testUser *testSSHUser, remoteCmd string) error {
+	// Se connecter en SSH avec la clé de test
+	args := []string{
+		"-i", testUser.KeyPath,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "PasswordAuthentication=no",
+		"-o", "PubkeyAuthentication=yes",
+		"-o", "BatchMode=yes",
+		"-o", "LogLevel=ERROR",
+		testUser.Username + "@localhost",
+		remoteCmd,
+	}
+
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func rotateAuthLog(logPath string) error {
+	st, err := os.Stat(logPath)
+	if err != nil {
+		return fmt.Errorf("stat before rotate: %w", err)
+	}
+	mode := st.Mode().Perm()
+
+	uid, gid := 0, 0
+	if sys, ok := st.Sys().(*syscall.Stat_t); ok {
+		uid = int(sys.Uid)
+		gid = int(sys.Gid)
+	}
+
+	if err := os.Rename(logPath, logPath+".1"); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create new log: %w", err)
+	}
+	_ = f.Close()
+
+	if err := os.Chown(logPath, uid, gid); err != nil {
+		return fmt.Errorf("chown new log: %w", err)
+	}
+	if err := os.Chmod(logPath, mode); err != nil {
+		return fmt.Errorf("chmod new log: %w", err)
+	}
+
+	if _, err := exec.LookPath("restorecon"); err == nil {
+		_ = exec.Command("restorecon", "-v", logPath).Run()
+	}
+
+	if err := exec.Command("systemctl", "reload", "rsyslog").Run(); err != nil {
+		_ = exec.Command("bash", "-c", "pidof rsyslogd >/dev/null 2>&1 && kill -HUP $(pidof rsyslogd)").Run()
+	}
+
+	return nil
+}
+
+// restoreRotatedLog restores the rotated log file to its original location
+func restoreRotatedLog(logPath string) error {
+	rotatedPath := logPath + ".1"
+
+	// Check if rotated file exists
+	if _, err := os.Stat(rotatedPath); os.IsNotExist(err) {
+		return nil // Nothing to restore
+	}
+
+	// Remove the new empty log
+	_ = os.Remove(logPath)
+
+	// Rename .1 back to original
+	if err := os.Rename(rotatedPath, logPath); err != nil {
+		return fmt.Errorf("restore log: %w", err)
+	}
+
+	// Reload rsyslog
+	if err := exec.Command("systemctl", "reload", "rsyslog").Run(); err != nil {
+		_ = exec.Command("bash", "-c", "pidof rsyslogd >/dev/null 2>&1 && kill -HUP $(pidof rsyslogd)").Run()
+	}
+
+	return nil
+}
+
+func getLogFile() (bool, string, uint64) {
+	possibleLogPaths := []string{
+		"/var/log/auth.log", // Debian/Ubuntu
+		"/var/log/secure",   // RHEL/CentOS/Fedora
+		"/var/log/messages", // openSUSE/autres
+	}
+
+	var logPath string
+	var inodeBeforeRotate uint64
+
+	for _, path := range possibleLogPaths {
+		stat, err := os.Stat(path)
+		if err == nil {
+			logPath = path
+			// Get inode
+			if sysStat, ok := stat.Sys().(*syscall.Stat_t); ok {
+				inodeBeforeRotate = sysStat.Ino
+				return true, logPath, inodeBeforeRotate
+			}
+		}
+	}
+	return false, "", 0
+}
+func TestSSHUserSession(t *testing.T) {
+	SkipIfNotAvailable(t)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+
+	isLogFileExist, _, _ := getLogFile()
+	// We skip test when we don't have a log file because we don't use journalctl for now
+	if !isLogFileExist {
+		t.Skip("Skip test if log file does not exist")
+	}
+
+	testUser, err := createTestUser()
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+	defer func() {
+		if err := testUser.cleanup(); err != nil {
+			t.Logf("warning: failed to cleanup test user: %v", err)
+		}
+	}()
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_rule_ssh_user_session",
+			Expression: `process.user_session.id != 0 && process.user_session.session_type == ssh && exec.user == "` + testUser.Username + `"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("ssh_then_pwd", func(t *testing.T) {
+		err := test.GetEventSent(t, func() error {
+			if err := sshConnectAsTestUser(testUser, "pwd"); err != nil {
+				fmt.Fprintf(os.Stderr, "ssh failed: %v\n", err)
+				return err
+			}
+			return nil
+		}, func(_ *rules.Rule, _ *model.Event) bool {
+			return true
+		}, time.Second*3, "test_rule_ssh_user_session")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = retry.Do(func() error {
+			msg := test.msgSender.getMsg("test_rule_ssh_user_session")
+			if msg == nil {
+				return errors.New("not found")
+			}
+			validateMessageSchema(t, string(msg.Data))
+
+			// Check all the fields
+			checkSSHUserSessionJSON(test, t, msg.Data)
+
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+
+	})
+}
+
+func TestSSHUserSessionRotated(t *testing.T) {
+	SkipIfNotAvailable(t)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+
+	isLogFileExist, logPath, inodeBeforeRotate := getLogFile()
+	// We skip test when we don't have a log file because we can't rotate it
+	if !isLogFileExist {
+		t.Skip("Skip test if log file does not exist")
+	}
+
+	testUser, err := createTestUser()
+	if err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+	defer func() {
+		if err := testUser.cleanup(); err != nil {
+			t.Logf("warning: failed to cleanup test user: %v", err)
+		}
+	}()
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_rule_ssh_user_session",
+			Expression: `exec.user_session.id != 0 && exec.user_session.session_type == ssh && exec.user == "` + testUser.Username + `"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	// Cleanup: restore log after test completion
+	t.Cleanup(func() {
+		_ = restoreRotatedLog(logPath)
+	})
+
+	if err := rotateAuthLog(logPath); err != nil {
+		t.Fatalf("rotateAuthLog failed: %v", err)
+	}
+
+	stat, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("failed to stat log file after rotation: %v", err)
+	}
+
+	var inodeAfterRotate uint64
+	if sysStat, ok := stat.Sys().(*syscall.Stat_t); ok {
+		inodeAfterRotate = sysStat.Ino
+	}
+
+	// Check that the inode has changed
+	assert.NotEqual(t, inodeBeforeRotate, inodeAfterRotate, "inode of %s should be different after rotate", logPath)
+
+	t.Run("ssh_then_pwd_after_rotation", func(t *testing.T) {
+		err := test.GetEventSent(t, func() error {
+			if err := sshConnectAsTestUser(testUser, "pwd"); err != nil {
+				fmt.Fprintf(os.Stderr, "ssh failed: %v\n", err)
+				return err
+			}
+			return nil
+		}, func(_ *rules.Rule, _ *model.Event) bool {
+			return true
+		}, time.Second*3, "test_rule_ssh_user_session")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = retry.Do(func() error {
+			msg := test.msgSender.getMsg("test_rule_ssh_user_session")
+			if msg == nil {
+				return errors.New("not found")
+			}
+			validateMessageSchema(t, string(msg.Data))
+
+			// Check all the fields
+			checkSSHUserSessionJSON(test, t, msg.Data)
+
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+
+	})
+}

--- a/pkg/security/tests/user_session_test.go
+++ b/pkg/security/tests/user_session_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
@@ -72,7 +71,7 @@ func TestK8SUserSession(t *testing.T) {
 			test.validateUserSessionSchema(t, event)
 
 			assert.NotEqual(t, 0, event.ProcessContext.UserSession.ID)
-			assert.Equal(t, int(usersession.UserSessionTypes["k8s"]), event.ProcessContext.UserSession.SessionType)
+			assert.Equal(t, int(model.UserSessionTypes["k8s"]), event.ProcessContext.UserSession.SessionType)
 			assert.Equal(t, "qwerty.azerty@datadoghq.com", event.ProcessContext.UserSession.K8SUsername)
 			assert.Equal(t, "azerty.qwerty@datadoghq.com", event.ProcessContext.UserSession.K8SUID)
 			assert.Equal(t, []string{


### PR DESCRIPTION
### What does this PR do?
This PR introduces the ability to track SSH sessions established on the host. It generates a unique identifier for each SSH session and enriches it with contextual details (stored in the UserSessionContext).
SSH sessions are inferred from the process tree whenever a process has sshd as its parent and is not already part of an existing session.
Additionally, the PR collects complementary information from host log files, with safeguards in place to validate IP addresses and ports.
### Motivation
Previously, for SSH connections, we could only associate the execution path with the host user account. This provided no visibility into the actual remote user initiating the SSH connection. With this PR, we bridge that gap and surface meaningful user context.
### Describe how you validated your changes

### Additional Notes
