### PR TITLE
Increase timeouts for e2e-process tests on Fargate to 5 min

### DIFF
--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -71,7 +71,7 @@ func (s *ECSFargateSuite) TestProcessCheck() {
 		assertProcessCollectedNew(c, payloads, false, "process-agent")
 		assertContainersCollectedNew(c, payloads, []string{"stress-ng"})
 		assertFargateHostname(t, payloads)
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 }
 
 type ECSFargateCoreAgentSuite struct {
@@ -104,7 +104,7 @@ func (s *ECSFargateCoreAgentSuite) TestProcessCheckInCoreAgent() {
 		requireProcessNotCollected(c, payloads, "process-agent")
 		assertContainersCollectedNew(c, payloads, []string{"stress-ng"})
 		assertFargateHostname(t, payloads)
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 }
 
 func assertFargateHostname(t assert.TestingT, payloads []*aggregator.ProcessPayload) {


### PR DESCRIPTION
### What does this PR do?

Increase timeout from 2min to 5min

### Motivation

Test flaked [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1164230949), but we can see in the [past history](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3A%22TestECSFargateTestSuite%2FTestProcessCheck%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fprocess%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40ci.job.name%2C%40git.branch&fromUser=false&index=citest&start=1757160551383&end=1759752551383&paused=false) that it generally succeeds. However with some test runs taking close to two minutes, it seems like a higher timeout can help reduce flakes.

<img width="1672" height="816" alt="image" src="https://github.com/user-attachments/assets/8f8e3504-0f07-44ec-91dc-9470b0edf9ab" />

### Describe how you validated your changes

### Additional Notes
