### PR TITLE
dyninst: fix plumbing of container ID to trace-agent

### DIFF
--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -114,7 +114,11 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 		tagURL := *u.cfg.url
 		tagURL.RawQuery = query.Encode()
 		logsURL = tagURL.String()
+	}
+	if metadata.EntityID != "" {
 		addHeader(ddHeaderEntityID, metadata.EntityID)
+	}
+	if metadata.ContainerID != "" {
 		addHeader(ddHeaderContainerID, metadata.ContainerID)
 	}
 	name = fmt.Sprintf("logs:%d", uploaderID)

--- a/pkg/dyninst/uploader/uploader_test.go
+++ b/pkg/dyninst/uploader/uploader_test.go
@@ -244,7 +244,8 @@ func TestLogsUploader(t *testing.T) {
 		)
 		defer uploaderFactory.Stop()
 		uploader := uploaderFactory.GetUploader(LogsUploaderMetadata{
-			Tags: "service:test",
+			ContainerID: "test_id",
+			EntityID:    "ci:test_id",
 		})
 
 		msg1 := json.RawMessage(`{"key":"value1"}`)
@@ -255,6 +256,8 @@ func TestLogsUploader(t *testing.T) {
 
 		// receive and validate request
 		req := <-ts.requests
+		assert.Equal(t, req.r.Header.Get(ddHeaderContainerID), "test_id")
+		assert.Equal(t, req.r.Header.Get(ddHeaderEntityID), "ci:test_id")
 		validateLogsRequest(t, []json.RawMessage{msg1, msg2}, req.r)
 
 		// send response and unblock handler


### PR DESCRIPTION
Before this patch, we were only sending the container ID to the trace-agent while uploading logs when we also had other tags to send (i.e. the SCI tags). There was no reason for this; now we always send a container ID when we know one. The trace-agent needs the container ID to augment the logs with many other tags, like the service name.

