### PR TITLE
Revert gitlab tokens user side

### DIFF
--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -17,7 +18,6 @@ from difflib import Differ
 from functools import lru_cache
 from itertools import product
 from pathlib import Path
-from sys import platform
 from typing import Any, Literal
 
 import gitlab

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -14,6 +14,7 @@ from invoke.exceptions import Exit
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.ciproviders.gitlab_api import (
     cancel_pipeline,
+    get_gitlab_bot_token,
     get_gitlab_repo,
     gitlab_configuration_is_modified,
     refresh_pipeline,
@@ -519,7 +520,7 @@ def get_schedules(_, repo: str = 'DataDog/datadog-agent'):
     Pretty-print all pipeline schedules on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     for schedule in gitlab_repo.pipelineschedules.list(per_page=100, all=True):
         schedule.pprint()
@@ -531,7 +532,7 @@ def get_schedule(_, schedule_id, repo: str = 'DataDog/datadog-agent'):
     Pretty-print a single pipeline schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.get(schedule_id)
 
@@ -546,7 +547,7 @@ def create_schedule(_, description, ref, cron, cron_timezone=None, active=False,
     Note that unless you explicitly specify the --active flag, the schedule will be created as inactive.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.create(
         {'description': description, 'ref': ref, 'cron': cron, 'cron_timezone': cron_timezone, 'active': active}
@@ -563,7 +564,7 @@ def edit_schedule(
     Edit an existing pipeline schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     data = {'description': description, 'ref': ref, 'cron': cron, 'cron_timezone': cron_timezone}
     data = {key: value for (key, value) in data.items() if value is not None}
@@ -579,7 +580,7 @@ def activate_schedule(_, schedule_id, repo: str = 'DataDog/datadog-agent'):
     Activate an existing pipeline schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.update(schedule_id, {'active': True})
 
@@ -592,7 +593,7 @@ def deactivate_schedule(_, schedule_id, repo: str = 'DataDog/datadog-agent'):
     Deactivate an existing pipeline schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.update(schedule_id, {'active': False})
 
@@ -605,7 +606,7 @@ def delete_schedule(_, schedule_id, repo: str = 'DataDog/datadog-agent'):
     Delete an existing pipeline schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     gitlab_repo.pipelineschedules.delete(schedule_id)
 
@@ -618,7 +619,7 @@ def create_schedule_variable(_, schedule_id, key, value, repo: str = 'DataDog/da
     Create a variable for an existing schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.get(schedule_id)
     schedule.variables.create({'key': key, 'value': value})
@@ -632,7 +633,7 @@ def edit_schedule_variable(_, schedule_id, key, value, repo: str = 'DataDog/data
     Edit an existing variable for a schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.get(schedule_id)
     schedule.variables.update(key, {'value': value})
@@ -646,7 +647,7 @@ def delete_schedule_variable(_, schedule_id, key, repo: str = 'DataDog/datadog-a
     Delete an existing variable for a schedule on the repository.
     """
 
-    gitlab_repo = get_gitlab_repo(repo)
+    gitlab_repo = get_gitlab_repo(repo, token=get_gitlab_bot_token())
 
     schedule = gitlab_repo.pipelineschedules.get(schedule_id)
     schedule.variables.delete(key)


### PR DESCRIPTION
### What does this PR do?

The first revert PR for #40181 was reverting this only for the CI.

- GITLAB_TOKEN takes precedence locally
- Pipeline schedules still use the bot token

### Motivation

### Describe how you validated your changes

### Additional Notes
