### PR TITLE
[EBPF-828] gpu: support retries of NVML init in system-probe

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -113,10 +113,10 @@ func (c *Check) ensureInitDeviceCache() error {
 		return nil
 	}
 
-	var err error
-	c.deviceCache, err = ddnvml.NewDeviceCache()
-	if err != nil {
-		return fmt.Errorf("failed to initialize device cache: %w", err)
+	c.deviceCache = ddnvml.NewDeviceCache()
+
+	if c.deviceCache.GetLastInitError() != nil {
+		return fmt.Errorf("failed to initialize device cache: %w", c.deviceCache.GetLastInitError())
 	}
 
 	return nil

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -173,7 +173,9 @@ func (c *Check) Run() error {
 	// Refresh SP cache before collecting metrics, if it is available
 	if c.spCache != nil {
 		if err := c.spCache.Refresh(); err != nil && logLimitCheck.ShouldLog() {
-			log.Warnf("error refreshing system-probe cache: %v", err)
+			if logLimitCheck.ShouldLog() {
+				log.Warnf("error refreshing system-probe cache: %v", err)
+			}
 			// Continue with NVML-only metrics, SP collectors will return empty metrics
 		}
 	}
@@ -192,7 +194,9 @@ func (c *Check) Run() error {
 func (c *Check) getGPUToContainersMap() map[string]*workloadmeta.Container {
 	allPhysicalDevices, err := c.deviceCache.AllPhysicalDevices()
 	if err != nil {
-		log.Warnf("Error getting all physical devices: %s", err)
+		if logLimitCheck.ShouldLog() {
+			log.Warnf("Error getting all physical devices: %s", err)
+		}
 		return nil
 	}
 	gpuToContainers := make(map[string]*workloadmeta.Container, len(allPhysicalDevices))

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -115,8 +115,8 @@ func (c *Check) ensureInitDeviceCache() error {
 
 	c.deviceCache = ddnvml.NewDeviceCache()
 
-	if c.deviceCache.EnsureInit() != nil {
-		return fmt.Errorf("failed to initialize device cache: %w", c.deviceCache.EnsureInit())
+	if err := c.deviceCache.EnsureInit(); err != nil {
+		return fmt.Errorf("failed to initialize device cache: %w", err)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/gpu/nvidia/base_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base_test.go
@@ -42,7 +42,8 @@ func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Dev
 
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache := ddnvml.NewDeviceCache()
-	devices := deviceCache.AllPhysicalDevices()
+	devices, err := deviceCache.AllPhysicalDevices()
+	require.NoError(t, err)
 	require.NotEmpty(t, devices)
 	return devices[0]
 }

--- a/pkg/collector/corechecks/gpu/nvidia/base_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base_test.go
@@ -41,8 +41,7 @@ func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Dev
 	}
 
 	ddnvml.WithMockNVML(t, nvmlMock)
-	deviceCache, err := ddnvml.NewDeviceCache()
-	require.NoError(t, err)
+	deviceCache := ddnvml.NewDeviceCache()
 	devices := deviceCache.AllPhysicalDevices()
 	require.NotEmpty(t, devices)
 	return devices[0]

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -38,8 +38,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
 	ddnvml.WithMockNVML(t, nvmlMock)
-	deviceCache, err := ddnvml.NewDeviceCache()
-	require.NoError(t, err)
+	deviceCache := ddnvml.NewDeviceCache()
 	deps := &CollectorDependencies{DeviceCache: deviceCache}
 	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory}, nil)
 	require.NotNil(t, collectors)
@@ -125,8 +124,7 @@ func TestGetDeviceTagsMapping(t *testing.T) {
 			ddnvml.WithMockNVML(t, nvmlMock)
 
 			// Execute
-			deviceCache, err := ddnvml.NewDeviceCache()
-			require.NoError(t, err)
+			deviceCache := ddnvml.NewDeviceCache()
 			tagsMapping := GetDeviceTagsMapping(deviceCache, fakeTagger)
 
 			// Assert
@@ -141,8 +139,7 @@ func TestAllCollectorsWork(t *testing.T) {
 
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled(), testutil.WithMockAllFunctions())
 	ddnvml.WithMockNVML(t, nvmlMock)
-	deviceCache, err := ddnvml.NewDeviceCache()
-	require.NoError(t, err)
+	deviceCache := ddnvml.NewDeviceCache()
 	deps := &CollectorDependencies{DeviceCache: deviceCache}
 	collectors, err := BuildCollectors(deps, nil)
 	require.NoError(t, err)

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -413,7 +413,8 @@ func createMockDevice(t *testing.T, deviceUUID string) ddnvml.Device {
 	ddnvml.WithMockNVML(t, nvmlMock)
 
 	deviceCache := ddnvml.NewDeviceCache()
-	devices := deviceCache.AllPhysicalDevices()
+	devices, err := deviceCache.AllPhysicalDevices()
+	require.NoError(t, err)
 	require.Len(t, devices, 1)
 
 	return devices[0]

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -412,9 +412,7 @@ func createMockDevice(t *testing.T, deviceUUID string) ddnvml.Device {
 	}
 	ddnvml.WithMockNVML(t, nvmlMock)
 
-	deviceCache, err := ddnvml.NewDeviceCache()
-	require.NoError(t, err)
-
+	deviceCache := ddnvml.NewDeviceCache()
 	devices := deviceCache.AllPhysicalDevices()
 	require.Len(t, devices, 1)
 

--- a/pkg/collector/corechecks/gpu/nvidia/helpers.go
+++ b/pkg/collector/corechecks/gpu/nvidia/helpers.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"golang.org/x/exp/constraints"
@@ -21,6 +22,8 @@ import (
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var logLimiter = log.NewLogLimit(20, 10*time.Minute)
 
 // boolToFloat converts a boolean value to float64 (1.0 for true, 0.0 for false)
 func boolToFloat(val bool) float64 {
@@ -82,7 +85,9 @@ func filterSupportedAPIs(device ddnvml.Device, apiCalls []apiCallInfo) []apiCall
 func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Component) map[string][]string {
 	devCount, err := deviceCache.Count()
 	if err != nil {
-		log.Warnf("Error getting device count: %s", err)
+		if logLimiter.ShouldLog() {
+			log.Warnf("Error getting device count: %s", err)
+		}
 		return nil
 	}
 	if devCount == 0 {
@@ -93,7 +98,9 @@ func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Componen
 
 	allPhysicalDevices, err := deviceCache.AllPhysicalDevices()
 	if err != nil {
-		log.Warnf("Error getting all physical devices: %s", err)
+		if logLimiter.ShouldLog() {
+			log.Warnf("Error getting all physical devices: %s", err)
+		}
 		return nil
 	}
 	for _, dev := range allPhysicalDevices {

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -122,14 +122,10 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 		visibleDevicesCache:          make(map[int][]ddnvml.Device),
 		cudaVisibleDevicesPerProcess: make(map[int]string),
 		workloadmeta:                 opts.wmeta,
+		deviceCache:                  ddnvml.NewDeviceCache(),
 	}
 
 	var err error
-	ctx.deviceCache, err = ddnvml.NewDeviceCache()
-	if err != nil {
-		return nil, fmt.Errorf("error creating device cache: %w", err)
-	}
-
 	ctx.timeResolver, err = ktime.NewResolver()
 	if err != nil {
 		return nil, fmt.Errorf("error creating time resolver: %w", err)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -132,6 +132,7 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 	}
 
 	if opts.fatbinParsingEnabled {
+		// TODO: Refactor this so that the kernel cache accepts a smVersionSet that can change over time
 		smVersionSet, err := ctx.deviceCache.SMVersionSet()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get SM version set: %w", err)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -132,7 +132,11 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 	}
 
 	if opts.fatbinParsingEnabled {
-		ctx.cudaKernelCache, err = cuda.NewKernelCache(opts.procRoot, ctx.deviceCache.SMVersionSet(), opts.tm, opts.config.KernelCacheQueueSize)
+		smVersionSet, err := ctx.deviceCache.SMVersionSet()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get SM version set: %w", err)
+		}
+		ctx.cudaKernelCache, err = cuda.NewKernelCache(opts.procRoot, smVersionSet, opts.tm, opts.config.KernelCacheQueueSize)
 		if err != nil {
 			return nil, fmt.Errorf("error creating kernel cache: %w", err)
 		}
@@ -237,7 +241,11 @@ func (ctx *systemContext) getCurrentActiveGpuDevice(pid int, tid int, containerI
 		// filter on the devices that are available to the process, not on the
 		// devices available on the host system.
 		var err error // avoid shadowing visibleDevices, declare error before so we can use = instead of :=
-		visibleDevices, err = ctx.filterDevicesForContainer(ctx.deviceCache.AllPhysicalDevices(), containerID)
+		allPhysicalDevices, err := ctx.deviceCache.AllPhysicalDevices()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get all physical devices: %w", err)
+		}
+		visibleDevices, err = ctx.filterDevicesForContainer(allPhysicalDevices, containerID)
 		if err != nil {
 			return nil, fmt.Errorf("error filtering devices for container %s: %w", containerID, err)
 		}

--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -8,7 +8,6 @@
 package safenvml
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -18,23 +17,25 @@ import (
 // DeviceCache is a cache of GPU devices, with some methods to easily access devices by UUID or index
 type DeviceCache interface {
 	// GetByUUID returns a device by its UUID
-	GetByUUID(uuid string) (Device, bool)
+	GetByUUID(uuid string) (Device, error)
 	// GetByIndex returns a device by its index
 	GetByIndex(index int) (Device, error)
 	// Count returns the number of physical devices in the cache
-	Count() int
+	Count() (int, error)
 	// SMVersionSet returns a set of all SM versions in the cache
-	SMVersionSet() map[uint32]struct{}
+	SMVersionSet() (map[uint32]struct{}, error)
 	// All returns all devices in the cache
-	All() []Device
+	All() ([]Device, error)
 	// AllPhysicalDevices returns all root devices in the cache
-	AllPhysicalDevices() []Device
+	AllPhysicalDevices() ([]Device, error)
 	// AllMigDevices returns all MIG children in the cache
-	AllMigDevices() []Device
+	AllMigDevices() ([]Device, error)
 	// Cores returns the number of cores for a device with a given UUID. Returns an error if the device is not found.
 	Cores(uuid string) (uint64, error)
-	// GetLastInitError returns the last error that occurred during initialization, or nil if the cache is initialized
-	GetLastInitError() error
+	// EnsureInit ensures that the cache is initialized, returns an error if the initialization fails
+	// this function is called by the other methods of the interface so it's not necessary to call it manually, unless
+	// you want to ensure the cache is initialized before calling the other methods
+	EnsureInit() error
 }
 
 // deviceCache is an implementation of DeviceCache
@@ -63,22 +64,11 @@ func NewDeviceCacheWithOptions(lib SafeNVML) DeviceCache {
 		lib:          lib,
 	}
 
-	// Try to initialize the cache if possible, if not we will try to initialize it later
-	_ = cache.ensureInit()
-
 	return cache
 }
 
-// GetLastInitError returns the error that occurred during initialization, or nil if the cache is initialized
-func (c *deviceCache) GetLastInitError() error {
-	if !c.initialized {
-		return errors.New("cache not initialized")
-	}
-
-	return c.lastInitError
-}
-
-func (c *deviceCache) ensureInit() error {
+// EnsureInit ensures that the cache is initialized, returns an error if the initialization fails
+func (c *deviceCache) EnsureInit() error {
 	if c.initialized {
 		return nil
 	}
@@ -140,18 +130,21 @@ func (c *deviceCache) ensureInit() error {
 }
 
 // GetByUUID returns a device by its UUID
-func (c *deviceCache) GetByUUID(uuid string) (Device, bool) {
-	if err := c.ensureInit(); err != nil {
-		return nil, false
+func (c *deviceCache) GetByUUID(uuid string) (Device, error) {
+	if err := c.EnsureInit(); err != nil {
+		return nil, fmt.Errorf("failed to initialize device cache: %w", err)
 	}
 
 	device, ok := c.uuidToDevice[uuid]
-	return device, ok
+	if !ok {
+		return nil, fmt.Errorf("device %s not found", uuid)
+	}
+	return device, nil
 }
 
 // GetByIndex returns a device by its index in the host
 func (c *deviceCache) GetByIndex(index int) (Device, error) {
-	if err := c.ensureInit(); err != nil {
+	if err := c.EnsureInit(); err != nil {
 		return nil, err
 	}
 
@@ -163,47 +156,55 @@ func (c *deviceCache) GetByIndex(index int) (Device, error) {
 }
 
 // Count returns the number of physical devices in the cache
-func (c *deviceCache) Count() int {
-	if err := c.ensureInit(); err != nil {
-		return 0
+func (c *deviceCache) Count() (int, error) {
+	if err := c.EnsureInit(); err != nil {
+		return 0, fmt.Errorf("failed to initialize device cache: %w", err)
 	}
 
-	return len(c.allPhysicalDevices)
+	return len(c.allPhysicalDevices), nil
 }
 
 // SMVersionSet returns a set of all SM versions in the cache
-func (c *deviceCache) SMVersionSet() map[uint32]struct{} {
-	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+func (c *deviceCache) SMVersionSet() (map[uint32]struct{}, error) {
+	if err := c.EnsureInit(); err != nil {
+		return nil, fmt.Errorf("failed to initialize device cache: %w", err)
+	}
 
-	return c.smVersionSet
+	return c.smVersionSet, nil
 }
 
 // All returns all devices in the cache
-func (c *deviceCache) All() []Device {
-	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+func (c *deviceCache) All() ([]Device, error) {
+	if err := c.EnsureInit(); err != nil {
+		return nil, fmt.Errorf("failed to initialize device cache: %w", err)
+	}
 
-	return c.allDevices
+	return c.allDevices, nil
 }
 
 // AllPhysicalDevices returns all physical devices in the cache
-func (c *deviceCache) AllPhysicalDevices() []Device {
-	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+func (c *deviceCache) AllPhysicalDevices() ([]Device, error) {
+	if err := c.EnsureInit(); err != nil {
+		return nil, fmt.Errorf("failed to initialize device cache: %w", err)
+	}
 
-	return c.allPhysicalDevices
+	return c.allPhysicalDevices, nil
 }
 
 // AllMigDevices returns all MIG children in the cache
-func (c *deviceCache) AllMigDevices() []Device {
-	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+func (c *deviceCache) AllMigDevices() ([]Device, error) {
+	if err := c.EnsureInit(); err != nil {
+		return nil, fmt.Errorf("failed to initialize device cache: %w", err)
+	}
 
-	return c.allMigDevices
+	return c.allMigDevices, nil
 }
 
 // Cores returns the number of cores for a device with a given UUID. Returns an error if the device is not found.
 func (c *deviceCache) Cores(uuid string) (uint64, error) {
-	device, ok := c.GetByUUID(uuid)
-	if !ok {
-		return 0, fmt.Errorf("device %s not found", uuid)
+	device, err := c.GetByUUID(uuid)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get device %s: %w", uuid, err)
 	}
 	return uint64(device.GetDeviceInfo().CoreCount), nil
 }

--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -8,7 +8,9 @@
 package safenvml
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -31,6 +33,8 @@ type DeviceCache interface {
 	AllMigDevices() []Device
 	// Cores returns the number of cores for a device with a given UUID. Returns an error if the device is not found.
 	Cores(uuid string) (uint64, error)
+	// GetLastInitError returns the last error that occurred during initialization, or nil if the cache is initialized
+	GetLastInitError() error
 }
 
 // deviceCache is an implementation of DeviceCache
@@ -40,32 +44,70 @@ type deviceCache struct {
 	allMigDevices      []Device
 	uuidToDevice       map[string]Device
 	smVersionSet       map[uint32]struct{}
+	lib                SafeNVML
+	initMutex          sync.Mutex
+	initialized        bool
+	lastInitError      error
 }
 
 // NewDeviceCache creates a new DeviceCache
-func NewDeviceCache() (DeviceCache, error) {
-	lib, err := GetSafeNvmlLib()
-	if err != nil {
-		return nil, err
-	}
-
-	return NewDeviceCacheWithOptions(lib)
+func NewDeviceCache() DeviceCache {
+	return NewDeviceCacheWithOptions(nil)
 }
 
 // NewDeviceCacheWithOptions creates a new DeviceCache with an already initialized NVML library
-func NewDeviceCacheWithOptions(lib SafeNVML) (DeviceCache, error) {
+func NewDeviceCacheWithOptions(lib SafeNVML) DeviceCache {
 	cache := &deviceCache{
 		uuidToDevice: make(map[string]Device),
 		smVersionSet: make(map[uint32]struct{}),
+		lib:          lib,
 	}
 
-	count, err := lib.DeviceGetCount()
+	// Try to initialize the cache if possible, if not we will try to initialize it later
+	_ = cache.ensureInit()
+
+	return cache
+}
+
+// GetLastInitError returns the error that occurred during initialization, or nil if the cache is initialized
+func (c *deviceCache) GetLastInitError() error {
+	if !c.initialized {
+		return errors.New("cache not initialized")
+	}
+
+	return c.lastInitError
+}
+
+func (c *deviceCache) ensureInit() error {
+	if c.initialized {
+		return nil
+	}
+
+	c.initMutex.Lock()
+	defer c.initMutex.Unlock()
+
+	// Check again after locking to ensure no race condition
+	if c.initialized {
+		return nil
+	}
+
+	if c.lib == nil {
+		lib, err := GetSafeNvmlLib()
+		if err != nil {
+			log.Warnf("error getting NVML library: %v", err)
+			c.lastInitError = err
+			return err
+		}
+		c.lib = lib
+	}
+
+	count, err := c.lib.DeviceGetCount()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for i := 0; i < count; i++ {
-		nvmlDev, err := lib.DeviceGetHandleByIndex(i)
+		nvmlDev, err := c.lib.DeviceGetHandleByIndex(i)
 		if err != nil {
 			log.Warnf("error getting device by index %d: %s", i, err)
 			continue
@@ -79,29 +121,40 @@ func NewDeviceCacheWithOptions(lib SafeNVML) (DeviceCache, error) {
 			continue
 		}
 
-		cache.uuidToDevice[dev.UUID] = dev
-		cache.allDevices = append(cache.allDevices, dev)
-		cache.allPhysicalDevices = append(cache.allPhysicalDevices, dev)
-		cache.smVersionSet[dev.SMVersion] = struct{}{}
+		c.uuidToDevice[dev.UUID] = dev
+		c.allDevices = append(c.allDevices, dev)
+		c.allPhysicalDevices = append(c.allPhysicalDevices, dev)
+		c.smVersionSet[dev.SMVersion] = struct{}{}
 
 		for _, migChild := range dev.MIGChildren {
-			cache.uuidToDevice[migChild.UUID] = migChild
-			cache.allDevices = append(cache.allDevices, migChild)
-			cache.allMigDevices = append(cache.allMigDevices, migChild)
+			c.uuidToDevice[migChild.UUID] = migChild
+			c.allDevices = append(c.allDevices, migChild)
+			c.allMigDevices = append(c.allMigDevices, migChild)
 		}
 	}
 
-	return cache, nil
+	c.initialized = true
+	c.lastInitError = nil
+
+	return nil
 }
 
 // GetByUUID returns a device by its UUID
 func (c *deviceCache) GetByUUID(uuid string) (Device, bool) {
+	if err := c.ensureInit(); err != nil {
+		return nil, false
+	}
+
 	device, ok := c.uuidToDevice[uuid]
 	return device, ok
 }
 
 // GetByIndex returns a device by its index in the host
 func (c *deviceCache) GetByIndex(index int) (Device, error) {
+	if err := c.ensureInit(); err != nil {
+		return nil, err
+	}
+
 	if index < 0 || index >= len(c.allDevices) {
 		return nil, fmt.Errorf("index %d out of range", index)
 	}
@@ -111,26 +164,38 @@ func (c *deviceCache) GetByIndex(index int) (Device, error) {
 
 // Count returns the number of physical devices in the cache
 func (c *deviceCache) Count() int {
+	if err := c.ensureInit(); err != nil {
+		return 0
+	}
+
 	return len(c.allPhysicalDevices)
 }
 
 // SMVersionSet returns a set of all SM versions in the cache
 func (c *deviceCache) SMVersionSet() map[uint32]struct{} {
+	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+
 	return c.smVersionSet
 }
 
 // All returns all devices in the cache
 func (c *deviceCache) All() []Device {
+	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+
 	return c.allDevices
 }
 
 // AllPhysicalDevices returns all physical devices in the cache
 func (c *deviceCache) AllPhysicalDevices() []Device {
+	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+
 	return c.allPhysicalDevices
 }
 
 // AllMigDevices returns all MIG children in the cache
 func (c *deviceCache) AllMigDevices() []Device {
+	_ = c.ensureInit() // Ignore error, as we will return the default set if the cache is not initialized anyways
+
 	return c.allMigDevices
 }
 

--- a/pkg/gpu/safenvml/cache_test.go
+++ b/pkg/gpu/safenvml/cache_test.go
@@ -27,9 +27,9 @@ func TestDeviceCache(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 	require.Equal(t, len(testutil.GPUUUIDs), cache.Count())
 }
 
@@ -60,9 +60,9 @@ func TestDeviceCachePartialFailure(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 	require.Equal(t, 2, cache.Count())
 
 	// Verify we can get the working devices
@@ -90,9 +90,9 @@ func TestDeviceCacheGetByIndex(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 
 	// Test get by index
 	device, err := cache.GetByIndex(0)
@@ -121,9 +121,9 @@ func TestDeviceCacheSMVersionSet(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 
 	// Test SM version set
 	smVersions := cache.SMVersionSet()
@@ -142,9 +142,9 @@ func TestDeviceCacheAll(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 
 	// cache.Count() should *only* counts physical devices
 	require.Equal(t, len(testutil.GPUUUIDs), cache.Count(), "Didn't find expected number of physical devices in cache")
@@ -166,9 +166,9 @@ func TestDeviceCacheCores(t *testing.T) {
 	WithMockNVML(t, mockNvml)
 
 	// Create device cache
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 
 	// Test getting cores
 	cores, err := cache.Cores(testutil.DefaultGpuUUID)
@@ -188,9 +188,9 @@ func TestDeviceCacheAllPhysicalDevices(t *testing.T) {
 	)
 	WithMockNVML(t, mockNvml)
 
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
 	require.NotNil(t, cache)
+	require.NoError(t, cache.GetLastInitError())
 
 	// Test get all devices
 	physicalDevices := cache.AllPhysicalDevices()
@@ -210,8 +210,8 @@ func TestDeviceCacheAllMigDevices(t *testing.T) {
 	)
 	WithMockNVML(t, mockNvml)
 
-	cache, err := NewDeviceCache()
-	require.NoError(t, err)
+	cache := NewDeviceCache()
+	require.NoError(t, cache.GetLastInitError())
 	require.NotNil(t, cache)
 
 	migDevices := cache.AllMigDevices()

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -179,9 +179,9 @@ func (g *statsGenerator) getNormalizationFactors(stats []model.StatsTuple) (map[
 
 	normFactors := make(map[string]normalizationFactors)
 	for uuid, usage := range usages {
-		device, ok := g.sysCtx.deviceCache.GetByUUID(uuid)
-		if !ok {
-			return nil, fmt.Errorf("cannot find device for UUID %s", uuid)
+		device, err := g.sysCtx.deviceCache.GetByUUID(uuid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get device for UUID %s: %w", uuid, err)
 		}
 
 		var deviceFactors normalizationFactors


### PR DESCRIPTION
### What does this PR do?

This PR changes the `DeviceCache` so that it's no longer initialized on creation, but rather on use. It requires changing the signature of the rest of `DeviceCache` methods to return an error. Each of them will check if the library is initialized, and if not they will try to do it. If the initialization fails, they will return an error.

It replicates the behavior we have in the core check, where we would be trying to initialize NVML libraries on each `Run()` until it initialized successfully. Now the system-probe module will start up even if NVML is not accessible, fixing issues where the driver might not have been loaded when system-probe started.

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-828 

Ensuring compatibility of the system-probe module when using the NVIDIA GPU operator with operator-managed drivers, which can be loaded after system-probe starts.

### Describe how you validated your changes

Unit tests and e2e tests cover the refactor.

### Additional Notes
