### PR TITLE
Update docs/dev/agent-api.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -277,6 +277,7 @@
 /Dockerfiles/agent/bouncycastle-fips     @DataDog/agent-metric-pipelines
 
 /docs/                                  @DataDog/agent-devx
+/docs/dev/agent_api.md                  @DataDog/agent-runtimes
 /docs/dev/checks/                       @DataDog/agent-runtimes
 /docs/cloud-workload-security/          @DataDog/documentation @DataDog/agent-security
 

--- a/docs/dev/agent_api.md
+++ b/docs/dev/agent_api.md
@@ -2,25 +2,20 @@
 The core Agent exposes a variety of HTTP and GRPC endpoints that can be organized into two
 groups:
 1. **Control**: These endpoints are used to send commands that can control and inspect the state of the running Agent.
-2. **Telemetry**: These expose some internal telemetry that is useful for profiling and debugging.
+2. **Inter-process communication**: These endpoints are used by the different agent processes to communicate between each other.
+3. **Telemetry**: These expose some internal telemetry that is useful for profiling and debugging.
 
 ## Control API
-This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`. The listening interface and port can be configured using the `cmd_host` and `cmd_port` config options.
+This API is accessible via HTTPS only and listens by default on the `localhost` interface on port `5001`.
+The listening interface and port can be configured using the `cmd_host` and `cmd_port` config options.
 
-### Authentication
-To avoid unprivileged users accessing the Agent control API, authentication is required and based on a generated token.
-The token is written to a file (`auth_token`) that's only readable by the user that is running the Agent.
+It is considered internal, endpoints can change at every version, and it should not be relied on by users.
 
-By default, the `auth_token` file is written to the same directory where the config is located. To specify a custom location, use the config option `auth_token_file_path`.
+## Inter-process Communication API
+Similarly to the control API, this API is accessible via HTTPS only, and listens by default on the `localhost` interface on port `5009`.
+The listening interface and port can be configured using the `agent_ipc.host` and `agent_ipc.port` config options.
 
-### Example
-```
-$ curl -qs -H "authorization: Bearer $(cat /path/to/auth_token)" -k https://localhost:5001/agent/version
-{"Major":7,"Minor":41,"Patch":0,"Pre":"rc.3","Meta":"git.238.453e769","Commit":"453e7695a4"}%
-```
-
-### Full endpoint list
-https://github.com/DataDog/datadog-agent/blob/453e7695a43fa3c162e1240863999c9ddc91fbdd/cmd/agent/api/internal/agent/agent.go#L49-L73
+It is considered internal, endpoints can change at every version, and it should not be relied on by users.
 
 ## Telemetry API
 There are 3 different systems exposing data on the same port but at


### PR DESCRIPTION
### What does this PR do?
Update docs/dev/agent-api.md, which was somewhat outdated.
Add the new IPC API.
Stop explaining how to query the http APIs of the core-agent, as we consider them internal details.

### Motivation
Have updated documentation.

### Additional Notes
This relies on https://github.com/DataDog/datadog-agent/pull/41476 (which enables IPC API on 5009 by default).
I'll wait for it to be merged to merge this one.