### PR TITLE
Add coat metric about state of trace-agent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -358,6 +358,7 @@
 /comp/metadata/packagesigning @DataDog/agent-delivery
 /comp/process/connectionscheck @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
 /comp/trace/etwtracer @DataDog/windows-products
+/comp/trace-telemetry @DataDog/agent-runtimes
 /comp/updater/daemonchecker @DataDog/fleet
 /comp/updater/ssistatus @DataDog/fleet
 /comp/autoscaling/datadogclient @DataDog/container-integrations

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -150,6 +150,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/snmptraps"
 	snmptrapsServer "github.com/DataDog/datadog-agent/comp/snmptraps/server"
 	syntheticsTestsfx "github.com/DataDog/datadog-agent/comp/syntheticstestscheduler/fx"
+	tracetelemetryfx "github.com/DataDog/datadog-agent/comp/trace-telemetry/fx"
 	traceagentStatusImpl "github.com/DataDog/datadog-agent/comp/trace/status/statusimpl"
 	daemoncheckerfx "github.com/DataDog/datadog-agent/comp/updater/daemonchecker/fx"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
@@ -534,6 +535,7 @@ func getSharedFxOption() fx.Option {
 		workloadfilterfx.Module(),
 		connectivitycheckerfx.Module(),
 		configstreamfx.Module(),
+		tracetelemetryfx.Module(),
 	)
 }
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -674,6 +674,12 @@ Package payloadmodifier defines the trace payload modifier component interface
 
 Package status implements the core status component information provider interface
 
+### [comp/trace-telemetry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/trace-telemetry)
+
+*Datadog Team*: agent-runtimes
+
+Package tracetelemetry sends telemetry about the trace-agent and its state
+
 ## [comp/updater](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/updater) (Component Bundle)
 
 *Datadog Team*: fleet windows-products

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -457,16 +457,16 @@ func TestRun(t *testing.T) {
 
 	a.start()
 
-	// Default configuration has 4 jobs with different schedules:
-	assert.Equal(t, 4, len(r.(*runnerMock).jobs))
+	// Default configuration has 5 jobs with different schedules:
+	assert.Equal(t, 5, len(r.(*runnerMock).jobs))
 
 	// Verify we have the expected number of profiles across all jobs
 	totalProfiles := 0
 	for _, job := range r.(*runnerMock).jobs {
 		totalProfiles += len(job.profiles)
 	}
-	// Default config has 10 profiles total (checks, logs-and-metrics, database, api, ondemand, service-discovery, runtime-started, runtime-running, hostname, otlp)
-	assert.Equal(t, 10, totalProfiles)
+	// Default config has 11 profiles total (checks, logs-and-metrics, database, api, ondemand, service-discovery, runtime-started, runtime-running, hostname, otlp, trace-agent)
+	assert.Equal(t, 11, totalProfiles)
 }
 
 func TestReportMetricBasic(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -376,6 +376,18 @@ var defaultProfiles = `
       start_after: 30
       iterations: 0
       period: 900
+  - name: trace-agent
+    metric:
+      exclude:
+        zero_metric: true
+      metrics:
+        - name: trace.running
+          aggregate_tags:
+            - state
+    schedule:
+      start_after: 30
+      iterations: 0
+      period: 900
 `
 
 func compileMetricsExclude(p *Profile) error {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -385,7 +385,7 @@ var defaultProfiles = `
           aggregate_tags:
             - state
     schedule:
-      start_after: 30
+      start_after: 60
       iterations: 0
       period: 900
 `

--- a/comp/trace-telemetry/def/component.go
+++ b/comp/trace-telemetry/def/component.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package tracetelemetry sends telemetry about the trace-agent and its state
+package tracetelemetry
+
+// team: agent-runtimes
+
+// Component is the component type.
+type Component interface{}

--- a/comp/trace-telemetry/fx/fx.go
+++ b/comp/trace-telemetry/fx/fx.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the trace-telemetry component
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	tracetelemetry "github.com/DataDog/datadog-agent/comp/trace-telemetry/def"
+	tracetelemetryimpl "github.com/DataDog/datadog-agent/comp/trace-telemetry/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			tracetelemetryimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[tracetelemetry.Component](),
+		// force the instantiation of trace-telemetry
+		fx.Invoke(func(_ tracetelemetry.Component) {}),
+	)
+}

--- a/comp/trace-telemetry/impl/trace-telemetry.go
+++ b/comp/trace-telemetry/impl/trace-telemetry.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package tracetelemetryimpl implements the trace-telemetry component interface
+package tracetelemetryimpl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	"github.com/DataDog/datadog-agent/comp/core/ipc/httphelpers"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	tracetelemetry "github.com/DataDog/datadog-agent/comp/trace-telemetry/def"
+)
+
+// Requires defines the dependencies for the trace-telemetry component
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+
+	Config    config.Component
+	Client    ipc.HTTPClient
+	Telemetry telemetry.Component
+}
+
+// Provides defines the output of the trace-telemetry component
+type Provides struct {
+	Comp tracetelemetry.Component
+}
+
+type tracetelemetryImpl struct {
+	config config.Component
+	client ipc.HTTPClient
+	metric telemetry.Gauge
+
+	// whether the trace-agent is running
+	running atomic.Bool
+	// whether the trace-agent is sending data
+	sending atomic.Bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewComponent creates a new trace-telemetry component
+func NewComponent(reqs Requires) (Provides, error) {
+	metric := reqs.Telemetry.NewGauge("trace", "running", []string{"state"}, "Whether the trace-agent is running and sending data")
+
+	t := &tracetelemetryImpl{
+		config: reqs.Config,
+		client: reqs.Client,
+		metric: metric,
+	}
+	provides := Provides{
+		Comp: t,
+	}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(_ context.Context) error {
+			t.Start()
+			return nil
+		},
+		OnStop: func(_ context.Context) error {
+			t.Stop()
+			return nil
+		},
+	})
+
+	return provides, nil
+}
+
+type traceAgentExpvars struct {
+	TraceWriterValues traceWriter `json:"trace_writer"`
+	StatsWriterValues statsWriter `json:"stats_writer"`
+}
+
+type traceWriter struct {
+	Bytes int64 `json:"bytes"`
+}
+
+type statsWriter struct {
+	Bytes int64 `json:"bytes"`
+}
+
+func (t *tracetelemetryImpl) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.ctx = ctx
+	t.cancel = cancel
+
+	go func() {
+		// trace-agent resets the expvars every minute
+		ticker := time.NewTicker(time.Second * 50)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				t.updateState()
+
+				var state string
+				if t.running.Load() {
+					if t.sending.Load() {
+						state = "working"
+					} else {
+						state = "idle"
+					}
+				} else {
+					state = "off"
+				}
+				t.metric.Set(1, state)
+			case <-t.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (t *tracetelemetryImpl) getTraceAgentExpvars() (traceAgentExpvars, error) {
+	port := t.config.GetInt("apm_config.debug.port")
+
+	url := fmt.Sprintf("https://localhost:%d/debug/vars", port)
+	resp, err := t.client.Get(url, httphelpers.WithCloseConnection)
+	if err != nil {
+		return traceAgentExpvars{}, err
+	}
+
+	var values traceAgentExpvars
+	if err := json.Unmarshal(resp, &values); err != nil {
+		return traceAgentExpvars{}, err
+	}
+	return values, nil
+}
+
+func (t *tracetelemetryImpl) updateState() {
+	if t.sending.Load() {
+		// if we've established that trace-agent is sending data, don't update the state
+		return
+	}
+
+	values, err := t.getTraceAgentExpvars()
+	if err != nil {
+		// keep previous information that we had about trace-agent
+		return
+	}
+
+	t.running.Store(true)
+	if values.TraceWriterValues.Bytes > 0 || values.StatsWriterValues.Bytes > 0 {
+		t.sending.Store(true)
+	}
+}
+
+func (t *tracetelemetryImpl) Stop() {
+	t.cancel()
+}


### PR DESCRIPTION
### What does this PR do?
Add a coat metric about state of trace-agent.

### Motivation
Having telemetry on whether the trace-agent is running, and if so whether it sends data to the backend.

### Describe how you validated your changes
Manually checked that it worked as expected, for each of the three "states" (off, idle, working).

### Additional Notes
