### PR TITLE
Skip SNMP autodiscovery E2E tests

### DIFF
--- a/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
+++ b/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
@@ -31,6 +31,8 @@ func autoDiscoverySuiteProvisioner(agentConfig string) provisioners.Provisioner 
 }
 
 func TestAutoDiscoverySuite(t *testing.T) {
+	// TODO: Fix this test
+	t.Skip("Skipping test because it fails")
 	e2e.Run(t, &autoDiscoverySuite{}, e2e.WithProvisioner(autoDiscoverySuiteProvisioner(``)))
 }
 


### PR DESCRIPTION
### What does this PR do?

https://dd.slack.com/archives/C07RHJTEFRD/p1759843596422569
Skip SNMP autodiscovery E2E tests because they are failing, the problem is that we can suddenly contact other IPs than `127.0.0.1`, like `127.0.0.0`, `127.0.0.2`, ..., I'm not sure why?

### Motivation

### Describe how you validated your changes

### Additional Notes
