### PR TITLE
Treat blank metadata as missing.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -117,7 +117,7 @@ func mergeProfileDefinition(targetDefinition *profiledefinition.ProfileDefinitio
 				resource.Fields = make(map[string]profiledefinition.MetadataField, len(baseResource.Fields))
 			}
 			for field, symbol := range baseResource.Fields {
-				if _, ok := resource.Fields[field]; !ok {
+				if value, ok := resource.Fields[field]; !ok || value.IsEmpty() {
 					resource.Fields[field] = symbol
 				}
 			}

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
@@ -444,6 +444,73 @@ func Test_mergeProfileDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "blank metadata fields",
+			baseDefinition: profiledefinition.ProfileDefinition{
+				Metadata: profiledefinition.MetadataConfig{
+					"device": {
+						Fields: map[string]profiledefinition.MetadataField{
+							"vendor": {
+								Value: "f5",
+							},
+							"description": {
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.1.1.0",
+									Name: "sysDescr",
+								},
+							},
+							"sys_object_id": {
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.1.2.0",
+									Name: "sysObjectID",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetDefinition: profiledefinition.ProfileDefinition{
+				Metadata: profiledefinition.MetadataConfig{
+					"device": {
+						Fields: map[string]profiledefinition.MetadataField{
+							"vendor": {},
+							"description": {
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "100.100.100.100",
+									Name: "customDescription",
+								},
+							},
+							"sys_object_id": {
+								Symbol: profiledefinition.SymbolConfig{},
+							},
+						},
+					},
+				},
+			},
+			expectedDefinition: profiledefinition.ProfileDefinition{
+				Metadata: profiledefinition.MetadataConfig{
+					"device": {
+						Fields: map[string]profiledefinition.MetadataField{
+							"vendor": {
+								Value: "f5",
+							},
+							"description": {
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "100.100.100.100",
+									Name: "customDescription",
+								},
+							},
+							"sys_object_id": {
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.1.2.0",
+									Name: "sysObjectID",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -54,12 +54,21 @@ type MetadataField struct {
 	Value   string         `yaml:"value,omitempty" json:"value,omitempty"`
 }
 
+// IsEmpty is true if this is nil or the zero value.
+func (f *MetadataField) IsEmpty() bool {
+	if f == nil {
+		return true
+	}
+	return f.Symbol == SymbolConfig{} && len(f.Symbols) == 0 && f.Value == ""
+
+}
+
 // Clone duplicates this MetadataField
-func (c MetadataField) Clone() MetadataField {
+func (f MetadataField) Clone() MetadataField {
 	return MetadataField{
-		Symbol:  c.Symbol.Clone(),
-		Symbols: CloneSlice(c.Symbols),
-		Value:   c.Value,
+		Symbol:  f.Symbol.Clone(),
+		Symbols: CloneSlice(f.Symbols),
+		Value:   f.Value,
 	}
 }
 

--- a/pkg/networkdevice/profile/profiledefinition/metadata_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata_test.go
@@ -6,9 +6,10 @@
 package profiledefinition
 
 import (
-	"github.com/stretchr/testify/assert"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func makeMetadata() MetadataConfig {
@@ -87,4 +88,23 @@ func TestCloneMetadata(t *testing.T) {
 	assert.Equal(t, makeMetadata(), metadata)
 	// New one is different
 	assert.NotEqual(t, metadata, metaCopy)
+}
+
+func TestIsEmpty(t *testing.T) {
+	m := MetadataField{}
+	assert.True(t, m.IsEmpty())
+	m = MetadataField{
+		Symbol: SymbolConfig{OID: "foo"},
+	}
+	assert.False(t, m.IsEmpty())
+	m = MetadataField{
+		Symbols: []SymbolConfig{
+			{},
+		},
+	}
+	assert.False(t, m.IsEmpty())
+	m = MetadataField{
+		Value: "foo",
+	}
+	assert.False(t, m.IsEmpty())
 }


### PR DESCRIPTION
### What does this PR do?

This makes empty metadata fields count as missing fields for the purposes of determining whether to apply a base profile's metadata instead.

### Motivation

A customer managed to create a custom profile where sysobjectid was set to an empty config (instead of being missing entirely), and this results in some very weird behavior because the profile will still apply to devices properly but the web UI won't know what sysobjectid the device has.

### Describe how you validated your changes

I updated the unit tests to check this case.

### Additional Notes
