### PR TITLE
[EBPF-836] update(gpu): support gpu hotplug and dynamic device list changes

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -32,9 +32,10 @@ const (
 var logLimiter = log.NewLogLimit(20, 10*time.Minute)
 
 type collector struct {
-	id      string
-	catalog workloadmeta.AgentType
-	store   workloadmeta.Component
+	id        string
+	catalog   workloadmeta.AgentType
+	store     workloadmeta.Component
+	seenUUIDs map[string]struct{}
 }
 
 func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, error) {
@@ -141,8 +142,9 @@ func (c *collector) fillProcesses(gpuDeviceInfo *workloadmeta.GPU, device ddnvml
 func NewCollector() (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
-			id:      collectorID,
-			catalog: workloadmeta.NodeAgent,
+			id:        collectorID,
+			catalog:   workloadmeta.NodeAgent,
+			seenUUIDs: map[string]struct{}{},
 		},
 	}, nil
 }
@@ -169,27 +171,33 @@ func (c *collector) Pull(_ context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get NVML library : %w", err)
 	}
+
 	deviceCache := ddnvml.NewDeviceCacheWithOptions(lib)
-	if err := deviceCache.EnsureInit(); err != nil {
+	if err := deviceCache.Refresh(); err != nil {
 		return fmt.Errorf("failed to initialize device cache: %w", err)
 	}
+
 	// driver version is equal to all devices of the same vendor
 	// currently we handle only nvidia.
 	// in the future this function should be refactored to support more vendors
 	driverVersion, err := lib.SystemGetDriverVersion()
-	//we try to get the driver version as best effort, just log warning if it fails
+	// we try to get the driver version as best effort, just log warning if it fails
 	if err != nil {
 		if logLimiter.ShouldLog() {
 			log.Warnf("%v", err)
 		}
 	}
 
-	var events []workloadmeta.CollectorEvent
+	// note: the device list can change over time so we need to set/unset for reconciliation
 	allDevices, err := deviceCache.All()
 	if err != nil {
 		// Should not happen as we check the last init error for the library
 		return fmt.Errorf("failed to get all devices: %w", err)
 	}
+
+	// add/update current devices
+	seenUUIDs := map[string]struct{}{}
+	var events []workloadmeta.CollectorEvent
 	for _, dev := range allDevices {
 		gpu, err := c.getGPUDeviceInfo(dev)
 		gpu.DriverVersion = driverVersion
@@ -203,7 +211,28 @@ func (c *collector) Pull(_ context.Context) error {
 			Entity: gpu,
 		}
 		events = append(events, event)
+		seenUUIDs[dev.GetDeviceInfo().UUID] = struct{}{}
 	}
+
+	// remove previous devices that are no more available
+	for uuid := range c.seenUUIDs {
+		if _, ok := seenUUIDs[uuid]; ok {
+			continue
+		}
+
+		events = append(events, workloadmeta.CollectorEvent{
+			Source: workloadmeta.SourceRuntime,
+			Type:   workloadmeta.EventTypeUnset,
+			Entity: &workloadmeta.GPU{
+				EntityID: workloadmeta.EntityID{
+					ID:   uuid,
+					Kind: workloadmeta.KindGPU,
+				},
+			},
+		})
+	}
+
+	c.seenUUIDs = seenUUIDs
 
 	c.store.Notify(events)
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -196,7 +196,7 @@ func (c *collector) Pull(_ context.Context) error {
 	}
 
 	// add/update current devices
-	seenUUIDs := map[string]struct{}{}
+	currentUUIDs := map[string]struct{}{}
 	var events []workloadmeta.CollectorEvent
 	for _, dev := range allDevices {
 		gpu, err := c.getGPUDeviceInfo(dev)
@@ -211,12 +211,12 @@ func (c *collector) Pull(_ context.Context) error {
 			Entity: gpu,
 		}
 		events = append(events, event)
-		seenUUIDs[dev.GetDeviceInfo().UUID] = struct{}{}
+		currentUUIDs[dev.GetDeviceInfo().UUID] = struct{}{}
 	}
 
 	// remove previous devices that are no more available
 	for uuid := range c.seenUUIDs {
-		if _, ok := seenUUIDs[uuid]; ok {
+		if _, ok := currentUUIDs[uuid]; ok {
 			continue
 		}
 
@@ -232,7 +232,7 @@ func (c *collector) Pull(_ context.Context) error {
 		})
 	}
 
-	c.seenUUIDs = seenUUIDs
+	c.seenUUIDs = currentUUIDs
 
 	c.store.Notify(events)
 

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -10,6 +10,8 @@ package gpu
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -70,11 +72,12 @@ func Factory(tagger tagger.Component, telemetry telemetry.Component, wmeta workl
 
 func newCheck(tagger tagger.Component, telemetry telemetry.Component, wmeta workloadmeta.Component) check.Check {
 	return &Check{
-		CheckBase:  core.NewCheckBase(CheckName),
-		tagger:     tagger,
-		telemetry:  newCheckTelemetry(telemetry),
-		wmeta:      wmeta,
-		deviceTags: make(map[string][]string),
+		CheckBase:   core.NewCheckBase(CheckName),
+		tagger:      tagger,
+		telemetry:   newCheckTelemetry(telemetry),
+		wmeta:       wmeta,
+		deviceTags:  make(map[string][]string),
+		deviceCache: ddnvml.NewDeviceCache(),
 	}
 }
 
@@ -111,52 +114,56 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, 
 	return nil
 }
 
-func (c *Check) ensureInitDeviceCache() error {
-	if c.deviceCache != nil {
-		return nil
-	}
-
-	c.deviceCache = ddnvml.NewDeviceCache()
-
-	if err := c.deviceCache.EnsureInit(); err != nil {
-		return fmt.Errorf("failed to initialize device cache: %w", err)
-	}
-
-	return nil
-}
-
 // ensureInitCollectors initializes the NVML library and the collectors if they are not already initialized.
 // It returns an error if the initialization fails.
 func (c *Check) ensureInitCollectors() error {
-	//TODO: in the future we need to support hot-plugging of GPU devices,
-	// as we currently create a collector per GPU device.
-	// also we map the device tags in this function only once, so new hot-lugged devices won't have the tags
-	if c.collectors != nil {
-		return nil
-	}
-
-	if err := c.ensureInitDeviceCache(); err != nil {
-		return fmt.Errorf("failed to initialize device cache: %w", err)
-	}
-
-	// device events gatherer must be running in order for devices to be properly registered
-	// when building the collectors
-	if err := c.deviceEvtGatherer.Start(); err != nil {
-		return fmt.Errorf("failed starting event set gatherer: %w", err)
-	}
-
-	deps := &nvidia.CollectorDependencies{
-		DeviceCache:          c.deviceCache,
-		DeviceEventsGatherer: c.deviceEvtGatherer,
-		SystemProbeCache:     c.spCache,
-	}
-	collectors, err := nvidia.BuildCollectors(deps)
+	// the list of devices can change over time, so grab the latest and:
+	// - remove collectors for the devices that are not present anymore
+	// - collect devices for which a new collector must be added
+	physicalDevices, err := c.deviceCache.AllPhysicalDevices()
 	if err != nil {
-		return fmt.Errorf("failed to build NVML collectors: %w", err)
+		return fmt.Errorf("failed to retrieve physical devices: %w", err)
+	}
+	curDevices := map[string]ddnvml.Device{}
+	for _, d := range physicalDevices {
+		curDevices[d.GetDeviceInfo().UUID] = d
+	}
+
+	// discard collectors of devices that are no more available
+	collectors := []nvidia.Collector{}
+	collectorUUIDs := map[string]struct{}{}
+	for _, c := range c.collectors {
+		if _, ok := curDevices[c.DeviceUUID()]; ok {
+			collectors = append(collectors, c)
+			collectorUUIDs[c.DeviceUUID()] = struct{}{}
+		}
+	}
+
+	// figure out which devices do not have a collector yet and build new ones accordingly
+	missingDevices := []ddnvml.Device{}
+	for uuid, d := range curDevices {
+		if _, ok := collectorUUIDs[uuid]; !ok {
+			missingDevices = append(missingDevices, d)
+		}
+	}
+	if len(missingDevices) > 0 {
+		newCollectors, err := nvidia.BuildCollectors(&nvidia.CollectorDependencies{
+			Devices:              missingDevices,
+			DeviceEventsGatherer: c.deviceEvtGatherer,
+			SystemProbeCache:     c.spCache,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to build NVML collectors: %w", err)
+		}
+		collectors = append(collectors, newCollectors...)
 	}
 
 	c.collectors = collectors
-	c.deviceTags = nvidia.GetDeviceTagsMapping(c.deviceCache, c.tagger)
+
+	// recompute device->tags mapping if necessary
+	if !slices.Equal(slices.Sorted(maps.Keys(c.deviceTags)), slices.Sorted(maps.Keys(curDevices))) {
+		c.deviceTags = nvidia.GetDeviceTagsMapping(c.deviceCache, c.tagger)
+	}
 	return nil
 }
 
@@ -186,8 +193,8 @@ func (c *Check) Run() error {
 	// Commit the metrics even in case of an error
 	defer snd.Commit()
 
-	if err := c.ensureInitDeviceCache(); err != nil {
-		return fmt.Errorf("failed to initialize device cache: %w", err)
+	if err := c.deviceCache.Refresh(); err != nil {
+		return fmt.Errorf("failed to refresh device cache: %w", err)
 	}
 
 	// Refresh SP cache before collecting metrics, if it is available

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -9,10 +9,12 @@ package gpu
 
 import (
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -92,12 +94,6 @@ func TestEmitNvmlMetrics(t *testing.T) {
 		})
 	}
 
-	// Set device tags
-	check.deviceTags = map[string][]string{
-		device1UUID: {"gpu_uuid:" + device1UUID, "gpu_vendor:nvidia"},
-		device2UUID: {"gpu_uuid:" + device2UUID, "gpu_vendor:nvidia"},
-	}
-
 	// Set up GPU and container tags
 	containerID := "container1"
 	containerTags := []string{"container_id:" + containerID}
@@ -125,10 +121,10 @@ func TestEmitNvmlMetrics(t *testing.T) {
 		var expectedTags []string
 		if deviceUUID == device1UUID {
 			// Device 1 has container tags
-			expectedTags = append([]string{"gpu_uuid:" + deviceUUID, "gpu_vendor:nvidia"}, containerTags...)
+			expectedTags = append([]string{"gpu_uuid:" + deviceUUID}, containerTags...)
 		} else {
 			// Device 2 has no container tags
-			expectedTags = []string{"gpu_uuid:" + deviceUUID, "gpu_vendor:nvidia"}
+			expectedTags = []string{"gpu_uuid:" + deviceUUID}
 		}
 		slices.Sort(expectedTags)
 
@@ -197,6 +193,68 @@ func TestRunDoesNotError(t *testing.T) {
 	// we need to cancel the check to make sure all resources and async workers are released
 	// before deinitializing the mock library at test cleanup
 	t.Cleanup(func() { checkGeneric.Cancel() })
+}
+
+func TestCollectorsOnDeviceChanges(t *testing.T) {
+	// note: bump this when we'll add new collectors in nvidia.BuildCollectors
+	const numSupportedCollectorTypes = 5
+
+	// mock up device count so that we can check when check collectors are created/destroyed
+	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMockAllFunctions())
+	ddnvml.WithMockNVML(t, nvmlMock)
+	curDeviceCount := atomic.Int32{}
+	curDeviceCount.Store(int32(len(testutil.GPUUUIDs)) - 2)
+	nvmlMock.DeviceGetCountFunc = func() (int, nvml.Return) { return int(curDeviceCount.Load()), nvml.SUCCESS }
+
+	// assert function to be used below, checking that the created collectors map to the current devices
+	assertCollectors := func(collectors []nvidia.Collector) {
+		visibleDevices := int(curDeviceCount.Load())
+		assert.Len(t, collectors, visibleDevices*numSupportedCollectorTypes)
+
+		expectedUUIDs := map[string]int{}
+		for i := range visibleDevices { // check only on visible devices
+			expectedUUIDs[testutil.GPUUUIDs[i]] = numSupportedCollectorTypes
+		}
+
+		actualUUIDs := map[string]int{}
+		for _, c := range collectors {
+			actualUUIDs[c.DeviceUUID()]++
+		}
+
+		assert.Equal(t, expectedUUIDs, actualUUIDs)
+	}
+
+	// create check instance using mocks
+	iCheck := newCheck(taggerfxmock.SetupFakeTagger(t), testutil.GetTelemetryMock(t), testutil.GetWorkloadMetaMock(t))
+	check, ok := iCheck.(*Check)
+	require.True(t, ok)
+
+	// enable GPU check in configuration right before Configure
+	pkgconfigsetup.Datadog().SetWithoutSource("gpu.enabled", true)
+	t.Cleanup(func() { pkgconfigsetup.Datadog().SetWithoutSource("gpu.enabled", false) })
+
+	// configure check
+	require.NoError(t, check.Configure(mocksender.CreateDefaultDemultiplexer(), integration.FakeConfigHash, []byte{}, []byte{}, "test"))
+	require.Empty(t, check.collectors)
+	t.Cleanup(func() { check.Cancel() })
+
+	// do a first run and check that collectors have been created
+	require.NoError(t, check.Run())
+	assertCollectors(check.collectors)
+
+	// a second run should not trigger any new device being added
+	require.NoError(t, check.Run())
+	assertCollectors(check.collectors)
+
+	// simulate device hot-plug
+	curDeviceCount.Add(2)
+	require.NoError(t, check.Run())
+	assertCollectors(check.collectors)
+
+	// simulate device falling off bus
+	curDeviceCount.Add(-1)
+	require.NoError(t, check.Run())
+	assertCollectors(check.collectors)
 }
 
 // mockCollector implements the nvidia.Collector interface for testing

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -38,6 +38,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
 	ddnvml.WithMockNVML(t, nvmlMock)
+	deviceCache := ddnvml.NewDeviceCache()
 	devices, err := deviceCache.AllPhysicalDevices()
 	require.NoError(t, err)
 	deps := &CollectorDependencies{Devices: devices}

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -38,8 +38,9 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled())
 	ddnvml.WithMockNVML(t, nvmlMock)
-	deviceCache := ddnvml.NewDeviceCache()
-	deps := &CollectorDependencies{DeviceCache: deviceCache}
+	devices, err := deviceCache.AllPhysicalDevices()
+	require.NoError(t, err)
+	deps := &CollectorDependencies{Devices: devices}
 	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
@@ -143,7 +144,9 @@ func TestAllCollectorsWork(t *testing.T) {
 	eventsGatherer := NewDeviceEventsGatherer()
 	require.NoError(t, eventsGatherer.Start())
 	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
-	deps := &CollectorDependencies{DeviceCache: deviceCache, DeviceEventsGatherer: eventsGatherer}
+	devices, err := deviceCache.AllPhysicalDevices()
+	require.NoError(t, err)
+	deps := &CollectorDependencies{Devices: devices, DeviceEventsGatherer: eventsGatherer}
 	collectors, err := BuildCollectors(deps)
 	require.NoError(t, err)
 	require.NotNil(t, collectors)

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -41,8 +41,8 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	deviceCache := ddnvml.NewDeviceCache()
 	devices, err := deviceCache.AllPhysicalDevices()
 	require.NoError(t, err)
-	deps := &CollectorDependencies{Devices: devices}
-	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
+	deps := &CollectorDependencies{}
+	collectors, err := buildCollectors(devices, deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
 }
@@ -147,8 +147,8 @@ func TestAllCollectorsWork(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
 	devices, err := deviceCache.AllPhysicalDevices()
 	require.NoError(t, err)
-	deps := &CollectorDependencies{Devices: devices, DeviceEventsGatherer: eventsGatherer}
-	collectors, err := BuildCollectors(deps)
+	deps := &CollectorDependencies{DeviceEventsGatherer: eventsGatherer}
+	collectors, err := BuildCollectors(devices, deps)
 	require.NoError(t, err)
 	require.NotNil(t, collectors)
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -133,6 +133,11 @@ type DeviceEventsGatherer struct {
 	devices    map[string]*deviceEventsEventsCache // uuid -> cache
 }
 
+// Started returns true if event collection has been started
+func (c *DeviceEventsGatherer) Started() bool {
+	return c.running.Load()
+}
+
 // Start initializes the gatherer and starts event collection
 func (c *DeviceEventsGatherer) Start() error {
 	if c.running.Load() {

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -390,6 +390,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_wakeup_size"), 3000)     // 3000 bytes is about ~10-20 events depending on the specific type
 	cfg.BindEnvAndSetDefault(join(gpuNS, "attacher_detailed_logs"), false)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "ringbuffer_flush_interval"), 1*time.Second)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "device_cache_refresh_interval"), 5*time.Second)
 
 	// gpu - stream config
 	cfg.BindEnvAndSetDefault(join(gpuNS, "streams", "max_kernel_launches"), 1000)

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	StreamConfig StreamConfig
 	// AttacherDetailedLogs indicates whether the probe should enable detailed logs for the uprobe attacher.
 	AttacherDetailedLogs bool
+	// DeviceCacheRefreshInterval is the interval at which the probe scans for the latest devices
+	DeviceCacheRefreshInterval time.Duration
 }
 
 // StreamConfig is the configuration for the streams.
@@ -84,6 +86,7 @@ func New() *Config {
 			MaxPendingKernelSpans: spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "streams", "max_pending_kernel_spans")),
 			MaxPendingMemorySpans: spCfg.GetInt(sysconfig.FullKeyPath(consts.GPUNS, "streams", "max_pending_memory_spans")),
 		},
-		AttacherDetailedLogs: spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "attacher_detailed_logs")),
+		AttacherDetailedLogs:       spCfg.GetBool(sysconfig.FullKeyPath(consts.GPUNS, "attacher_detailed_logs")),
+		DeviceCacheRefreshInterval: spCfg.GetDuration(sysconfig.FullKeyPath(consts.GPUNS, "device_cache_refresh_interval")),
 	}
 }

--- a/pkg/gpu/cuda/kernel_cache_test.go
+++ b/pkg/gpu/cuda/kernel_cache_test.go
@@ -110,7 +110,10 @@ func TestKernelCacheLoadKernelData(t *testing.T) {
 	}
 	require.NotZero(t, kernelAddress, "kernel address should be found")
 
-	kc, err := NewKernelCache(procRoot, cudatestutil.SamplesSMVersionSet(), testutil.GetTelemetryMock(t), 100)
+	getSMVersionSet := func() (map[uint32]struct{}, error) {
+		return cudatestutil.SamplesSMVersionSet(), nil
+	}
+	kc, err := NewKernelCache(procRoot, getSMVersionSet, testutil.GetTelemetryMock(t), 100)
 	require.NoError(t, err)
 	kc.Start()
 	t.Cleanup(kc.Stop)
@@ -169,7 +172,10 @@ func TestKernelCacheLoadKernelData(t *testing.T) {
 }
 
 func TestKernelCacheLoadKernelDataError(t *testing.T) {
-	kc, err := NewKernelCache(kernel.ProcFSRoot(), cudatestutil.SamplesSMVersionSet(), testutil.GetTelemetryMock(t), 100)
+	getSMVersionSet := func() (map[uint32]struct{}, error) {
+		return cudatestutil.SamplesSMVersionSet(), nil
+	}
+	kc, err := NewKernelCache(kernel.ProcFSRoot(), getSMVersionSet, testutil.GetTelemetryMock(t), 100)
 	require.NoError(t, err)
 	kc.Start()
 	t.Cleanup(kc.Stop)

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -336,6 +336,7 @@ func (p *Probe) setupSharedBuffer(o *manager.Options) {
 		},
 	}
 
+	// todo(jasondellaluce): device count can change over time, we may resize this in the future
 	devCount, err := p.sysCtx.deviceCache.Count()
 	if err != nil {
 		log.Warnf("failed to get device count to scale ring buffer size: %v. Will use 1 device for the ring buffer size calculation", err)

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -67,6 +67,9 @@ func (s *probeTestSuite) getProbe() *Probe {
 	// Ensure we flush quickly, so that we don't have to wait as much for the pending events to be processed.
 	cfg.RingBufferFlushInterval = 500 * time.Millisecond
 
+	// Ensure we refresh the cache quickly, but still allow some throttling
+	cfg.DeviceCacheRefreshInterval = 500 * time.Millisecond
+
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
 	deps := ProbeDependencies{
 		ProcessMonitor: consumerstestutil.NewTestProcessConsumer(t),


### PR DESCRIPTION
### What does this PR do?

This adapts the GPU device cache (and its consumers) to support the assumption of the device list to potentially change over time. This can happen due to hotplug, runtime exclusion/error, or the device "falling off the bus".

### Motivation

Currently we initialize the cache just once, and assume the device list to never change over time.

### Describe how you validated your changes

Unit tests and local testing of agent/sysprobe.

### Additional Notes
