### PR TITLE
[EBPF] gpu: do not panic on unknown event types

### DIFF
--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -209,12 +209,12 @@ func isStreamSpecificEvent(et gpuebpf.CudaEventType) bool {
 func (c *cudaEventConsumer) handleEvent(header *gpuebpf.CudaEventHeader, dataPtr unsafe.Pointer, dataLen int) error {
 	eventType := gpuebpf.CudaEventType(header.Type)
 
-	// Acts as a sanity check to ensure that we're not missing any event types
-	if counter, ok := c.telemetry.eventCounterByType[eventType]; !ok {
+	counter, ok := c.telemetry.eventCounterByType[eventType]
+	if !ok {
+		c.telemetry.eventErrors.Inc(telemetryEventTypeUnknown, telemetryEventErrorUnknownType)
 		return fmt.Errorf("unknown event type: %d", header.Type)
-	} else {
-		counter.Inc()
 	}
+	counter.Inc()
 
 	if isStreamSpecificEvent(eventType) {
 		return c.handleStreamEvent(header, dataPtr, dataLen)

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -252,7 +252,6 @@ func (c *cudaEventConsumer) handleStreamEvent(header *gpuebpf.CudaEventHeader, d
 		if logLimitProbe.ShouldLog() {
 			log.Warnf("error getting stream handler for stream id %d: %v", header.Stream_id, err)
 		}
-
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Ensures that the consumer does not panic when faced with an event with unknown type.

### Motivation

Avoid panics with unexpected data.

### Describe how you validated your changes

Added a unit test that reproduced the panic and now passes

### Additional Notes

Discovered by the fuzzer
