### PR TITLE
Fail network test when packetLoss is 100%.

### DIFF
--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -300,29 +300,7 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 		RunType: w.testCfg.cfg.RunType,
 	}
 
-	if w.tracerouteError != nil || result.Netstats.PacketLossPercentage == 100 {
-		result.Status = "failed"
-		errMsg := ""
-		if w.tracerouteError != nil {
-			errMsg = w.tracerouteError.Error()
-		} else {
-			errMsg = "no connection established"
-		}
-		result.Failure = common.APIError{
-			Code:    "UNKNOWN",
-			Message: errMsg,
-		}
-	} else {
-		for _, res := range w.assertionResult {
-			if !res.Valid || res.Failure.Code != "" {
-				result.Status = "failed"
-				result.Failure = common.APIError{
-					Code:    incorrectAssertion,
-					Message: w.tracerouteError.Error(),
-				}
-			}
-		}
-	}
+	s.setResultStatus(w, &result)
 
 	return &common.TestResult{
 		Location: struct {
@@ -333,6 +311,45 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 		Test:   t,
 		V:      1,
 	}, nil
+}
+
+func (s *syntheticsTestScheduler) setResultStatus(w *workerResult, result *common.Result) {
+	if result.Netstats.PacketLossPercentage == 100 {
+		if !hasAssertionOn100PacketLoss(w.assertionResult) {
+			result.Status = "failed"
+			result.Failure = common.APIError{
+				Code:    "NETUNREACH",
+				Message: "The remote server network is unreachable.",
+			}
+		}
+	}
+	if w.tracerouteError != nil {
+		result.Status = "failed"
+		result.Failure = common.APIError{
+			Code:    "UNKNOWN",
+			Message: w.tracerouteError.Error(),
+		}
+	}
+	if result.Status != "failed" {
+		for _, res := range w.assertionResult {
+			if !res.Valid || res.Failure.Code != "" {
+				result.Status = "failed"
+				result.Failure = common.APIError{
+					Code:    incorrectAssertion,
+					Message: w.tracerouteError.Error(),
+				}
+			}
+		}
+	}
+}
+
+func hasAssertionOn100PacketLoss(assertionResults []common.AssertionResult) bool {
+	for _, assertion := range assertionResults {
+		if assertion.Type == common.AssertionTypePacketLoss && assertion.Operator == common.OperatorIs && assertion.Expected == "100" {
+			return true
+		}
+	}
+	return false
 }
 
 // generateRandomStringUInt63 returns a cryptographically random uint63 as decimal string.

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -300,11 +300,17 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 		RunType: w.testCfg.cfg.RunType,
 	}
 
-	if w.tracerouteError != nil {
+	if w.tracerouteError != nil || result.Netstats.PacketLossPercentage == 100 {
 		result.Status = "failed"
+		errMsg := ""
+		if w.tracerouteError != nil {
+			errMsg = w.tracerouteError.Error()
+		} else {
+			errMsg = "no connection established"
+		}
 		result.Failure = common.APIError{
 			Code:    "UNKNOWN",
-			Message: w.tracerouteError.Error(),
+			Message: errMsg,
 		}
 	} else {
 		for _, res := range w.assertionResult {

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -245,6 +245,54 @@ func TestNetworkPathToTestResult(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "100% packet loss",
+			worker: workerResult{
+				tracerouteResult: payload.NetworkPath{
+					E2eProbe: payload.E2eProbe{
+						PacketsSent:          0,
+						PacketsReceived:      0,
+						PacketLossPercentage: 100,
+						Jitter:               0,
+						RTT: payload.E2eProbeRttLatency{
+							Avg: 0, Min: 0, Max: 0,
+						},
+					},
+					Traceroute: payload.Traceroute{
+						HopCount: payload.HopCountStats{Avg: 5, Min: 4, Max: 6},
+					},
+				},
+				tracerouteCfg: trCfg,
+				testCfg: SyntheticsTestCtx{
+					cfg: common.SyntheticsTestConfig{
+						PublicID: "pub-123",
+						Type:     "network",
+						Version:  1,
+						Config: struct {
+							Assertions []common.Assertion   `json:"assertions"`
+							Request    common.ConfigRequest `json:"request"`
+						}{
+							Request: common.ICMPConfigRequest{
+								Host: "8.8.8.8",
+								NetworkConfigRequest: common.NetworkConfigRequest{
+									SourceService:      &src,
+									DestinationService: &dst,
+									MaxTTL:             &icmpTTL,
+									Timeout:            &icmpTimeout,
+								},
+							},
+						},
+					},
+				},
+				triggeredAt: now.Add(-3 * time.Second),
+				startedAt:   now.Add(-2 * time.Second),
+				finishedAt:  now,
+				duration:    2 * time.Second,
+				hostname:    "agent-host",
+			},
+			expectFail:  true,
+			expectError: false,
+		},
+		{
 			name: "failure case",
 			worker: workerResult{
 				tracerouteResult: payload.NetworkPath{},

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -293,6 +293,60 @@ func TestNetworkPathToTestResult(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "100% packet loss with assertion on it",
+			worker: workerResult{
+				tracerouteResult: payload.NetworkPath{
+					E2eProbe: payload.E2eProbe{
+						PacketsSent:          0,
+						PacketsReceived:      0,
+						PacketLossPercentage: 100,
+						Jitter:               0,
+						RTT: payload.E2eProbeRttLatency{
+							Avg: 0, Min: 0, Max: 0,
+						},
+					},
+					Traceroute: payload.Traceroute{
+						HopCount: payload.HopCountStats{Avg: 5, Min: 4, Max: 6},
+					},
+				},
+				tracerouteCfg: trCfg,
+				testCfg: SyntheticsTestCtx{
+					cfg: common.SyntheticsTestConfig{
+						PublicID: "pub-123",
+						Type:     "network",
+						Version:  1,
+						Config: struct {
+							Assertions []common.Assertion   `json:"assertions"`
+							Request    common.ConfigRequest `json:"request"`
+						}{
+							Request: common.ICMPConfigRequest{
+								Host: "8.8.8.8",
+								NetworkConfigRequest: common.NetworkConfigRequest{
+									SourceService:      &src,
+									DestinationService: &dst,
+									MaxTTL:             &icmpTTL,
+									Timeout:            &icmpTimeout,
+								},
+							},
+						},
+					},
+				},
+				assertionResult: []common.AssertionResult{{
+					Operator: common.OperatorIs,
+					Type:     common.AssertionTypePacketLoss,
+					Expected: "100",
+					Valid:    true,
+				}},
+				triggeredAt: now.Add(-3 * time.Second),
+				startedAt:   now.Add(-2 * time.Second),
+				finishedAt:  now,
+				duration:    2 * time.Second,
+				hostname:    "agent-host",
+			},
+			expectFail:  false,
+			expectError: false,
+		},
+		{
 			name: "failure case",
 			worker: workerResult{
 				tracerouteResult: payload.NetworkPath{},


### PR DESCRIPTION
### What does this PR do?

Fail network test when packetLoss is 100%.

### Motivation

datadog-traceroute doesn't send an error when a 100% packet loss which means no connection could be established.

### Describe how you validated your changes

### Additional Notes
