### PR TITLE
[CONTP-983] fix flaky unit test

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -425,7 +425,12 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	podsCache := kubelet.PodList{
 		Items: pods,
 	}
-	cache.Cache.Set("KubeletPodListCacheKey", podsCache, 2*time.Second)
+
+	// Cache never expires because the unit tests below are not covering the case
+	// of cache miss. They are only testing parsePods behaves correctly depending
+	// on the cluster agent version and the agent configuration.
+	cache.Cache.Set("KubeletPodListCacheKey", podsCache, -1)
+
 	kubeUtilFake := &kubelet.KubeUtil{}
 
 	type fields struct {


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky unit test caused by potential nil pointer dereference. 

Here is the reported panic:

```
=== FAIL: comp/core/workloadmeta/collectors/internal/kubemetadata TestKubeMetadataCollector_parsePods (2.73s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x1419b4ee1]
goroutine 49 [running]:
testing.tRunner.func1.2({0x141d15ae0, 0x141b543c0})
	c:/go/1.24.7/go/src/testing/testing.go:1734 +0x3d7
testing.tRunner.func1()
	c:/go/1.24.7/go/src/testing/testing.go:1737 +0x696
panic({0x141d15ae0?, 0x141b543c0?})
	c:/go/1.24.7/go/src/runtime/panic.go:792 +0x132
github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.(*kubeletClient).query(0x0, {0x142295c90, 0x142d6c860}, {0x141fe290e, 0x5})
	C:/buildroot/datadog-agent/pkg/util/kubernetes/kubelet/kubelet_client.go:174 +0x81
github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.(*KubeUtil).QueryKubelet(...)
	C:/buildroot/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:358
github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.(*KubeUtil).getLocalPodList(0xc000981d40, {0x142295c90, 0x142d6c860})
	C:/buildroot/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:219 +0x265
github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.(*KubeUtil).GetLocalPodList(...)
	C:/buildroot/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:315
github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet.(*KubeUtil).GetNodename(0xc000981d40, {0x142295c90, 0x142d6c860})
	C:/buildroot/datadog-agent/pkg/util/kubernetes/kubelet/kubelet.go:191 +0x7e
github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata.(*collector).parsePods(0xc0007a9e50, {0x142295c90, 0x142d6c860}, {0xc000824088, 0x1, 0x141ae1a20?}, 0xc0007a9e20)
	C:/buildroot/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go:199 +0x210
github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata.TestKubeMetadataCollector_parsePods.func1(0xc000796000)
	C:/buildroot/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go:765 +0x43d
testing.tRunner(0xc000796000, 0xc0000520b0)
	c:/go/1.24.7/go/src/testing/testing.go:1792 +0x1dd
created by testing.(*T).Run in goroutine 93
	c:/go/1.24.7/go/src/testing/testing.go:1851 +0x8f9
```

This panic happens in the following scenario:
- pod list is set in the cache in the unit test with an expiration of 2 seconds [here](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go#L428)
- [This](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go#L578-L634) is the test case causing the panic.
- The problem happens [here](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/pkg/util/kubernetes/kubelet/kubelet.go#L207-L219) : if the cache data expires, [this](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/pkg/util/kubernetes/kubelet/kubelet.go#L219) line will be invoked.
- The line mentioned just above results [in querying the local kubelet for the pod list. ](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/pkg/util/kubernetes/kubelet/kubelet.go#L358)
- However, the unit test doesn't intend to test this path in the code:[ the kubeletClient is nil in the fake kubecollector.](https://github.com/DataDog/datadog-agent/blob/b9c9636f1f88fce9f23f381475b65006e596d5b3/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go#L429), resulting in a nil pointer dereference.

### Motivation

### Describe how you validated your changes

Unit tests.

### Additional Notes

I was able to reproduce the panic by reducing the expiration to 1 microsecond. 
