### PR TITLE
Retry fetching the Cluster ID for host tags

### DIFF
--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -23,6 +23,7 @@ import (
 	ec2tags "github.com/DataDog/datadog-agent/pkg/util/ec2/tags"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/cloudprovider"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clusterinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -66,6 +67,7 @@ func getProvidersDefinitions(conf model.Reader) map[string]*providerDef {
 
 	if env.IsFeaturePresent(env.Kubernetes) {
 		providers["kubernetes"] = &providerDef{10, k8s.NewKubeNodeTagsProvider(conf).GetTags}
+		providers["kubernetes_cluster_agent_tags"] = &providerDef{10, clusterinfo.GetClusterAgentStaticTags}
 	}
 
 	if env.IsFeaturePresent(env.Docker) {
@@ -143,10 +145,6 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 			log.Info("Adding both tags cluster_name and kube_cluster_name. You can use 'disable_cluster_name_tag_key' in the Agent config to keep the kube_cluster_name tag only")
 		}
 		hostTags = appendToHostTags(hostTags, clusterNameTags)
-	}
-
-	if clusterID, err := clustername.GetClusterID(); err == nil && clusterID != "" {
-		hostTags = appendToHostTags(hostTags, []string{tags.OrchClusterID + ":" + clusterID})
 	}
 
 	if kubeDistro, err := cloudprovider.GetName(ctx); err == nil && kubeDistro != "" {

--- a/go.mod
+++ b/go.mod
@@ -541,7 +541,7 @@ require (
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chrusty/protoc-gen-jsonschema v0.0.0-20240212064413-73d5723042b8 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect

--- a/pkg/util/kubernetes/clusterinfo/tags.go
+++ b/pkg/util/kubernetes/clusterinfo/tags.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package clusterinfo provides utilities to retrieve cluster information from the Cluster Agent
+package clusterinfo
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/cenkalti/backoff/v5"
+)
+
+// GetClusterAgentStaticTags gets the tags from the cluster-agent
+// Currently only ClusterID for orch_cluster_id tag
+// Context is passed to match the host tags interface
+func GetClusterAgentStaticTags(context.Context) ([]string, error) {
+	clusterID, err := clustername.GetClusterID()
+	if err != nil {
+		return nil, err
+	}
+
+	if clusterID != "" {
+		return []string{tags.OrchClusterID + ":" + clusterID}, nil
+	}
+
+	return nil, nil
+}
+
+// GetClusterAgentStaticTagsWithRetry gets the tags from the cluster-agent with a constant backoff policy
+func GetClusterAgentStaticTagsWithRetry() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	backoffPolicy := backoff.NewConstantBackOff(1 * time.Second)
+	res, err := backoff.Retry(ctx, func() ([]string, error) {
+		return GetClusterAgentStaticTags(ctx)
+	}, backoff.WithBackOff(backoffPolicy))
+
+	return res, err
+}


### PR DESCRIPTION
### What does this PR do?

Fix cases where the Cluster ID is not send in host tags as the Cluster Agent was not yet ready or the calls failed for any reason.

### Motivation

The Cluster ID has become a key information that we cannot miss similarly to the cluster name.

### Describe how you validated your changes

Non-regression only, deploy the Agent+Cluster Agent in Kubernetes and verify that the host tags on the **node** Agent contains the cluster id tag.

### Additional Notes
