### PR TITLE
process: fix wrong injection status on retries

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -231,7 +231,7 @@ func TestServiceStoreLifetimeProcessCollectionDisabled(t *testing.T) {
 			expectStored: []*workloadmeta.Process{makeProcessEntity(pidNewService, baseTime.Add(-2*time.Minute), nil, workloadmeta.InjectionNotInjected)},
 		},
 		{
-			name: "injection_state_already_reported_no_duplicate",
+			name: "preserve injection state",
 			existingProcesses: []*workloadmeta.Process{
 				makeProcessEntity(pidInjectedOnly, baseTime.Add(-2*time.Minute), nil, workloadmeta.InjectionInjected), // Already reported in previous cycle
 			},
@@ -425,7 +425,7 @@ func TestServiceStoreLifetime(t *testing.T) {
 			expectStored: []*workloadmeta.Process{makeProcessEntity(pidRecentService, baseTime.Add(time.Minute+30*time.Second), languagePython, workloadmeta.InjectionUnknown)},
 		},
 		{
-			name: "injection_state_already_reported_no_duplicate",
+			name: "preserve injection state",
 			existingServiceData: []*workloadmeta.Process{
 				makeProcessEntity(pidInjectedOnly, baseTime.Add(-2*time.Minute), nil, workloadmeta.InjectionInjected), // Already reported in previous cycle
 			},


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the injection status of a new process, when in the injected state, will switch to not injected when the collector retries getting the Service info.

### Motivation

Fix wrong injection state.

### Describe how you validated your changes

Covered by additional unit tests.

### Additional Notes
