### PR TITLE
[EBPF] gpu: skip cgroup tests when cgroupfs is readonly

### DIFF
--- a/.gitlab/functional_test/oracle.yml
+++ b/.gitlab/functional_test/oracle.yml
@@ -1,4 +1,5 @@
 oracle:
+  allow_failure: true  # incident-43807 related fix, Oracle job is failing
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   stage: functional_test

--- a/pkg/gpu/cgroups_test.go
+++ b/pkg/gpu/cgroups_test.go
@@ -29,6 +29,17 @@ import (
 	"github.com/cilium/ebpf/link"
 )
 
+func isCgroupfsReadonly() bool {
+	sysfsPath := filepath.Join("/sys/fs/cgroup", "test")
+	err := os.MkdirAll(sysfsPath, 0755)
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(sysfsPath)
+
+	return true
+}
+
 func TestInsertDeviceAllowLine(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -271,6 +282,10 @@ func TestDetachAllDeviceCgroupPrograms(t *testing.T) {
 		t.Skip("Test requires cgroupv2")
 	}
 
+	if isCgroupfsReadonly() {
+		t.Skip("Test requires a writable cgroupfs")
+	}
+
 	// We will be testing by reading /dev/null, so we need to make sure it's accessible
 	// before we start the test
 	devnull, err := os.Open("/dev/null")
@@ -354,6 +369,10 @@ func TestConfigureCgroupV1DeviceAllow(t *testing.T) {
 		t.Skip("Test requires cgroupv1")
 	}
 
+	if isCgroupfsReadonly() {
+		t.Skip("Test requires a writable cgroupfs")
+	}
+
 	// We will be testing by reading /dev/null, so we need to make sure it's accessible
 	// before we start the test
 	devnull, err := os.Open("/dev/null")
@@ -399,6 +418,10 @@ func TestConfigureCgroupV1DeviceAllow(t *testing.T) {
 func TestGetAbsoluteCgroupForProcess(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("Test requires root privileges")
+	}
+
+	if isCgroupfsReadonly() {
+		t.Skip("Test requires a writable cgroupfs")
 	}
 
 	currentCgroup, err := getAbsoluteCgroupForProcess("", "/", uint32(os.Getpid()), uint32(os.Getpid()), containerdcgroups.Mode())

--- a/pkg/gpu/cgroups_test.go
+++ b/pkg/gpu/cgroups_test.go
@@ -33,11 +33,11 @@ func isCgroupfsReadonly() bool {
 	sysfsPath := filepath.Join("/sys/fs/cgroup", "test")
 	err := os.MkdirAll(sysfsPath, 0755)
 	if err != nil {
-		return false
+		return true
 	}
 	defer os.RemoveAll(sysfsPath)
 
-	return true
+	return false
 }
 
 func TestInsertDeviceAllowLine(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Skips cgroup tests for `pkg/gpu` when the cgroupfs is not writable.

Additionally, it marks the oracle job as allowed to fail, as it started to fail at the same point as the pkg/gpu tests.

### Motivation

FIx for #incident-43807

### Describe how you validated your changes

CI green. These tests also execute in KMT, where we have full access to the cgroup, so we do not lose coverage.

### Additional Notes
