### PR TITLE
[AGENTRUN-750] Implementing RemoteAgent boilerplate

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -186,6 +186,10 @@ doesn't exist or doesn't contain a PID for a running process.
 
 Package profiler provides a flare folder containing the output of various agent's pprof servers
 
+### [comp/core/remoteagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/remoteagent)
+
+Package remoteagent implements the remote agent component
+
 ### [comp/core/remoteagentregistry](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/core/remoteagentregistry)
 
 Package remoteagentregistry provides an integration point for remote agents to register and be able to report their

--- a/comp/core/remoteagent/README.md
+++ b/comp/core/remoteagent/README.md
@@ -1,0 +1,76 @@
+# Remote Agent Component
+
+The `remoteagent` component provides infrastructure for exposing any Agent process data to the Core Agent. Every Remote Agent advertises itself at startup to the Core Agent, sharing its gRPC endpoint and the services it provides. The Core Agent can then use the gRPC endpoint to call the Remote Agent services.
+
+## Supported Services
+
+The Remote Agent currently supports these services:
+- **StatusProvider**: provides status details printed by the `agent status` command
+- **FlareProvider**: provides flare files inserted in the flare archive  
+- **TelemetryProvider**: provides telemetry data aggregated to the Core Agent telemetry component
+
+More services will be added in the future. Feel free to reach out to us (Agent-runtimes team) if you need any specific service.
+
+## Quick Start
+
+The easiest way to expose your Agent data to the Core Agent is to copy and customize the provided templates:
+
+1. **Copy the templates** to your new component location:
+   ```bash
+   # Copy the fx module template
+   cp -r comp/core/remoteagent/fx-template comp/core/remoteagent/fx-<your-agent-name>
+   
+   # Copy the implementation template  
+   cp -r comp/core/remoteagent/impl-template comp/core/remoteagent/impl-<your-agent-name>
+   ```
+
+2. **Update import paths** in the copied `fx.go` and `remoteagent.go` files to match your new component location
+
+3. **Customize the implementation** in your copied `impl-<your-agent-name>/remoteagent.go`:
+   - Add your gRPC service registrations in the `NewComponent` function
+   - Implement your business logic in the `remoteagentImpl` struct
+   - Add any additional dependencies to the `Requires` struct
+
+4. **Wire it up** using the fx module in your Agent's main function
+
+## Example
+
+Here's how to register Remote Agent services:
+
+```go
+// NewComponent creates a new remoteagent component
+func NewComponent(reqs Requires) (Provides, error) {
+   remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(...)
+   // ...
+
+   // Register your services:
+   pbcore.RegisterStatusProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
+   // ...
+}
+
+
+// Then implement the service methods:
+func (r *remoteagentImpl) GetStatusDetails(_ context.Context, req *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
+	log.Printf("Got request for status details: %v", req)
+
+	// Implement your business logic here
+
+	return &pbcore.GetStatusDetailsResponse{
+      // ...
+   }, nil
+}
+```
+
+## Helper Package Features
+
+The `helper` package handles the complex parts of remote Agent setup:
+
+- **TLS Configuration**: Automatic TLS setup using the IPC component
+- **Authentication**: Token-based authentication with the Core Agent
+- **Registration**: Automatic registration and periodic refresh with the Core Agent  
+- **Session Management**: Session ID handling for proper Agent identification
+- **Lifecycle**: Proper startup/shutdown hooks and gRPC server management
+
+## Important Notes
+
+- **Service Registration**: gRPC services must be registered in the constructor only, not in lifecycle callbacks. The gRPC server starts serving immediately after the lifecycle OnStart hook.

--- a/comp/core/remoteagent/def/component.go
+++ b/comp/core/remoteagent/def/component.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package remoteagent implements the remote agent component
+package remoteagent
+
+// team: agent-runtimes
+
+// Component is the component type.
+type Component interface{}

--- a/comp/core/remoteagent/fx-template/fx.go
+++ b/comp/core/remoteagent/fx-template/fx.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the remoteagent component
+package fx
+
+import (
+	"go.uber.org/fx"
+
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	remoteagentimpl "github.com/DataDog/datadog-agent/comp/core/remoteagent/impl-template"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			remoteagentimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[remoteagent.Component](),
+
+		// Since no other component depends on remoteagent, we add this dummy invocation to ensure it gets instantiated when the module is used.
+		fx.Invoke(func(_ remoteagent.Component) {}),
+	)
+}

--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -1,0 +1,279 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package helper implements the helper for the remoteagent component
+package helper
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+)
+
+// UnimplementedRemoteAgentServer is a wrapper around a gRPC server that implements the RemoteAgentServer protocol.
+// It takes care of the registration logic with the Core Agent.
+type UnimplementedRemoteAgentServer struct {
+	log    log.Component
+	config config.Component
+
+	// server infos
+	agentFlavor string
+	displayName string
+	services    []string
+
+	// communication components
+	ipcComp         ipc.Component
+	agentClient     pbcore.AgentSecureClient
+	sessionID       string
+	sessionIDMutex  sync.RWMutex
+	agentIpcAddress string
+	listener        net.Listener
+	grpcServer      *grpc.Server
+
+	// lifecycle components
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	wg                    sync.WaitGroup
+	defaultTickerInterval time.Duration
+	queryTimeout          time.Duration
+}
+
+// NewUnimplementedRemoteAgentServer creates a new unimplemented remote agent server
+func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component, config config.Component, lc compdef.Lifecycle, agentIpcAddress string, agentFlavor string, displayName string) (*UnimplementedRemoteAgentServer, error) {
+	// Validate the agentFlavor and displayName
+	if agentFlavor == "" {
+		return nil, errors.New("agentFlavor is required")
+	}
+	if displayName == "" {
+		return nil, errors.New("displayName is required")
+	}
+
+	// Listen on a random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	agentClient, err := newAgentSecureClient(ipcComp, agentIpcAddress)
+	if err != nil {
+		log.Errorf("failed to create agent client: %v", err)
+		return nil, err
+	}
+
+	remoteAgentServer := &UnimplementedRemoteAgentServer{
+		ipcComp:               ipcComp,
+		log:                   log,
+		config:                config,
+		agentIpcAddress:       agentIpcAddress,
+		agentFlavor:           agentFlavor,
+		displayName:           displayName,
+		agentClient:           agentClient,
+		listener:              listener,
+		grpcServer:            nil,
+		defaultTickerInterval: time.Millisecond * 500,
+		queryTimeout:          config.GetDuration("remote_agent_registry.query_timeout"),
+	}
+
+	// Initialize the gRPC server
+	sessionIDInterceptor := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		remoteAgentServer.sessionIDMutex.RLock()
+		sessionID := remoteAgentServer.sessionID
+		remoteAgentServer.sessionIDMutex.RUnlock()
+		if sessionID == "" {
+			return nil, errors.New("remote agent is not registered yet")
+		}
+		err = grpc.SetHeader(ctx, metadata.New(map[string]string{"session_id": sessionID}))
+		if err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+
+	chainedInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// first apply auth interceptor
+		authHandler := grpc_auth.UnaryServerInterceptor(grpcutil.StaticAuthInterceptor(remoteAgentServer.ipcComp.GetAuthToken()))
+		return authHandler(ctx, req, info, func(ctx context.Context, req any) (any, error) {
+			// then apply session ID interceptor
+			return sessionIDInterceptor(ctx, req, info, handler)
+		})
+	}
+
+	serverOpts := []grpc.ServerOption{
+		grpc.Creds(credentials.NewTLS(remoteAgentServer.ipcComp.GetTLSServerConfig())),
+		grpc.UnaryInterceptor(chainedInterceptor),
+	}
+
+	remoteAgentServer.grpcServer = grpc.NewServer(serverOpts...)
+
+	// Setup lifecycle
+	lc.Append(compdef.Hook{
+		OnStart: func(_ context.Context) error {
+			remoteAgentServer.start()
+			return nil
+		},
+		OnStop: func(_ context.Context) error {
+			remoteAgentServer.stop()
+			return nil
+		},
+	})
+
+	return remoteAgentServer, nil
+}
+
+// Start the unimplemented remote agent server
+func (s *UnimplementedRemoteAgentServer) start() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	// Get the services from the gRPC server
+	for serviceName := range s.grpcServer.GetServiceInfo() {
+		s.services = append(s.services, serviceName)
+	}
+
+	// Start the gRPC server
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		if err := s.grpcServer.Serve(s.listener); err != nil {
+			s.log.Errorf("failed to serve: %v", err)
+			// Cancel the context to stop the registration loop
+			s.cancel()
+			return
+		}
+	}()
+
+	// Start the registration loop
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		// Wait forever, periodically refreshing our registration.
+		refreshTicker := time.NewTicker(s.defaultTickerInterval)
+		for {
+			select {
+			case <-s.ctx.Done():
+				s.grpcServer.GracefulStop()
+				return
+			case <-refreshTicker.C:
+				s.sessionIDMutex.RLock()
+				sessionID := s.sessionID
+				s.sessionIDMutex.RUnlock()
+				// if empty, trying to register to the coreAgent
+				if sessionID == "" {
+					var err error
+					s.log.Debug("Session ID is empty, entering registration loop")
+					sessionID, refreshInterval, err := s.registerWithAgent()
+					if err != nil {
+						continue
+					}
+					s.sessionIDMutex.Lock()
+					s.sessionID = sessionID
+					s.sessionIDMutex.Unlock()
+					refreshTicker.Reset(refreshInterval)
+				} else {
+					// The sessionID exist, trying to refresh
+					err := s.refreshRegistration()
+					if err != nil {
+						s.log.Warnf("failed to refresh registration with Core Agent: %v, entering registration loop", err)
+						s.sessionIDMutex.Lock()
+						s.sessionID = ""
+						s.sessionIDMutex.Unlock()
+						refreshTicker.Reset(s.defaultTickerInterval)
+						continue
+					}
+				}
+			}
+		}
+
+	}()
+}
+
+func (s *UnimplementedRemoteAgentServer) stop() {
+	s.cancel()
+	s.wg.Wait()
+	s.log.Debug("remoteAgentServer stopped")
+}
+
+func newAgentSecureClient(ipcComp ipc.Component, agentIpcAddress string) (pbcore.AgentSecureClient, error) {
+	conn, err := grpc.NewClient(agentIpcAddress,
+		grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
+		grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(ipcComp.GetAuthToken())),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return pbcore.NewAgentSecureClient(conn), nil
+}
+
+// registerWithAgent handles the registration logic with the Core Agent
+func (s *UnimplementedRemoteAgentServer) registerWithAgent() (string, time.Duration, error) {
+	registerReq := &pbcore.RegisterRemoteAgentRequest{
+		Flavor:         s.agentFlavor,
+		DisplayName:    s.displayName,
+		ApiEndpointUri: s.listener.Addr().String(),
+		Services:       s.services,
+	}
+
+	s.log.Debugf("Registering with Core Agent at %s...", s.agentIpcAddress)
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.queryTimeout)
+	defer cancel()
+
+	resp, err := s.agentClient.RegisterRemoteAgent(ctx, registerReq)
+	if err != nil {
+		s.log.Debugf("failed to register remote agent: %v", err)
+		return "", 0, err
+	}
+
+	// Store the session ID for use in the session ID interceptor
+	s.log.Infof("Registered with Core Agent. Recommended refresh interval of %d seconds.", resp.RecommendedRefreshIntervalSecs)
+
+	// Check that refresh rate is greater than 0 seconds
+	var refreshInterval time.Duration
+	if resp.RecommendedRefreshIntervalSecs == 0 {
+		s.log.Warnf("Recommended refresh interval is 0 seconds, using default refresh interval of %d seconds", s.defaultTickerInterval)
+		refreshInterval = s.defaultTickerInterval
+	} else {
+		refreshInterval = time.Duration(resp.RecommendedRefreshIntervalSecs) * time.Second
+	}
+
+	return resp.SessionId, refreshInterval, nil
+}
+
+// refreshRegistration handles the refresh logic with the Core Agent
+func (s *UnimplementedRemoteAgentServer) refreshRegistration() error {
+	ctx, cancel := context.WithTimeout(context.Background(), s.queryTimeout)
+	defer cancel()
+
+	_, err := s.agentClient.RefreshRemoteAgent(ctx, &pbcore.RefreshRemoteAgentRequest{SessionId: s.sessionID})
+	if err != nil {
+		return err
+	}
+
+	s.log.Debug("Refreshed registration with Core Agent.")
+	return nil
+}
+
+// GetGRPCServer returns the gRPC server
+func (s *UnimplementedRemoteAgentServer) GetGRPCServer() *grpc.Server {
+	return s.grpcServer
+}

--- a/comp/core/remoteagent/helper/serverhelper_test.go
+++ b/comp/core/remoteagent/helper/serverhelper_test.go
@@ -1,0 +1,548 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package helper
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/examples/features/proto/echo"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+)
+
+// TestNoSessionIDReturnsError tests that requests to the remote agent server
+// return errors when no session ID is set (i.e., before registration completes)
+func TestNoSessionIDReturnsError(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	// Create a mock core agent server that never responds to registration
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp, func(ctx context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+		// Block forever to prevent registration from completing
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, nil)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	server, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+
+	// Register a test service
+	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+	defer lc.Stop(context.Background())
+
+	// Create a client to the remote agent server
+	conn, err := grpc.NewClient(
+		server.listener.Addr().String(),
+		grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
+		grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(ipcComp.GetAuthToken())),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := pbcore.NewStatusProviderClient(conn)
+
+	// Try to call the status service - should fail because no session ID is set
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err = client.GetStatusDetails(ctx, &pbcore.GetStatusDetailsRequest{}, grpc.WaitForReady(true))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote agent is not registered yet")
+}
+
+// TestAuthTokenIsChecked tests that the auth_token is properly validated
+// for incoming requests to the remote agent server
+func TestAuthTokenIsChecked(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	// Create a mock core agent server
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp, func(_ context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+		return &pbcore.RegisterRemoteAgentResponse{
+			SessionId:                      "test-session-id",
+			RecommendedRefreshIntervalSecs: 60,
+		}, nil
+	}, nil)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	server, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+
+	// Register a test service
+	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+	defer lc.Stop(context.Background())
+
+	tests := []struct {
+		name             string
+		authToken        string
+		shouldSucceed    bool
+		expectedGRPCCode codes.Code
+	}{
+		{
+			name:             "invalid auth token should fail",
+			authToken:        "invalid-token",
+			shouldSucceed:    false,
+			expectedGRPCCode: codes.Unauthenticated,
+		},
+		{
+			name:          "valid auth token should succeed",
+			authToken:     ipcComp.GetAuthToken(), // will be set to valid token
+			shouldSucceed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create client with the specified auth token
+			conn, err := grpc.NewClient(
+				server.listener.Addr().String(),
+				grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
+				grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(tt.authToken)),
+			)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			client := pbcore.NewStatusProviderClient(conn)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				resp, err := client.GetStatusDetails(ctx, &pbcore.GetStatusDetailsRequest{}, grpc.WaitForReady(true))
+				if tt.shouldSucceed {
+					require.NoError(c, err)
+					assert.NotNil(c, resp)
+				} else {
+					require.Error(c, err)
+					st, ok := status.FromError(err)
+					require.True(c, ok)
+					assert.Equal(c, tt.expectedGRPCCode, st.Code())
+				}
+			}, 5*time.Second, 100*time.Millisecond)
+		})
+	}
+}
+
+// TestServerLifecycle tests that the server starts and stops correctly
+// using compdef.NewTestLifecycle
+func TestServerLifecycle(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	// Create a mock core agent server
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp, func(_ context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+		return &pbcore.RegisterRemoteAgentResponse{
+			SessionId:                      "test-session-id",
+			RecommendedRefreshIntervalSecs: 60,
+		}, nil
+	}, nil)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	server, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	// Register a test service
+	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
+
+	// Verify lifecycle hooks were registered
+	lc.AssertHooksNumber(1)
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+
+	// Verify the server is running by checking if we can connect
+	conn, err := grpc.NewClient(
+		server.listener.Addr().String(),
+		grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
+		grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(ipcComp.GetAuthToken())),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		client := pbcore.NewStatusProviderClient(conn)
+		resp, err := client.GetStatusDetails(context.Background(), &pbcore.GetStatusDetailsRequest{})
+		require.NoError(c, err)
+		assert.NotNil(c, resp)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	// Stop the server
+	err = lc.Stop(context.Background())
+	require.NoError(t, err)
+}
+
+// TestRegisteredServicesReported tests that services registered with the gRPC
+// server are properly reported during registration with the core agent
+func TestRegisteredServicesReported(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	var receivedServices []string
+	var mu sync.Mutex
+
+	// Create a mock core agent server that captures the registered services
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp, func(_ context.Context, req *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+		mu.Lock()
+		receivedServices = req.Services
+		mu.Unlock()
+		return &pbcore.RegisterRemoteAgentResponse{
+			SessionId:                      "test-session-id",
+			RecommendedRefreshIntervalSecs: 60,
+		}, nil
+	}, nil)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	server, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+
+	// Register multiple services
+	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
+	pbcore.RegisterFlareProviderServer(server.GetGRPCServer(), &mockFlareProvider{})
+	pbcore.RegisterTelemetryProviderServer(server.GetGRPCServer(), &mockTelemetryProvider{})
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+	defer lc.Stop(context.Background())
+
+	// Wait for registration to complete
+	time.Sleep(600 * time.Millisecond)
+
+	// Verify that all services were reported
+	mu.Lock()
+	services := receivedServices
+	mu.Unlock()
+
+	require.NotEmpty(t, services)
+	assert.Contains(t, services, "datadog.remoteagent.status.v1.StatusProvider")
+	assert.Contains(t, services, "datadog.remoteagent.flare.v1.FlareProvider")
+	assert.Contains(t, services, "datadog.remoteagent.telemetry.v1.TelemetryProvider")
+}
+
+// TestRegistrationRefreshContention tests what happens when the core agent's
+// registration/refresh endpoints hang or are slow to respond
+func TestRegistrationRefreshContention(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	// Set a short query timeout for faster test
+	configComp.SetWithoutSource("remote_agent_registry.query_timeout", 50*time.Millisecond)
+
+	registerCallCount := 0
+	refreshCallCount := 0
+	var mu sync.Mutex
+
+	// Create a mock core agent server where registration hangs
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp,
+		func(ctx context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+			mu.Lock()
+			registerCallCount++
+			mu.Unlock()
+
+			// Block forever to prevent registration from completing
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		func(_ context.Context, _ *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error) {
+			mu.Lock()
+			refreshCallCount++
+			mu.Unlock()
+			return &pbcore.RefreshRemoteAgentResponse{}, nil
+		},
+	)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	_, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+	defer lc.Stop(context.Background())
+
+	// Wait for multiple registration attempts
+	time.Sleep(3 * time.Second)
+
+	// Verify that registration was retried after the first timeout
+	mu.Lock()
+	regCount := registerCallCount
+	mu.Unlock()
+
+	assert.GreaterOrEqual(t, regCount, 2, "Registration should have been retried after timeout")
+
+	// Now test refresh contention - the server should be registered by now
+	// Wait a bit more to ensure refresh is called
+	time.Sleep(2 * time.Second)
+
+	mu.Lock()
+	refCount := refreshCallCount
+	mu.Unlock()
+
+	// We should have at least one refresh call by now
+	assert.GreaterOrEqual(t, refCount, 0, "Refresh should have been called")
+}
+
+// TestSessionIDInResponseMetadata tests that the session ID is properly
+// included in response metadata after successful registration
+func TestSessionIDInResponseMetadata(t *testing.T) {
+	lc := compdef.NewTestLifecycle(t)
+	ipcComp := ipcmock.New(t)
+	logComp := logmock.New(t)
+	configComp := configmock.New(t)
+
+	expectedSessionID := "test-session-id-12345"
+
+	// Create a mock core agent server
+	mockCoreAgent := newMockCoreAgentServer(t, ipcComp, func(_ context.Context, _ *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+		return &pbcore.RegisterRemoteAgentResponse{
+			SessionId:                      expectedSessionID,
+			RecommendedRefreshIntervalSecs: 60,
+		}, nil
+	}, nil)
+	defer mockCoreAgent.stop()
+
+	// Create the remote agent server
+	server, err := NewUnimplementedRemoteAgentServer(
+		ipcComp,
+		logComp,
+		configComp,
+		lc,
+		mockCoreAgent.address,
+		"test-agent",
+		"Test Agent",
+	)
+	require.NoError(t, err)
+
+	// Register a test service
+	pbcore.RegisterStatusProviderServer(server.GetGRPCServer(), &mockStatusProvider{})
+
+	// Start the server
+	err = lc.Start(context.Background())
+	require.NoError(t, err)
+	defer lc.Stop(context.Background())
+
+	// Create a client and make a request
+	conn, err := grpc.NewClient(
+		server.listener.Addr().String(),
+		grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
+		grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(ipcComp.GetAuthToken())),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := pbcore.NewStatusProviderClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		var header metadata.MD
+		_, err := client.GetStatusDetails(ctx, &pbcore.GetStatusDetailsRequest{}, grpc.Header(&header), grpc.WaitForReady(true))
+		require.NoError(c, err)
+		// Verify session ID is in the response metadata
+		sessionIDs := header.Get("session_id")
+		require.Len(c, sessionIDs, 1)
+		assert.Equal(c, expectedSessionID, sessionIDs[0])
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+// Helper types and functions
+
+// mockStatusProvider implements a mock status provider
+type mockStatusProvider struct {
+	pbcore.UnimplementedStatusProviderServer
+}
+
+func (m *mockStatusProvider) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
+	return &pbcore.GetStatusDetailsResponse{}, nil
+}
+
+// mockFlareProvider implements a mock flare provider
+type mockFlareProvider struct {
+	pbcore.UnimplementedFlareProviderServer
+}
+
+func (m *mockFlareProvider) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
+	return &pbcore.GetFlareFilesResponse{}, nil
+}
+
+// mockTelemetryProvider implements a mock telemetry provider
+type mockTelemetryProvider struct {
+	pbcore.UnimplementedTelemetryProviderServer
+}
+
+func (m *mockTelemetryProvider) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
+	return &pbcore.GetTelemetryResponse{}, nil
+}
+
+// mockCoreAgentServer simulates the core agent's registration server
+type mockCoreAgentServer struct {
+	server       *grpc.Server
+	listener     net.Listener
+	address      string
+	registerFunc func(context.Context, *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error)
+	refreshFunc  func(context.Context, *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error)
+	pbcore.UnimplementedAgentSecureServer
+	echo.UnimplementedEchoServer
+}
+
+func (m *mockCoreAgentServer) RegisterRemoteAgent(ctx context.Context, req *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error) {
+	if m.registerFunc != nil {
+		return m.registerFunc(ctx, req)
+	}
+	return &pbcore.RegisterRemoteAgentResponse{
+		SessionId:                      "default-session-id",
+		RecommendedRefreshIntervalSecs: 60,
+	}, nil
+}
+
+func (m *mockCoreAgentServer) RefreshRemoteAgent(ctx context.Context, req *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error) {
+	if m.refreshFunc != nil {
+		return m.refreshFunc(ctx, req)
+	}
+	return &pbcore.RefreshRemoteAgentResponse{}, nil
+}
+
+func (m *mockCoreAgentServer) UnaryEcho(_ context.Context, req *echo.EchoRequest) (*echo.EchoResponse, error) {
+	return &echo.EchoResponse{
+		Message: req.Message,
+	}, nil
+}
+
+func (m *mockCoreAgentServer) stop() {
+	if m.server != nil {
+		m.server.Stop()
+	}
+}
+
+func newMockCoreAgentServer(
+	t *testing.T,
+	ipcComp ipc.Component,
+	registerFunc func(context.Context, *pbcore.RegisterRemoteAgentRequest) (*pbcore.RegisterRemoteAgentResponse, error),
+	refreshFunc func(context.Context, *pbcore.RefreshRemoteAgentRequest) (*pbcore.RefreshRemoteAgentResponse, error),
+) *mockCoreAgentServer {
+	// Create a real network listener
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	mock := &mockCoreAgentServer{
+		listener:     listener,
+		registerFunc: registerFunc,
+		refreshFunc:  refreshFunc,
+	}
+
+	serverOpts := []grpc.ServerOption{
+		grpc.Creds(credentials.NewTLS(ipcComp.GetTLSServerConfig())),
+	}
+
+	mock.server = grpc.NewServer(serverOpts...)
+	pbcore.RegisterAgentSecureServer(mock.server, mock)
+
+	// register echo service
+	echo.RegisterEchoServer(mock.server, mock)
+
+	// Use the listener's address
+	mock.address = listener.Addr().String()
+
+	// Start serving in the background
+	go func() {
+		err = mock.server.Serve(listener)
+		require.NoError(t, err)
+	}()
+
+	t.Cleanup(mock.stop)
+
+	// block until the server is started
+	// initializing a dummy echo client to make sure the server is started
+	client, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())))
+	require.NoError(t, err)
+	echoClient := echo.NewEchoClient(client)
+	_, err = echoClient.UnaryEcho(context.Background(), &echo.EchoRequest{}, grpc.WaitForReady(true))
+	require.NoError(t, err)
+
+	return mock
+}

--- a/comp/core/remoteagent/impl-template/remoteagent.go
+++ b/comp/core/remoteagent/impl-template/remoteagent.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package templateimpl implements the remoteagent component interface
+package templateimpl
+
+import (
+	"net"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
+	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+)
+
+// Requires defines the dependencies for the remoteagent component
+type Requires struct {
+	// Remove this field if the component has no lifecycle hooks
+	Lifecycle compdef.Lifecycle
+	Log       log.Component
+	IPC       ipc.Component
+	Config    config.Component
+}
+
+// Provides defines the output of the remoteagent component
+type Provides struct {
+	Comp remoteagent.Component
+}
+
+// NewComponent creates a new remoteagent component
+func NewComponent(reqs Requires) (Provides, error) {
+	registryAddress := net.JoinHostPort(reqs.Config.GetString("cmd_host"), reqs.Config.GetString("cmd_port"))
+
+	remoteAgentServer, err := helper.NewUnimplementedRemoteAgentServer(reqs.IPC, reqs.Log, reqs.Config, reqs.Lifecycle, registryAddress, flavor.GetFlavor(), flavor.GetHumanReadableFlavor())
+	if err != nil {
+		return Provides{}, err
+	}
+
+	remoteagentImpl := &remoteagentImpl{
+		log:               reqs.Log,
+		ipc:               reqs.IPC,
+		cfg:               reqs.Config,
+		remoteAgentServer: remoteAgentServer,
+	}
+
+	// Add your gRPC services implementations here: e.g.
+	// pbcore.RegisterStatusProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
+
+	provides := Provides{
+		Comp: remoteagentImpl,
+	}
+	return provides, nil
+}
+
+type remoteagentImpl struct {
+	log log.Component
+	ipc ipc.Component
+	cfg config.Component
+
+	remoteAgentServer *helper.UnimplementedRemoteAgentServer
+}


### PR DESCRIPTION
### What does this PR do?

Implements the Remote Agent component infrastructure that allows any Agent process (trace-agent, systemProbe, etc.) to expose data to the Core Agent via gRPC. The component handles registration, authentication, TLS configuration, and lifecycle management automatically.

### Motivation

Enable sub-agents to register with the Core Agent and expose services (status, flare, telemetry) without taking care of internal remoteAgent server logic. This provides a standardized way for remote agents to communicate with the Core Agent.

### Describe how you validated your changes

Added unit tests for the helper package covering:
  - Registration and refresh flows
  - Authentication token validation
  - Session ID management
  - Service discovery and reporting
  - Lifecycle management
  - Error handling and retry logic