### PR TITLE
[EBPF-835] gpu: fix TestProbe flakes

### DIFF
--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
+const expectedCudaSampleMaxMemory = uint64(110)
+
 // TestMain defined to run initialization before any test is run
 func TestMain(m *testing.M) {
 	memPools.ensureInitNoTelemetry()
@@ -79,36 +81,30 @@ func (s *probeTestSuite) getProbe() *Probe {
 	return probe
 }
 
-func (s *probeTestSuite) TestCanLoad() {
-	t := s.T()
-
-	probe := s.getProbe()
-	data, err := probe.GetAndFlush()
-	require.NoError(t, err)
-	require.NotNil(t, data)
+type cudaSampleStreams struct {
+	stream *StreamHandler
+	global *StreamHandler
 }
 
-func (s *probeTestSuite) TestCanReceiveEvents() {
+func (s *probeTestSuite) waitForExpectedCudasampleEvents(probe *Probe, pid int) cudaSampleStreams {
 	t := s.T()
 
-	probe := s.getProbe()
-	cmd, err := testutil.RunSample(t, testutil.CudaSample)
-	require.NoError(t, err)
-
-	var handlerStream, handlerGlobal *StreamHandler
+	var handlers cudaSampleStreams
 	require.Eventually(t, func() bool {
-		handlerStream, handlerGlobal = nil, nil // Ensure we see both handlers in the same iteration
+		handlers = cudaSampleStreams{stream: nil, global: nil} // Ensure we see both handlers in the same iteration
 		for _, h := range probe.streamHandlers.allStreams() {
-			if h.metadata.pid == uint32(cmd.Process.Pid) {
+			if h.metadata.pid == uint32(pid) {
 				if h.metadata.streamID == 0 {
-					handlerGlobal = h
+					handlers.global = h
 				} else {
-					handlerStream = h
+					handlers.stream = h
 				}
 			}
 		}
 
-		return probe.streamHandlers.globalStreamsCount() == 1 && probe.streamHandlers.streamsCount() == 1 && handlerStream != nil && handlerGlobal != nil && len(handlerStream.pendingKernelSpans) > 0 && len(handlerGlobal.pendingMemorySpans) > 0
+		hasGlobalStreams := probe.streamHandlers.globalStreamsCount() == 1 && handlers.global != nil && len(handlers.global.pendingMemorySpans) > 0
+		hasNonGlobalStreams := probe.streamHandlers.streamsCount() == 1 && handlers.stream != nil && len(handlers.stream.pendingKernelSpans) > 0
+		return hasGlobalStreams && hasNonGlobalStreams
 	}, 3*time.Second, 100*time.Millisecond, "stream and global handlers not found: existing is %v", probe.consumer.streamHandlers)
 
 	// Check that we're receiving the events we expect
@@ -143,13 +139,34 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 		assert.Empty(c, actualEvents, "unexpected events: %v", actualEvents)
 	}, 3*time.Second, 100*time.Millisecond, "events not found")
 
+	return handlers
+}
+
+func (s *probeTestSuite) TestCanLoad() {
+	t := s.T()
+
+	probe := s.getProbe()
+	data, err := probe.GetAndFlush()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+}
+
+func (s *probeTestSuite) TestCanReceiveEvents() {
+	t := s.T()
+
+	probe := s.getProbe()
+	cmd, err := testutil.RunSample(t, testutil.CudaSample)
+	require.NoError(t, err)
+
+	handlers := s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
+
 	// Check device assignments
 	require.Contains(t, probe.consumer.sysCtx.selectedDeviceByPIDAndTID, cmd.Process.Pid)
 	tidMap := probe.consumer.sysCtx.selectedDeviceByPIDAndTID[cmd.Process.Pid]
 	require.Len(t, tidMap, 1)
 	require.ElementsMatch(t, []int{cmd.Process.Pid}, maps.Keys(tidMap))
 
-	streamPastData := handlerStream.getPastData()
+	streamPastData := handlers.stream.getPastData()
 	require.NotNil(t, streamPastData)
 	require.Equal(t, 2, len(streamPastData.kernels))
 	for i := range 2 {
@@ -159,7 +176,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 		require.Greater(t, span.endKtime, span.startKtime)
 	}
 
-	globalPastData := handlerGlobal.getPastData()
+	globalPastData := handlers.global.getPastData()
 	require.NotNil(t, globalPastData)
 	require.Equal(t, 1, len(globalPastData.allocations))
 	alloc := globalPastData.allocations[0]
@@ -176,49 +193,19 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
-		return probe.streamHandlers.allStreamsCount() == 2
-	}, 3*time.Second, 100*time.Millisecond, "stream handlers count mismatch: expected: 2, got: %d", probe.streamHandlers.allStreamsCount())
+	_ = s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
 
 	stats, err := probe.GetAndFlush()
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	require.NotEmpty(t, stats.Metrics)
 
-	// Check expected events are received, using the telemetry counts
-	telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)
-	require.True(t, ok)
-
-	eventMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
-	require.NoError(t, err)
-
-	expectedEvents := map[string]int{
-		ebpf.CudaEventTypeKernelLaunch.String():      2,
-		ebpf.CudaEventTypeSetDevice.String():         1,
-		ebpf.CudaEventTypeMemory.String():            2,
-		ebpf.CudaEventTypeSync.String():              4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
-		ebpf.CudaEventTypeVisibleDevicesSet.String(): 1,
-		ebpf.CudaEventTypeSyncDevice.String():        1,
-	}
-
-	actualEvents := make(map[string]int)
-	for _, m := range eventMetrics {
-		if evType, ok := m.Tags()["event_type"]; ok {
-			actualEvents[evType] = int(m.Value())
-		}
-	}
-
-	require.ElementsMatch(t, maps.Keys(expectedEvents), maps.Keys(actualEvents))
-	for evName, value := range expectedEvents {
-		require.Equal(t, value, actualEvents[evName], "event %s count mismatch", evName)
-	}
-
 	// Ensure the metrics we get are correct
 	metricKey := model.StatsKey{PID: uint32(cmd.Process.Pid), DeviceUUID: testutil.DefaultGpuUUID}
 	metrics := getMetricsEntry(metricKey, stats)
 	require.NotNil(t, metrics)
 	require.Greater(t, metrics.UsedCores, 0.0) // core usage depends on the time this took to run, so it's not deterministic
-	require.Equal(t, metrics.Memory.MaxBytes, uint64(110))
+	require.Equal(t, expectedCudaSampleMaxMemory, metrics.Memory.MaxBytes)
 
 	// Check that the context was updated with the events
 	require.Equal(t, probe.sysCtx.cudaVisibleDevicesPerProcess[cmd.Process.Pid], "42")
@@ -240,11 +227,7 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 	cmd, err := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
 	require.NoError(t, err)
 
-	//TODO: change this check to  count telemetry counter of the consumer (once added).
-	// we are expecting 2 different streamhandlers because cudasample generates 3 events in total for 2 different streams (stream 0 and stream 30)
-	require.Eventually(t, func() bool {
-		return probe.streamHandlers.allStreamsCount() == 2
-	}, 3*time.Second, 100*time.Millisecond, "stream handlers count mismatch: expected: 2, got: %d", probe.streamHandlers.allStreamsCount())
+	_ = s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
 
 	stats, err := probe.GetAndFlush()
 	require.NoError(t, err)
@@ -254,7 +237,7 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 	require.NotNil(t, metrics)
 
 	require.Greater(t, metrics.UsedCores, 0.0) // average core usage depends on the time this took to run, so it's not deterministic
-	require.Equal(t, metrics.Memory.MaxBytes, uint64(110))
+	require.Equal(t, expectedCudaSampleMaxMemory, metrics.Memory.MaxBytes)
 }
 
 func (s *probeTestSuite) TestDetectsContainer() {
@@ -265,21 +248,10 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	// note: after starting, the program will wait ~5s before making any CUDA call
 	pid, cid := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
 
-	require.Eventually(t, func() bool {
-		return probe.streamHandlers.allStreamsCount() > 0
-	}, 3*time.Second, 100*time.Millisecond, "stream handlers count mismatch: expected: 1, got: %d", probe.streamHandlers.allStreamsCount())
+	handlers := s.waitForExpectedCudasampleEvents(probe, pid)
 
-	// Check that the stream handlers have the correct container ID assigned
-	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-		nStreamsFound := 0
-		for _, handler := range probe.streamHandlers.allStreams() {
-			if handler.metadata.pid == uint32(pid) {
-				nStreamsFound++
-				require.Equal(c, cid, handler.metadata.containerID)
-			}
-		}
-		require.NotZero(c, nStreamsFound)
-	}, 6*time.Second, 100*time.Millisecond)
+	require.Equal(t, cid, handlers.global.metadata.containerID)
+	require.Equal(t, cid, handlers.stream.metadata.containerID)
 
 	// Check that stats are properly collected
 	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
@@ -293,7 +265,7 @@ func (s *probeTestSuite) TestDetectsContainer() {
 
 		// core usage depends on the time this took to run, so it's not deterministic
 		require.Greater(c, pidStats.UsedCores, 0.0)
-		require.Equal(c, pidStats.Memory.MaxBytes, uint64(110))
+		require.Equal(c, expectedCudaSampleMaxMemory, pidStats.Memory.MaxBytes)
 	}, 3*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/gpu/testdata/common_functions.h
+++ b/pkg/gpu/testdata/common_functions.h
@@ -74,4 +74,8 @@ cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, int kind) {
     return 0;
 }
 
+cudaError_t cudaDeviceSynchronize() {
+    return 0;
+}
+
 #endif // COMMON_FUNCTIONS_H

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -9,10 +9,6 @@
 #include <unistd.h>
 #include "common_functions.h"
 
-cudaError_t cudaDeviceSynchronize() {
-    return 0;
-}
-
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
     cudaEvent_t event = 42;
@@ -40,6 +36,10 @@ int main(int argc, char **argv) {
     cudaMalloc(&ptr, 100);
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
+
+    // Sleep for 10ms to ensure that there's time separating the first span and next
+    // spans
+    usleep(10000);
 
     cudaMemcpy((void *)0x1234, (void *)0x5678, 100, 0); // kind 0 is cudaMemcpyHostToDevice
 


### PR DESCRIPTION
### What does this PR do?

This PR attempts to fix `pkg.gpu/TestProbe` flakes by refactoring the tests so that all of them wait until all events have been processed before testing assertions.  It also adds a `usleep` call in the CUDA sample program to ensure that the different kernel/memory spans will execute at different times.

### Motivation

Reduce flakiness.

### Describe how you validated your changes

CI passing and later observation of the tests, as we don't have a reliable way to reproduce the flaky tests.

### Additional Notes
