### PR TITLE
Implement support for wildcard tag collection in KSM check

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/resourcetags.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/resourcetags.go
@@ -10,6 +10,8 @@ package transformers
 
 import (
 	"fmt"
+	"strings"
+
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 )
@@ -60,14 +62,23 @@ func RetrieveMetadataTags(
 	for name, value := range labels {
 		if tagKey, ok := labelsAsTags[name]; ok {
 			tags = append(tags, fmt.Sprintf("%s:%s", tagKey, value))
+		} else if templateKey, ok := labelsAsTags["*"]; ok {
+			tags = append(tags, replaceTemplate(templateKey, "%%label%%", name, value))
 		}
 	}
 
 	for name, value := range annotations {
 		if tagKey, ok := annotationsAsTags[name]; ok {
 			tags = append(tags, fmt.Sprintf("%s:%s", tagKey, value))
+		} else if templateKey, ok := annotationsAsTags["*"]; ok {
+			tags = append(tags, replaceTemplate(templateKey, "%%annotation%%", name, value))
 		}
 	}
 
 	return tags
+}
+
+func replaceTemplate(s string, old string, new string, value string) string {
+	replacedKey := strings.ReplaceAll(s, old, new)
+	return fmt.Sprintf("%s:%s", replacedKey, value)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/resourcetags_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/resourcetags_test.go
@@ -111,6 +111,67 @@ func TestRetrieveMetadataTags(t *testing.T) {
 			annotationsAsTags: map[string]string{"annotation-key": "annotation_key"},
 			want:              []string{"application:my-app"},
 		},
+		{
+			name: "has only wildcards with no prefix",
+			labels: map[string]string{
+				"app":  "my-app",
+				"team": "my-team",
+			},
+			annotations: map[string]string{
+				"random-annotation":  "value",
+				"another-annotation": "another-value",
+			},
+			labelsAsTags:      map[string]string{"*": "%%label%%"},
+			annotationsAsTags: map[string]string{"*": "%%annotation%%"},
+			want: []string{"app:my-app", "team:my-team",
+				"random-annotation:value", "another-annotation:another-value"},
+		},
+		{
+			name: "has wildcards with prefix",
+			labels: map[string]string{
+				"app":  "my-app",
+				"team": "my-team",
+			},
+			annotations: map[string]string{
+				"random-annotation":  "value",
+				"another-annotation": "another-value",
+			},
+			labelsAsTags:      map[string]string{"*": "prefix_%%label%%"},
+			annotationsAsTags: map[string]string{"*": "prefix_%%annotation%%"},
+			want: []string{"prefix_app:my-app", "prefix_team:my-team",
+				"prefix_random-annotation:value", "prefix_another-annotation:another-value"},
+		},
+		{
+			name: "has wildcards with prefix",
+			labels: map[string]string{
+				"app":  "my-app",
+				"team": "my-team",
+			},
+			annotations: map[string]string{
+				"random-annotation":  "value",
+				"another-annotation": "another-value",
+			},
+			labelsAsTags:      map[string]string{"*": "prefix_%%label%%"},
+			annotationsAsTags: map[string]string{"*": "prefix_%%annotation%%"},
+			want: []string{"prefix_app:my-app", "prefix_team:my-team",
+				"prefix_random-annotation:value", "prefix_another-annotation:another-value"},
+		},
+		{
+			name: "has wildcards with prefix and specific tag mapping",
+			labels: map[string]string{
+				"app":  "my-app",
+				"team": "my-team",
+			},
+			annotations: map[string]string{
+				"random-annotation":  "value",
+				"another-annotation": "another-value",
+			},
+
+			labelsAsTags:      map[string]string{"*": "prefix_%%label%%", "app": "application"}, // expecting that app maps to application and not prefix_app
+			annotationsAsTags: map[string]string{"*": "prefix_%%annotation%%"},
+			want: []string{"application:my-app", "prefix_team:my-team",
+				"prefix_random-annotation:value", "prefix_another-annotation:another-value"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
This PR adds support for collecting all Kubernetes resource labels and annotations as tags in the KSM check. When a Datadog Agent is deployed with a wildcard mapping (`"*": <tag_key>`) in the `kubernetesResourcesAnnotationsAsTags` or `kubernetesResourcesLabelsAsTags` fields, any label or annotation without an explicit mapping will now be tagged accordingly. The expected behavior is described in our [public documentation](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator#tag-extraction).

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-4854

### Describe how you validated your changes
- Added unit tests ✅ 
- Created a minikube cluster and deployed DDA with the following configuration:
```yaml
...
  kubernetesResourcesAnnotationsAsTags:
    nodes:
      foo.bar: foobar
      "*": test_%%annotation%%
    pods:
      quux: quuuuuux
  kubernetesResourceLabelsAsTags:
    services:
      "*": labeltest_%%label%%
```
- Performed the following commands using `kubectl`
+ Annotate `node/jon-wildcard-tag-collection-test` with  `foo.bar="baz"`
+ Annotate `node/jon-wildcard-tag-collection-dev` with `other.annotation="2"`
+ Annotate `pod/datadog-agent-mjl86` with `quux="6"`
+ Label `svc/datadog-agent-cluster-agent-admission-controller` with `my_label="7"`
And observed all of the expected behaviors. These include:

1. Node `jon-wildcard-tag-collection-test` is tagged `foobar:baz` and `test_other.annotation:2`
<img width="663" height="211" alt="image" src="https://github.com/user-attachments/assets/90b06fd5-5c7a-4c91-a47c-f86a7e8997cf" />

2. Pod `datadog-agent-mjl86` is tagged `quuuuuux:6`
<img width="188" height="209" alt="image" src="https://github.com/user-attachments/assets/6f69c535-8654-465f-9362-87706be33798" />

3. Service `datadog-agent-cluster-agent-admission-controller` is tagged with `labeltest_my_label:7`. 
<img width="242" height="238" alt="image" src="https://github.com/user-attachments/assets/18641f10-5b2e-4d7d-a094-a4b5df8d49cd" />

### Additional Notes
- A more general implementation would support general regex matching. This would require changing the types of `K8sProcessorContext.labelsAsTags` and `.annotationsAsTags`, which are widely referenced in the codebase and would need a much larger refactor, so this is not implemented here.