### PR TITLE
feat: add option to fetch_secret.sh to format secret

### DIFF
--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -4,6 +4,7 @@ retry_count=0
 max_retries=10
 parameter_name="$1"
 parameter_field="$2"
+format="${3:-table}"
 
 set +x
 
@@ -13,7 +14,7 @@ while [[ $retry_count -lt $max_retries ]]; do
         if [[ "$(uname -s)" == "Darwin" ]]; then
             vault_name="kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent"
         fi
-        result="$(vault kv get -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)"
+        result="$(vault kv get -format="${format}" -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)"
     else
         result="$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)"
     fi

--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -12,14 +12,14 @@ set +x
 
 while [[ $retry_count -lt $max_retries ]]; do
     if [ -n "$parameter_field" ]; then
-				# Using Vault; format parameter is respected
+        # Using Vault; format parameter is respected
         vault_name="kv/k8s/${POD_NAMESPACE}/datadog-agent"
         if [[ "$(uname -s)" == "Darwin" ]]; then
             vault_name="kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent"
         fi
         result="$(vault kv get -format="${format}" -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)"
     else
-				# Using SSM; the [<format>] parameter is ignore
+        # Using SSM; the [<format>] parameter is ignored
         result="$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)"
     fi
     error="$(<errorFile)"

--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Usage: fetch_secret.sh <param-name> <param-field> [<format>]
+
 retry_count=0
 max_retries=10
 parameter_name="$1"
@@ -10,12 +12,14 @@ set +x
 
 while [[ $retry_count -lt $max_retries ]]; do
     if [ -n "$parameter_field" ]; then
+				# Using Vault; format parameter is respected
         vault_name="kv/k8s/${POD_NAMESPACE}/datadog-agent"
         if [[ "$(uname -s)" == "Darwin" ]]; then
             vault_name="kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent"
         fi
         result="$(vault kv get -format="${format}" -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)"
     else
+				# Using SSM; the [<format>] parameter is ignore
         result="$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)"
     fi
     error="$(<errorFile)"


### PR DESCRIPTION
### What does this PR do?

Adds option to `fetch_secret.sh` to format the secret retrieved from vault. The option is not required and the default format is table (the same default that vault has). Therefore, the script should work exactly the same as before.

### Motivation

The below ticket requires the fetched secret to be in the json format. The script did not have the ability to specify format.

https://datadoghq.atlassian.net/browse/BARX-1081

### Describe how you validated your changes

Script was ran locally and verified to work.

### Additional Notes
