### PR TITLE
Add loader and installer to go-deps tasks

### DIFF
--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -81,6 +81,14 @@ BINARIES: dict[str, dict] = {
         "entrypoint": "cmd/otel-agent",
         "platforms": ["linux/x64", "linux/arm64"],
     },
+    "loader": {
+        "entrypoint": "cmd/loader",
+        "platforms": ["linux/x64", "linux/arm64", "darwin/x64", "darwin/arm64"],
+    },
+    "installer": {
+        "entrypoint": "cmd/installer",
+        "platforms": ["linux/x64", "linux/arm64", "win32/x64"],
+    },
 }
 
 METRIC_GO_DEPS_DIFF = "datadog.agent.go_dependencies.difference"


### PR DESCRIPTION
### What does this PR do?
Add `loader` and `installer` to `go-deps` tasks.

### Motivation
Being able to use those tasks for those processes.
Have package diff shown on the PR for those processes.
