### PR TITLE
Pin agent-release-management to the 7.71.x branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,7 +238,7 @@ variables:
   VIRUS_TOTAL: virus-total # windows-products
   # End vault variables
 
-  DD_PKG_VERSION: "latest"
+  DD_PKG_VERSION: "0.5.0"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy

--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -24,6 +24,7 @@
         --release-version $RELEASE_VERSION \
         --target-repo $TARGET_REPO \
         --target-channel $BUCKET_BRANCH \
+        --target-branch 7.71.x \
         $AUTO_RELEASE \
         $FOLLOW
   dependencies: []

--- a/.gitlab/trigger_release/installer.yml
+++ b/.gitlab/trigger_release/installer.yml
@@ -26,6 +26,7 @@
         --release-version $RELEASE_VERSION \
         --target-repo $TARGET_REPO \
         --target-channel $BUCKET_BRANCH \
+        --target-branch 7.71.x \
         $AUTO_RELEASE \
         $FOLLOW
   dependencies: []


### PR DESCRIPTION
### What does this PR do?

Updates the `7.71.x` branch of `datadog-agent` to use the `7.71.x` branch of `agent-release-management`.
Pins the `dd-pkg` version to `0.50.0` to not include https://github.com/DataDog/dd-pkg/pull/100, which prevents using `dd-pkg` for prod releases if a non-`main` branch of `agent-release-management` is used.

### Motivation

Pin `agent-release-management` for the `7.71.x` release to introduce new changes on `main` without disrupting the ongoing release.

### Describe how you validated your changes

CI passes.

### Additional Notes

n/a
