### PR TITLE
[AGENTRUN-757] Fix new-e2e installer tests with trace loader

### DIFF
--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -21,7 +21,7 @@ import (
 const Traces DataType = "traces"
 
 func setupAPM(config pkgconfigmodel.Setup) {
-	config.BindEnvAndSetDefault("apm_config.socket_activation.enabled", false, "DD_APM_SOCKET_ACTIVATION_ENABLED")
+	config.BindEnvAndSetDefault("apm_config.socket_activation.enabled", true, "DD_APM_SOCKET_ACTIVATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.enabled", true, "DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.keep_values", []string{}, "DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.obfuscate_sql_values", []string{}, "DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES")

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -21,7 +21,7 @@ import (
 const Traces DataType = "traces"
 
 func setupAPM(config pkgconfigmodel.Setup) {
-	config.BindEnvAndSetDefault("apm_config.socket_activation.enabled", true, "DD_APM_SOCKET_ACTIVATION_ENABLED")
+	config.BindEnvAndSetDefault("apm_config.socket_activation.enabled", false, "DD_APM_SOCKET_ACTIVATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.enabled", true, "DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.keep_values", []string{}, "DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.elasticsearch.obfuscate_sql_values", []string{}, "DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES")

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -215,8 +215,11 @@ func (h *Host) WaitForFileExists(useSudo bool, filePaths ...string) {
 // This is because of a race condition where the trace agent is not ready to receive traces and we send them
 // meaning that the traces are lost
 func (h *Host) WaitForTraceAgentSocketReady() {
-	_, err := h.remote.Execute("timeout=30; while ! grep -q 'Listening for traces at unix://' <(sudo journalctl _PID=`systemctl show -p MainPID datadog-agent-trace | cut -d\"=\" -f2`); do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]")
-	require.NoError(h.t(), err, "trace agent did not become ready")
+	require.EventuallyWithT(h.t(), func(t *assert.CollectT) {
+		// this endpoint is no-op but it will fail if the trace agent is not ready
+		_, err := h.remote.Execute("curl -XGET --unix-socket /var/run/datadog/apm.socket http:/services")
+		require.NoError(t, err)
+	}, 30*time.Second, 1*time.Second, "trace agent did not become ready")
 }
 
 // BootstrapperVersion returns the version of the bootstrapper on the host.


### PR DESCRIPTION
### What does this PR do?
Fix new-e2e installer tests with trace loader enabled.

Now making a request to the endpoint to know if the trace-agent is listening.
Previously the timeout was not checked so if the condition failed it would wait forever.
Replaced using `EventuallyWithT` for a simpler check.

### Motivation
Have the tests passing when the feature is enabled.

### Describe how you validated your changes
CI

### Additional Notes
The first commit of this PR enabled socket-activation to make sure the tests passed, the second commit disabled it again.
