### PR TITLE
[CONS-7687] Fix container filter for podman

### DIFF
--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -61,23 +61,13 @@ var ContainerRegexp = regexp.MustCompile(ContainerRegexpStr)
 
 // ContainerFilter returns a filter that will match cgroup folders containing a container id
 func ContainerFilter(_, name string) (string, error) {
-	// Handle libpod- prefix for Podman rootless containers
-	// Rootless Podman uses cgroup paths like: libpod-<container-id>.scope
-	if strings.HasPrefix(name, "libpod-") {
-		// Filter out libpod conmon processes (container monitor)
-		if strings.HasPrefix(name, "libpod-conmon-") {
-			return "", nil
-		}
-		name = strings.TrimPrefix(name, "libpod-")
-		name = strings.TrimSuffix(name, ".scope")
-	}
-
 	match := ContainerRegexp.FindString(name)
 
 	// With systemd cgroup driver, there may be a `.mount` cgroup on top of the normal one
 	// While existing, no process is attached to it and thus holds no stats
+	// Also filter out conmon monitor processes for CRI-O and Podman
 	if match != "" {
-		if strings.HasSuffix(name, ".mount") || strings.HasPrefix(name, "crio-conmon-") {
+		if strings.HasSuffix(name, ".mount") || strings.HasPrefix(name, "crio-conmon-") || strings.HasPrefix(name, "libpod-conmon-") {
 			return "", nil
 		}
 

--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -61,6 +61,17 @@ var ContainerRegexp = regexp.MustCompile(ContainerRegexpStr)
 
 // ContainerFilter returns a filter that will match cgroup folders containing a container id
 func ContainerFilter(_, name string) (string, error) {
+	// Handle libpod- prefix for Podman rootless containers
+	// Rootless Podman uses cgroup paths like: libpod-<container-id>.scope
+	if strings.HasPrefix(name, "libpod-") {
+		// Filter out libpod conmon processes (container monitor)
+		if strings.HasPrefix(name, "libpod-conmon-") {
+			return "", nil
+		}
+		name = strings.TrimPrefix(name, "libpod-")
+		name = strings.TrimSuffix(name, ".scope")
+	}
+
 	match := ContainerRegexp.FindString(name)
 
 	// With systemd cgroup driver, there may be a `.mount` cgroup on top of the normal one


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where processes running in Podman rootless containers are not associated with their containers in the Datadog UI. This PR implements two minimal fixes to correctly detect and collect PIDs from Podman rootless containers.

### Motivation
**Root Cause**:
At `pkg/process/util/containers/containers.go:180`, `collector.GetPIDs()` returns `nil` because podman places PIDs in a `/container` subdirectory within the cgroup, not in the parent `cgroup.procs` file.

#### Cgroup Structure in Podman Rootless:
```
/sys/fs/cgroup/.../libpod-<container-id>.scope/
├── cgroup.procs          
└── container/
    └── cgroup.procs      ← PIDs ARE HERE
```

### Describe how you validated your changes
#### Setup Podman Rootless Environment
```bash
# Run test containers
podman run -d --name tomcat-test tomcat:latest
podman run -d --name nginx-test nginx:latest

podman machine ssh cons7687-test -- 'podman ps'
  ⎿  CONTAINER ID  IMAGE                                         COMMAND               CREATED         STATUS         PORTS               NAMES         
     cc46e4fa01a5  docker.io/library/tomcat:latest               catalina.sh run       2 hours ago     Up 2 hours     8080/tcp            tomcat-test
     e642fd5db33e  docker.io/library/nginx:latest                nginx -g daemon o...  2 hours ago     Up 2 hours     80/tcp              nginx-test
     53a87c9161f1  agent               /bin/entrypoint.s...  17 minutes ago  Up 17 minutes  8126/tcp, 8125/udp  dd-agent-fixed

# Verify libpod- cgroup paths
podman inspect tomcat-test --format "{{.State.Pid}}"  # Get PID
cat /proc/<PID>/cgroup  # Should show: ...libpod-<container-id>.scope/...
```

Verify cgroup path pattern
```
#For Tomcat Container (PID 2451):
cat /proc/2451/cgroup
  0::/user.slice/user-503.slice/user@503.service/user.slice/libpod-cc46e4fa01a5bdd083625c1fdf39f78ac08b5aa8b67ace49a8c5fae18c55f14e.scope/container

#For Nginx Container (PID 2618):
cat /proc/2618/cgroup
  0::/user.slice/user-503.slice/user@503.service/user.slice/libpod-e642fd5db33e09804ca98cbaed18b96ee50a85e82a242ea2f0df3f00bdbf6654.scope/container
```
Notice that container subdir inside cgroup path

#### Install Agent and Verify
1.  Check agent status: `datadog-agent status`

2. Verify in Datadog UI:
- Go to Infrastructure → Containers
- Search for your hostname
- Check Processes linked to containers - should show java/tomcat process 
<img width="1664" height="859" alt="Screenshot 2025-10-02 at 3 08 38 PM" src="https://github.com/user-attachments/assets/a8cb8b67-0b80-47d3-9dd8-c64d23b76b33" />




### Additional Notes

