### PR TITLE
feat(stale): Increase the limit of stale operations

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,6 +31,7 @@ jobs:
           # Stale configuration
           days-before-stale: 15
           days-before-close: 30
+          operations-per-run: 100
 
           # Issue configuration
           stale-issue-message: |


### PR DESCRIPTION

### What does this PR do?
As we are trying to deal with the current backlog, we need an acceleration to converge faster. We'll check if this new value does not create a risk of reaching the github rate limit


### Motivation
The workflow is currently [complaining](https://github.com/DataDog/datadog-agent/actions/runs/18257202317/job/51980201918) because we are hitting the limit of allowed operations. 

### Describe how you validated your changes
n/a, this is just a configuration change

### Additional Notes
