### PR TITLE
Update System Probe Test Timeout

### DIFF
--- a/test/new-e2e/tests/windows/remoteexecutable.go
+++ b/test/new-e2e/tests/windows/remoteexecutable.go
@@ -120,7 +120,7 @@ func (rs *RemoteExecutable) CopyFiles() error {
 func (rs *RemoteExecutable) RunTests(timeoutarg string) error {
 
 	if timeoutarg == "" {
-		timeoutarg = "2m"
+		timeoutarg = "5m"
 	}
 	tmo := "\"-test.timeout=" + timeoutarg + "\""
 


### PR DESCRIPTION
### What does this PR do?
Updates the timeout to reduce timeouts from the system probe `TestVMSuite`. This will hopefully allow us to remove the flake mark from this tests.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1723

### Describe how you validated your changes
Only updates e2e tests

### Additional Notes
