### PR TITLE
usm: http2: Fix time comparison for incomplete requests

### DIFF
--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -75,10 +75,10 @@ func TestIncompleteBuffer(t *testing.T) {
 		}
 		buffer.Add(request)
 		_ = buffer.Flush(time.Time{})
-		require.True(t, len(buffer.data) > 0)
+		require.NotEmpty(t, buffer.data)
 
 		buffer.data[0].Stream.Request_started = uint64(startTime - buffer.minAgeNano)
 		_ = buffer.Flush(time.Time{})
-		assert.True(t, len(buffer.data) == 0)
+		require.Empty(t, buffer.data)
 	})
 }

--- a/pkg/network/protocols/http2/incomplete_stats_test.go
+++ b/pkg/network/protocols/http2/incomplete_stats_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
@@ -58,8 +59,9 @@ func TestIncompleteBuffer(t *testing.T) {
 	t.Run("removing old incomplete", func(t *testing.T) {
 		// Testing the scenario where an incomplete request is removed after a certain time.
 		buffer := NewIncompleteBuffer(config.New()).(*incompleteBuffer)
-		now := time.Now()
-		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
+		startTime, err := ebpf.NowNanoseconds()
+		require.NoError(t, err)
+		buffer.minAgeNano = (1 * time.Second).Nanoseconds()
 		request := &EbpfTx{
 			Tuple: ConnTuple{
 				Sport: 6000,
@@ -68,15 +70,15 @@ func TestIncompleteBuffer(t *testing.T) {
 				Path: http2Path{
 					Static_table_entry: EmptyPathValue,
 				},
-				Request_started: uint64(now.UnixNano()),
+				Request_started: uint64(startTime),
 			},
 		}
 		buffer.Add(request)
-		_ = buffer.Flush(now)
+		_ = buffer.Flush(time.Time{})
+		require.True(t, len(buffer.data) > 0)
 
-		assert.True(t, len(buffer.data) > 0)
-		now = now.Add(35 * time.Second)
-		_ = buffer.Flush(now)
+		buffer.data[0].Stream.Request_started = uint64(startTime - buffer.minAgeNano)
+		_ = buffer.Flush(time.Time{})
 		assert.True(t, len(buffer.data) == 0)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Fixes time comparison for incomplete HTTP/2 requests in USM.

### Motivation

The time comparison logic for incomplete HTTP/2 requests was not working correctly, which could lead to incorrect handling of request timeouts or incomplete request detection.

### Describe how you validated your changes

### Additional Notes

This is part of USMON-658 to improve HTTP/2 monitoring reliability.

🤖 Generated with [Claude Code](https://claude.ai/code)