### PR TITLE
[CWS] Add skip on Usergroup Test for centos7

### DIFF
--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -11,6 +11,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -28,6 +29,9 @@ func TestUserGroup(t *testing.T) {
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
 	}
+	checkKernelCompatibility(t, "UserGroup test not consistent on CentOS7", func(kv *kernel.Version) bool {
+		return kv.IsRH7Kernel()
+	})
 
 	ruleDefs := []*rules.RuleDefinition{
 		{


### PR DESCRIPTION
### What does this PR do?
Skip the UserGroup Test on CentOS7.

### Motivation
This test is very flaky on CentOS7. After multiple unsuccessful attempts to make it consistant, we concluded that it was better to skip it, to guarantee the consistency of our testsuite.

### Describe how you validated your changes

### Additional Notes
