### PR TITLE
KSM Core: Container resources metrics are now only emitted for scheduled pods

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -197,7 +197,8 @@ func containerResourceOwnerGenerator(c v1.Container, p *v1.Pod, resourceType str
 // owner of the pod.
 func (f *extendedPodFactory) customResourceOwnerGenerator(p *v1.Pod, resourceType string, contType ContainerType) *metric.Family {
 	// We want to omit pods that have succeeded, as those no longer count towards resource allocation
-	if p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
+	// We also skip Pods that are not scheduled yet as their request/limits value are not actually allocated yet
+	if p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed || p.Spec.NodeName == "" {
 		return &metric.Family{}
 	}
 

--- a/releasenotes/notes/ksm-metrics-scheduled-0b476a8be2beecf9.yaml
+++ b/releasenotes/notes/ksm-metrics-scheduled-0b476a8be2beecf9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The following Kubernetes State Core check metrics now aggregate only scheduled Pods to reflect actually used resources:
+    - `kubernetes_state.container.<cpu|memory>_requested.total`
+    - `kubernetes_state.container.<cpu|memory>_limit.total`


### PR DESCRIPTION
### What does this PR do?

The KSM metrics `kubernetes_state.container.<cpu|memory>_<requested|limit>.total` currently consider all Pods in the cluster, which does not reflect the resources _actually requested_, since the unscheduled Pods do not participate in the used capacity.

### Motivation

Better reflect the actually requested resources in the Cluster.

### Describe how you validated your changes

Deploy Pods with impossible to satisfy resource requests (like 50M CPU), observe that the `kubernetes_state.container.<cpu|memory>_<requested|limit>.total` are not affected by these unscheduled Pods.

### Additional Notes
