### PR TITLE
Fixing flaky cert store e2e tests

### DIFF
--- a/test/new-e2e/tests/windows/components/certificatehost/component.go
+++ b/test/new-e2e/tests/windows/components/certificatehost/component.go
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package certificatehost contains code to setup a Windows host for remote certificate testing
+package certificatehost
+
+import (
+	"github.com/DataDog/test-infra-definitions/common"
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/powershell"
+)
+
+// Manager contains the resources to manage a certificate host setup
+type Manager struct {
+	namer namer.Namer
+	host  *remote.Host
+
+	Resources []pulumi.Resource
+}
+
+// NewCertificateHost creates a new instance of the Certificate Host setup component
+// This component configures a Windows host to allow remote certificate access via SMB and RemoteRegistry
+func NewCertificateHost(e *config.CommonEnvironment, host *remote.Host, options ...Option) (*Manager, error) {
+	params, err := common.ApplyOption(&Configuration{}, options)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := &Manager{
+		namer: e.CommonNamer().WithPrefix("certificate-host"),
+		host:  host,
+	}
+
+	var deps []pulumi.ResourceOption
+
+	// Create test user and add to administrators group
+	if params.Username != "" && params.Password != "" {
+		cmd, err := host.OS.Runner().Command(manager.namer.ResourceName("create-user"), &command.Args{
+			Create: pulumi.Sprintf("net user %s %s /add", params.Username, params.Password),
+		}, deps...)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, utils.PulumiDependsOn(cmd))
+		manager.Resources = append(manager.Resources, cmd)
+
+		cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("add-to-admin"), &command.Args{
+			Create: pulumi.Sprintf("net localgroup administrators %s /add", params.Username),
+		}, deps...)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, utils.PulumiDependsOn(cmd))
+		manager.Resources = append(manager.Resources, cmd)
+	}
+
+	// Configure registry for remote access
+	cmd, err := host.OS.Runner().Command(manager.namer.ResourceName("set-registry-policy"), &command.Args{
+		Create: pulumi.String(`New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -Force -ErrorAction SilentlyContinue; Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -Name LocalAccountTokenFilterPolicy -Value 1 -Type DWORD`),
+	}, deps...)
+	if err != nil {
+		return nil, err
+	}
+	deps = append(deps, utils.PulumiDependsOn(cmd))
+	manager.Resources = append(manager.Resources, cmd)
+
+	// Configure firewall to allow SMB
+	cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("configure-firewall"), &command.Args{
+		Create: pulumi.String(`New-NetFirewallRule -DisplayName "Allow SMB TCP 445" -Direction Inbound -Protocol TCP -LocalPort 445 -Action Allow -ErrorAction SilentlyContinue`),
+	}, deps...)
+	if err != nil {
+		return nil, err
+	}
+	deps = append(deps, utils.PulumiDependsOn(cmd))
+	manager.Resources = append(manager.Resources, cmd)
+
+	// Start and enable RemoteRegistry service
+	cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("start-remote-registry"), &command.Args{
+		Create: pulumi.String(powershell.PsHost().
+			StartService("RemoteRegistry").
+			Compile()),
+	}, deps...)
+	if err != nil {
+		return nil, err
+	}
+	deps = append(deps, utils.PulumiDependsOn(cmd))
+	manager.Resources = append(manager.Resources, cmd)
+
+	// Create self-signed certificate if requested
+	if params.CreateSelfSignedCert {
+		certSubject := params.CertSubject
+		if certSubject == "" {
+			certSubject = "CN=test_cert"
+		}
+		cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("create-certificate"), &command.Args{
+			Create: pulumi.Sprintf(`New-SelfSignedCertificate -Subject "%s" -CertStoreLocation "Cert:\LocalMachine\My" -KeyExportPolicy Exportable -KeySpec Signature -KeyLength 2048 -KeyAlgorithm RSA -HashAlgorithm SHA256`, certSubject),
+		}, deps...)
+		if err != nil {
+			return nil, err
+		}
+		manager.Resources = append(manager.Resources, cmd)
+	}
+
+	return manager, nil
+}

--- a/test/new-e2e/tests/windows/components/certificatehost/params.go
+++ b/test/new-e2e/tests/windows/components/certificatehost/params.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package certificatehost
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// Configuration defines the configuration for the certificate host setup
+type Configuration struct {
+	// Username for the test user to create
+	Username string
+	// Password for the test user
+	Password string
+	// CreateSelfSignedCert determines whether to create a self-signed certificate
+	CreateSelfSignedCert bool
+	// CertSubject is the subject for the self-signed certificate (defaults to "CN=test_cert")
+	CertSubject string
+	// PulumiResourceOptions are additional Pulumi resource options
+	PulumiResourceOptions []pulumi.ResourceOption
+}
+
+// Option is a function that modifies the Configuration
+type Option = func(*Configuration) error
+
+// WithUser sets the username and password for the test user
+func WithUser(username, password string) Option {
+	return func(c *Configuration) error {
+		c.Username = username
+		c.Password = password
+		return nil
+	}
+}
+
+// WithSelfSignedCert enables creation of a self-signed certificate
+func WithSelfSignedCert(subject string) Option {
+	return func(c *Configuration) error {
+		c.CreateSelfSignedCert = true
+		if subject != "" {
+			c.CertSubject = subject
+		}
+		return nil
+	}
+}
+
+// WithPulumiResourceOptions sets the Pulumi resource options
+func WithPulumiResourceOptions(opts ...pulumi.ResourceOption) Option {
+	return func(c *Configuration) error {
+		c.PulumiResourceOptions = utils.MergeOptions(c.PulumiResourceOptions, opts...)
+		return nil
+	}
+}

--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/powershell"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/components/certificatehost"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/components/defender"
 
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
@@ -56,6 +57,23 @@ func multiVMEnvProvisioner() provisioners.PulumiEnvRunFunc[multiVMEnv] {
 		}
 		certificateHost.Export(ctx, &env.CertificateHost.HostOutput)
 
+		// Setup Windows Defender to be disabled
+		defenderManager, err := defender.NewDefender(awsEnv.CommonEnvironment, certificateHost,
+			defender.WithDefenderDisabled())
+		if err != nil {
+			return err
+		}
+
+		// Setup the certificate host with required configuration
+		// This depends on Defender being configured first
+		_, err = certificatehost.NewCertificateHost(awsEnv.CommonEnvironment, certificateHost,
+			certificatehost.WithUser(TestUser, TestPassword),
+			certificatehost.WithSelfSignedCert("CN=test_cert"),
+			certificatehost.WithPulumiResourceOptions(pulumi.DependsOn(defenderManager.Resources)))
+		if err != nil {
+			return err
+		}
+
 		return nil
 	}
 }
@@ -77,55 +95,7 @@ func (v *multiVMSuite) SetupSuite() {
 	agentHost := v.Env().AgentHost
 	certificateHost := v.Env().CertificateHost
 
-	createTestUser := fmt.Sprintf("net user %s %s /add", TestUser, TestPassword)
-	addAdmingroup := fmt.Sprintf("net localgroup administrators %s /add", TestUser)
-	selfSignedCert := `New-SelfSignedCertificate -Subject "CN=test_cert" ` +
-		`-CertStoreLocation "Cert:\\LocalMachine\\My" ` +
-		`-KeyExportPolicy Exportable -KeySpec Signature ` +
-		`-KeyLength 2048 -KeyAlgorithm RSA -HashAlgorithm SHA256`
-
-	createTestUserOut, err := certificateHost.Execute(createTestUser)
-	v.Require().NoError(err)
-	v.Require().NotEmpty(createTestUserOut)
-
-	addAdmingroupOut, err := certificateHost.Execute(addAdmingroup)
-	v.Require().NoError(err)
-	v.Require().NotEmpty(addAdmingroupOut)
-
-	err = windowsCommon.DisableDefender(certificateHost)
-	v.Require().NoError(err)
-
-	// This will require a reboot to apply the policy
-	// Reboot will be done once everything else is configured on certificateHost
-	err = windowsCommon.SetNewItemDWORDProperty(certificateHost, `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`,
-		"LocalAccountTokenFilterPolicy", 1)
-	v.Require().NoError(err)
-
-	_, err = certificateHost.Execute(`New-NetFirewallRule -DisplayName "Allow SMB TCP 445" -Direction Inbound -Protocol TCP -LocalPort 445 -Action Allow`)
-	v.Require().NoError(err)
-
-	err = windowsCommon.StartService(certificateHost, "RemoteRegistry")
-	v.Require().NoError(err)
-
-	selfSignedCertOut, err := certificateHost.Execute(selfSignedCert)
-	v.Require().NoError(err)
-	v.Require().NotEmpty(selfSignedCertOut)
-
-	// When setting, LocalAccountTokenFilterPolicy, we need to reboot the host to apply the policy
-	err = RebootHost(certificateHost)
-	v.Require().NoError(err)
-
-	// Reconnect to the host
-	err = certificateHost.Reconnect()
-	v.Require().NoError(err)
-
-	// Start the LanmanServer to ensure that the Agent can connect to the IPC$ share
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		err = windowsCommon.StartService(certificateHost, "LanmanServer")
-		assert.NoError(c, err)
-	}, 10*time.Minute, 10*time.Second)
-
-	// Wait for the LanmanServer service to be running
+	// Wait for LanmanServer to be running
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		output, err := windowsCommon.GetServiceStatus(certificateHost, "LanmanServer")
 		if err != nil {
@@ -136,13 +106,13 @@ func (v *multiVMSuite) SetupSuite() {
 		v.T().Logf("LanmanServer status: %s", output)
 	}, 10*time.Minute, 10*time.Second)
 
+	// Install the agent
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
 	v.Require().NoError(err)
 	v.T().Logf("Using Agent: %#v", agentPackage)
 	_, err = windowsAgent.InstallAgent(agentHost,
 		windowsAgent.WithPackage(agentPackage))
 	v.Require().NoError(err)
-
 }
 
 func (v *multiVMSuite) TestGetRemoteCertificate() {
@@ -161,7 +131,7 @@ instances:
 	_, err := agentHost.WriteFile("C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml", []byte(checkConfig))
 	v.Require().NoError(err)
 
-	err = windowsCommon.RestartService(agentHost, "datadogagent")
+	err = restartAgent(v, agentHost)
 	v.Require().NoError(err)
 
 	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
@@ -210,7 +180,7 @@ instances:
 	_, err := agentHost.WriteFile("C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml", []byte(checkConfig))
 	v.Require().NoError(err)
 
-	err = windowsCommon.RestartService(agentHost, "datadogagent")
+	err = restartAgent(v, agentHost)
 	v.Require().NoError(err)
 
 	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
@@ -243,8 +213,20 @@ instances:
 
 }
 
-func RebootHost(host *components.RemoteHost) error {
-	_, err := powershell.PsHost().Reboot().Execute(host)
+func restartAgent(v *multiVMSuite, host *components.RemoteHost) error {
+
+	// Make sure the agent is running before restarting it
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		output, err := windowsCommon.GetServiceStatus(host, "datadogagent")
+		if err != nil {
+			v.T().Logf("Getting datadogagent status failed %v", err)
+		}
+		assert.NoError(c, err)
+		assert.Contains(c, output, "Running")
+		v.T().Logf("datadogagent status: %s", output)
+	}, 10*time.Minute, 10*time.Second)
+
+	err := windowsCommon.RestartService(host, "datadogagent")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?
This PR fixes the flaky Windows Certificate Store e2e tests. The tests can fail when restarting the datadogagent service. This is due to the test trying to restart the Agent before it is in the `RUNNING` state. The test also moves some of its setup to the provisioner so that the VM is configured before tests are run.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1724
https://datadoghq.atlassian.net/browse/WINA-1578

### Describe how you validated your changes
Ran the cert store e2e tests

### Additional Notes
