### PR TITLE
Fix SNMP autodiscovery E2E tests

### DIFF
--- a/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
+++ b/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
@@ -31,8 +31,6 @@ func autoDiscoverySuiteProvisioner(agentConfig string) provisioners.Provisioner 
 }
 
 func TestAutoDiscoverySuite(t *testing.T) {
-	// TODO: Fix this test
-	t.Skip("Skipping test because it fails")
 	e2e.Run(t, &autoDiscoverySuite{}, e2e.WithProvisioner(autoDiscoverySuiteProvisioner(``)))
 }
 

--- a/test/new-e2e/tests/ndm/snmp/compose-vm/snmpCompose.yaml
+++ b/test/new-e2e/tests/ndm/snmp/compose-vm/snmpCompose.yaml
@@ -3,7 +3,7 @@ services:
   snmp:
     image: "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/datadog/docker-library:snmp"
     ports:
-      - "1161:1161/udp"
+      - "127.0.0.1:1161:1161/udp"
     command: --args-from-file=/usr/snmpsim/data/args_list.txt --variation-modules-dir=/usr/local/snmpsim/variation
     volumes:
       - /tmp/data/:/usr/snmpsim/data/


### PR DESCRIPTION
### What does this PR do?

This PR fixes the SNMP autodiscovery E2E tests by specifically binding the SNMPSim docker container to `127.0.0.1:1161:1161/udp` in the compose used by the autodiscovery test.

### Motivation

https://dd.slack.com/archives/C07RHJTEFRD/p1759843596422569

The problem was the SNMPSim container suddenly started responding to IPs in the `127.0.0.0/8` range (the loopback interface IP range) instead of only `127.0.0.1` (thus our autodiscovery started discovering other devices than `127.0.0.1` which was not expected). This behavior specifically started with [Docker v28](https://docs.docker.com/engine/release-notes/28/) onwards, which added to start accepting packets from all the loopback interface IP range (`127.0.0.0/8`) rather than only `127.0.0.1`.

### Describe how you validated your changes

The test passes.

### Additional Notes
