### PR TITLE
Sync `static_quality_gates` job dependencies

### DIFF
--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -10,8 +10,6 @@ static_quality_gates:
   needs:
     - agent_deb-x64-a7
     - agent_deb-x64-a7-fips
-    - agent_deb-arm64-a7
-    - agent_deb-arm64-a7-fips
     - agent_rpm-x64-a7
     - agent_rpm-x64-a7-fips
     - agent_rpm-arm64-a7
@@ -29,14 +27,6 @@ static_quality_gates:
     - docker_build_cluster_agent_arm64
     - docker_build_dogstatsd_amd64
     - docker_build_dogstatsd_arm64
-    - docker_build_agent7_windows1809
-    - docker_build_agent7_windows1809_core
-    - docker_build_agent7_windows1809_core_jmx
-    - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
-    - docker_build_agent7_windows2022_jmx
     - dogstatsd_deb-x64
     - dogstatsd_deb-arm64
     - dogstatsd_rpm-x64
@@ -45,8 +35,6 @@ static_quality_gates:
     - iot_agent_deb-arm64
     - iot_agent_deb-armhf
     - iot_agent_rpm-x64
-    - iot_agent_rpm-arm64
-    - iot_agent_rpm-armhf
     - iot_agent_suse-x64
     - windows_msi_and_bosh_zip_x64-a7
   script:


### PR DESCRIPTION
### What does this PR do?

Sync the `static_quality_gates` job dependencies with [the list of artifacts](https://github.com/DataDog/datadog-agent/blob/yoanngh/static-quality-gates-needs-sync/test/static/static_quality_gates.yml) it uses to compute static quality gates.

### Motivation

This change will avoid having this job waiting for jobs it doesn't need, thus reducing the CI pipeline execution time.

### Describe how you validated your changes

### Additional Notes
