### PR TITLE
Remove unused import from trace-agent coverage build

### DIFF
--- a/cmd/trace-agent/subcommands/coverage/command.go
+++ b/cmd/trace-agent/subcommands/coverage/command.go
@@ -20,11 +20,9 @@ import (
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logfx "github.com/DataDog/datadog-agent/comp/core/log/fx"
-	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 // SetupCoverageCommand adds the coverage command to the trace-agent command tree.


### PR DESCRIPTION
### What does this PR do?

Remove an import no longer used in coverage computation build

### Motivation

Fix the coverage pipeline

### Describe how you validated your changes

### Additional Notes
