### PR TITLE
Inline installer build into datadog-agent build definition

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -349,8 +349,9 @@ if windows_target?
     windows_symbol_stripping_file bin
   end
 
-  # We need to strip the debug symbols from the rtloader files
+  # We need to strip the debug symbols from the rtloader files and from the installer
   windows_symbol_stripping_file "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
+  windows_symbol_stripping_file "#{install_dir}\\datadog-installer.exe"
 
   if windows_signing_enabled?
     # Sign additional binaries from here.
@@ -373,7 +374,8 @@ if windows_target?
 
     BINARIES_TO_SIGN = GO_BINARIES + PYTHON_BINARIES + OPENSSL_BINARIES + [
       "#{install_dir}\\bin\\agent\\ddtray.exe",
-      "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
+      "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll",
+      "#{install_dir}\\datadog-installer.exe",
     ]
 
     BINARIES_TO_SIGN.each do |bin|

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -144,12 +144,10 @@ build do
   # We do this in the same software definition to avoid redundant copying, as it's based on the same source
   if linux_target? and !heroku_target?
     command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
-    mkdir "#{install_dir}/bin"
-    copy 'bin/installer', "#{install_dir}/bin/"
-    move "#{install_dir}/bin/installer/installer", "#{install_dir}/embedded/bin"
+    move 'bin/installer/installer', "#{install_dir}/embedded/bin"
   elsif windows_target?
     command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
-    copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
+    move 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
   end
 
   unless windows_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -24,8 +24,6 @@ unless do_repackage?
   dependency "libjemalloc" if linux_target?
 
   dependency 'datadog-agent-dependencies'
-
-  dependency "installer" if linux_target? and !heroku_target?
 end
 
 source path: '..',
@@ -142,8 +140,16 @@ build do
   platform = windows_arch_i386? ? "x86" : "x64"
   command "dda inv -- -e trace-agent.build --install-path=#{install_dir} --major-version #{major_version_arg} --flavor #{flavor_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
+  # Build the installer
+  # We do this in the same software definition to avoid redundant copying, as it's based on the same source
   if linux_target? and !heroku_target?
-      move "#{install_dir}/bin/installer/installer", "#{install_dir}/embedded/bin"
+    command "invoke installer.build --no-cgo --run-path=/opt/datadog-packages/run --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    mkdir "#{install_dir}/bin"
+    copy 'bin/installer', "#{install_dir}/bin/"
+    move "#{install_dir}/bin/installer/installer", "#{install_dir}/embedded/bin"
+  elsif windows_target?
+    command "dda inv -- -e installer.build --install-path=#{install_dir}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
+    copy 'bin/installer/installer.exe', "#{install_dir}/datadog-installer.exe"
   end
 
   unless windows_target?

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -21,21 +21,18 @@ def agent_package(
     skip_deps=False,
     build_upgrade=False,
 ):
-    # Build installer
-    # TODO: merge into agent omnibus build
-    # TODO: must build installer first so the final build-summary.json
-    #       is from the Agent omnibus build
-    omnibus_build(
-        ctx,
-        skip_deps=skip_deps,
-        target_project="installer",
-    )
-
     # Build agent
     omnibus_build(
         ctx,
         flavor=flavor,
         skip_deps=skip_deps,
+    )
+
+    # Move the installer binary to a separate folder
+    os.makedirs(os.path.join(OPT_SOURCE_DIR, "datadog-installer"))
+    shutil.move(
+        os.path.join(OPT_SOURCE_DIR, "datadog-agent", "datadog-installer.exe"),
+        os.path.join(OPT_SOURCE_DIR, "datadog-installer"),
     )
 
     # Package Agent into MSI

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -8,7 +8,7 @@ static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 340.18 MiB
   max_on_wire_size: 91.08 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 985.29 MiB
+  max_on_disk_size: 1015.38 MiB
   max_on_wire_size: 150.78 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 702.14 MiB


### PR DESCRIPTION
### What does this PR do?

Inlines the installer build into the datadog-agent Omnibus software definition, and merges both builds in Windows, where they were still separate.

### Motivation

Due to how Omnibus software definitions work, this was copying almost the entire datadog-agent repo twice for each build, as both installer.rb and datadog-agent.rb were using a path source to the root of the datadog-agent source code. This is not very noticeable in Linux builds, where these copies are happening in parallel, but it adds close to 10 minutes of build time to Windows builds, as the installer was being built in a separate omnibus run.

Rather than just merge builds in Windows to do the same as in Linux, it's better to also just avoid copying everything twice altogether. Even if parallelized, these would still unnecessarily slow down Windows builds down, knowing that IO performance is typically worse there.

### Describe how you validated your changes

Green CI.

### Additional Notes

Important note: This PR bumps the MSI on-disk quality gate because of how the change affects how the size is computed. We use the generated zip file, and not the MSI, when computing the uncompressed package size. Before this PR, the installer was not being built on the same zip as the regular Agent package, and thus the computation didn't include the installer's size. This can be confirmed by the fact that the size of the MSI file has barely changed.

I'm not sure whether we can now just remove the Omnibus installer project and copy, hence I'll probably defer that for a future follow-up.