### PR TITLE
[APM] Skip macrobenchmarks on coverage pipelines

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -6,9 +6,9 @@ variables:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   timeout: 1h
   rules:
+    - !reference [.except_coverage_pipeline]
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
-    - !reference [.except_coverage_pipeline]
     - !reference [.on_scheduled_main]
     - !reference [.manual]
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -10,6 +10,7 @@ variables:
       when: always
     - !reference [.on_scheduled_main]
     - !reference [.manual]
+    - !reference [.except_coverage_pipeline]
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
   needs: ["setup_agent_version"]

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -8,9 +8,9 @@ variables:
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
+    - !reference [.except_coverage_pipeline]
     - !reference [.on_scheduled_main]
     - !reference [.manual]
-    - !reference [.except_coverage_pipeline]
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
   needs: ["setup_agent_version"]


### PR DESCRIPTION
### What does this PR do?
This pipeline creates a duplicated artifact that performs worse than regular builds. It should not be used on macrobenchmarks results.

### Motivation

### Describe how you validated your changes

### Additional Notes
