### PR TITLE
Fix RemoteAgentRegistry Unit Test

### DIFF
--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -89,6 +89,10 @@ func TestGetRegisteredAgentsIdleTimeout(t *testing.T) {
 	require.Equal(t, "Test Agent", agents[0].DisplayName)
 	require.Equal(t, "test-agent", agents[0].SanitizedDisplayName)
 
+	// wait a bit to make sure the remoteAgent gRPC server had the time to start
+	// otherwise it will return the error `grpc: the server has been stopped`
+	time.Sleep(1 * time.Second)
+
 	// Stopping the remote agent should remove it from the registry
 	remoteAgent.Stop()
 	time.Sleep(10 * time.Second)


### PR DESCRIPTION
### What does this PR do?

This PR updates the TestGetRegisteredAgentsIdleTimeout unit test by introducing a short delay between the creation of the fake remoteAgent instance and its subsequent stop() call.

### Motivation

Without this delay, a race condition can occur between the non-blocking startup of the gRPC server and its shutdown. This causes the test to intermittently fail due to the server being stopped before it has fully started, leading to an error when attempting to start a gRPC server that has already been terminated.

### Describe how you validated your changes

I reran the test multiple times to ensure stability. However, since the issue is timing-dependent, reproducing it consistently is difficult. The added delay mitigates the observed race condition in repeated test runs.