### PR TITLE
[EBPF-827] update(gpu): emit count metrics for NVIDIA Xid errors

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -41,13 +41,14 @@ var logLimitCheck = log.NewLogLimit(20, 10*time.Minute)
 // Check represents the GPU check that will be periodically executed via the Run() function
 type Check struct {
 	core.CheckBase
-	collectors  []nvidia.Collector       // collectors for NVML metrics
-	tagger      tagger.Component         // Tagger instance to add tags to outgoing metrics
-	telemetry   *checkTelemetry          // Telemetry component to emit internal telemetry
-	wmeta       workloadmeta.Component   // Workloadmeta store to get the list of containers
-	deviceTags  map[string][]string      // deviceTags is a map of device UUID to tags
-	deviceCache ddnvml.DeviceCache       // deviceCache is a cache of GPU devices
-	spCache     *nvidia.SystemProbeCache // spCache manages system-probe GPU stats and client (only initialized when gpu_monitoring is enabled in system-probe)
+	collectors        []nvidia.Collector           // collectors for NVML metrics
+	tagger            tagger.Component             // Tagger instance to add tags to outgoing metrics
+	telemetry         *checkTelemetry              // Telemetry component to emit internal telemetry
+	wmeta             workloadmeta.Component       // Workloadmeta store to get the list of containers
+	deviceTags        map[string][]string          // deviceTags is a map of device UUID to tags
+	deviceCache       ddnvml.DeviceCache           // deviceCache is a cache of GPU devices
+	spCache           *nvidia.SystemProbeCache     // spCache manages system-probe GPU stats and client (only initialized when gpu_monitoring is enabled in system-probe)
+	deviceEvtGatherer *nvidia.DeviceEventsGatherer // deviceEvtGatherer asynchronously listens for device events and gathers them
 }
 
 type checkTelemetry struct {
@@ -100,6 +101,12 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, 
 		return err
 	}
 
+	var err error
+	c.deviceEvtGatherer, err = nvidia.NewDeviceEventsGatherer()
+	if err != nil {
+		return fmt.Errorf("failed creating event set gatherer: %w", err)
+	}
+
 	// Compute whether we should prefer system-probe process metrics
 	if pkgconfigsetup.SystemProbe().GetBool("gpu_monitoring.enabled") {
 		c.spCache = nvidia.NewSystemProbeCache()
@@ -136,9 +143,16 @@ func (c *Check) ensureInitCollectors() error {
 		return fmt.Errorf("failed to initialize device cache: %w", err)
 	}
 
+	// device events gatherer must be running in order for devices to be properly registered
+	// when building the collectors
+	if err := c.deviceEvtGatherer.Start(); err != nil {
+		return fmt.Errorf("failed starting event set gatherer: %w", err)
+	}
+
 	deps := &nvidia.CollectorDependencies{
-		DeviceCache:      c.deviceCache,
-		SystemProbeCache: c.spCache,
+		DeviceCache:          c.deviceCache,
+		DeviceEventsGatherer: c.deviceEvtGatherer,
+		SystemProbeCache:     c.spCache,
 	}
 	collectors, err := nvidia.BuildCollectors(deps)
 	if err != nil {
@@ -152,8 +166,14 @@ func (c *Check) ensureInitCollectors() error {
 
 // Cancel stops the check
 func (c *Check) Cancel() {
+	if err := c.deviceEvtGatherer.Stop(); err != nil {
+		log.Warnf("error stopping event set gatherer: %v", err)
+	}
+
 	if lib, err := ddnvml.GetSafeNvmlLib(); err == nil {
-		_ = lib.Shutdown()
+		if err := lib.Shutdown(); err != nil {
+			log.Warnf("error shutting down NVML lib: %v", err)
+		}
 	}
 
 	c.CheckBase.Cancel()
@@ -182,6 +202,12 @@ func (c *Check) Run() error {
 			}
 			// Continue with NVML-only metrics, SP collectors will return empty metrics
 		}
+	}
+
+	// Attempt refreshing device events
+	if err := c.deviceEvtGatherer.Refresh(); err != nil && logLimitCheck.ShouldLog() {
+		log.Warnf("error refreshing device events cache: %v", err)
+		// Might cause empty metrics in collectors depending on device events
 	}
 
 	// build the mapping of GPU devices -> containers to allow tagging device

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -136,7 +136,11 @@ func (c *Check) ensureInitCollectors() error {
 		return fmt.Errorf("failed to initialize device cache: %w", err)
 	}
 
-	collectors, err := nvidia.BuildCollectors(&nvidia.CollectorDependencies{DeviceCache: c.deviceCache}, c.spCache)
+	deps := &nvidia.CollectorDependencies{
+		DeviceCache:      c.deviceCache,
+		SystemProbeCache: c.spCache,
+	}
+	collectors, err := nvidia.BuildCollectors(deps)
 	if err != nil {
 		return fmt.Errorf("failed to build NVML collectors: %w", err)
 	}

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -171,6 +171,10 @@ func TestRunDoesNotError(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, checkGeneric.Run())
+
+	// we need to cancel the check to make sure all resources and async workers are released
+	// before deinitializing the mock library at test cleanup
+	checkGeneric.Cancel()
 }
 
 // mockCollector implements the nvidia.Collector interface for testing

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -174,7 +174,7 @@ func TestRunDoesNotError(t *testing.T) {
 
 	// we need to cancel the check to make sure all resources and async workers are released
 	// before deinitializing the mock library at test cleanup
-	checkGeneric.Cancel()
+	t.Cleanup(func() { checkGeneric.Cancel() })
 }
 
 // mockCollector implements the nvidia.Collector interface for testing

--- a/pkg/collector/corechecks/gpu/nvidia/base_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-// setupMockDevice creates a mock device for testing with optional customization.
-// If customize is nil, returns a basic mock device with all functions enabled.
-// If customize is provided, allows overriding specific device functions.
-func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Device) ddnvml.Device {
-	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
+func setupMockDeviceWithLibOpts(t *testing.T, customize func(device *mock.Device) *mock.Device, extraLibOpts ...testutil.NvmlMockOption) ddnvml.Device {
+	libOpts := []testutil.NvmlMockOption{
+		testutil.WithMIGDisabled(),
+		testutil.WithDeviceCount(1),
+	}
+	nvmlMock := testutil.GetBasicNvmlMockWithOptions(append(libOpts, extraLibOpts...)...)
 	device := testutil.GetDeviceMock(0, testutil.WithMockAllDeviceFunctions())
 
 	// Apply customization if provided
@@ -46,6 +47,13 @@ func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Dev
 	require.NoError(t, err)
 	require.NotEmpty(t, devices)
 	return devices[0]
+}
+
+// setupMockDevice creates a mock device for testing with optional customization.
+// If customize is nil, returns a basic mock device with all functions enabled.
+// If customize is provided, allows overriding specific device functions.
+func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Device) ddnvml.Device {
+	return setupMockDeviceWithLibOpts(t, customize)
 }
 
 func TestNewBaseCollector(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -43,9 +43,10 @@ const (
 	sampling  CollectorName = "sampling"  // Consolidates process, samples
 
 	// Specialized collectors (kept separate)
-	field CollectorName = "fields"
-	gpm   CollectorName = "gpm"
-	ebpf  CollectorName = "ebpf"
+	field        CollectorName = "fields"
+	gpm          CollectorName = "gpm"
+	ebpf         CollectorName = "ebpf"
+	deviceEvents CollectorName = "device_events"
 )
 
 // Metric represents a single metric collected from the NVML library.
@@ -81,14 +82,17 @@ var factory = map[CollectorName]subsystemBuilder{
 	sampling:  newSamplingCollector,  // Consolidates process, samples
 
 	// Specialized collectors that remain unchanged (complex or unique logic)
-	field: newFieldsCollector,
-	gpm:   newGPMCollector,
+	field:        newFieldsCollector,
+	gpm:          newGPMCollector,
+	deviceEvents: newDeviceEventsCollector,
 }
 
 // CollectorDependencies holds the dependencies needed to create a set of collectors.
 type CollectorDependencies struct {
 	// DeviceCache is a cache of GPU devices.
 	DeviceCache ddnvml.DeviceCache
+	// DeviceEventsGatherer acts like a cache for the most recent device events
+	DeviceEventsGatherer *DeviceEventsGatherer
 	// SystemProbeCache is a (optional) cache of the latest metrics obtained from system probe
 	SystemProbeCache *SystemProbeCache
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -132,7 +132,7 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 	if deps.SystemProbeCache != nil {
 		log.Info("GPU monitoring probe is enabled in system-probe, creating ebpf collectors for all devices")
 		for _, dev := range allPhysicalDevices {
-			spCollector, err := newEbpfCollector(dev, deps)
+			spCollector, err := newEbpfCollector(dev, deps.SystemProbeCache)
 			if err != nil {
 				log.Warnf("failed to create system-probe collector for device %s: %s", dev.GetDeviceInfo().UUID, err)
 				continue

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -28,7 +28,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 
 	// On the first call, this function returns correctly. On the second it fails.
 	// We need this as we cannot rely on the order of the subsystems in the map.
-	factory := func(_ ddnvml.Device) (Collector, error) {
+	factory := func(_ ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
 		if !factorySucceeded {
 			factorySucceeded = true
 			return succeedCollector, nil
@@ -40,7 +40,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache := ddnvml.NewDeviceCache()
 	deps := &CollectorDependencies{DeviceCache: deviceCache}
-	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory}, nil)
+	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
 }
@@ -150,7 +150,7 @@ func TestAllCollectorsWork(t *testing.T) {
 	for _, collector := range collectors {
 		result, err := collector.Collect()
 		require.NoError(t, err, "collector %s failed to collect", collector.Name())
-		require.NotEmpty(t, result, "collector %s returned empty result", collector.Name())
+			require.NotEmpty(t, result, "collector %s returned empty result", collector.Name())
 		seenCollectors[collector.Name()] = struct{}{}
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -102,14 +102,10 @@ func (c *deviceEventsCollector) Collect() ([]Metric, error) {
 		c.metricsByXidCode[evt.EventData].Value++
 	}
 
-	// collect metrics in a deterministic order
-	xidCodes := slices.Collect(maps.Keys(c.metricsByXidCode))
-	slices.Sort(xidCodes)
 	var metrics []Metric
-	for _, xidCode := range xidCodes {
-		metrics = append(metrics, *c.metricsByXidCode[xidCode])
+	for _, m := range c.metricsByXidCode {
+		metrics = append(metrics, *m)
 	}
-
 	return metrics, nil
 }
 
@@ -174,7 +170,7 @@ func (c *DeviceEventsGatherer) Stop() error {
 	c.evtSetMtx.Lock()
 	defer c.evtSetMtx.Unlock()
 	if err := c.lib.EventSetFree(c.evtSet); err != nil {
-		return fmt.Errorf("failed freeing event set: %w", err)
+		log.Errorf("failed freeing event set: %v", err)
 	}
 	c.evtSet = nil
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -1,0 +1,417 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+const (
+	eventSetMask                = uint64(nvml.EventTypeXidCriticalError)
+	eventSetWaitTimeout         = 1000 * time.Millisecond
+	devicePendingEventQueueSize = 1000
+	xidOriginDriver             = "driver"
+	xidOriginHardware           = "hardware"
+	xidOriginUnknown            = "unknown"
+)
+
+// helps mocking an actual events gatherer in tests
+type deviceEventsCollectorCache interface {
+	GetEvents(deviceUUID string) ([]ddnvml.DeviceEventData, error)
+	RegisterDevice(device ddnvml.Device) error
+}
+
+type deviceEventsCollector struct {
+	device           ddnvml.Device
+	eventsCache      deviceEventsCollectorCache
+	metricsByXidCode map[uint64]*Metric
+}
+
+func newDeviceEventsCollector(device ddnvml.Device, deps *CollectorDependencies) (c Collector, err error) {
+	return newDeviceEventsCollectorWithCache(device, deps.DeviceEventsGatherer)
+}
+
+// used internally for testing
+func newDeviceEventsCollectorWithCache(device ddnvml.Device, cache deviceEventsCollectorCache) (c Collector, err error) {
+	if cache == nil {
+		return nil, fmt.Errorf("device events gatherer cannot be nil")
+	}
+	if err := cache.RegisterDevice(device); err != nil {
+		return nil, err
+	}
+
+	return &deviceEventsCollector{
+		device:           device,
+		eventsCache:      cache,
+		metricsByXidCode: map[uint64]*Metric{},
+	}, nil
+}
+
+func (c *deviceEventsCollector) DeviceUUID() string {
+	return c.device.GetDeviceInfo().UUID
+}
+
+func (c *deviceEventsCollector) Name() CollectorName {
+	return deviceEvents
+}
+
+func (c *deviceEventsCollector) Collect() ([]Metric, error) {
+	events, err := c.eventsCache.GetEvents(c.DeviceUUID())
+	if err != nil {
+		return nil, fmt.Errorf("failed collecting device events: %w", err)
+	}
+
+	for _, evt := range events {
+		if evt.EventType != nvml.EventTypeXidCriticalError {
+			// currently considering only xid events
+			continue
+		}
+
+		if _, ok := c.metricsByXidCode[evt.EventData]; !ok {
+			xidOrigin, ok := xidCodeToOrigin[evt.EventData]
+			if !ok {
+				xidOrigin = xidOriginUnknown
+			}
+			c.metricsByXidCode[evt.EventData] = &Metric{
+				Name:     "errors.xid.total",
+				Type:     metrics.CountType,
+				Priority: High,
+				Tags: []string{
+					"type:" + strconv.Itoa(int(evt.EventData)),
+					"origin:" + xidOrigin,
+				},
+			}
+		}
+
+		c.metricsByXidCode[evt.EventData].Value++
+	}
+
+	// collect metrics in a deterministic order
+	xidCodes := slices.Collect(maps.Keys(c.metricsByXidCode))
+	slices.Sort(xidCodes)
+	var metrics []Metric
+	for _, xidCode := range xidCodes {
+		metrics = append(metrics, *c.metricsByXidCode[xidCode])
+	}
+
+	return metrics, nil
+}
+
+// NewDeviceEventsGatherer creates a new cache that gathers NVML device events
+func NewDeviceEventsGatherer() (*DeviceEventsGatherer, error) {
+	lib, err := ddnvml.GetSafeNvmlLib()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NVML library: %w", err)
+	}
+	return &DeviceEventsGatherer{
+		lib:     lib,
+		devices: map[string]*deviceEventsEventsCache{},
+	}, nil
+}
+
+type deviceEventsEventsCache struct {
+	latestEvents  []ddnvml.DeviceEventData
+	pendingEvents chan ddnvml.DeviceEventData
+}
+
+type DeviceEventsGatherer struct {
+	running    atomic.Bool
+	wg         sync.WaitGroup
+	lib        ddnvml.SafeNVML
+	evtSetMtx  sync.Mutex
+	evtSet     nvml.EventSet
+	devicesMtx sync.Mutex
+	devices    map[string]*deviceEventsEventsCache // uuid -> cache
+}
+
+func (c *DeviceEventsGatherer) Start() error {
+	if c.running.Load() {
+		return nil
+	}
+
+	c.evtSetMtx.Lock()
+	defer c.evtSetMtx.Unlock()
+
+	var err error
+	c.evtSet, err = c.lib.EventSetCreate()
+	if err != nil {
+		return fmt.Errorf("failed to create NVML event set: %w", err)
+	}
+
+	c.running.Store(true)
+	c.wg.Add(1)
+	go c.asyncFetchWorker()
+	return nil
+}
+
+func (c *DeviceEventsGatherer) Stop() error {
+	if !c.running.Load() {
+		return nil
+	}
+
+	c.running.Store(false)
+	c.wg.Wait()
+
+	c.evtSetMtx.Lock()
+	defer c.evtSetMtx.Unlock()
+	if err := c.lib.EventSetFree(c.evtSet); err != nil {
+		return fmt.Errorf("failed freeing event set: %w", err)
+	}
+	c.evtSet = nil
+
+	c.devicesMtx.Lock()
+	defer c.devicesMtx.Unlock()
+	for _, cache := range c.devices {
+		close(cache.pendingEvents)
+	}
+	clear(c.devices)
+
+	return nil
+}
+
+func (c *DeviceEventsGatherer) getDeviceCache(deviceUUID string) *deviceEventsEventsCache {
+	c.devicesMtx.Lock()
+	defer c.devicesMtx.Unlock()
+
+	if cache, ok := c.devices[deviceUUID]; ok {
+		return cache
+	}
+	return nil
+}
+
+func (c *DeviceEventsGatherer) GetRegisteredDeviceUUIDs() []string {
+	c.devicesMtx.Lock()
+	defer c.devicesMtx.Unlock()
+
+	uuids := slices.Collect(maps.Keys(c.devices))
+	slices.Sort(uuids) // make order deterministic
+	return uuids
+}
+
+func (c *DeviceEventsGatherer) Refresh() error {
+	for _, uuid := range c.GetRegisteredDeviceUUIDs() {
+		cache := c.getDeviceCache(uuid)
+		if cache == nil {
+			log.Debugf("event set gatherer: could not find cache for %s while refreshing", uuid)
+			continue
+		}
+		cache.latestEvents = nil
+		nPending := len(cache.pendingEvents)
+		for range nPending {
+			cache.latestEvents = append(cache.latestEvents, <-cache.pendingEvents)
+		}
+	}
+	return nil
+}
+
+// GetEvents returns the latest batch of cached events for the given device UUID
+func (c *DeviceEventsGatherer) GetEvents(deviceUUID string) ([]ddnvml.DeviceEventData, error) {
+	if cache := c.getDeviceCache(deviceUUID); cache != nil {
+		return c.getDeviceCache(deviceUUID).latestEvents, nil
+	}
+	log.Debugf("event set gatherer: could not find cache for %s while getting events", deviceUUID)
+	return nil, nil
+}
+
+func (c *DeviceEventsGatherer) RegisterDevice(device ddnvml.Device) error {
+	evtTypes, err := device.GetSupportedEventTypes()
+	if err != nil {
+		return fmt.Errorf("failed to query supported device event types: %w", err)
+	}
+
+	if (evtTypes & eventSetMask) == 0 {
+		return errUnsupportedDevice
+	}
+
+	// device registrations might happen after the async gatherer is already started.
+	// NVIDIA docs do not mention much about thread safety, so we opt for protecting
+	// the event set manually for safety
+	c.evtSetMtx.Lock()
+	defer c.evtSetMtx.Unlock()
+	if c.evtSet == nil {
+		return fmt.Errorf("failed registering device events on stopped gatherer")
+	}
+	if err := device.RegisterEvents(evtTypes&eventSetMask, c.evtSet); err != nil {
+		return fmt.Errorf("failed registering device events: %w", err)
+	}
+
+	// mark device as registered and create its cache
+	c.devicesMtx.Lock()
+	defer c.devicesMtx.Unlock()
+	c.devices[device.GetDeviceInfo().UUID] = &deviceEventsEventsCache{
+		pendingEvents: make(chan ddnvml.DeviceEventData, devicePendingEventQueueSize),
+	}
+
+	return nil
+}
+
+func (c *DeviceEventsGatherer) asyncFetchWorker() {
+	defer c.wg.Done()
+
+	log.Debugf("event set gatherer: starting async worker")
+	defer log.Debugf("event set gatherer: stopping async worker")
+
+	for {
+		if !c.running.Load() {
+			return
+		}
+
+		c.evtSetMtx.Lock()
+		evt, err := c.lib.EventSetWait(c.evtSet, eventSetWaitTimeout)
+		c.evtSetMtx.Unlock()
+		if ddnvml.IsTimeout(err) {
+			continue
+		}
+		if err != nil {
+			log.Debugf("event set gatherer: error during wait: %s", err.Error())
+			continue
+		}
+		if evt.DeviceUUID == "" {
+			continue
+		}
+
+		devCache := c.getDeviceCache(evt.DeviceUUID)
+		if devCache == nil {
+			log.Debugf("event set gatherer: could not find cache for %s while fetching", evt.DeviceUUID)
+			continue
+		}
+
+		select {
+		case devCache.pendingEvents <- evt:
+		default:
+			log.Debugf("event set gatherer: event discarded for device %s", evt.DeviceUUID)
+		}
+	}
+}
+
+// see https://docs.nvidia.com/deploy/xid-errors/index.html#working-with-xid-errors
+// this is an opinionated categorization of xid failure codes based on the documented
+// possible causes. The goal is to provide the metric with a readable tag of where the
+// issue can come from (to at least spot device/driver errors). Unused xid codes are omitted.
+var xidCodeToOrigin = map[uint64]string{
+	1:   xidOriginHardware, // Invalid or corrupted push buffer stream
+	2:   xidOriginHardware, // Invalid or corrupted push buffer stream
+	3:   xidOriginHardware, // Invalid or corrupted push buffer stream
+	4:   xidOriginHardware, // GPU semaphore timeout
+	6:   xidOriginHardware, // Invalid or corrupted push buffer stream
+	7:   xidOriginHardware, // Invalid or corrupted push buffer address
+	8:   xidOriginHardware, // GPU stopped processing
+	9:   xidOriginDriver,   // Driver error programming GPU
+	11:  xidOriginHardware, // Invalid or corrupted push buffer stream
+	12:  xidOriginDriver,   // Driver error handling GPU exception
+	13:  xidOriginHardware, // Graphics Engine Exception
+	16:  xidOriginDriver,   // Display engine hung
+	18:  xidOriginDriver,   // Bus mastering disabled in PCI Config Space
+	19:  xidOriginDriver,   // Display Engine error
+	20:  xidOriginHardware, // Invalid or corrupted Mpeg push buffer
+	21:  xidOriginHardware, // Invalid or corrupted Motion Estimation push buffer
+	22:  xidOriginHardware, // Invalid or corrupted Video Processor push buffer
+	24:  xidOriginHardware, // GPU semaphore timeout
+	25:  xidOriginHardware, // Invalid or illegal push buffer stream
+	26:  xidOriginDriver,   // Framebuffer timeout
+	27:  xidOriginDriver,   // Video processor exception
+	28:  xidOriginDriver,   // Video processor exception
+	29:  xidOriginDriver,   // Video processor exception
+	30:  xidOriginDriver,   // GPU semaphore access error
+	31:  xidOriginHardware, // GPU memory page fault
+	32:  xidOriginHardware, // Invalid or corrupted push buffer stream
+	33:  xidOriginDriver,   // Internal micro-controller error
+	34:  xidOriginDriver,   // Video processor exception
+	35:  xidOriginDriver,   // Video processor exception
+	36:  xidOriginDriver,   // Video processor exception
+	37:  xidOriginDriver,   // Driver firmware error
+	38:  xidOriginDriver,   // Driver firmware error
+	42:  xidOriginDriver,   // Video processor exception
+	43:  xidOriginDriver,   // GPU stopped processing
+	44:  xidOriginDriver,   // Graphics Engine fault during context switch
+	45:  xidOriginDriver,   // Preemptive cleanup due to previous errors
+	46:  xidOriginDriver,   // GPU stopped processing
+	47:  xidOriginDriver,   // Video processor exception
+	48:  xidOriginHardware, // Double Bit ECC Error
+	54:  xidOriginHardware, // Auxiliary power is not connected to the GPU board
+	56:  xidOriginDriver,   // Display Engine error
+	57:  xidOriginHardware, // Error programming video memory interface
+	58:  xidOriginHardware, // Unstable video memory interface detected
+	59:  xidOriginDriver,   // Internal micro-controller error (older drivers)
+	60:  xidOriginDriver,   // Video processor exception
+	61:  xidOriginDriver,   // Internal micro-controller breakpoint/warning
+	62:  xidOriginDriver,   // Internal micro-controller halt (newer drivers)
+	63:  xidOriginHardware, // ECC page retirement or row remapping recording event
+	64:  xidOriginHardware, // ECC page retirement or row remapper recording failure
+	65:  xidOriginDriver,   // Video processor exception
+	66:  xidOriginDriver,   // Illegal access by driver
+	67:  xidOriginDriver,   // Illegal access by driver
+	68:  xidOriginHardware, // NVDEC0 Exception
+	69:  xidOriginHardware, // Graphics Engine class error
+	70:  xidOriginHardware, // Unknown Error
+	71:  xidOriginHardware, // Unknown Error
+	72:  xidOriginHardware, // Unknown Error
+	73:  xidOriginHardware, // NVENC2 Error
+	74:  xidOriginHardware, // NVLINK Error
+	75:  xidOriginHardware, // Unknown Error
+	76:  xidOriginHardware, // Unknown Error
+	77:  xidOriginHardware, // Unknown Error
+	78:  xidOriginDriver,   // vGPU Start Error
+	79:  xidOriginHardware, // GPU has fallen off the bus
+	80:  xidOriginHardware, // Corrupted data sent to GPU
+	81:  xidOriginHardware, // VGA Subsystem Error
+	82:  xidOriginHardware, // NVJPG0 Error
+	83:  xidOriginHardware, // NVDEC1 Error
+	84:  xidOriginHardware, // NVDEC2 Error
+	85:  xidOriginHardware, // Unknown Error
+	86:  xidOriginHardware, // OFA Exception
+	88:  xidOriginHardware, // NVDEC3 Error
+	89:  xidOriginHardware, // NVDEC4 Error
+	92:  xidOriginHardware, // High single-bit ECC error rate
+	93:  xidOriginDriver,   // Non-fatal violation of provisioned InfoROM wear limit
+	94:  xidOriginHardware, // Contained ECC error
+	95:  xidOriginHardware, // Uncontained ECC error
+	96:  xidOriginHardware, // NVDEC5 Error
+	97:  xidOriginHardware, // NVDEC6 Error
+	98:  xidOriginHardware, // NVDEC7 Error
+	99:  xidOriginHardware, // NVJPG1 Error
+	100: xidOriginHardware, // NVJPG2 Error
+	101: xidOriginHardware, // NVJPG3 Error
+	102: xidOriginHardware, // NVJPG4 Error
+	103: xidOriginHardware, // NVJPG5 Error
+	104: xidOriginHardware, // NVJPG6 Error
+	105: xidOriginHardware, // NVJPG7 Error
+	106: xidOriginHardware, // SMBPBI Test Message
+	107: xidOriginHardware, // SMBPBI Test Message Silent
+	109: xidOriginHardware, // Context Switch Timeout Error
+	110: xidOriginHardware, // Security Fault Error
+	111: xidOriginHardware, // Display Bundle Error Event
+	112: xidOriginHardware, // Display Supervisor Error
+	113: xidOriginHardware, // DP Link Training Error
+	114: xidOriginHardware, // Display Pipeline Underflow Error
+	115: xidOriginHardware, // Display Core Channel Error
+	116: xidOriginHardware, // Display Window Channel Error
+	117: xidOriginHardware, // Display Cursor Channel Error
+	118: xidOriginHardware, // Display Pixel Pipeline Error
+	119: xidOriginHardware, // GSP RPC Timeout
+	120: xidOriginHardware, // GSP Error
+	121: xidOriginHardware, // C2C Link Error
+	122: xidOriginHardware, // SPI PMU RPC Read Failure
+	123: xidOriginHardware, // SPI PMU RPC Write Failure
+	124: xidOriginHardware, // SPI PMU RPC Erase Failure
+	125: xidOriginHardware, // Inforom FS Failure
+	137: xidOriginHardware, // NVLink FLA privilege error
+	140: xidOriginHardware, // Unrecovered ECC Error
+	143: xidOriginHardware, // GPU Initialization Failure
+}

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -43,6 +43,8 @@ func TestDeviceEventsGatherer_RegisterWithUnsupportedEvents(t *testing.T) {
 }
 
 func TestDeviceEventsGatherer_GetWithUnregistered(t *testing.T) {
+	safenvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
+
 	gatherer, err := NewDeviceEventsGatherer()
 	require.NoError(t, err)
 	require.NoError(t, gatherer.Start())

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -137,12 +136,12 @@ type mockDeviceEventsCollectorCache struct {
 	err    error
 }
 
-func (m *mockDeviceEventsCollectorCache) RegisterDevice(device ddnvml.Device) error {
+func (m *mockDeviceEventsCollectorCache) RegisterDevice(device safenvml.Device) error {
 	m.uuids = append(m.uuids, device.GetDeviceInfo().UUID)
 	return nil
 }
 
-func (m *mockDeviceEventsCollectorCache) GetEvents(deviceUUID string) ([]safenvml.DeviceEventData, error) {
+func (m *mockDeviceEventsCollectorCache) GetEvents(_ string) ([]safenvml.DeviceEventData, error) {
 	return m.events, m.err
 }
 
@@ -166,7 +165,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 	require.Empty(t, mm)
 
 	// make sure non-xid events are ignored
-	cache.events = []ddnvml.DeviceEventData{
+	cache.events = []safenvml.DeviceEventData{
 		{
 			DeviceUUID: uuid,
 			EventType:  nvml.EventMigConfigChange,
@@ -180,7 +179,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 	// since we don't change events between subsequent calls, we check
 	// that the counter is increased
 	xidErrorsMetricName := "errors.xid.total"
-	cache.events = []ddnvml.DeviceEventData{
+	cache.events = []safenvml.DeviceEventData{
 		{
 			DeviceUUID: uuid,
 			EventType:  nvml.EventTypeXidCriticalError,
@@ -204,7 +203,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 	assert.Equal(t, float64(2), mm[0].Value)
 
 	// make sure different xid errors produce distinct metric contexts
-	cache.events = []ddnvml.DeviceEventData{
+	cache.events = []safenvml.DeviceEventData{
 		{
 			DeviceUUID: uuid,
 			EventType:  nvml.EventTypeXidCriticalError,

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -1,0 +1,239 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceEventsGatherer_RegisterBeforeStart(t *testing.T) {
+	device := setupMockDevice(t, nil)
+
+	gatherer, err := NewDeviceEventsGatherer()
+	require.NoError(t, err)
+
+	assert.Error(t, gatherer.RegisterDevice(device))
+}
+
+func TestDeviceEventsGatherer_RegisterWithUnsupportedEvents(t *testing.T) {
+	device := setupMockDevice(t, func(device *mock.Device) *mock.Device {
+		device.GetSupportedEventTypesFunc = func() (uint64, nvml.Return) {
+			return 0, nvml.SUCCESS
+		}
+		return device
+	})
+
+	gatherer, err := NewDeviceEventsGatherer()
+	require.NoError(t, err)
+	assert.Error(t, gatherer.RegisterDevice(device))
+}
+
+func TestDeviceEventsGatherer_GetWithUnregistered(t *testing.T) {
+	gatherer, err := NewDeviceEventsGatherer()
+	require.NoError(t, err)
+	require.NoError(t, gatherer.Start())
+	t.Cleanup(func() { require.NoError(t, gatherer.Stop()) })
+
+	assert.Empty(t, gatherer.GetRegisteredDeviceUUIDs())
+
+	events, err := gatherer.GetEvents("some-uuid")
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
+	// by controlling this, we can influence the gathered device events
+	gatheredDeviceEvents := make(chan nvml.EventData, 10)
+	t.Cleanup(func() { close(gatheredDeviceEvents) })
+
+	// setup mock device, and the nvml lib to return events at our command
+	device := setupMockDeviceWithLibOpts(t, nil,
+		testutil.WithSymbolsMock(map[string]struct{}{"nvmlDeviceGetUUID": {}}),
+		testutil.WithEventSetCreate(func() (nvml.EventSet, nvml.Return) {
+			return &mock.EventSet{
+				FreeFunc: func() nvml.Return { return nvml.SUCCESS },
+				WaitFunc: func(v uint32) (nvml.EventData, nvml.Return) {
+					if len(gatheredDeviceEvents) == 0 {
+						time.Sleep(time.Duration(v) * time.Millisecond)
+						return nvml.EventData{}, nvml.ERROR_TIMEOUT
+					}
+					return <-gatheredDeviceEvents, nvml.SUCCESS
+				},
+			}, nvml.SUCCESS
+		}))
+
+	// create gatherer after lib initialization so that it picks up the mock
+	gatherer, err := NewDeviceEventsGatherer()
+	require.NoError(t, err)
+	require.NoError(t, gatherer.Start())
+	t.Cleanup(func() { require.NoError(t, gatherer.Stop()) })
+
+	// register device in gatherer
+	uuid := device.GetDeviceInfo().UUID
+	require.NoError(t, gatherer.RegisterDevice(device))
+	require.Len(t, gatherer.GetRegisteredDeviceUUIDs(), 1)
+	require.Equal(t, uuid, gatherer.GetRegisteredDeviceUUIDs()[0])
+
+	// no events should be available initially
+	events, err := gatherer.GetEvents(uuid)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	// create an event to be gathered, then make sure it is not available until we refresh
+	sampleDeviceEvent := nvml.EventData{
+		Device:    &mock.Device{GetUUIDFunc: func() (string, nvml.Return) { return uuid, nvml.SUCCESS }},
+		EventType: nvml.EventTypeXidCriticalError,
+		EventData: 31, // sample xid error for invalid mem access
+	}
+	gatheredDeviceEvents <- sampleDeviceEvent
+	time.Sleep(time.Duration(float64(eventSetWaitTimeout) * 1.2)) // wait for timeout (with some tolerance)
+	events, err = gatherer.GetEvents(uuid)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	// after refreshing, the event should be present
+	require.NoError(t, gatherer.Refresh())
+	events, err = gatherer.GetEvents(uuid)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, safenvml.DeviceEventData{
+		DeviceUUID: uuid,
+		EventType:  sampleDeviceEvent.EventType,
+		EventData:  sampleDeviceEvent.EventData,
+	}, events[0])
+
+	// make sure the latest events cache is consistent up until the next refresh
+	for i := 0; i < 10; i++ {
+		events, err = gatherer.GetEvents(uuid)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+	}
+
+	// after refresh, latest events cache should be empty (no new events gathered)
+	require.NoError(t, gatherer.Refresh())
+	events, err = gatherer.GetEvents(uuid)
+	require.NoError(t, err)
+	require.Empty(t, events)
+}
+
+type mockDeviceEventsCollectorCache struct {
+	uuids  []string
+	events []safenvml.DeviceEventData
+	err    error
+}
+
+func (m *mockDeviceEventsCollectorCache) RegisterDevice(device ddnvml.Device) error {
+	m.uuids = append(m.uuids, device.GetDeviceInfo().UUID)
+	return nil
+}
+
+func (m *mockDeviceEventsCollectorCache) GetEvents(deviceUUID string) ([]safenvml.DeviceEventData, error) {
+	return m.events, m.err
+}
+
+func TestDeviceEventsCollector(t *testing.T) {
+	cache := mockDeviceEventsCollectorCache{}
+	device := setupMockDevice(t, nil)
+	collector, err := newDeviceEventsCollectorWithCache(device, &cache)
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+
+	// make sure metadata is all good
+	uuid := device.GetDeviceInfo().UUID
+	require.Equal(t, uuid, collector.DeviceUUID())
+	require.Len(t, cache.uuids, 1)
+	require.Equal(t, cache.uuids[0], uuid)
+	require.Equal(t, deviceEvents, collector.Name())
+
+	// no metrics until no event is received
+	mm, err := collector.Collect()
+	require.NoError(t, err)
+	require.Empty(t, mm)
+
+	// make sure non-xid events are ignored
+	cache.events = []ddnvml.DeviceEventData{
+		{
+			DeviceUUID: uuid,
+			EventType:  nvml.EventMigConfigChange,
+		},
+	}
+	mm, err = collector.Collect()
+	require.NoError(t, err)
+	require.Empty(t, mm)
+
+	// add event to cache and check that metrics are properly computed.
+	// since we don't change events between subsequent calls, we check
+	// that the counter is increased
+	xidErrorsMetricName := "errors.xid.total"
+	cache.events = []ddnvml.DeviceEventData{
+		{
+			DeviceUUID: uuid,
+			EventType:  nvml.EventTypeXidCriticalError,
+			EventData:  31,
+		},
+	}
+	mm, err = collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, mm, 1)
+	assert.Equal(t, Metric{
+		Name:     xidErrorsMetricName,
+		Value:    1,
+		Type:     metrics.CountType,
+		Priority: High,
+		Tags:     []string{"type:31", "origin:hardware"},
+	}, mm[0])
+
+	mm, err = collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, mm, 1)
+	assert.Equal(t, float64(2), mm[0].Value)
+
+	// make sure different xid errors produce distinct metric contexts
+	cache.events = []ddnvml.DeviceEventData{
+		{
+			DeviceUUID: uuid,
+			EventType:  nvml.EventTypeXidCriticalError,
+			EventData:  12,
+		},
+	}
+	mm2, err := collector.Collect()
+	require.NoError(t, err)
+	require.Len(t, mm2, 2)
+	assert.Equal(t, []Metric{
+		{
+			Name:     xidErrorsMetricName,
+			Value:    1,
+			Type:     metrics.CountType,
+			Priority: High,
+			Tags:     []string{"type:12", "origin:driver"},
+		},
+		{
+			Name:     xidErrorsMetricName,
+			Value:    2,
+			Type:     metrics.CountType,
+			Priority: High,
+			Tags:     []string{"type:31", "origin:hardware"},
+		},
+	}, mm2)
+
+	// make sure there's no update in case we have no cached events
+	cache.events = nil
+	mm3, err := collector.Collect()
+	require.NoError(t, err)
+	require.Equal(t, mm2, mm3)
+}

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -215,7 +215,7 @@ func TestDeviceEventsCollector(t *testing.T) {
 	mm2, err := collector.Collect()
 	require.NoError(t, err)
 	require.Len(t, mm2, 2)
-	assert.Equal(t, []Metric{
+	assert.ElementsMatch(t, []Metric{
 		{
 			Name:     xidErrorsMetricName,
 			Value:    1,

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -82,14 +82,14 @@ type ebpfCollector struct {
 }
 
 // newEbpfCollector creates a new eBPF-based collector for the given device.
-func newEbpfCollector(device ddnvml.Device, cache *SystemProbeCache) (*ebpfCollector, error) {
-	if cache == nil {
+func newEbpfCollector(device ddnvml.Device, deps *CollectorDependencies) (*ebpfCollector, error) {
+	if deps.SystemProbeCache == nil {
 		return nil, fmt.Errorf("system-probe cache cannot be nil")
 	}
 
 	return &ebpfCollector{
 		device:        device,
-		cache:         cache,
+		cache:         deps.SystemProbeCache,
 		activeMetrics: make(map[model.StatsKey]bool),
 	}, nil
 }

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -82,14 +82,14 @@ type ebpfCollector struct {
 }
 
 // newEbpfCollector creates a new eBPF-based collector for the given device.
-func newEbpfCollector(device ddnvml.Device, deps *CollectorDependencies) (*ebpfCollector, error) {
-	if deps.SystemProbeCache == nil {
+func newEbpfCollector(device ddnvml.Device, cache *SystemProbeCache) (*ebpfCollector, error) {
+	if cache == nil {
 		return nil, fmt.Errorf("system-probe cache cannot be nil")
 	}
 
 	return &ebpfCollector{
 		device:        device,
-		cache:         deps.SystemProbeCache,
+		cache:         cache,
 		activeMetrics: make(map[model.StatsKey]bool),
 	}, nil
 }

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -113,7 +113,7 @@ func testCollectWithInvalidCache(t *testing.T) {
 	dev := createMockDevice(t, testutil.DefaultGpuUUID)
 	cache := NewSystemProbeCache()
 
-	collector, err := newEbpfCollector(dev, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(dev, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -138,7 +138,7 @@ func testCollectWithSingleActiveProcess(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(device, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -199,7 +199,7 @@ func testCollectWithMultipleActiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(device, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -239,7 +239,7 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(device, cache)
 	require.NoError(t, err)
 
 	// First collect with process 123
@@ -305,7 +305,7 @@ func testCollectFiltersByDeviceUUID(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(device, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -361,7 +361,7 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
+	collector, err := newEbpfCollector(device, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -113,7 +113,7 @@ func testCollectWithInvalidCache(t *testing.T) {
 	dev := createMockDevice(t, testutil.DefaultGpuUUID)
 	cache := NewSystemProbeCache()
 
-	collector, err := newEbpfCollector(dev, cache)
+	collector, err := newEbpfCollector(dev, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -138,7 +138,7 @@ func testCollectWithSingleActiveProcess(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -199,7 +199,7 @@ func testCollectWithMultipleActiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -239,7 +239,7 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	// First collect with process 123
@@ -305,7 +305,7 @@ func testCollectFiltersByDeviceUUID(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -361,7 +361,7 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &CollectorDependencies{SystemProbeCache: cache})
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()

--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -24,7 +24,7 @@ type fieldsCollector struct {
 	fieldMetrics []fieldValueMetric
 }
 
-func newFieldsCollector(device ddnvml.Device) (Collector, error) {
+func newFieldsCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
 	c := &fieldsCollector{
 		device: device,
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -69,7 +69,7 @@ var allGpmMetrics = map[nvml.GpmMetricId]gpmMetric{
 	},
 }
 
-func newGPMCollector(device ddnvml.Device) (c Collector, err error) {
+func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collector, err error) {
 	support, err := device.GpmQueryDeviceSupport()
 	if err != nil {
 		return nil, fmt.Errorf("failed to query for GPM support: %w", err)

--- a/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
@@ -30,7 +30,7 @@ func TestGPMCollectorSupportDetection(t *testing.T) {
 	mocklib := testutil.GetBasicNvmlMock()
 	safenvml.WithMockNVML(t, mocklib)
 
-	collector, err := newGPMCollector(mockDevice)
+	collector, err := newGPMCollector(mockDevice, nil)
 	assert.Nil(t, collector)
 	assert.ErrorIs(t, err, errUnsupportedDevice)
 	assert.Equal(t, 0, mockLib.freedSamples, "all allocated samples should be freed (none allocated in this case)")
@@ -48,7 +48,7 @@ func TestGPMCollectorSampleAllocFailure(t *testing.T) {
 
 	safenvml.WithMockNVML(t, mockLib)
 
-	collector, err := newGPMCollector(mockDevice)
+	collector, err := newGPMCollector(mockDevice, nil)
 	assert.Nil(t, collector)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to allocate GPM sample")
@@ -79,7 +79,7 @@ func TestGPMCollectorAllMetricsUnsupported(t *testing.T) {
 	}
 
 	safenvml.WithMockNVML(t, mockLib)
-	collector, err := newGPMCollector(mockDevice)
+	collector, err := newGPMCollector(mockDevice, nil)
 	assert.Nil(t, collector)
 	assert.ErrorIs(t, err, errUnsupportedDevice)
 }
@@ -112,7 +112,7 @@ func TestGPMCollectorSomeMetricsUnsupported(t *testing.T) {
 
 	safenvml.WithMockNVML(t, mockLib)
 
-	collector, err := newGPMCollector(mockDevice)
+	collector, err := newGPMCollector(mockDevice, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)
 	gpmCol := collector.(*gpmCollector)
@@ -189,7 +189,7 @@ func TestGPMCollectorCollectReturnsMetrics(t *testing.T) {
 
 	safenvml.WithMockNVML(t, mockLib)
 
-	collector, err := newGPMCollector(mockDevice)
+	collector, err := newGPMCollector(mockDevice, nil)
 	require.NoError(t, err)
 	gpmCol := collector.(*gpmCollector)
 

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -190,6 +190,6 @@ func newStatefulCollector(name CollectorName, device ddnvml.Device, apiCalls []a
 var sampleAPIFactory = createSampleAPIs
 
 // newSamplingCollector creates a collector that consolidates all sampling collector types
-func newSamplingCollector(device ddnvml.Device) (Collector, error) {
+func newSamplingCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
 	return newStatefulCollector(sampling, device, sampleAPIFactory())
 }

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -54,7 +54,7 @@ func TestNewSampleCollector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockDevice := setupMockDevice(t, tt.customSetup)
 
-			collector, err := newSamplingCollector(mockDevice)
+			collector, err := newSamplingCollector(mockDevice, nil)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -130,7 +130,7 @@ func TestCollectProcessUtilization(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice)
+			collector, err := newSamplingCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()
@@ -190,7 +190,7 @@ func TestCollectProcessUtilization_Error(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice)
+			collector, err := newSamplingCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()
@@ -267,7 +267,7 @@ func TestProcessUtilizationTimestampUpdate(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice)
+			collector, err := newSamplingCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			bc := collector.(*baseCollector)
@@ -374,7 +374,7 @@ func TestProcessUtilization_SmActiveCalculation(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice)
+			collector, err := newSamplingCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -399,6 +399,6 @@ func createStatelessAPIs() []apiCallInfo {
 var statelessAPIFactory = createStatelessAPIs
 
 // newStatelessCollector creates a collector that consolidates all stateless collector types
-func newStatelessCollector(device ddnvml.Device) (Collector, error) {
+func newStatelessCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
 	return NewBaseCollector(stateless, device, statelessAPIFactory())
 }

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -24,7 +24,7 @@ func TestNewStatelessCollector(t *testing.T) {
 	device := setupMockDevice(t, nil)
 
 	// Test that the stateless collector creates the expected dynamic API set
-	collector, err := newStatelessCollector(device)
+	collector, err := newStatelessCollector(device, nil)
 	require.NoError(t, err)
 	require.NotNil(t, collector)
 
@@ -93,7 +93,7 @@ func TestCollectProcessMemory(t *testing.T) {
 				return device
 			})
 
-			collector, err := newStatelessCollector(mockDevice)
+			collector, err := newStatelessCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()
@@ -127,7 +127,7 @@ func TestCollectProcessMemory_Error(t *testing.T) {
 		return device
 	})
 
-	collector, err := newStatelessCollector(mockDevice)
+	collector, err := newStatelessCollector(mockDevice, nil)
 	require.NoError(t, err)
 
 	processMetrics, err := collector.Collect()
@@ -166,7 +166,7 @@ func TestProcessMemoryMetricTags(t *testing.T) {
 		return device
 	})
 
-	collector, err := newStatelessCollector(mockDevice)
+	collector, err := newStatelessCollector(mockDevice, nil)
 	require.NoError(t, err)
 
 	processMetrics, err := collector.Collect()
@@ -276,7 +276,7 @@ func TestNVLinkCollector_Initialization(t *testing.T) {
 			}
 
 			mockDevice := setupMockDevice(t, tt.customSetup)
-			c, err := newStatelessCollector(mockDevice)
+			c, err := newStatelessCollector(mockDevice, nil)
 
 			if tt.wantError {
 				require.Error(t, err)
@@ -376,7 +376,7 @@ func TestNVLinkCollector_Collection(t *testing.T) {
 				return device
 			})
 
-			collector, err := newStatelessCollector(mockDevice)
+			collector, err := newStatelessCollector(mockDevice, nil)
 			require.NoError(t, err)
 
 			// Collect metrics

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -95,6 +95,19 @@ type SafeDevice interface {
 	IsMigDeviceHandle() (bool, error)
 	// GetVirtualizationMode returns the virtualization mode of the device
 	GetVirtualizationMode() (nvml.GpuVirtualizationMode, error)
+	// GetSupportedEventTypes returns a bitmask of all supported device events
+	GetSupportedEventTypes() (uint64, error)
+	// RegisterEvents registers the device for events to be waited in the given set
+	RegisterEvents(evtTypes uint64, evtSet nvml.EventSet) error
+}
+
+// DeviceEventData holds basic information about a device event
+type DeviceEventData struct {
+	DeviceUUID        string
+	EventType         uint64
+	EventData         uint64
+	GPUInstanceID     uint32
+	ComputeInstanceID uint32
 }
 
 // DeviceInfo holds common cached properties for a GPU device

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -332,3 +332,19 @@ func (d *safeDeviceImpl) GetVirtualizationMode() (nvml.GpuVirtualizationMode, er
 	mode, ret := d.nvmlDevice.GetVirtualizationMode()
 	return mode, NewNvmlAPIErrorOrNil("GetVirtualizationMode", ret)
 }
+
+func (d *safeDeviceImpl) GetSupportedEventTypes() (uint64, error) {
+	if err := d.lib.lookup(toNativeName("GetSupportedEventTypes")); err != nil {
+		return 0, err
+	}
+	types, ret := d.nvmlDevice.GetSupportedEventTypes()
+	return types, NewNvmlAPIErrorOrNil("GetSupportedEventTypes", ret)
+}
+
+func (d *safeDeviceImpl) RegisterEvents(evtTypes uint64, evtSet nvml.EventSet) error {
+	if err := d.lib.lookup(toNativeName("RegisterEvents")); err != nil {
+		return err
+	}
+	ret := d.nvmlDevice.RegisterEvents(evtTypes, evtSet)
+	return NewNvmlAPIErrorOrNil("RegisterEvents", ret)
+}

--- a/pkg/gpu/safenvml/errors.go
+++ b/pkg/gpu/safenvml/errors.go
@@ -55,3 +55,9 @@ func IsUnsupported(err error) bool {
 		(errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_NOT_SUPPORTED) ||
 			errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_FUNCTION_NOT_FOUND))
 }
+
+// IsTimeout checks if an error indicates that no event arrived in specified timeout or that an interrupt arrived
+func IsTimeout(err error) bool {
+	var nvmlErr *NvmlAPIError
+	return err != nil && errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_TIMEOUT)
+}

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -11,9 +11,11 @@
 package safenvml
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
@@ -48,6 +50,10 @@ func getNonCriticalAPIs() []string {
 		"nvmlGpmMetricsGet",
 		"nvmlGpmQueryDeviceSupport",
 		"nvmlGpmSampleGet",
+		"nvmlEventSetCreate",
+		"nvmlEventSetFree",
+		"nvmlEventSetWait_v1",
+		"nvmlEventSetWait_v2", // it can be either v1 or v2
 		toNativeName("GetArchitecture"),
 		toNativeName("GetAttributes"),
 		toNativeName("GetBAR1MemoryInfo"),
@@ -78,6 +84,8 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetUtilizationRates"),
 		toNativeName("IsMigDeviceHandle"),
 		toNativeName("GetVirtualizationMode"),
+		toNativeName("GetSupportedEventTypes"),
+		toNativeName("RegisterEvents"),
 	}
 }
 
@@ -105,6 +113,12 @@ type SafeNVML interface {
 	GpmSampleFree(sample nvml.GpmSample) error
 	// GpmMetricsGet calculates the metrics from the given samples
 	GpmMetricsGet(metrics *nvml.GpmMetricsGetType) error
+	// EventSetCreate creates an event set object
+	EventSetCreate() (nvml.EventSet, error)
+	// EventSetFree frees an event set object
+	EventSetFree(evtSet nvml.EventSet) error
+	// EventSetWait waits (up to timeout) for an event to appear on the given set and returns it
+	EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (DeviceEventData, error)
 }
 
 type safeNvml struct {
@@ -186,6 +200,54 @@ func (s *safeNvml) GpmMetricsGet(metrics *nvml.GpmMetricsGetType) error {
 	}
 	ret := s.lib.GpmMetricsGet(metrics)
 	return NewNvmlAPIErrorOrNil("GpmMetricsGet", ret)
+}
+
+func (d *safeNvml) EventSetCreate() (nvml.EventSet, error) {
+	if err := d.lookup("nvmlEventSetCreate"); err != nil {
+		return nil, err
+	}
+	evtSet, ret := d.lib.EventSetCreate()
+	return evtSet, NewNvmlAPIErrorOrNil("nvmlEventSetCreate", ret)
+}
+
+func (d *safeNvml) EventSetFree(evtSet nvml.EventSet) error {
+	if err := d.lookup("nvmlEventSetFree"); err != nil {
+		return err
+	}
+	ret := d.lib.EventSetFree(evtSet)
+	return NewNvmlAPIErrorOrNil("nvmlEventSetFree", ret)
+}
+
+func (d *safeNvml) EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (DeviceEventData, error) {
+	v1Err := errors.Join(d.lookup("nvmlEventSetWait_v1"))
+	v2Err := errors.Join(d.lookup("nvmlEventSetWait_v2"))
+	if v1Err != nil && v2Err != nil {
+		return DeviceEventData{}, errors.Join(v1Err, v2Err)
+	}
+	if timeout < time.Millisecond {
+		return DeviceEventData{}, errors.New("can't use sub-millisecond timeout in EventSetWait")
+	}
+
+	data, ret := d.lib.EventSetWait(evtSet, uint32(timeout.Milliseconds()))
+	retErr := NewNvmlAPIErrorOrNil("nvmlEventSetWait", ret)
+	safeData := DeviceEventData{
+		EventType:         data.EventType,
+		EventData:         data.EventData,
+		GPUInstanceID:     data.GpuInstanceId,
+		ComputeInstanceID: data.ComputeInstanceId,
+	}
+
+	// attempt safe resolution of device UUID
+	if data.Device != nil {
+		uuid, err := (&safeDeviceImpl{nvmlDevice: data.Device, lib: d}).GetUUID()
+		if err != nil {
+			err = fmt.Errorf("can't retrieve device UUID: %w", err)
+			return DeviceEventData{}, errors.Join(err, retErr)
+		}
+		safeData.DeviceUUID = uuid
+	}
+
+	return safeData, retErr
 }
 
 // populateCapabilities verifies nvml API symbols exist in the native library (libnvidia-ml.so).

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -202,25 +202,25 @@ func (s *safeNvml) GpmMetricsGet(metrics *nvml.GpmMetricsGetType) error {
 	return NewNvmlAPIErrorOrNil("GpmMetricsGet", ret)
 }
 
-func (d *safeNvml) EventSetCreate() (nvml.EventSet, error) {
-	if err := d.lookup("nvmlEventSetCreate"); err != nil {
+func (s *safeNvml) EventSetCreate() (nvml.EventSet, error) {
+	if err := s.lookup("nvmlEventSetCreate"); err != nil {
 		return nil, err
 	}
-	evtSet, ret := d.lib.EventSetCreate()
+	evtSet, ret := s.lib.EventSetCreate()
 	return evtSet, NewNvmlAPIErrorOrNil("nvmlEventSetCreate", ret)
 }
 
-func (d *safeNvml) EventSetFree(evtSet nvml.EventSet) error {
-	if err := d.lookup("nvmlEventSetFree"); err != nil {
+func (s *safeNvml) EventSetFree(evtSet nvml.EventSet) error {
+	if err := s.lookup("nvmlEventSetFree"); err != nil {
 		return err
 	}
-	ret := d.lib.EventSetFree(evtSet)
+	ret := s.lib.EventSetFree(evtSet)
 	return NewNvmlAPIErrorOrNil("nvmlEventSetFree", ret)
 }
 
-func (d *safeNvml) EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (DeviceEventData, error) {
-	v1Err := errors.Join(d.lookup("nvmlEventSetWait_v1"))
-	v2Err := errors.Join(d.lookup("nvmlEventSetWait_v2"))
+func (s *safeNvml) EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (DeviceEventData, error) {
+	v1Err := errors.Join(s.lookup("nvmlEventSetWait_v1"))
+	v2Err := errors.Join(s.lookup("nvmlEventSetWait_v2"))
 	if v1Err != nil && v2Err != nil {
 		return DeviceEventData{}, errors.Join(v1Err, v2Err)
 	}
@@ -228,7 +228,7 @@ func (d *safeNvml) EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (De
 		return DeviceEventData{}, errors.New("can't use sub-millisecond timeout in EventSetWait")
 	}
 
-	data, ret := d.lib.EventSetWait(evtSet, uint32(timeout.Milliseconds()))
+	data, ret := s.lib.EventSetWait(evtSet, uint32(timeout.Milliseconds()))
 	retErr := NewNvmlAPIErrorOrNil("nvmlEventSetWait", ret)
 	safeData := DeviceEventData{
 		EventType:         data.EventType,
@@ -239,7 +239,7 @@ func (d *safeNvml) EventSetWait(evtSet nvml.EventSet, timeout time.Duration) (De
 
 	// attempt safe resolution of device UUID
 	if data.Device != nil {
-		uuid, err := (&safeDeviceImpl{nvmlDevice: data.Device, lib: d}).GetUUID()
+		uuid, err := (&safeDeviceImpl{nvmlDevice: data.Device, lib: s}).GetUUID()
 		if err != nil {
 			err = fmt.Errorf("can't retrieve device UUID: %w", err)
 			return DeviceEventData{}, errors.Join(err, retErr)

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
-	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"go.uber.org/fx"
 
@@ -311,7 +310,7 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 			return DefaultNvidiaDriverVersion, nvml.SUCCESS
 		},
 		EventSetCreateFunc: func() (nvml.EventSet, nvml.Return) {
-			return &mock.EventSet{
+			return &nvmlmock.EventSet{
 				FreeFunc: func() nvml.Return {
 					return nvml.SUCCESS
 				},

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -266,6 +266,12 @@ func WithDeviceCount(count int) NvmlMockOption {
 			lib.DeviceGetCountFunc = func() (int, nvml.Return) {
 				return count, nvml.SUCCESS
 			}
+			lib.DeviceGetHandleByIndexFunc = func(index int) (nvml.Device, nvml.Return) {
+				if index >= count {
+					return nil, nvml.ERROR_INVALID_ARGUMENT
+				}
+				return GetDeviceMock(index), nvml.SUCCESS
+			}
 		})
 	}
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -11,8 +11,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"go.uber.org/fx"
 
@@ -175,6 +177,9 @@ func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Devi
 		GetVirtualizationModeFunc: func() (nvml.GpuVirtualizationMode, nvml.Return) {
 			return nvml.GPU_VIRTUALIZATION_MODE_NONE, nvml.SUCCESS
 		},
+		GetSupportedEventTypesFunc: func() (uint64, nvml.Return) {
+			return nvml.EventTypeAll, nvml.SUCCESS
+		},
 	}
 
 	for _, opt := range opts {
@@ -255,6 +260,26 @@ func WithMIGDisabled() NvmlMockOption {
 	}
 }
 
+// WithDeviceCount influences the return value of DeviceGetCount for the nvml mock
+func WithDeviceCount(count int) NvmlMockOption {
+	return func(o *nvmlMockOptions) {
+		o.libOptions = append(o.libOptions, func(lib *nvmlmock.Interface) {
+			lib.DeviceGetCountFunc = func() (int, nvml.Return) {
+				return count, nvml.SUCCESS
+			}
+		})
+	}
+}
+
+// WithEventSetCreate influences the definition of EventSetCreateFunc
+func WithEventSetCreate(eventSetCreate func() (nvml.EventSet, nvml.Return)) NvmlMockOption {
+	return func(o *nvmlMockOptions) {
+		o.libOptions = append(o.libOptions, func(lib *nvmlmock.Interface) {
+			lib.EventSetCreateFunc = eventSetCreate
+		})
+	}
+}
+
 // GetBasicNvmlMock returns a mock of the nvml.Interface with a single device with 10 cores,
 // useful for basic tests that need only the basic interaction with NVML to be working.
 func GetBasicNvmlMock() *nvmlmock.Interface {
@@ -284,6 +309,23 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 		},
 		SystemGetDriverVersionFunc: func() (string, nvml.Return) {
 			return DefaultNvidiaDriverVersion, nvml.SUCCESS
+		},
+		EventSetCreateFunc: func() (nvml.EventSet, nvml.Return) {
+			return &mock.EventSet{
+				FreeFunc: func() nvml.Return {
+					return nvml.SUCCESS
+				},
+				WaitFunc: func(v uint32) (nvml.EventData, nvml.Return) {
+					time.Sleep(time.Duration(v) * time.Millisecond)
+					return nvml.EventData{}, nvml.ERROR_TIMEOUT
+				},
+			}, nvml.SUCCESS
+		},
+		EventSetFreeFunc: func(eventSet nvml.EventSet) nvml.Return {
+			return eventSet.Free()
+		},
+		EventSetWaitFunc: func(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return) {
+			return eventSet.Wait(v)
 		},
 		ExtensionsFunc: opts.extensionsFunc,
 	}

--- a/releasenotes/notes/gpu-xid-error-metric-bce4098236a91879.yaml
+++ b/releasenotes/notes/gpu-xid-error-metric-bce4098236a91879.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    GPU: emit count metrics for NVIDIA Xid errors


### PR DESCRIPTION
### What does this PR do?

This adds a new `gpu.errors.xid.total` metric counting [xid errors on NVIDIA devices](https://docs.nvidia.com/deploy/xid-errors/index.html). The metric has context partitioned by device and xid error code.

Behind the scenes, this is implemented through a more comprehensive async collector of NVIDIA device events, which in the future could be used for computing new metrics in the future.

### Motivation

Xid errors represent runtime failures in GPUs, thus giving valuable visibility on the health of each device.

### Describe how you validated your changes

Unit tests, plus running it live with custom GPU kernel causing invalid memory access.

### Additional Notes
