### PR TITLE
[BARX-1219] Update agent-release-management to use new MSI artifact location

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -21,6 +21,13 @@ deploy_packages_windows-x64-7:
       --include "datadog-installer-*-1-x86_64.zip"
       --include "datadog-installer-*-1-x86_64.exe"
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-installer-*-1-x86_64.debug.zip"
+      --include "datadog-installer-*-1-x86_64.zip"
+      --include "datadog-installer-*-1-x86_64.exe"
+      $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID $S3_RELEASE_INSTALLER_ARTIFACTS_URI/msi/x86_64/
   artifacts:
     paths:
       - $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -21,6 +21,7 @@ deploy_packages_windows-x64-7:
       --include "datadog-installer-*-1-x86_64.zip"
       --include "datadog-installer-*-1-x86_64.exe"
       $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID $S3_RELEASE_ARTIFACTS_URI/msi/x86_64/
+    # TODO: When this snippet is removed, change upload destination in agent-release-management https://github.com/DataDog/agent-release-management/blob/27bcd404709e4e7aaea3b1d5f272fab5be999a57/ci/libraries/msi.sh#L862-L869
     - $S3_CP_CMD
       --recursive
       --exclude "*"


### PR DESCRIPTION
### What does this PR do?

The `agent-release-management` pipeline expects the windows artifacts to be uploaded to the `datadog-installer` path. This PR temporarily patches the problem by uploading the artifacts to the new and old destination.

### Motivation

https://datadoghq.atlassian.net/browse/BARX-1219

### Describe how you validated your changes

### Additional Notes
