### PR TITLE
Reducing the size of the sketch payload size

### DIFF
--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -44,22 +44,14 @@ func buildSketchPayload() *gogen.SketchPayload {
 
 	sketch := &gogen.SketchPayload_Sketch{
 		Metric: "example.metric",
-		Host:   "my-hostname",
 		Distributions: []gogen.SketchPayload_Sketch_Distribution{
 			{
-				Ts:    now,
-				Cnt:   1,
-				Min:   0.1,
-				Max:   0.5,
-				Avg:   0.3,
-				Sum:   0.3,
-				V:     []float64{0.3},
-				G:     []uint32{1},
-				Delta: []uint32{0},
-				Buf:   []float64{0.3},
+				Ts:  now,
+				Cnt: 1,
+				V:   []float64{0.3},
+				G:   []uint32{1},
 			},
 		},
-		Tags: []string{"tag1:value1", "tag2:value2"},
 		Metadata: &gogen.Metadata{
 			Origin: &gogen.Origin{
 				OriginProduct:  10,
@@ -69,21 +61,9 @@ func buildSketchPayload() *gogen.SketchPayload {
 		},
 	}
 
-	metadata := &gogen.CommonMetadata{
-		AgentVersion: "1.0.0",
-		Timezone:     "UTC",
-		CurrentEpoch: float64(now),
-		InternalIp:   "10.0.0.1",
-		PublicIp:     "1.2.3.4",
-		ApiKey:       "your-api-key",
-	}
-
-	payload := &gogen.SketchPayload{
+	return &gogen.SketchPayload{
 		Sketches: []gogen.SketchPayload_Sketch{*sketch},
-		Metadata: *metadata,
 	}
-
-	return payload
 }
 
 func getEndpointsInfo(cfg model.Reader) []endpointInfo {


### PR DESCRIPTION
### What does this PR do?

We have a connectivity check that probes the `/sketch` endpoint--this is adding a new metric to a customer's account, so we want to minimize the size of this metric for customers.

### Motivation

### Describe how you validated your changes

I wrote a script to compare the before and after sizes:
```
package main

import (
	"fmt"
	"time"

	"github.com/DataDog/agent-payload/v5/gogen"
)

func buildBefore() *gogen.SketchPayload {
	now := time.Now().Unix()

	sketch := &gogen.SketchPayload_Sketch{
		Metric: "example.metric",
		Host:   "my-hostname",
		Distributions: []gogen.SketchPayload_Sketch_Distribution{
			{
				Ts:    now,
				Cnt:   1,
				Min:   0.1,
				Max:   0.5,
				Avg:   0.3,
				Sum:   0.3,
				V:     []float64{0.3},
				G:     []uint32{1},
				Delta: []uint32{0},
				Buf:   []float64{0.3},
			},
		},
		Tags: []string{"tag1:value1", "tag2:value2"},
		Metadata: &gogen.Metadata{
			Origin: &gogen.Origin{
				OriginProduct:  10,
				OriginCategory: 0,
				OriginService:  0,
			},
		},
	}

	metadata := &gogen.CommonMetadata{
		AgentVersion: "1.0.0",
		Timezone:     "UTC",
		CurrentEpoch: float64(now),
		InternalIp:   "10.0.0.1",
		PublicIp:     "1.2.3.4",
		ApiKey:       "your-api-key",
	}

	return &gogen.SketchPayload{
		Sketches: []gogen.SketchPayload_Sketch{*sketch},
		Metadata: *metadata,
	}
}

func buildAfter() *gogen.SketchPayload {
	now := time.Now().Unix()

	sketch := &gogen.SketchPayload_Sketch{
		Metric: "example.metric",
		Distributions: []gogen.SketchPayload_Sketch_Distribution{
			{
				Ts:  now,
				Cnt: 1,
				V:   []float64{0.3},
				G:   []uint32{1},
			},
		},
		Metadata: &gogen.Metadata{
			Origin: &gogen.Origin{
				OriginProduct:  10,
				OriginCategory: 0,
				OriginService:  0,
			},
		},
	}

	return &gogen.SketchPayload{
		Sketches: []gogen.SketchPayload_Sketch{*sketch},
	}
}

func main() {
	before := buildBefore()
	after := buildAfter()

	b1, _ := before.Marshal()
	b2, _ := after.Marshal()

	fmt.Printf("Before size: %d bytes\n", len(b1))
	fmt.Printf("After  size: %d bytes\n", len(b2))
}
```

❗❗ **The results were that the size of the payload went down from 192 bytes to 49 bytes.** ❗❗

### Additional Notes
