### PR TITLE
[serverless] disable integration tests

### DIFF
--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,17 +1,18 @@
 name: "Serverless Integration Tests"
 
 on:
-  pull_request:
-    branches-ignore:
-      - 'mq-working-branch-*'
-    paths:
-      - 'cmd/serverless/**'
-      - 'pkg/serverless/**'
-      - 'test/integration/serverless/**'
-      - '.github/workflows/serverless-integration.yml'
-      - 'go.mod'
-  schedule:
-    - cron: '0 14 * * *' # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
+  # -- Disabled, only runs manually --
+  # pull_request:
+  #   branches-ignore:
+  #     - 'mq-working-branch-*'
+  #   paths:
+  #     - 'cmd/serverless/**'
+  #     - 'pkg/serverless/**'
+  #     - 'test/integration/serverless/**'
+  #     - '.github/workflows/serverless-integration.yml'
+  #     - 'go.mod'
+  # schedule:
+  #   - cron: '0 14 * * *' # cron schedule uses UTC timezone. Run tests at the beginning of the day in US-East
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
### What does this PR do?

Disables the Serverless integration tests in Pull Requests and CRON jobs.

### Motivation

We haven't updated the code in a couple months and we no longer will package the Go Datadog Agent for Serverless in AWS Lambda – which the tests check on.

### Describe how you validated your changes

N/A

### Additional Notes

Tests are outdated and we don't currently have an owner for them.
