### PR TITLE
[automated] Static quality gates threshold update

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,57 +1,57 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 703.13 MiB
-  max_on_wire_size: 178.38 MiB
+  max_on_disk_size: 702.15 MiB
+  max_on_wire_size: 177.79 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 697.61 MiB
-  max_on_wire_size: 177.15 MiB
+  max_on_disk_size: 696.65 MiB
+  max_on_wire_size: 176.53 MiB
 static_quality_gate_agent_heroku_amd64:
-  max_on_disk_size: 341.62 MiB
-  max_on_wire_size: 91.52 MiB
+  max_on_disk_size: 340.18 MiB
+  max_on_wire_size: 91.08 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 990.42 MiB
-  max_on_wire_size: 152.42 MiB
+  max_on_disk_size: 985.29 MiB
+  max_on_wire_size: 150.78 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 703.12 MiB
+  max_on_disk_size: 702.14 MiB
   max_on_wire_size: 180.53 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 697.6 MiB
-  max_on_wire_size: 178.87 MiB
+  max_on_disk_size: 696.64 MiB
+  max_on_wire_size: 178.79 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 689.82 MiB
-  max_on_wire_size: 162.16 MiB
+  max_on_disk_size: 686.31 MiB
+  max_on_wire_size: 161.22 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 685.08 MiB
-  max_on_wire_size: 161.11 MiB
+  max_on_disk_size: 681.84 MiB
+  max_on_wire_size: 160.18 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 703.12 MiB
+  max_on_disk_size: 702.14 MiB
   max_on_wire_size: 180.53 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 697.6 MiB
-  max_on_wire_size: 178.87 MiB
+  max_on_disk_size: 696.64 MiB
+  max_on_wire_size: 178.79 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 689.82 MiB
-  max_on_wire_size: 162.16 MiB
+  max_on_disk_size: 686.31 MiB
+  max_on_wire_size: 161.22 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 685.08 MiB
-  max_on_wire_size: 161.11 MiB
+  max_on_disk_size: 681.84 MiB
+  max_on_wire_size: 160.18 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 774.54 MiB
-  max_on_wire_size: 266.46 MiB
+  max_on_disk_size: 773.59 MiB
+  max_on_wire_size: 266.06 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 785.2 MiB
-  max_on_wire_size: 252.92 MiB
+  max_on_disk_size: 781.7 MiB
+  max_on_wire_size: 251.85 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 965.41 MiB
-  max_on_wire_size: 335.08 MiB
+  max_on_disk_size: 964.45 MiB
+  max_on_wire_size: 334.68 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 964.66 MiB
-  max_on_wire_size: 317.54 MiB
+  max_on_disk_size: 961.17 MiB
+  max_on_wire_size: 316.44 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 213.74 MiB
-  max_on_wire_size: 73.2 MiB
+  max_on_wire_size: 73.14 MiB
 static_quality_gate_docker_cluster_agent_arm64:
   max_on_disk_size: 229.68 MiB
-  max_on_wire_size: 69.48 MiB
+  max_on_wire_size: 69.41 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.12 MiB
   max_on_wire_size: 3.29 MiB
@@ -68,14 +68,14 @@ static_quality_gate_dogstatsd_deb_amd64:
   max_on_disk_size: 30.53 MiB
   max_on_wire_size: 8.75 MiB
 static_quality_gate_dogstatsd_deb_arm64:
-  max_on_disk_size: 29.12 MiB
+  max_on_disk_size: 29.11 MiB
   max_on_wire_size: 7.71 MiB
 static_quality_gate_dogstatsd_rpm_amd64:
   max_on_disk_size: 30.53 MiB
-  max_on_wire_size: 8.77 MiB
+  max_on_wire_size: 8.76 MiB
 static_quality_gate_dogstatsd_suse_amd64:
   max_on_disk_size: 30.53 MiB
-  max_on_wire_size: 8.77 MiB
+  max_on_wire_size: 8.76 MiB
 static_quality_gate_iot_agent_deb_amd64:
   max_on_disk_size: 54.97 MiB
   max_on_wire_size: 14.45 MiB


### PR DESCRIPTION
### Motivation
- #41618
- https://dd.slack.com/archives/C08SK4B0FK8/p1759749186523349?thread_ts=1759740357.942799&cid=C08SK4B0FK8

### What does this PR do?
```
git checkout 957f81209296841f75ad22a8b6a1be243dbc4dfc
wget https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1161487078/artifacts/raw/static_gate_report.json

BUCKET_BRANCH=main \
CI_COMMIT_BRANCH=main \
CI_COMMIT_REF_SLUG=main \
CI_COMMIT_SHORT_SHA=957f8120 \
    dda inv -- quality-gates.manual-threshold-update
```
`main` and `957f8120` come from the failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1161487079