### PR TITLE
[CWS] Fix cgroup context fallback

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -53,8 +53,8 @@ type ResolverInterface interface {
 	RegisterListener(Event, utils.Listener[*cgroupModel.CacheEntry]) error
 }
 
-// CGroupFSInterface defines the interface for CGroupFS operations
-type CGroupFSInterface interface {
+// FSInterface defines the interface for CGroupFS operations
+type FSInterface interface {
 	FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, utils.CGroupContext, string, error)
 	GetCgroupPids(cgroupID string) ([]uint32, error)
 }
@@ -63,7 +63,7 @@ type CGroupFSInterface interface {
 type Resolver struct {
 	*utils.Notifier[Event, *cgroupModel.CacheEntry]
 	sync.Mutex
-	cgroupFS           CGroupFSInterface
+	cgroupFS           FSInterface
 	statsdClient       statsd.ClientInterface
 	cgroups            *simplelru.LRU[uint64, *model.CGroupContext]
 	hostWorkloads      *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
@@ -72,7 +72,7 @@ type Resolver struct {
 }
 
 // NewResolver returns a new cgroups monitor
-func NewResolver(statsdClient statsd.ClientInterface, cgroupFS CGroupFSInterface) (*Resolver, error) {
+func NewResolver(statsdClient statsd.ClientInterface, cgroupFS FSInterface) (*Resolver, error) {
 	if cgroupFS == nil {
 		cgroupFS = utils.DefaultCGroupFS()
 	}

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -1,0 +1,303 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package cgroup
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+// MockCGroupFS implements a mock for CGroupFSInterface
+type MockCGroupFS struct {
+	mock.Mock
+}
+
+func (m *MockCGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, utils.CGroupContext, string, error) {
+	args := m.Called(tgid, pid)
+	return args.Get(0).(containerutils.ContainerID), args.Get(1).(utils.CGroupContext), args.String(2), args.Error(3)
+}
+
+func (m *MockCGroupFS) GetCgroupPids(cgroupID string) ([]uint32, error) {
+	args := m.Called(cgroupID)
+	return args.Get(0).([]uint32), args.Error(1)
+}
+
+// createTestResolver creates a resolver with mocked dependencies for testing
+func createTestResolver(t *testing.T) (*Resolver, *MockCGroupFS) {
+	mockCGroupFS := &MockCGroupFS{}
+
+	resolver, err := NewResolver(nil, mockCGroupFS)
+	assert.NoError(t, err)
+
+	return resolver, mockCGroupFS
+}
+
+// createTestProcess creates a ProcessCacheEntry for testing
+func createTestProcess(pid, ppid uint32, containerID containerutils.ContainerID) *model.ProcessCacheEntry {
+	process := &model.ProcessCacheEntry{
+		ProcessContext: model.ProcessContext{
+			Process: model.Process{
+				PIDContext: model.PIDContext{
+					Pid: pid,
+				},
+				PPid:        ppid,
+				ContainerID: containerID,
+				CGroup: model.CGroupContext{
+					CGroupID: "",
+					CGroupFile: model.PathKey{
+						Inode:   0,
+						MountID: 0,
+					},
+				},
+			},
+		},
+	}
+	return process
+}
+
+func TestResolvePidCgroupFallback_SuccessDirectResolution(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	expectedContext := utils.CGroupContext{
+		CGroupID:          "test-cgroup-id",
+		CGroupFileMountID: 42,
+		CGroupFileInode:   9876,
+	}
+
+	// Mock successful direct resolution
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID("container-123"),
+		expectedContext,
+		"/sys/fs/cgroup/test",
+		nil,
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.True(t, result)
+	assert.Equal(t, containerutils.CGroupID("test-cgroup-id"), process.CGroup.CGroupID)
+	assert.Equal(t, uint32(42), process.CGroup.CGroupFile.MountID)
+	assert.Equal(t, uint64(9876), process.CGroup.CGroupFile.Inode)
+	assert.Equal(t, containerutils.ContainerID("container-123"), process.ContainerID)
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_FailInvalidPPid(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+
+	// Test case 1: PPid equals Pid
+	process1 := createTestProcess(1234, 1234, "")
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	result1 := resolver.resolvePidCgroupFallback(process1)
+	assert.False(t, result1)
+
+	// Test case 2: PPid is 0
+	process2 := createTestProcess(1234, 0, "")
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	result2 := resolver.resolvePidCgroupFallback(process2)
+	assert.False(t, result2)
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_SuccessFromHistory(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	// Add parent cgroup to history
+	parentInode := uint64(9999)
+	resolver.history.Add(uint32(5678), parentInode)
+
+	// Add parent cgroup context to cache
+	parentCgroup := &model.CGroupContext{
+		CGroupID: "parent-cgroup-id",
+		CGroupFile: model.PathKey{
+			Inode:   parentInode,
+			MountID: 123,
+		},
+	}
+	resolver.cgroups.Add(parentInode, parentCgroup)
+
+	// Mock failed direct resolution
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.True(t, result)
+	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), process.CGroup.CGroupID)
+	assert.Equal(t, uint32(123), process.CGroup.CGroupFile.MountID)
+	assert.Equal(t, parentInode, process.CGroup.CGroupFile.Inode)
+	// Note: containerutils.FindContainerID would be called here, but we can't easily mock it
+	// in this example as it's a package function
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_SuccessFromParentProc(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	expectedContext := utils.CGroupContext{
+		CGroupID:          "parent-cgroup-id",
+		CGroupFileMountID: 567,
+		CGroupFileInode:   8888,
+	}
+
+	// Mock failed direct resolution
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	// Mock successful parent resolution
+	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
+		containerutils.ContainerID("parent-container-456"),
+		expectedContext,
+		"/sys/fs/cgroup/parent",
+		nil,
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.True(t, result)
+	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), process.CGroup.CGroupID)
+	assert.Equal(t, uint32(567), process.CGroup.CGroupFile.MountID)
+	assert.Equal(t, uint64(8888), process.CGroup.CGroupFile.Inode)
+	assert.Equal(t, containerutils.ContainerID("parent-container-456"), process.ContainerID)
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_CompleteFailure(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	// Mock failed direct resolution
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	// Mock failed parent resolution
+	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("parent not found"),
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.False(t, result)
+	// Process should remain unchanged
+	assert.Equal(t, containerutils.CGroupID(""), process.CGroup.CGroupID)
+	assert.Equal(t, uint32(0), process.CGroup.CGroupFile.MountID)
+	assert.Equal(t, uint64(0), process.CGroup.CGroupFile.Inode)
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_HistoryFoundButCgroupMissing(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	// Add parent to history but not to cgroups cache
+	resolver.history.Add(uint32(5678), uint64(9999))
+
+	expectedContext := utils.CGroupContext{
+		CGroupID:          "fallback-cgroup-id",
+		CGroupFileMountID: 789,
+		CGroupFileInode:   7777,
+	}
+
+	// Mock failed direct resolution
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("not found"),
+	)
+
+	// Mock successful parent proc resolution as fallback
+	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
+		containerutils.ContainerID("fallback-container-789"),
+		expectedContext,
+		"/sys/fs/cgroup/fallback",
+		nil,
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.True(t, result)
+	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id"), process.CGroup.CGroupID)
+	assert.Equal(t, uint32(789), process.CGroup.CGroupFile.MountID)
+	assert.Equal(t, uint64(7777), process.CGroup.CGroupFile.Inode)
+	assert.Equal(t, containerutils.ContainerID("fallback-container-789"), process.ContainerID)
+
+	mockFS.AssertExpectations(t)
+}
+
+func TestResolvePidCgroupFallback_EmptyCGroupIDIgnored(t *testing.T) {
+	resolver, mockFS := createTestResolver(t)
+	process := createTestProcess(1234, 5678, "")
+
+	// Mock resolution that returns empty CGroupID (should be ignored)
+	mockFS.On("FindCGroupContext", uint32(1234), uint32(1234)).Return(
+		containerutils.ContainerID("some-container"),
+		utils.CGroupContext{
+			CGroupID:          "", // Empty CGroupID
+			CGroupFileMountID: 42,
+			CGroupFileInode:   9876,
+		},
+		"/sys/fs/cgroup/test",
+		nil,
+	)
+
+	// Should fallback to parent resolution
+	mockFS.On("FindCGroupContext", uint32(5678), uint32(5678)).Return(
+		containerutils.ContainerID(""),
+		utils.CGroupContext{},
+		"",
+		errors.New("parent not found"),
+	)
+
+	result := resolver.resolvePidCgroupFallback(process)
+
+	assert.False(t, result)
+	mockFS.AssertExpectations(t)
+}

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-// MockCGroupFS implements a mock for CGroupFSInterface
+// MockCGroupFS implements a mock for FSInterface
 type MockCGroupFS struct {
 	mock.Mock
 }

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -436,7 +436,7 @@ func TestMountResolver(t *testing.T) {
 		pid uint32 = 1
 	)
 
-	cr, _ := cgroup.NewResolver(nil)
+	cr, _ := cgroup.NewResolver(nil, nil)
 
 	// Create mount resolver
 	mr, _ := NewResolver(nil, cr, nil, ResolverOpts{})
@@ -504,7 +504,7 @@ func TestMountGetParentPath(t *testing.T) {
 	}
 
 	// Create mount resolver
-	cr, _ := cgroup.NewResolver(nil)
+	cr, _ := cgroup.NewResolver(nil, nil)
 	mr, _ := NewResolver(nil, cr, nil, ResolverOpts{})
 	for _, m := range mounts {
 		mr.mounts.Add(m.MountID, m)
@@ -545,7 +545,7 @@ func TestMountLoop(t *testing.T) {
 	}
 
 	// Create mount resolver
-	cr, _ := cgroup.NewResolver(nil)
+	cr, _ := cgroup.NewResolver(nil, nil)
 	mr, _ := NewResolver(nil, cr, nil, ResolverOpts{})
 	for _, m := range mounts {
 		mr.mounts.Add(m.MountID, m)
@@ -558,7 +558,7 @@ func TestMountLoop(t *testing.T) {
 
 func BenchmarkGetParentPath(b *testing.B) {
 	// Create mount resolver
-	cr, _ := cgroup.NewResolver(nil)
+	cr, _ := cgroup.NewResolver(nil, nil)
 	mr, _ := NewResolver(nil, cr, nil, ResolverOpts{})
 
 	mr.mounts.Add(1, &model.Mount{

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -127,7 +127,7 @@ func newResolver() (*EBPFResolver, error) {
 		return nil, err
 	}
 
-	cgroupsResolver, err := cgroup.NewResolver(nil)
+	cgroupsResolver, err := cgroup.NewResolver(nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -102,7 +102,7 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		}
 	}
 
-	cgroupsResolver, err := cgroup.NewResolver(statsdClient)
+	cgroupsResolver, err := cgroup.NewResolver(statsdClient, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/resolvers_ebpfless.go
+++ b/pkg/security/resolvers/resolvers_ebpfless.go
@@ -30,7 +30,7 @@ type EBPFLessResolvers struct {
 
 // NewEBPFLessResolvers creates a new instance of EBPFLessResolvers
 func NewEBPFLessResolvers(config *config.Config, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, opts Opts) (*EBPFLessResolvers, error) {
-	cgroupsResolver, err := cgroup.NewResolver(statsdClient)
+	cgroupsResolver, err := cgroup.NewResolver(statsdClient, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -286,6 +286,11 @@ func TestCGroupSnapshot(t *testing.T) {
 	}
 	defer test.Close()
 
+	p, ok := test.probe.PlatformProbe.(*probe.EBPFProbe)
+	if !ok {
+		t.Skip("not supported")
+	}
+
 	testFile, _, err := test.Path("test-open")
 	if err != nil {
 		t.Fatal(err)
@@ -299,11 +304,6 @@ func TestCGroupSnapshot(t *testing.T) {
 	var syscallTesterStats unix.Stat_t
 	if err := unix.Stat(syscallTester, &syscallTesterStats); err != nil {
 		t.Fatal(err)
-	}
-
-	p, ok := test.probe.PlatformProbe.(*probe.EBPFProbe)
-	if !ok {
-		t.Skip("not supported")
 	}
 
 	var cmd *exec.Cmd

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -89,7 +90,7 @@ func parseProcControlGroupsData(data []byte, validateCgroupEntry func(string, st
 			return err
 		}
 
-		if isValid, err = validateCgroupEntry(id, ctrl, path); isValid {
+		if isValid, err = validateCgroupEntry(id, ctrl, path); isValid && err != nil {
 			return nil
 		}
 
@@ -247,6 +248,10 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 
 			if exists, err = checkPidExists(cgroupPath, pid); err == nil && exists {
 				cgroupID := containerutils.CGroupID(cfs.removeMountPointFromCGroupPath(cgroupPath))
+				if cgroupID == "" {
+					seclog.Warnf("Error finding cgroupID for pid %d in %s, resolved as empty ID", pid, cgroupPath)
+					continue
+				}
 				ctrID := containerutils.FindContainerID(cgroupID)
 				cgroupContext.CGroupID = cgroupID
 				containerID = ctrID
@@ -262,12 +267,16 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 				} else if err = unix.Stat(cgroupPath, &fileStats); err == nil {
 					cgroupContext.CGroupFileInode = fileStats.Ino
 				}
-
-				return true, err
+				if err == nil {
+					return true, nil
+				}
+				seclog.Warnf("Unable to stat cgroup path %s", cgroupPath)
 			}
 		}
-
-		// return the lastest error
+		// not found
+		if err == nil {
+			err = os.ErrNotExist
+		}
 		return false, err
 	})
 	if err != nil {

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -90,7 +90,7 @@ func parseProcControlGroupsData(data []byte, validateCgroupEntry func(string, st
 			return err
 		}
 
-		if isValid, err = validateCgroupEntry(id, ctrl, path); isValid && err != nil {
+		if isValid, err = validateCgroupEntry(id, ctrl, path); isValid && err == nil {
 			return nil
 		}
 


### PR DESCRIPTION
### What does this PR do?

Cgroup resolution fallbacks added in https://github.com/DataDog/datadog-agent/pull/41451 were not totally satisfying. 

This PR:
* adds an "history cache" to maintain a map between exited parents and their cgroups, which could help to assign parent's cgroup
* loose comparison of cgroup by looking only at cgroup inode (and no more its mount id, as for the same cgroup it can be different if the cgroupfs is accessed withing another mount point)
* now the fallback logic is:
- * first we fallback on procfs for the current process
- * if the procfs fallback failed (like for short lived processes) we fallback by looking at the new history map for its father one
- * if we don't have any, we fallback another time on procfs but looking at the parent's one this time
* add more log + cleanup

### Motivation

Try to get rid off processes without cgroup context

### Describe how you validated your changes

It has been validated by deploying it on staging, here's the confirmation that the 3 fallbacks are useful:
<img width="1803" height="416" alt="image" src="https://github.com/user-attachments/assets/4a70005f-6e92-4b23-aa23-6b970bae408d" />


### Additional Notes

Even if the situation is way better with those fallbacks, I still can see some rare cases where fallbacks fails to resolve a process cgroup (in most case it's at snapshot time so not so critical).

My hypothesis on the last failures is that they are due to high high system pressure where we can loss a kernel fork event (breaking the parent/child cgroup heritage), in addition of short lived processes (making the procfs fallbacks useless).
IMHO the situation is totally fine as it is, but we may want to invest more and add some logic/cache kernel side if we really want to solve the issue.

For the record, here's my test program that let me reproduce locally the issue by spamming short lived processes:

```
#define _GNU_SOURCE

#include <stdio.h>
#include <unistd.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <string.h>
#include <errno.h>
#include <sys/wait.h>
#include <stdlib.h>

/* #define CGROUP_PATH "/sys/fs/cgroup/systemd/system.slice" */ // CGROUP V1
#define CGROUP_PATH "/sys/fs/cgroup/system.slice"

#define TEST_CGROUP_NAME "my_test_cgroup.service"

// Utility function to build the cgroup path
// Returns a pointer to a dynamically allocated string (to be freed with free)
static char* build_cgroup_path(const char* cgroup_name, const char* file) {
    char* path;
    if (file) {
        asprintf(&path, "%s/%s/%s", CGROUP_PATH, cgroup_name, file);
    } else {
        asprintf(&path, "%s/%s", CGROUP_PATH, cgroup_name);
    }
    return path;
}

int create_new_cgroup(const char* cgroup_name) {
    struct stat st;
    
    // Build the complete cgroup path
    char* full_path = build_cgroup_path(cgroup_name, NULL);
    
    // Check if the cgroup already exists
    if (stat(full_path, &st) == 0) {
        if (S_ISDIR(st.st_mode)) {
            printf("Cgroup %s already exists\n", cgroup_name);
            free(full_path);
            return 0; // Cgroup already exists, it's OK
        } else {
            fprintf(stderr, "Error: %s exists but is not a directory\n", full_path);
            free(full_path);
            return 1;
        }
    }
    
    // Cgroup doesn't exist, create it
    if (mkdir(full_path, 0755) == -1) {
        fprintf(stderr, "Error creating cgroup %s: %s\n", 
                full_path, strerror(errno));
        free(full_path);
        return 1;
    }
    
    /* printf("Cgroup %s created successfully\n", cgroup_name); */
    free(full_path);
    return 0;
}

int delete_cgroup(const char* cgroup_name) {
    struct stat st;
    
    // Build the complete cgroup path
    char* full_path = build_cgroup_path(cgroup_name, NULL);
    
    // Check if the cgroup exists
    if (stat(full_path, &st) == -1) {
        if (errno == ENOENT) {
            printf("Cgroup %s doesn't exist, nothing to delete\n", cgroup_name);
            free(full_path);
            return 0; // No error if cgroup doesn't exist
        } else {
            fprintf(stderr, "Error checking cgroup %s: %s\n", 
                    full_path, strerror(errno));
            free(full_path);
            return 1;
        }
    }
    
    // Check that it's actually a directory
    if (!S_ISDIR(st.st_mode)) {
        fprintf(stderr, "Error: %s is not a directory\n", full_path);
        free(full_path);
        return 1;
    }
    
    // Remove the cgroup directory
    if (rmdir(full_path) == -1) {
        fprintf(stderr, "Error removing cgroup %s: %s\n", 
                full_path, strerror(errno));
        free(full_path);
        return 1;
    }
    
    /* printf("Cgroup %s deleted successfully\n", cgroup_name); */
    free(full_path);
    return 0;
}

int push_pid_to_cgroup(const char* cgroup_name, int pid) {
    FILE *file;
    
    // Build the complete path to cgroup.procs
    char* cgroup_procs_path = build_cgroup_path(cgroup_name, "cgroup.procs");
    
    // Open the cgroup.procs file for writing
    file = fopen(cgroup_procs_path, "w");
    if (file == NULL) {
        fprintf(stderr, "Error opening %s: %s\n", 
                cgroup_procs_path, strerror(errno));
        free(cgroup_procs_path);
        return 1;
    }
    
    // Write the PID to the file
    if (fprintf(file, "%d\n", pid) < 0) {
        fprintf(stderr, "Error writing PID %d to %s: %s\n", 
                pid, cgroup_procs_path, strerror(errno));
        fclose(file);
        free(cgroup_procs_path);
        return 1;
    }
    
    // Close the file
    if (fclose(file) != 0) {
        fprintf(stderr, "Error closing %s: %s\n", 
                cgroup_procs_path, strerror(errno));
        free(cgroup_procs_path);
        return 1;
    }
    
    printf("PID %d added to cgroup %s successfully\n", pid, cgroup_name);
    free(cgroup_procs_path);
    return 0;
}

int print_current_pid_cgroup() {
    FILE *file;
    char *line = NULL;
    size_t len = 0;
    ssize_t read;
    int current_pid = (int)getpid();
    char *cgroup_path = NULL;
    
    // Open /proc/self/cgroup
    file = fopen("/proc/self/cgroup", "r");
    if (file == NULL) {
        fprintf(stderr, "Error opening /proc/self/cgroup: %s\n", strerror(errno));
        return 1;
    }
    
    // Read line by line to find the systemd cgroup
    while ((read = getline(&line, &len, file)) != -1) {
        // Look for the systemd cgroup line (contains "name=systemd:")
        /* if (strstr(line, "name=systemd:") != NULL) { */ // CGROUP V1
        if (strstr(line, "0::") != NULL) {
            // Find the second colon to extract the cgroup path
            char *first_colon = strchr(line, ':');
            if (first_colon != NULL) {
                char *second_colon = strchr(first_colon + 1, ':');
                if (second_colon != NULL) {
                    // Extract the cgroup path (after the second colon)
                    cgroup_path = strdup(second_colon + 1);
                    // Remove trailing newline if present
                    char *newline = strchr(cgroup_path, '\n');
                    if (newline != NULL) {
                        *newline = '\0';
                    }
                    break;
                }
            }
        }
    }
    
    fclose(file);
    free(line);
    
    if (cgroup_path != NULL) {
        printf("PID: %i, current cgroup: %s\n", current_pid, cgroup_path);
        free(cgroup_path);
        return 0;
    } else {
        printf("PID: %i, current cgroup: systemd cgroup not found\n", current_pid);
        return 1;
    }
}

int exec_date() {
    // Execute /usr/bin/date
    char *argv[] = {"date", NULL};
    char *envp[] = {NULL};
        
    if (execve("/usr/bin/date", argv, envp) == -1) {
        fprintf(stderr, "Error executing date: %s\n", strerror(errno));
        return 1;
    }
}

void test(void) {
    int child = fork();
    if (child == 0) { // child
        // sleep to wait being transfered to another cgroup
        /* sleep(1); */
        /* print_current_pid_cgroup(); */

        int grandchildren = fork();
        if (grandchildren == 0) {
            /* print_current_pid_cgroup(); */
            exec_date();
        /* } else { wait(NULL); } */
        }
    } else {
        // push child to another cgroup
        push_pid_to_cgroup(TEST_CGROUP_NAME, child);

        /* // wait child */
        /* wait(NULL); */
    }
}

int main(void) {
    // get current cgroup
    print_current_pid_cgroup();

    // create new cgroup
    delete_cgroup(TEST_CGROUP_NAME);
    if (create_new_cgroup(TEST_CGROUP_NAME)) {
        return (1);
    }

#define MAX_FORK 500
    for (int i = 0; i < MAX_FORK; i++) {
        int pid = fork();
        if (pid == 0) { // child
            /* print_current_pid_cgroup(); */
            if (i == MAX_FORK - 1) {
                test();
            } else continue;
        } else { // parent
            /* wait(NULL); */
            break;
        }
    }    
    
    return (0);
}

```