### PR TITLE
usm: http2: tests: Fix crash when status code not found in stats map

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -290,7 +290,7 @@ func (ew *EventWrapper) RequestStarted() uint64 {
 }
 
 // SetRequestMethod sets the HTTP method of the transaction.
-func (ew *EventWrapper) SetRequestMethod(method http.Method) {
+func (ew *EventWrapper) SetRequestMethod(http.Method) {
 	// if we set Static_table_entry to be different from 0, and no indexed value, it will default to 0 which is "UNKNOWN"
 	ew.Stream.Request_method.Static_table_entry = 1
 }

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1809,8 +1810,9 @@ func validateStats(t *testing.T, usmMonitor *Monitor, res, expectedEndpoints map
 			}
 			count := statusCodeStats.Count
 			newKey := usmhttp.Key{
-				Path:   usmhttp.Path{Content: key.Path.Content},
-				Method: key.Method,
+				ConnectionKey: key.ConnectionKey,
+				Path:          usmhttp.Path{Content: key.Path.Content},
+				Method:        key.Method,
 			}
 			if _, ok := res[newKey]; !ok {
 				res[newKey] = count
@@ -1825,6 +1827,7 @@ func validateStats(t *testing.T, usmMonitor *Monitor, res, expectedEndpoints map
 	}
 
 	for key, endpointCount := range res {
+		key.ConnectionKey = types.ConnectionKey{}
 		_, ok := expectedEndpoints[key]
 		if !ok {
 			return false

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1798,11 +1798,16 @@ func validateStats(t *testing.T, usmMonitor *Monitor, res, expectedEndpoints map
 			if statusCode == 0 {
 				statusCode = 200
 			}
-			hasTag := stat.Data[statusCode].StaticTags == ebpftls.ConnTagGo
+			statusCodeStats, ok := stat.Data[statusCode]
+			if !ok {
+				t.Logf("Bug was found; Path: %q; Status Code: %d; data: %#v", key.Path.Content.Get(), statusCode, stat.Data)
+				return false
+			}
+			hasTag := statusCodeStats.StaticTags == ebpftls.ConnTagGo
 			if hasTag != isTLS {
 				continue
 			}
-			count := stat.Data[statusCode].Count
+			count := statusCodeStats.Count
 			newKey := usmhttp.Key{
 				Path:   usmhttp.Path{Content: key.Path.Content},
 				Method: key.Method,


### PR DESCRIPTION
## Summary
Fixes a crash in HTTP2 monitoring tests caused by missing status code entries in the stats map.

## Test plan
The fix adds a check to verify the status code exists in the stats map before accessing it. When the status code is not found, it logs details and returns false instead of crashing.

## Changes
- Added existence check for status code in `stat.Data` map before accessing
- Added debug logging when bug condition is detected (missing status code)
- Prevents panic when `statusCodeStats` is nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)