### PR TITLE
ECS Managed Instance support

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -516,9 +516,11 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 	}
 	clusterLow, clusterOrch, clusterHigh, clusterStandard := clusterTags.Compute()
 
-	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
+	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate || task.LaunchType == workloadmeta.ECSLaunchTypeManagedInstance {
 		taskTags.AddLow(tags.AvailabilityZoneDeprecated, task.AvailabilityZone) // Deprecated
 		taskTags.AddLow(tags.AvailabilityZone, task.AvailabilityZone)
+		// TODO: When daemon scheduling is available for managed instances,
+		// managed instances should collect resource tags like EC2
 	} else if c.collectEC2ResourceTags {
 		addResourceTags(taskTags, task.ContainerInstanceTags)
 		addResourceTags(taskTags, task.Tags)
@@ -556,7 +558,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 		})
 	}
 
-	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
+	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate || task.LaunchType == workloadmeta.ECSLaunchTypeManagedInstance {
 		low, orch, high, standard := taskTags.Compute()
 		tagInfos = append(tagInfos, &types.TagInfo{
 			Source:               taskSource,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -120,6 +120,9 @@ const (
 	// ECS Fargate can be considered as a runtime in the sense that we don't
 	// know the actual runtime but we need to identify it's Fargate
 	ContainerRuntimeECSFargate ContainerRuntime = "ecsfargate"
+	// ECS Managed Instance can be considered as a runtime in the sense that we don't
+	// know the actual runtime but we need to identify it's Managed Instance
+	ContainerRuntimeECSManagedInstance ContainerRuntime = "ecsmanagedinstance"
 )
 
 // ContainerRuntimeFlavor is the container runtime with respect to the OCI spect
@@ -159,8 +162,9 @@ type ECSLaunchType string
 
 // Defined ECSLaunchTypes
 const (
-	ECSLaunchTypeEC2     ECSLaunchType = "ec2"
-	ECSLaunchTypeFargate ECSLaunchType = "fargate"
+	ECSLaunchTypeEC2             ECSLaunchType = "ec2"
+	ECSLaunchTypeFargate         ECSLaunchType = "fargate"
+	ECSLaunchTypeManagedInstance ECSLaunchType = "managed_instance"
 )
 
 // AgentType defines the workloadmeta agent type

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -514,6 +514,8 @@ func toProtoLaunchType(launchType workloadmeta.ECSLaunchType) (pb.ECSLaunchType,
 		return pb.ECSLaunchType_EC2, nil
 	case workloadmeta.ECSLaunchTypeFargate:
 		return pb.ECSLaunchType_FARGATE, nil
+	case workloadmeta.ECSLaunchTypeManagedInstance:
+		return pb.ECSLaunchType_MANAGED_INSTANCE, nil
 	}
 
 	return pb.ECSLaunchType_EC2, fmt.Errorf("unknown launch type: %s", launchType)

--- a/pkg/collector/corechecks/containerlifecycle/processor.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor.go
@@ -157,7 +157,7 @@ func (p *processor) processTask(task *workloadmeta.ECSTask) error {
 	event.withEventType(types.EventNameDelete)
 	event.withObjectID(task.GetID().ID)
 	event.withSource(string(workloadmeta.SourceNodeOrchestrator))
-	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate {
+	if task.LaunchType == workloadmeta.ECSLaunchTypeFargate || task.LaunchType == workloadmeta.ECSLaunchTypeManagedInstance {
 		event.withSource(string(workloadmeta.SourceRuntime))
 	}
 	// we don't have exit timestamp for tasks in the response of metadata v1 api, so we use the current timestamp

--- a/pkg/config/env/environment.go
+++ b/pkg/config/env/environment.go
@@ -47,6 +47,10 @@ func IsECS() bool {
 		return false
 	}
 
+	if IsECSManagedInstance() {
+		return false
+	}
+
 	if os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
 		os.Getenv("ECS_CONTAINER_METADATA_URI") != "" ||
 		os.Getenv("ECS_CONTAINER_METADATA_URI_V4") != "" {
@@ -63,6 +67,11 @@ func IsECS() bool {
 // IsECSFargate returns whether the Agent is running in ECS Fargate
 func IsECSFargate() bool {
 	return os.Getenv("ECS_FARGATE") != "" || os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_FARGATE"
+}
+
+// IsECSManagedInstance returns whether the Agent is running in ECS Managed Instance
+func IsECSManagedInstance() bool {
+	return os.Getenv("AWS_EXECUTION_ENV") == "AWS_ECS_MANAGED_INSTANCES"
 }
 
 // IsHostProcAvailable returns whether host proc is available or not

--- a/pkg/config/env/environment_container_features.go
+++ b/pkg/config/env/environment_container_features.go
@@ -21,6 +21,8 @@ const (
 	ECSEC2 Feature = "ecsec2"
 	// ECSFargate environment
 	ECSFargate Feature = "ecsfargate"
+	// ECSManagedInstance environment
+	ECSManagedInstance Feature = "ecsmanagedinstance"
 	// EKSFargate environment
 	EKSFargate Feature = "eksfargate"
 	// KubeOrchestratorExplorer can be enabled

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -43,6 +43,7 @@ func init() {
 	registerFeature(Kubernetes)
 	registerFeature(ECSEC2)
 	registerFeature(ECSFargate)
+	registerFeature(ECSManagedInstance)
 	registerFeature(EKSFargate)
 	registerFeature(KubeOrchestratorExplorer)
 	registerFeature(ECSOrchestratorExplorer)
@@ -61,6 +62,7 @@ func IsAnyContainerFeaturePresent() bool {
 		IsFeaturePresent(Kubernetes) ||
 		IsFeaturePresent(ECSEC2) ||
 		IsFeaturePresent(ECSFargate) ||
+		IsFeaturePresent(ECSManagedInstance) ||
 		IsFeaturePresent(EKSFargate) ||
 		IsFeaturePresent(CloudFoundry) ||
 		IsFeaturePresent(Podman)
@@ -190,6 +192,15 @@ func isCriSupported() bool {
 func detectAWSEnvironments(features FeatureMap, cfg model.Reader) {
 	if IsECSFargate() {
 		features[ECSFargate] = struct{}{}
+		if cfg.GetBool("orchestrator_explorer.enabled") &&
+			cfg.GetBool("ecs_task_collection_enabled") {
+			features[ECSOrchestratorExplorer] = struct{}{}
+		}
+		return
+	}
+
+	if IsECSManagedInstance() {
+		features[ECSManagedInstance] = struct{}{}
 		if cfg.GetBool("orchestrator_explorer.enabled") &&
 			cfg.GetBool("ecs_task_collection_enabled") {
 			features[ECSOrchestratorExplorer] = struct{}{}

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -159,6 +159,7 @@ message KubernetesPod {
 enum ECSLaunchType {
   EC2 = 0;
   FARGATE = 1;
+  MANAGED_INSTANCE = 2;
 }
 
 message ECSTask {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -345,8 +345,9 @@ func (ContainerHealth) EnumDescriptor() ([]byte, []int) {
 type ECSLaunchType int32
 
 const (
-	ECSLaunchType_EC2     ECSLaunchType = 0
-	ECSLaunchType_FARGATE ECSLaunchType = 1
+	ECSLaunchType_EC2              ECSLaunchType = 0
+	ECSLaunchType_FARGATE          ECSLaunchType = 1
+	ECSLaunchType_MANAGED_INSTANCE ECSLaunchType = 2
 )
 
 // Enum value maps for ECSLaunchType.
@@ -354,10 +355,12 @@ var (
 	ECSLaunchType_name = map[int32]string{
 		0: "EC2",
 		1: "FARGATE",
+		2: "MANAGED_INSTANCE",
 	}
 	ECSLaunchType_value = map[string]int32{
-		"EC2":     0,
-		"FARGATE": 1,
+		"EC2":              0,
+		"FARGATE":          1,
+		"MANAGED_INSTANCE": 2,
 	}
 )
 

--- a/pkg/util/containers/metrics/ecsmanagedinstance/collector.go
+++ b/pkg/util/containers/metrics/ecsmanagedinstance/collector.go
@@ -1,0 +1,288 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+
+package ecsmanagedinstance
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+const (
+	collectorID       = "ecs_managed_instance"
+	collectorPriority = 0
+
+	ecsTaskTimeout = 2 * time.Second
+	// cpuKey represents the cpu key used in the resource limits map returned by the ECS API
+	cpuKey = "CPU"
+	// memoryKey represents the memory key used in the resource limits map returned by the ECS API
+	memoryKey = "Memory"
+)
+
+var ecsUnsetMemoryLimit = uint64(math.Pow(2, 62))
+
+func init() {
+	provider.RegisterCollector(provider.CollectorFactory{
+		ID: collectorID,
+		Constructor: func(cache *provider.Cache, _ option.Option[workloadmeta.Component]) (provider.CollectorMetadata, error) {
+			return newEcsManagedInstanceCollector(cache)
+		},
+	})
+}
+
+type ecsManagedInstanceCollector struct {
+	client v2.Client
+
+	taskSpec *v2.Task
+	taskLock sync.Mutex
+}
+
+// newEcsManagedInstanceCollector returns a new *ecsManagedInstanceCollector.
+func newEcsManagedInstanceCollector(cache *provider.Cache) (provider.CollectorMetadata, error) {
+	var collectorMetadata provider.CollectorMetadata
+
+	if !env.IsFeaturePresent(env.ECSManagedInstance) {
+		return collectorMetadata, provider.ErrPermaFail
+	}
+
+	client, err := metadata.V2()
+	if err != nil {
+		return collectorMetadata, provider.ConvertRetrierErr(err)
+	}
+
+	collector := &ecsManagedInstanceCollector{client: client}
+	collectors := &provider.Collectors{
+		Stats:   provider.MakeRef[provider.ContainerStatsGetter](collector, collectorPriority),
+		Network: provider.MakeRef[provider.ContainerNetworkStatsGetter](collector, collectorPriority),
+	}
+
+	return provider.CollectorMetadata{
+		ID: collectorID,
+		Collectors: provider.CollectorCatalog{
+			provider.NewRuntimeMetadata(string(provider.RuntimeNameECSManagedInstance), ""): provider.MakeCached(collectorID, cache, collectors),
+		},
+	}, nil
+}
+
+// ID returns the collector ID.
+func (e *ecsManagedInstanceCollector) ID() string { return collectorID }
+
+// GetContainerStats returns stats by container ID.
+//
+//nolint:revive // TODO(CINT) Fix revive linter
+func (e *ecsManagedInstanceCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+	stats, err := e.stats(containerID)
+	if err != nil {
+		return nil, err
+	}
+	containerStats := convertEcsStats(stats)
+
+	// Data from Task spec are not mandatory, do not return an error
+	if err := e.getTask(); err == nil {
+		fillFromSpec(containerStats, e.taskSpec)
+	} else {
+		log.Warnf("Unable to get ECS Managed Instance task metadata, err: %v", err)
+	}
+
+	return containerStats, nil
+}
+
+// GetContainerNetworkStats returns network stats by container ID.
+//
+//nolint:revive // TODO(CINT) Fix revive linter
+func (e *ecsManagedInstanceCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+	stats, err := e.stats(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertNetworkStats(stats), nil
+}
+
+// stats returns stats by container ID, it uses an in-memory cache to reduce the number of api calls.
+// Cache expires every 2 minutes and can also be invalidated using the cacheValidity argument.
+func (e *ecsManagedInstanceCollector) stats(containerID string) (*v2.ContainerStats, error) {
+	stats, err := e.client.GetContainerStats(context.TODO(), containerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container stats for %s: %w", containerID, err)
+	}
+
+	return stats, nil
+}
+
+func convertEcsStats(ecsStats *v2.ContainerStats) *provider.ContainerStats {
+	if ecsStats == nil {
+		return nil
+	}
+
+	dataTimestamp, err := time.Parse(time.RFC3339Nano, ecsStats.Timestamp)
+	if err != nil {
+		dataTimestamp = time.Now()
+	}
+
+	return &provider.ContainerStats{
+		Timestamp: dataTimestamp,
+		CPU:       convertCPUStats(&ecsStats.CPU),
+		Memory:    convertMemoryStats(&ecsStats.Memory),
+		IO:        convertIOStats(&ecsStats.IO),
+	}
+}
+
+func (e *ecsManagedInstanceCollector) getTask() error {
+	if e.taskSpec != nil {
+		return nil
+	}
+
+	// We can observe a nil task and refresh multiple times, which is not optimal
+	// but better than paying the lock cost forever.
+	e.taskLock.Lock()
+	defer e.taskLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ecsTaskTimeout)
+	defer cancel()
+
+	task, err := e.client.GetTask(ctx)
+	if err != nil {
+		return err
+	}
+
+	e.taskSpec = task
+	return nil
+}
+
+func convertNetworkStats(ecsStats *v2.ContainerStats) *provider.ContainerNetworkStats {
+	if ecsStats == nil {
+		return nil
+	}
+
+	dataTimestamp, err := time.Parse(time.RFC3339Nano, ecsStats.Timestamp)
+	if err != nil {
+		dataTimestamp = time.Now()
+	}
+
+	// networks is not useful for ECS Managed Instance as the endpoint
+	// already reports a name (like `eth0`)
+	stats := &provider.ContainerNetworkStats{
+		Timestamp: dataTimestamp,
+	}
+	stats.Interfaces = make(map[string]provider.InterfaceNetStats)
+	var totalPacketsRcvd, totalPacketsSent, totalBytesRcvd, totalBytesSent uint64
+	for iface, statsPerInterface := range ecsStats.Networks {
+		iStats := provider.InterfaceNetStats{
+			BytesSent:   pointer.Ptr(float64(statsPerInterface.TxBytes)),
+			PacketsSent: pointer.Ptr(float64(statsPerInterface.TxPackets)),
+			BytesRcvd:   pointer.Ptr(float64(statsPerInterface.RxBytes)),
+			PacketsRcvd: pointer.Ptr(float64(statsPerInterface.RxPackets)),
+		}
+		stats.Interfaces[iface] = iStats
+
+		totalPacketsRcvd += statsPerInterface.RxPackets
+		totalPacketsSent += statsPerInterface.TxPackets
+		totalBytesRcvd += statsPerInterface.RxBytes
+		totalBytesSent += statsPerInterface.TxBytes
+	}
+
+	stats.PacketsRcvd = pointer.Ptr(float64(totalPacketsRcvd))
+	stats.PacketsSent = pointer.Ptr(float64(totalPacketsSent))
+	stats.BytesRcvd = pointer.Ptr(float64(totalBytesRcvd))
+	stats.BytesSent = pointer.Ptr(float64(totalBytesSent))
+
+	return stats
+}
+
+func convertCPUStats(cpuStats *v2.CPUStats) *provider.ContainerCPUStats {
+	if cpuStats == nil {
+		return nil
+	}
+
+	return &provider.ContainerCPUStats{
+		Total:  pointer.Ptr(float64(cpuStats.Usage.Total)),
+		System: pointer.Ptr(float64(cpuStats.Usage.Kernelmode)),
+		User:   pointer.Ptr(float64(cpuStats.Usage.Usermode)),
+	}
+}
+
+func convertMemoryStats(memStats *v2.MemStats) *provider.ContainerMemStats {
+	if memStats == nil {
+		return nil
+	}
+
+	cMemStats := &provider.ContainerMemStats{
+		UsageTotal: pointer.Ptr(float64(memStats.Usage)),
+		RSS:        pointer.Ptr(float64(memStats.Details.RSS)),
+		Cache:      pointer.Ptr(float64(memStats.Details.Cache)),
+		Pgfault:    pointer.Ptr(float64(memStats.Details.PgFault)), // ECS returns only PgFault. Should it be mapped to pgfault or pgmajfault ?
+	}
+
+	if memStats.Limit > 0 && memStats.Limit < ecsUnsetMemoryLimit {
+		cMemStats.Limit = pointer.Ptr(float64(memStats.Limit))
+	}
+
+	return cMemStats
+}
+
+func convertIOStats(ioStats *v2.IOStats) *provider.ContainerIOStats {
+	if ioStats == nil {
+		return nil
+	}
+
+	var readBytes, writeBytes uint64
+	for _, stat := range ioStats.BytesPerDeviceAndKind {
+		switch stat.Kind {
+		case "Read":
+			readBytes += stat.Value
+		case "Write":
+			writeBytes += stat.Value
+		default:
+			continue
+		}
+	}
+
+	var readOp, writeOp uint64
+	for _, stat := range ioStats.OPPerDeviceAndKind {
+		switch stat.Kind {
+		case "Read":
+			readOp += stat.Value
+		case "Write":
+			writeOp += stat.Value
+		default:
+			continue
+		}
+	}
+
+	return &provider.ContainerIOStats{
+		ReadBytes:       pointer.Ptr(float64(readBytes)),
+		WriteBytes:      pointer.Ptr(float64(writeBytes)),
+		ReadOperations:  pointer.Ptr(float64(readOp)),
+		WriteOperations: pointer.Ptr(float64(writeOp)),
+	}
+}
+
+func fillFromSpec(containerStats *provider.ContainerStats, taskSpec *v2.Task) {
+	// Handling Task CPU/Memory Limit (cannot be empty, mandatory on ECS Managed Instance)
+	taskCPULimit := taskSpec.Limits[cpuKey]
+	if taskCPULimit != 0 && containerStats.CPU != nil {
+		containerStats.CPU.Limit = pointer.Ptr(taskCPULimit * 100) // vCPU to percentage (0-N00%)
+	}
+
+	taskMemoryLimit := taskSpec.Limits[memoryKey]
+	if taskMemoryLimit != 0 && containerStats.Memory != nil && containerStats.Memory.Limit == nil {
+		containerStats.Memory.Limit = pointer.Ptr(taskMemoryLimit * 1024 * 1024) // Megabytes to bytes
+	}
+}

--- a/pkg/util/containers/metrics/ecsmanagedinstance/doc.go
+++ b/pkg/util/containers/metrics/ecsmanagedinstance/doc.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// Package ecsmanagedinstance implements the ECS Managed Instance metrics provider.
+// The ECS Managed Instance metrics provider collects container metrics from ECS tasks
+// running on managed instances using the ECS metadata API. This is used when running
+// the Datadog Agent as a sidecar on ECS Managed Instances.
+package ecsmanagedinstance

--- a/pkg/util/containers/metrics/facade.go
+++ b/pkg/util/containers/metrics/facade.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/cri"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/docker"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/ecsfargate"
+	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/ecsmanagedinstance"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/kubelet"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/system"
 )

--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -23,12 +23,13 @@ type Runtime string
 
 // Known container runtimes
 const (
-	RuntimeNameDocker     Runtime = "docker"
-	RuntimeNameContainerd Runtime = "containerd"
-	RuntimeNameCRIO       Runtime = "cri-o"
-	RuntimeNameGarden     Runtime = "garden"
-	RuntimeNamePodman     Runtime = "podman"
-	RuntimeNameECSFargate Runtime = "ecsfargate"
+	RuntimeNameDocker             Runtime = "docker"
+	RuntimeNameContainerd         Runtime = "containerd"
+	RuntimeNameCRIO               Runtime = "cri-o"
+	RuntimeNameGarden             Runtime = "garden"
+	RuntimeNamePodman             Runtime = "podman"
+	RuntimeNameECSFargate         Runtime = "ecsfargate"
+	RuntimeNameECSManagedInstance Runtime = "ecsmanagedinstance"
 )
 
 var (
@@ -56,6 +57,7 @@ var (
 		RuntimeNameGarden,
 		RuntimeNamePodman,
 		RuntimeNameECSFargate,
+		RuntimeNameECSManagedInstance,
 	}
 
 	// AllWindowsRuntimes lists all runtimes available on Windows


### PR DESCRIPTION
### What does this PR do?
Add support for ECS Managed Instances. At the moment daemon scheduling is not supported so we currently have to treat this as sidecar only. I do not believe this is the best approach. It currently mirrors fargate, but eventually we want to move to daemon scheduling when supported. I believe the launch type should be independent of whether it's a daemon or sidecar (fargate being the exception). This is a first draft, but I think more refactor is required.

### Motivation

### Describe how you validated your changes

### Additional Notes
