### PR TITLE
[NCM] Fix flaky profile match test

### DIFF
--- a/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
+++ b/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go
@@ -338,7 +338,7 @@ func TestCheck_FindMatchingProfile(t *testing.T) {
 
 	expected := &profile.NCMProfile{
 		BaseProfile: profile.BaseProfile{
-			Name: "p1",
+			Name: "p2",
 		},
 		Commands: map[profile.CommandType][]string{
 			profile.Running: {"show running-config"},

--- a/pkg/networkconfigmanagement/profile/profile_test.go
+++ b/pkg/networkconfigmanagement/profile/profile_test.go
@@ -41,9 +41,9 @@ func Test_GetProfileMap(t *testing.T) {
 						Name: "p1",
 					},
 					Commands: map[CommandType][]string{
-						Running: {"show running-config"},
-						Startup: {"show startup-config"},
-						Version: {"show version"},
+						Running: {"show run"},
+						Startup: {"show start"},
+						Version: {"show ver"},
 					},
 				},
 				"p2": &NCMProfile{
@@ -164,9 +164,9 @@ func Test_ParseNCMProfileFromFile(t *testing.T) {
 			profileFile: p1,
 			expectedDeviceProfile: &NCMProfile{
 				Commands: map[CommandType][]string{
-					Running: {"show running-config"},
-					Startup: {"show startup-config"},
-					Version: {"show version"},
+					Running: {"show run"},
+					Startup: {"show start"},
+					Version: {"show ver"},
 				},
 			},
 		},

--- a/pkg/networkconfigmanagement/test/conf.d/networkconfigmanagement.d/default_profiles/p1.json
+++ b/pkg/networkconfigmanagement/test/conf.d/networkconfigmanagement.d/default_profiles/p1.json
@@ -3,19 +3,19 @@
     {
       "type": "running",
       "values": [
-        "show running-config"
+        "show run"
       ]
     },
     {
       "type": "startup",
       "values": [
-        "show startup-config"
+        "show start"
       ]
     },
     {
       "type": "version",
       "values": [
-        "show version"
+        "show ver"
       ]
     }
   ]


### PR DESCRIPTION
### What does this PR do?
https://dd.slack.com/archives/C07S0UH4R0C/p1759346482080039
<img width="998" height="168" alt="image" src="https://github.com/user-attachments/assets/0615a8e5-c358-48e6-b9e9-ee57460baf3b" />
Failing test: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1158167713#L2222
```
    networkconfigmanagement_test.go:349: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/networkconfigmanagement/networkconfigmanagement_test.go:349
        	Error:      	Not equal: 
        	            	expected: &profile.NCMProfile{BaseProfile:profile.BaseProfile{Name:"p1"}, Commands:map[profile.CommandType][]string{"running":[]string{"show running-config"}, "startup":[]string{"show startup-config"}, "version":[]string{"show version"}}}
        	            	actual  : &profile.NCMProfile{BaseProfile:profile.BaseProfile{Name:"p2"}, Commands:map[profile.CommandType][]string{"running":[]string{"show running-config"}, "startup":[]string{"show startup-config"}, "version":[]string{"show version"}}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -2,3 +2,3 @@
        	            	  BaseProfile: (profile.BaseProfile) {
        	            	-  Name: (string) (len=2) "p1"
        	            	+  Name: (string) (len=2) "p2"
        	            	  },
        	Test:       	TestCheck_FindMatchingProfile
```
im sorry i repent for my sins of adding flaky test


### Motivation

### Describe how you validated your changes

### Additional Notes
