### PR TITLE
fix(stale): Remove the `pending` label

### DIFF
--- a/.github/workflows/check_issue_status.yml
+++ b/.github/workflows/check_issue_status.yml
@@ -1,4 +1,6 @@
 ---
+name: Check if datadog commented an issue
+
 on:
   issue_comment:
     types: [created]
@@ -6,6 +8,7 @@ on:
 jobs:
   check_comment:
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
     steps:
       - name: Check if there is a comment from a datadog member
         id: datadog-comment
@@ -51,9 +54,10 @@ jobs:
             for (const label of labels.data) {
               if (label.name === 'pending') {
                 await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: label.name
-            });
-
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name
+                });
+              }
+            }


### PR DESCRIPTION
### What does this PR do?
- Prevent running this workflow on PR, this is useless as the `pending` label is not set on PR
- Fix the remove label script which was missing parenthesis
- Give a name to the workflow

### Motivation
Better stale management

### Describe how you validated your changes
Local test of the script

### Additional Notes
