### PR TITLE
[Backport 7.72.x] [dyninst/irgen] Workaround DWARF containing repeated entries for the same variable

### DIFF
--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -130,5 +130,17 @@ func testAllProbes(t *testing.T, binPath string) {
 	v, err := irgen.GenerateIR(1, obj, probes)
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	// TODO: Validate more properties of the IR.
+	verifyIR(t, v)
+}
+
+func verifyIR(t *testing.T, ir *ir.Program) {
+	for _, s := range ir.Subprograms {
+		varNames := make(map[string]struct{})
+		for _, v := range s.Variables {
+			if _, ok := varNames[v.Name]; ok {
+				t.Fatalf("variable %s appears multiple times in subprogram %s", v.Name, s.Name)
+			}
+			varNames[v.Name] = struct{}{}
+		}
+	}
 }


### PR DESCRIPTION
Backport a590f161779d8d27c5b37e327fb704deac863f2b from #41583.

___

Fix for the bug observed in staging.
Validated manually on the binary with faulty debug information.
Once we understand how to trigger this go compiler bug, we will add automatic tests too.