### PR TITLE
[EBPF] gpu: fix panic in stream handling

### DIFF
--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -245,6 +245,8 @@ func (c *cudaEventConsumer) handleStreamEvent(header *gpuebpf.CudaEventHeader, d
 		if logLimitProbe.ShouldLog() {
 			log.Warnf("error getting stream handler for stream id %d: %v", header.Stream_id, err)
 		}
+
+		return err
 	}
 
 	switch eventType {

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -245,7 +245,6 @@ func (c *cudaEventConsumer) handleStreamEvent(header *gpuebpf.CudaEventHeader, d
 		if logLimitProbe.ShouldLog() {
 			log.Warnf("error getting stream handler for stream id %d: %v", header.Stream_id, err)
 		}
-
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

If we have an error getting the current stream, we should not try to process the event.

### Motivation

#incident-43873 

### Describe how you validated your changes

Added unit test reproducing the panic.

### Additional Notes

This failure path existed previously, where we would ignore the error from `getStream`, but in practice there were no situations were errors were emitted. However, with https://github.com/DataDog/datadog-agent/pull/41518 it was more frequent for this function to emit an error, which meant we were now triggering the bugged code path.