### PR TITLE
fix(octo-sts): Adapt the chainguard for backport PR to allow backport from release to main

### DIFF
--- a/.github/chainguard/self.backport-pr.create-pr.sts.yaml
+++ b/.github/chainguard/self.backport-pr.create-pr.sts.yaml
@@ -5,8 +5,8 @@ subject: repo:DataDog/datadog-agent:pull_request
 
 claim_pattern:
   event_name: pull_request
-  ref: refs/heads/main
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/backport-pr\.yml@refs/heads/main
+  ref: refs/heads/(main|7\.[0-9]+\.x)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/backport-pr\.yml@refs/heads/(main|7\.[0-9]+\.x)
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?
Update the chainguard condition to allow creating backport PR from release branches to main

### Motivation
Prevent [failure](https://github.com/DataDog/datadog-agent/actions/runs/18274395856/job/52023084545?pr=41607) when backporting the release notes

### Describe how you validated your changes
Validated locally with the JWT from [here](https://github.com/DataDog/datadog-agent/actions/runs/18274395856/job/52023084545?pr=41607) and the below command
```
DDOCTOSTS_ID_TOKEN=$(cat claims.json) dd-octo-sts check --scope \"DataDog/datadog-agent\" --policy self.backport-pr.create-pr
```
Before:
<img width="1301" height="423" alt="image" src="https://github.com/user-attachments/assets/f399454f-43de-4254-a0d8-2f536c564b81" />

After
<img width="1305" height="476" alt="image" src="https://github.com/user-attachments/assets/6854d1da-dca1-4f97-9545-90a8f2ab567e" />

### Additional Notes
