### PR TITLE
[Serverless-Init] Improve Tags Performance

### DIFF
--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -87,7 +87,7 @@ func buildEndpoints(coreConfig model.Reader) (*config.Endpoints, error) {
 	if err != nil {
 		return nil, err
 	}
-	if env.IsServerless() {
+	if env.IsLambda() {
 		// in AWS Lambda, we never want the batch strategy to flush with a tick
 		config.BatchWait = 365 * 24 * time.Hour
 	}

--- a/pkg/config/env/environment.go
+++ b/pkg/config/env/environment.go
@@ -81,7 +81,7 @@ func IsHostSysAvailable() bool {
 	return true
 }
 
-// IsServerless returns whether the Agent is running in a Lambda function
-func IsServerless() bool {
+// IsLambda returns whether the Agent is running in a Lambda function
+func IsLambda() bool {
 	return os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != ""
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2272,7 +2272,7 @@ func LoadDatadogCustom(config pkgconfigmodel.Config, origin string, secretResolv
 func LoadCustom(config pkgconfigmodel.Config, additionalKnownEnvVars []string) error {
 	log.Info("Starting to load the configuration")
 	if err := config.ReadInConfig(); err != nil {
-		if pkgconfigenv.IsServerless() {
+		if pkgconfigenv.IsLambda() {
 			log.Debug("No config file detected, using environment variable based configuration only")
 			// The remaining code in LoadCustom is not run to keep a low cold start time
 			return nil

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
+	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
@@ -32,7 +33,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1 // indirect

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -48,7 +49,11 @@ func NewPipeline(
 
 	var encoder processor.Encoder
 	if serverlessMeta.IsEnabled() {
-		encoder = processor.JSONServerlessEncoder
+		if env.IsLambda() {
+			encoder = processor.JSONServerlessEncoder
+		} else {
+			encoder = processor.JSONServerlessInitEncoder
+		}
 	} else if endpoints.UseHTTP {
 		encoder = processor.JSONEncoder
 	} else if endpoints.UseProto {

--- a/pkg/logs/processor/json_serverless.go
+++ b/pkg/logs/processor/json_serverless.go
@@ -16,6 +16,7 @@ import (
 // JSONServerlessEncoder is a shared json encoder sending a struct message field
 // instead of a bytes message field. This encoder is used in the AWS Lambda
 // serverless environment.
+// TODO(@nhulston) remove lambda encoder when Go Lambda Extension is fully retired.
 var JSONServerlessEncoder Encoder = &jsonServerlessEncoder{}
 
 // jsonEncoder transforms a message into a JSON byte array.

--- a/pkg/logs/processor/json_serverless_init.go
+++ b/pkg/logs/processor/json_serverless_init.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processor
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+)
+
+// JSONServerlessInitEncoder is a custom encoder used by serverless-init
+// (Google Cloud Run, Azure Container Apps, etc.) for improved performance.
+var JSONServerlessInitEncoder Encoder = &jsonServerlessInitEncoder{}
+
+// jsonServerlessInitEncoder transforms a message into a JSON byte array.
+type jsonServerlessInitEncoder struct{}
+
+// JSON representation of a message for serverless-init.
+type jsonServerlessInitPayload struct {
+	Message   string `json:"message"`
+	Status    string `json:"status"`
+	Timestamp int64  `json:"timestamp"`
+	Hostname  string `json:"hostname"`
+	Service   string `json:"service,omitempty"`
+	Source    string `json:"ddsource"`
+	Tags      string `json:"ddtags"`
+}
+
+// Encode encodes a message into a JSON byte array.
+func (j *jsonServerlessInitEncoder) Encode(msg *message.Message, hostname string) error {
+	if msg.State != message.StateRendered {
+		return fmt.Errorf("message passed to encoder isn't rendered")
+	}
+
+	ts := time.Now().UTC()
+	if !msg.ServerlessExtra.Timestamp.IsZero() {
+		ts = msg.ServerlessExtra.Timestamp
+	}
+
+	encoded, err := json.Marshal(jsonServerlessInitPayload{
+		Message:   toValidUtf8(msg.GetContent()),
+		Status:    msg.GetStatus(),
+		Timestamp: ts.UnixNano() / nanoToMillis,
+		Hostname:  hostname,
+		Service:   msg.Origin.Service(),
+		Source:    msg.Origin.Source(),
+		Tags:      msg.TagsToString(),
+	})
+
+	if err != nil {
+		return fmt.Errorf("can't encode the message: %v", err)
+	}
+
+	msg.SetEncoded(encoded)
+	return nil
+}

--- a/releasenotes/notes/serverless-init-cache-tags-to-string-1f3c0f0f5090c242.yaml
+++ b/releasenotes/notes/serverless-init-cache-tags-to-string-1f3c0f0f5090c242.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Cache result of `TagsToString()` in serverless-init to improve CPU performance.


### PR DESCRIPTION
### What does this PR do?

[Serverless-init](https://hub.docker.com/r/datadog/serverless-init) is a special build of the agent for Serverless containers like Google Cloud Run or Azure Container Apps.
- Create a custom JSON encoder for serverless-init
- Cache stringified tags since tags are constant in serverless-init. There is only one log source in serverless-init
- This significantly improves CPU performance. In my tests, we eliminated ~7% CPU usage that was being wasted:
```
% go tool pprof ./saved-profiles/cpu-tagstostring-before.pb.gz 
Duration: 60.14s, Total samples = 8.25s (13.72%)
(pprof) top -cum TagsToString
Showing top 10 nodes out of 52
      flat  flat%   sum%        cum   cum%
         0     0%     0%      0.60s  7.27%  github.com/DataDog/datadog-agent/pkg/logs/message.(*MessageMetadata).TagsToString (inline)
         0     0%     0%      0.60s  7.27%  github.com/DataDog/datadog-agent/pkg/logs/message.(*Origin).TagsToString
         0     0%     0%      0.60s  7.27%  github.com/DataDog/datadog-agent/pkg/logs/processor.(*Processor).processMessage
         0     0%     0%      0.60s  7.27%  github.com/DataDog/datadog-agent/pkg/logs/processor.(*Processor).run
         0     0%     0%      0.60s  7.27%  github.com/DataDog/datadog-agent/pkg/logs/processor.(*jsonServerlessEncoder).Encode

% go tool pprof ./saved-profiles/cpu-tagstostring-after.pb.gz
Duration: 60.08s, Total samples = 7.93s (13.20%)
(pprof) top -cum TagsToString
Focus expression matched no samples
```

Flame graph before:
<img width="1000" height="496" alt="Screenshot 2025-10-03 at 11 33 18 AM" src="https://github.com/user-attachments/assets/2c961269-a5b9-455e-a29a-3bff338b58f7" />


You can view the profiles yourself: [before](https://github.com/DataDog/serverless-init-performance-testing/blob/main/saved-profiles/cpu-tagstostring-before.pb.gz) and [after](https://github.com/DataDog/serverless-init-performance-testing/blob/main/saved-profiles/cpu-tagstostring-after.pb.gz)

### Motivation

Improve serverless-init performance

https://datadoghq.atlassian.net/browse/SVLS-7657

### Describe how you validated your changes

Via profiles and manually. I verified that tags still get added as expected on Google Cloud Run.

We also have [e2e tests](https://github.com/DataDog/serverless-e2e-serverless-init-gcp-tests) and [long-running tests](https://github.com/DataDog/serverless-init-self-monitoring) to detect regressions. We always run them before doing a release.

### Additional Notes
