### PR TITLE
[EBPF] kmt: skip local test jobs on mergequeue

### DIFF
--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -6,6 +6,7 @@
   needs: []
   rules:
     - !reference [.on_invoke_tasks_changes]
+    - !reference [.except_mergequeue]
   script:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "git@github.com:"
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)


### PR DESCRIPTION
### What does this PR do?

Ensures `kmt_local_test_*` jobs do not run on the MQ.

### Motivation

While they don't make the MQ longer, the frequency of KMT python changes is low enough that it's more likely for these jobs to cause problems (specially the macOS one) than to catch issues.

### Describe how you validated your changes

CI passing.

### Additional Notes
