### PR TITLE
bazel: add a systemd repo & targets

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -32,6 +32,14 @@ http_archive(
     url = "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz",
 )
 
+http_archive(
+    name = "systemd",
+    build_file = "//deps:systemd.BUILD.bazel",
+    sha256 = "acbd86d42ebc2b443722cb469ad215a140f504689c7a9133ecf91b235275a491",
+    strip_prefix = "systemd-253",
+    url = "https://github.com/systemd/systemd/archive/refs/tags/v253.tar.gz",
+)
+
 # Defines a "rules_foreign_cc" target to build openssl
 bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
 

--- a/deps/systemd.BUILD.bazel
+++ b/deps/systemd.BUILD.bazel
@@ -1,0 +1,33 @@
+"""Agent specific build file for systemd headers"""
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:private"],
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:LGPL-2.1+"],
+    license_text = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "systemd",
+    actual = "@systemd//:install",
+)
+
+pkg_files(
+    name = "headers",
+    srcs = glob(['src/systemd/*.h']),
+    prefix = "include/systemd",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":headers"],
+)


### PR DESCRIPTION
### What does this PR do?

This adds a systemd repo & the associated targets to install systemd headers

### Motivation

We need it to build the agent. See [ABLD-186](https://datadoghq.atlassian.net/browse/ABLD-186)

### Describe how you validated your changes

Locally tested that `bazelisk run -- @systemd//:install --destdir=/tmp/fakeprefix` does copy the files we expect:
```
/tmp/fakeprefix
└── include
    └── systemd
        ├── sd-bus.h
        ├── sd-bus-protocol.h
        ├── sd-bus-vtable.h
        ├── _sd-common.h
        ├── sd-daemon.h
        ├── sd-device.h
        ├── sd-dhcp6-client.h
        ├── sd-dhcp6-lease.h
        ├── sd-dhcp6-option.h
        ├── sd-dhcp-client.h
        ├── sd-dhcp-lease.h
        ├── sd-dhcp-option.h
        ├── sd-dhcp-server.h
        ├── sd-event.h
        ├── sd-gpt.h
        ├── sd-hwdb.h
        ├── sd-id128.h
        ├── sd-ipv4acd.h
        ├── sd-ipv4ll.h
        ├── sd-journal.h
        ├── sd-lldp.h
        ├── sd-lldp-rx.h
        ├── sd-lldp-tx.h
        ├── sd-login.h
        ├── sd-messages.h
        ├── sd-ndisc.h
        ├── sd-netlink.h
        ├── sd-network.h
        ├── sd-path.h
        ├── sd-radv.h
        ├── sd-resolve.h
        └── sd-utf8.h

3 directories, 32 files
```

### Additional Notes

I wasn't sure what to do for the default target since there's nothing to build and everything is already extracted by `http_archive`, I'm open to suggestions/alternative behaviors!

[ABLD-186]: https://datadoghq.atlassian.net/browse/ABLD-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ