### PR TITLE
ci: static_quality_gates need cws-instrumentation jobs

### DIFF
--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -27,6 +27,8 @@ static_quality_gates:
     - docker_build_agent7_jmx_arm64
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
+    - docker_build_cws_instrumentation_amd64
+    - docker_build_cws_instrumentation_arm64
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
     - docker_build_agent7_windows1809


### PR DESCRIPTION
### What does this PR do?

Add `docker_build_cws_instrumentation_amd64` and `docker_build_cws_instrumentation_arm64` jobs as dependency to the `static_quality_gates` job. 

### Motivation

The `static_quality_gates` job uses artifacts from these jobs to evaluate quality gates. 

### Describe how you validated your changes

### Additional Notes
