### PR TITLE
[tagger/subscription_manager] Inspect channel content in error case

### DIFF
--- a/comp/core/tagger/subscriber/subscription_manager_test.go
+++ b/comp/core/tagger/subscriber/subscription_manager_test.go
@@ -263,3 +263,81 @@ func TestUnsubscribe(t *testing.T) {
 
 	assert.NotPanics(t, func() { sm.Unsubscribe("non-existing-id") })
 }
+
+func TestInspectChannel(t *testing.T) {
+	tests := []struct {
+		name           string
+		channelBatches [][]types.EntityEvent
+		expected       subscriberChannelContent
+	}{
+		{
+			name:           "empty channel",
+			channelBatches: [][]types.EntityEvent{},
+			expected: subscriberChannelContent{
+				batches:        0,
+				totalEvents:    0,
+				eventsByPrefix: map[types.EntityIDPrefix]int{},
+				eventsByType:   map[string]int{},
+			},
+		},
+		{
+			name: "multiple batches",
+			channelBatches: [][]types.EntityEvent{
+				{
+					{
+						EventType: types.EventTypeAdded,
+						Entity: types.Entity{
+							ID: types.NewEntityID(types.ContainerID, "container-1"),
+						},
+					},
+					{
+						EventType: types.EventTypeModified,
+						Entity: types.Entity{
+							ID: types.NewEntityID(types.Process, "process-1"),
+						},
+					},
+				},
+				{
+					{
+						EventType: types.EventTypeAdded,
+						Entity: types.Entity{
+							ID: types.NewEntityID(types.ECSTask, "ecs-task-1"),
+						},
+					},
+					{
+						EventType: types.EventTypeDeleted,
+						Entity: types.Entity{
+							ID: types.NewEntityID(types.ContainerID, "container-2"),
+						},
+					},
+				},
+			},
+			expected: subscriberChannelContent{
+				batches:     2,
+				totalEvents: 4,
+				eventsByPrefix: map[types.EntityIDPrefix]int{
+					types.ContainerID: 2,
+					types.Process:     1,
+					types.ECSTask:     1,
+				},
+				eventsByType: map[string]int{
+					"Added":    2,
+					"Modified": 1,
+					"Deleted":  1,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ch := make(chan []types.EntityEvent, len(test.channelBatches))
+			for _, batch := range test.channelBatches {
+				ch <- batch
+			}
+
+			content := inspectChannel(ch)
+			assert.Equal(t, test.expected, content)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds more debugging information when this error is raised in the tagger subscription manager:
https://github.com/DataDog/datadog-agent/blob/e9d008bc177797b10e8195dee362e7ba8f527cdf/comp/core/tagger/subscriber/subscription_manager.go#L139

This is for debugging only, to help us better understand what happens in the rare cases when this error occurs

### Describe how you validated your changes

Added unit test.
