### PR TITLE
Fix VT scan on feature branches

### DIFF
--- a/.gitlab/scan/windows.yml
+++ b/.gitlab/scan/windows.yml
@@ -2,6 +2,10 @@
   stage: scan
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  rules:
+    - !reference [.on_deploy]
+    - !reference [.on_main]
+    - !reference [.except_mergequeue]
   variables:
     SCAN_ARTIFACT_PATTERN: "datadog-agent-7*.msi"
     OMNIBUS_PIPELINE_DIR: $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
@@ -13,11 +17,6 @@
     - dda inv --feat virustotal -- virustotal.submit --omnibus-pipeline-dir $OMNIBUS_PIPELINE_DIR --pattern $SCAN_ARTIFACT_PATTERN
 
 scan_packages_windows-x64:
-  rules:
-    - !reference [.on_deploy]
-    - !reference [.on_main]
-    - !reference [.except_mergequeue]
-    - when: on_success
   extends: .scan_windows_package
   needs: ["windows_msi_and_bosh_zip_x64-a7"]
   variables:
@@ -25,11 +24,6 @@ scan_packages_windows-x64:
   allow_failure: true
 
 scan_packages_windows-fips-x64:
-  rules:
-    - !reference [.on_deploy]
-    - !reference [.on_main]
-    - !reference [.except_mergequeue]
-    - when: on_success
   extends: .scan_windows_package
   needs: ["windows_msi_and_bosh_zip_x64-a7-fips"]
   variables:


### PR DESCRIPTION
### What does this PR do?
This PR fixes the VT scan to run only on `main` commit and deploy branches.
The `when: on_success` was causing it run in every commit.

### Motivation
Correct job definition for the VT scans.

### Describe how you validated your changes
No more VT scanning in branches.

### Additional Notes
