### PR TITLE
Fix `origin/` prefix being (now) prepended twice

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -312,7 +312,7 @@ def update_quality_gates_threshold(ctx, metric_handler, github):
             yaml.dump(file_content, f)
         ctx.run(f"git add {GATE_CONFIG_PATH}")
         print("Creating signed commits using Github API")
-        tree = create_tree(ctx, f"origin/{current_branch.name}")
+        tree = create_tree(ctx, current_branch.name)
         github.commit_and_push_signed(branch_name, commit_message, tree)
     else:
         print("Creating commits using your local git configuration, please make sure to sign them")


### PR DESCRIPTION
### Motivation
PR #40666 changed `create_tree`'s implementation in a way that the `origin/` prefix would be always prepended to the base branch passed to `get_common_ancestor`:
https://github.com/DataDog/datadog-agent/pull/40666/files#diff-d26984b57b4fcf2038d1a7c9278c071212c6b8ab96582aaef06e0e7a4d24efbdR366

This leads to the following [error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1161487079) in the `manual_gate_threshold_update` job: (thanks to @AliDatadog for [reporting](https://dd.slack.com/archives/C08SK4B0FK8/p1759740357942799))
```
Encountered a bad command exit code!
Command: 'git fetch origin origin/main'
Exit code: 128
Stdout:
Stderr:
fatal: couldn't find remote ref origin/main
```
The command should be: `git fetch origin main`.

### What does this PR do?
The present change fixes it by removing the (now) redundant `origin/` prefix that used to be prepended by `update_quality_gates_threshold`.