### PR TITLE
fix(dogstatsd): origin detection precedence for tag enrichment

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -16,9 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
-	"slices"
 	"sync"
 	"time"
 
@@ -367,7 +365,7 @@ func (t *localTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertyp
 		productOrigin = origindetection.ProductOriginDogStatsDLegacy
 	}
 
-	containerIDFromSocketCutIndex := len(types.ContainerID) + types.GetSeparatorLengh()
+	containerIDFromSocketCutIndex := len(types.ContainerID) + types.GetSeparatorLength()
 
 	// Generate container ID from Inode
 	if originInfo.LocalData.ContainerID == "" {
@@ -452,62 +450,62 @@ func (t *localTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertyp
 			return
 		}
 
-		var containerIDsFrom = make(map[string]string)
+		// Enrich tags prioritzing most reliable origin detection methods first.
 
-		// Tag using Local Data
+		// 1. ContainerID from LocalData (includes inode resolution)
+		if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, originInfo.LocalData.ContainerID), cardinality, tb); err != nil {
+			if pkglog.ShouldLog(pkglog.TraceLvl) {
+				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.ContainerID, err)
+			}
+		} else {
+			return
+		}
+
+		// 2. ContainerID from Unix Domain Socket (process ID-based)
 		if originInfo.ContainerIDFromSocket != packets.NoOrigin && len(originInfo.ContainerIDFromSocket) > containerIDFromSocketCutIndex {
 			containerID := originInfo.ContainerIDFromSocket[containerIDFromSocketCutIndex:]
-			containerIDsFrom["ContainerIDFromSocket"] = containerID
-			originFromClient := types.NewEntityID(types.ContainerID, containerID)
-			if err := t.AccumulateTagsFor(originFromClient, cardinality, tb); err != nil {
+			if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, containerID), cardinality, tb); err != nil {
 				t.log.Errorf("%s", err.Error())
+			} else {
+				return
 			}
 		}
 
-		if originInfo.LocalData.ContainerID != "" {
-			containerIDsFrom["ContainerIDFromLocalData"] = originInfo.LocalData.ContainerID
-		}
-		if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, originInfo.LocalData.ContainerID), cardinality, tb); err != nil && pkglog.ShouldLog(pkglog.TraceLvl) {
-			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.ContainerID, err)
-		}
-
-		if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.LocalData.PodUID), cardinality, tb); err != nil && pkglog.ShouldLog(pkglog.TraceLvl) {
-			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.PodUID, err)
-		}
-
-		// Accumulate tags for pod UID
-		if originInfo.ExternalData.PodUID != "" {
-			if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.ExternalData.PodUID), cardinality, tb); err != nil && pkglog.ShouldLog(pkglog.TraceLvl) {
-				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ExternalData.PodUID, err)
-			}
-		}
-
-		// Generate container ID from External Data
+		// 3. ContainerID generated from ExternalData
 		generatedContainerID, err := t.generateContainerIDFromExternalData(originInfo.ExternalData, metrics.GetProvider(option.New(t.workloadStore)).GetMetaCollector())
 		if err != nil && pkglog.ShouldLog(pkglog.TraceLvl) {
 			t.log.Tracef("Failed to generate container ID from %v: %s", originInfo.ExternalData, err)
 		}
 		if generatedContainerID != "" {
-			containerIDsFrom["ContainerIDFromExternalData"] = generatedContainerID
-		}
-
-		containerIDs := slices.Collect(maps.Values(containerIDsFrom))
-		// Check for container ID mismatch
-		// Do not use external data if there is a mismatch between the different resolutions
-		if len(containerIDs) > 1 &&
-			slices.ContainsFunc(containerIDs[1:], func(id string) bool { return id != containerIDs[0] }) {
-			t.telemetryStore.OriginInfoContainerIDMismatch.Inc()
-			t.log.Warnf("Container ID mismatch detected: %v", containerIDsFrom)
-		} else {
-			// Accumulate tags for generated container ID
-			// TODO (CONTP): investigate refactoring tag enrichment to return
-			// once higher priority containerID successfully resolves and adds tags
-			if generatedContainerID != "" {
-				if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, generatedContainerID), cardinality, tb); err != nil && pkglog.ShouldLog(pkglog.TraceLvl) {
+			if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, generatedContainerID), cardinality, tb); err != nil {
+				if pkglog.ShouldLog(pkglog.TraceLvl) {
 					t.log.Tracef("Cannot get tags for entity %s: %s", generatedContainerID, err)
 				}
+			} else {
+				return
 			}
 		}
+
+		// 4. PodUID from LocalData (dd.internal.entity_id)
+		if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.LocalData.PodUID), cardinality, tb); err != nil {
+			if pkglog.ShouldLog(pkglog.TraceLvl) {
+				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.PodUID, err)
+			}
+		} else {
+			return
+		}
+
+		// 5. PodUID from ExternalData
+		if originInfo.ExternalData.PodUID != "" {
+			if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.ExternalData.PodUID), cardinality, tb); err != nil {
+				if pkglog.ShouldLog(pkglog.TraceLvl) {
+					t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ExternalData.PodUID, err)
+				}
+			} else {
+				return
+			}
+		}
+
 	}
 
 	if err := t.globalTagBuilder(cardinality, tb); err != nil {

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -596,6 +596,12 @@ func TestEnrichTags(t *testing.T) {
 	containerName, initContainerName, containerID, initContainerID, podUID := "container-name", "init-container-name", "container-id", "init-container-id", "pod-uid"
 
 	// Fill fake tagger with entities
+
+	// Note: in the real tagger, the pod tags are tied to the container tags.
+	// However, this is not the case in the fake tagger.
+	// Hence, we should only expect the pod defined tags if tag enrichment directly
+	// queries for the pod entity because higher granular container tags failed to accumulate.
+
 	fakeTagger.SetTags(types.NewEntityID(types.KubernetesPodUID, podUID), "host", []string{"pod-low"}, []string{"pod-orch"}, []string{"pod-high"}, []string{"pod-std"})
 	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, containerID), "host", []string{"container-low"}, []string{"container-orch"}, []string{"container-high"}, []string{"container-std"})
 	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, initContainerID), "host", []string{"init-container-low"}, []string{"init-container-orch"}, []string{"init-container-high"}, []string{"init-container-std"})
@@ -659,7 +665,7 @@ func TestEnrichTags(t *testing.T) {
 				},
 				Cardinality:   "high",
 				ProductOrigin: origindetection.ProductOriginAPM},
-			expectedTags: []string{"container-low", "container-orch", "container-high", "pod-low", "pod-orch", "pod-high"},
+			expectedTags: []string{"container-low", "container-orch", "container-high"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -708,7 +714,7 @@ func TestEnrichTags(t *testing.T) {
 				},
 				Cardinality: "low",
 			},
-			expectedTags: []string{"pod-low", "container-low"},
+			expectedTags: []string{"container-low"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
@@ -735,7 +741,7 @@ func TestEnrichTags(t *testing.T) {
 				},
 				Cardinality: "high",
 			},
-			expectedTags: []string{"pod-low", "pod-orch", "pod-high", "container-low", "container-orch", "container-high"},
+			expectedTags: []string{"container-low", "container-orch", "container-high"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
@@ -749,7 +755,7 @@ func TestEnrichTags(t *testing.T) {
 				},
 				Cardinality: "low",
 			},
-			expectedTags: []string{"pod-low", "init-container-low"},
+			expectedTags: []string{"init-container-low"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&initContainerMetaCollector) },
 		},
 	} {
@@ -778,7 +784,7 @@ func TestEnrichTagsContainerIDMismatch(t *testing.T) {
 	localContainerID, externalContainerID, podUID := "local-container-id", "external-container-id", "pod-uid"
 	containerName := "container-name"
 
-	fakeTagger.SetTags(types.NewEntityID(types.KubernetesPodUID, podUID), "kubelet", []string{"pod-low"}, nil, nil, nil)
+	fakeTagger.SetTags(types.NewEntityID(types.KubernetesPodUID, podUID), "kubelet", []string{"directly-from-pod-low"}, nil, nil, nil)
 	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, localContainerID), "kubelet", []string{"local-container-low"}, nil, nil, nil)
 	fakeTagger.SetTags(types.NewEntityID(types.ContainerID, externalContainerID), "kubelet", []string{"external-container-low"}, nil, nil, nil)
 
@@ -811,7 +817,7 @@ func TestEnrichTagsContainerIDMismatch(t *testing.T) {
 		actualTags := tb.Get()
 
 		assert.Contains(t, actualTags, "local-container-low")
-		assert.Contains(t, actualTags, "pod-low")
+		assert.NotContains(t, actualTags, "directly-from-pod-low")
 		assert.NotContains(t, actualTags, "external-container-low")
 	})
 }

--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -61,10 +61,6 @@ type Store struct {
 	// to generate a container ID from Origin Info.
 	OriginInfoRequests telemetry.Counter
 
-	// OriginInfoContainerIDMismatch tracks the number of times container IDs from Origin Info
-	// were mismatched during enrichment.
-	OriginInfoContainerIDMismatch telemetry.Counter
-
 	LowCardinalityQueries          CardinalityTelemetry
 	OrchestratorCardinalityQueries CardinalityTelemetry
 	HighCardinalityQueries         CardinalityTelemetry
@@ -130,12 +126,6 @@ func NewStore(telemetryComp telemetry.Component) *Store {
 		// to generate a container ID from origin info.
 		OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
 			[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
-			commonOpts),
-
-		// OriginInfoContainerIDMismatch tracks the number of times container IDs from Origin Info
-		// were mismatched during enrichment.
-		OriginInfoContainerIDMismatch: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_container_id_mismatch",
-			[]string{}, "Number of times container IDs from Origin Info where mismatched during enrichment.",
 			commonOpts),
 
 		LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -16,8 +16,8 @@ const separatorLength = len(separator)
 
 var globalEntityID = NewEntityID(InternalID, "global-entity-id")
 
-// GetSeparatorLengh returns the length of the entityID separator
-func GetSeparatorLengh() int {
+// GetSeparatorLength returns the length of the entityID separator
+func GetSeparatorLength() int {
 	return separatorLength
 }
 

--- a/releasenotes/notes/dogstatsd-tag-enrichment-precedence-41b16bb6abefd5a8.yaml
+++ b/releasenotes/notes/dogstatsd-tag-enrichment-precedence-41b16bb6abefd5a8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Utilize single origin information source for DogStatsD tag 
+    enrichment to avoid tag duplication.


### PR DESCRIPTION
### What does this PR do?

Updates tag enrichment logic for unified Dogstatsd to enrich on only one entity ID, based on precedence.

### Motivation

#incident-41903. During OOM kills on busy hosts, origin detection fails on rare occasion causing incorrect metric contexts being generated.

To address these issues with duplicate/incorrect tag values from tag enrichment via origin detection, we’re changing the logic so that enrichment is based only on the highest-priority entity ID among all available IDs, rather than enriching separately on all container IDs and pod UIDs provided. 

Assuming that the provided containerID is correct, then all subsequent calls for tag accumulation on the "hypothetically" same containerID and podUID should return the same values. Therefore we can exit out from tag enrichment after the first hit.

### Describe how you validated your changes

Unit tests and CI

### Additional Notes

Removed the `OriginInfoContainerIDMismatch` because we will stop at the first valid containerID for tagging now. Thus, this metric does not provide value anymore in knowing whether we have incorrect tags on telemetry. It could still be useful for identifying other system issues with receiving faulty data related to ExternalData. 

For `GenerateContainerIDFromOriginInfo` we may want to consider also re-ordering the priority to use the Inode method as the second option and bumping down the more expensive and less reliable PIDtoCID method. Note, this doesn't affect DogStatsd, but rather other remote Agents that query the tagger such as trace-agent and process-agent.

https://github.com/DataDog/datadog-agent/blob/fc2014a0f3c1a5a3df8736a6663f7ba90328ab65/comp/core/tagger/impl/tagger.go#L257-L269