### PR TITLE
usm: http2: Change type and introduce static table

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -110,7 +110,7 @@ typedef enum {
 } __attribute__((packed)) static_table_value_t;
 
 typedef struct {
-    char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
+    __u8 buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
     __u32 original_index;
     __u8 string_len;
     bool is_huffman_encoded;

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -44,7 +44,34 @@ const (
 	MethodPatch
 	// MethodTrace represents the TRACE request method
 	MethodTrace
+	// MethodConnect represents the CONNECT request method
+	MethodConnect
 )
+
+var (
+	methods = []Method{
+		MethodPut,
+		MethodDelete,
+		MethodHead,
+		MethodOptions,
+		MethodPatch,
+		MethodGet,
+		MethodPost,
+		MethodTrace,
+		MethodConnect,
+	}
+	// StringToMethod maps string representations of the methods to their enums.
+	StringToMethod = map[string]Method{}
+	// MethodToString maps the enums to their string representations
+	MethodToString = map[Method]string{}
+)
+
+func init() {
+	for _, method := range methods {
+		StringToMethod[method.String()] = method
+		MethodToString[method] = method.String()
+	}
+}
 
 // Method returns a string representing the HTTP method of the request
 func (m Method) String() string {
@@ -65,6 +92,8 @@ func (m Method) String() string {
 		return "PATCH"
 	case MethodTrace:
 		return "TRACE"
+	case MethodConnect:
+		return "CONNECT"
 	default:
 		return "UNKNOWN"
 	}

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -197,6 +197,13 @@ func (ew *EventWrapper) ConnTuple() types.ConnectionKey {
 	}
 }
 
+var (
+	unsupportedMethods = map[http.Method]struct{}{
+		http.MethodConnect: {},
+		http.MethodTrace:   {},
+	}
+)
+
 // Method returns the HTTP method of the transaction.
 func (ew *EventWrapper) Method() http.Method {
 	var method string
@@ -236,6 +243,9 @@ func (ew *EventWrapper) Method() http.Method {
 
 	http2Method, ok := http.StringToMethod[strings.ToUpper(method)]
 	if !ok {
+		return http.MethodUnknown
+	}
+	if _, exists := unsupportedMethods[http2Method]; exists {
 		return http.MethodUnknown
 	}
 

--- a/pkg/network/protocols/http2/static_table.go
+++ b/pkg/network/protocols/http2/static_table.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http2
+
+import (
+	nethttp "net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+)
+
+var (
+	// methodStaticTable maps the methods in the static table, to a string representation.
+	methodStaticTable = map[uint8]http.Method{
+		GetValue:  http.MethodGet,
+		PostValue: http.MethodPost,
+	}
+
+	// statusStaticTable maps the kernel enum value to a HTTP status code.
+	statusStaticTable = map[uint8]uint16{
+		K200Value: nethttp.StatusOK,
+		K204Value: nethttp.StatusNoContent,
+		K206Value: nethttp.StatusPartialContent,
+		K304Value: nethttp.StatusNotModified,
+		K400Value: nethttp.StatusBadRequest,
+		K404Value: nethttp.StatusNotFound,
+		K500Value: nethttp.StatusInternalServerError,
+	}
+
+	// pathStaticTable maps the kernel enum values to the string representation in the static table.
+	pathStaticTable = map[uint8]*intern.StringValue{
+		EmptyPathValue: interner.GetString("/"),
+		IndexPathValue: interner.GetString("/index.html"),
+	}
+)

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -32,7 +32,7 @@ type HTTP2DynamicTableIndex struct {
 	Tup   ConnTuple
 }
 type HTTP2DynamicTableEntry struct {
-	Buffer             [160]int8
+	Buffer             [160]uint8
 	Original_index     uint32
 	String_len         uint8
 	Is_huffman_encoded bool


### PR DESCRIPTION
### What does this PR do?

This PR introduces HTTP/2 static table support in userspace and changes a type to allow automation.

### Motivation

- Enables the HTTP/2 static table to be used in user mode
- Changes type to support automation workflows

### Describe how you validated your changes

Standard testing procedures for HTTP/2 protocol handling.

### Additional Notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>