### PR TITLE
Fix logs agent verbose status output

### DIFF
--- a/comp/logs/agent/agentimpl/status_templates/logsagent.tmpl
+++ b/comp/logs/agent/agentimpl/status_templates/logsagent.tmpl
@@ -88,7 +88,7 @@
   =======
   {{- range .Tailers }}
 
-    - ID: {{ .Id }}
+    - ID: {{ .ID }}
       Type: {{ .Type }}
       {{- if .Info }}
       {{- range $key, $value := .Info }} {{ $len := len $value }} {{ if eq $len 1 }}


### PR DESCRIPTION
### What does this PR do?

[This PR](https://github.com/DataDog/datadog-agent/pull/40470) mistakenly regressed `agent status "logs agent" -v` used by the logs agent causing active tailers to be unable to be printed. 

### Motivation

Fix bug. 

### Describe how you validated your changes

`agent status "logs agent" -v` should dump all the active tailers. 

### Additional Notes
