### PR TITLE
[FA] Add mv and cp fleet operations

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -242,6 +242,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 		}
 		return err
 	case FileOperationCopy:
+		// TODO(go.1.25): os.Root.MkdirAll and os.Root.WriteFile are only available starting go 1.25
 		err := ensureDir(root, destinationPath)
 		if err != nil {
 			return err
@@ -271,6 +272,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 		}
 		return nil
 	case FileOperationMove:
+		// TODO(go.1.25): os.Root.Rename is only available starting go 1.25 so we'll use it instead
 		err := ensureDir(root, destinationPath)
 		if err != nil {
 			return err

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -37,6 +37,10 @@ const (
 	FileOperationMergePatch FileOperationType = "merge-patch"
 	// FileOperationDelete deletes the config at the given path.
 	FileOperationDelete FileOperationType = "delete"
+	// FileOperationCopy copies the config at the given path to the given path.
+	FileOperationCopy FileOperationType = "copy"
+	// FileOperationMove moves the config at the given path to the given path.
+	FileOperationMove FileOperationType = "move"
 )
 
 // Directories is the directories of the config.
@@ -163,6 +167,7 @@ func (o *Operations) Apply(rootPath string) error {
 type FileOperation struct {
 	FileOperationType FileOperationType `json:"file_op"`
 	FilePath          string            `json:"file_path"`
+	DestinationPath   string            `json:"destination_path,omitempty"`
 	Patch             json.RawMessage   `json:"patch,omitempty"`
 }
 
@@ -171,6 +176,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 		return fmt.Errorf("modifying config file %s is not allowed", a.FilePath)
 	}
 	path := strings.TrimPrefix(a.FilePath, "/")
+	destinationPath := strings.TrimPrefix(a.DestinationPath, "/")
 
 	switch a.FileOperationType {
 	case FileOperationPatch, FileOperationMergePatch:
@@ -235,6 +241,56 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 		return err
+	case FileOperationCopy:
+		err := ensureDir(root, destinationPath)
+		if err != nil {
+			return err
+		}
+
+		srcContent, err := root.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		err = root.MkdirAll(destinationPath, 0755)
+		if err != nil {
+			return err
+		}
+
+		// Create the destination with os.Root to ensure the path is clean
+		err = root.WriteFile(destinationPath, srcContent, 0644)
+		if err != nil {
+			return err
+		}
+		return nil
+	case FileOperationMove:
+		// TODO(go.1.25): os.Root.Rename is only available starting go 1.25 so we'll use it instead
+		err := ensureDir(root, destinationPath)
+		if err != nil {
+			return err
+		}
+
+		srcContent, err := root.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		err = root.MkdirAll(destinationPath, 0755)
+		if err != nil {
+			return err
+		}
+
+		// Create the destination with os.Root to ensure the path is clean
+		err = root.WriteFile(destinationPath, srcContent, 0644)
+		if err != nil {
+			return err
+		}
+
+		err = root.Remove(path)
+		if err != nil {
+			return err
+		}
+		return nil
 	case FileOperationDelete:
 		err := root.Remove(path)
 		if err != nil && !os.IsNotExist(err) {

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -252,6 +252,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
+		// TODO: this is 1.25+ only
 		err = root.MkdirAll(destinationPath, 0755)
 		if err != nil {
 			return err
@@ -275,6 +276,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
+		// TODO: this is 1.25+ only
 		err = root.MkdirAll(destinationPath, 0755)
 		if err != nil {
 			return err

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -247,7 +247,13 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
-		srcContent, err := root.ReadFile(path)
+		srcFile, err := root.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		srcContent, err := io.ReadAll(srcFile)
 		if err != nil {
 			return err
 		}
@@ -270,7 +276,13 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
-		srcContent, err := root.ReadFile(path)
+		srcFile, err := root.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		srcContent, err := io.ReadAll(srcFile)
 		if err != nil {
 			return err
 		}

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -252,20 +252,19 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
-		// TODO: this is 1.25+ only
-		err = root.MkdirAll(destinationPath, 0755)
+		// Create the destination with os.Root to ensure the path is clean
+		destFile, err := root.Create(destinationPath)
 		if err != nil {
 			return err
 		}
+		defer destFile.Close()
 
-		// Create the destination with os.Root to ensure the path is clean
-		err = root.WriteFile(destinationPath, srcContent, 0644)
+		_, err = destFile.Write(srcContent)
 		if err != nil {
 			return err
 		}
 		return nil
 	case FileOperationMove:
-		// TODO(go.1.25): os.Root.Rename is only available starting go 1.25 so we'll use it instead
 		err := ensureDir(root, destinationPath)
 		if err != nil {
 			return err
@@ -276,14 +275,14 @@ func (a *FileOperation) apply(root *os.Root) error {
 			return err
 		}
 
-		// TODO: this is 1.25+ only
-		err = root.MkdirAll(destinationPath, 0755)
+		// Create the destination with os.Root to ensure the path is clean
+		destFile, err := root.Create(destinationPath)
 		if err != nil {
 			return err
 		}
+		defer destFile.Close()
 
-		// Create the destination with os.Root to ensure the path is clean
-		err = root.WriteFile(destinationPath, srcContent, 0644)
+		_, err = destFile.Write(srcContent)
 		if err != nil {
 			return err
 		}

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -339,8 +339,8 @@ func TestBuildOperationsFromLegacyConfigFileKeepApplicationMonitoring(t *testing
 
 func TestOperationApply_Copy(t *testing.T) {
 	tmpDir := t.TempDir()
-	sourceFilePath := filepath.Join(tmpDir, "source.yaml")
-	destFilePath := filepath.Join(tmpDir, "dest.yaml")
+	sourceFilePath := filepath.Join(tmpDir, "datadog.yaml")
+	destFilePath := filepath.Join(tmpDir, "security-agent.yaml")
 
 	// Create source file
 	sourceContent := []byte("foo: bar\nbaz: qux\n")
@@ -353,8 +353,8 @@ func TestOperationApply_Copy(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationCopy,
-		FilePath:          "/source.yaml",
-		DestinationPath:   "/dest.yaml",
+		FilePath:          "/datadog.yaml",
+		DestinationPath:   "/security-agent.yaml",
 	}
 
 	err = op.apply(root)
@@ -372,8 +372,8 @@ func TestOperationApply_Copy(t *testing.T) {
 
 func TestOperationApply_Move(t *testing.T) {
 	tmpDir := t.TempDir()
-	sourceFilePath := filepath.Join(tmpDir, "source.yaml")
-	destFilePath := filepath.Join(tmpDir, "dest.yaml")
+	sourceFilePath := filepath.Join(tmpDir, "datadog.yaml")
+	destFilePath := filepath.Join(tmpDir, "otel-config.yaml")
 
 	// Create source file
 	sourceContent := []byte("foo: bar\nbaz: qux\n")
@@ -386,8 +386,8 @@ func TestOperationApply_Move(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationMove,
-		FilePath:          "/source.yaml",
-		DestinationPath:   "/dest.yaml",
+		FilePath:          "/datadog.yaml",
+		DestinationPath:   "/otel-config.yaml",
 	}
 
 	err = op.apply(root)
@@ -406,9 +406,9 @@ func TestOperationApply_Move(t *testing.T) {
 
 func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 	tmpDir := t.TempDir()
-	sourceFilePath := filepath.Join(tmpDir, "source.yaml")
-	destDir := filepath.Join(tmpDir, "nested", "dir")
-	destFilePath := filepath.Join(destDir, "dest.yaml")
+	sourceFilePath := filepath.Join(tmpDir, "datadog.yaml")
+	destDir := filepath.Join(tmpDir, "conf.d", "mycheck.d")
+	destFilePath := filepath.Join(destDir, "config.yaml")
 
 	// Create source file
 	sourceContent := []byte("foo: bar\nbaz: qux\n")
@@ -421,8 +421,8 @@ func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationCopy,
-		FilePath:          "/source.yaml",
-		DestinationPath:   "/nested/dir/dest.yaml",
+		FilePath:          "/datadog.yaml",
+		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
 	err = op.apply(root)
@@ -440,9 +440,9 @@ func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 
 func TestOperationApply_MoveWithNestedDestination(t *testing.T) {
 	tmpDir := t.TempDir()
-	sourceFilePath := filepath.Join(tmpDir, "source.yaml")
-	destDir := filepath.Join(tmpDir, "nested", "dir")
-	destFilePath := filepath.Join(destDir, "dest.yaml")
+	sourceFilePath := filepath.Join(tmpDir, "system-probe.yaml")
+	destDir := filepath.Join(tmpDir, "conf.d", "mycheck.d")
+	destFilePath := filepath.Join(destDir, "config.yaml")
 
 	// Create source file
 	sourceContent := []byte("foo: bar\nbaz: qux\n")
@@ -455,8 +455,8 @@ func TestOperationApply_MoveWithNestedDestination(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationMove,
-		FilePath:          "/source.yaml",
-		DestinationPath:   "/nested/dir/dest.yaml",
+		FilePath:          "/system-probe.yaml",
+		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
 	err = op.apply(root)
@@ -486,8 +486,8 @@ func TestOperationApply_CopyMissingSource(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationCopy,
-		FilePath:          "/nonexistent.yaml",
-		DestinationPath:   "/dest.yaml",
+		FilePath:          "/datadog.yaml",
+		DestinationPath:   "/security-agent.yaml",
 	}
 
 	err = op.apply(root)
@@ -503,8 +503,8 @@ func TestOperationApply_MoveMissingSource(t *testing.T) {
 
 	op := &FileOperation{
 		FileOperationType: FileOperationMove,
-		FilePath:          "/nonexistent.yaml",
-		DestinationPath:   "/dest.yaml",
+		FilePath:          "/datadog.yaml",
+		DestinationPath:   "/otel-config.yaml",
 	}
 
 	err = op.apply(root)


### PR DESCRIPTION
### What does this PR do?

Add mv and cp fleet operations

`os.Root.Rename`, `os.Root.MkdirAll`, `os.Root.WriteFile` and `os.Root.ReadFile` are available in go 1.25+, but the agent is currently in go1.24

### Motivation

### Describe how you validated your changes

### Additional Notes
