### PR TITLE
Fix `HasLogsSectionEnabled` and add tests for package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -368,6 +368,9 @@ issues:
     - path: comp/otelcol/otlp/configcheck/configcheck.go
       linters:
         - pkgconfigusage
+    - path: comp/otelcol/otlp/configcheck/configcheck_test.go
+      linters:
+        - pkgconfigusage
     - path: comp/otelcol/otlp/integrationtest/integration_test.go
       linters:
         - pkgconfigusage

--- a/comp/otelcol/otlp/configcheck/configcheck.go
+++ b/comp/otelcol/otlp/configcheck/configcheck.go
@@ -78,11 +78,8 @@ func IsEnabled(cfg configmodel.Reader) bool {
 	return hasSection(cfg, coreconfig.OTLPReceiverSubSectionKey)
 }
 
-// HasLogsSectionEnabled checks if OTLP logs are explicitly enabled in a given config.
-func HasLogsSectionEnabled(cfg configmodel.Reader) bool {
-	return hasSection(cfg, coreconfig.OTLPLogsEnabled) && cfg.GetBool(coreconfig.OTLPLogsEnabled)
-}
-
+// hasSection checks if a subsection of otlp_config section exists in a given config
+// It does not handle sections nested further down.
 func hasSection(cfg configmodel.Reader, section string) bool {
 	// HACK: We want to mark as enabled if the section is present, even if empty, so that we get errors
 	// from unmarshaling/validation done by the Collector code.

--- a/comp/otelcol/otlp/configcheck/configcheck_test.go
+++ b/comp/otelcol/otlp/configcheck/configcheck_test.go
@@ -1,0 +1,369 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+//go:build otlp
+
+package configcheck
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+)
+
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		envVars  map[string]string
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			yaml:     "",
+			expected: false,
+		},
+		{
+			name: "otlp_config section missing",
+			yaml: `
+some_other_config: value
+`,
+			expected: false,
+		},
+		{
+			name: "otlp_config exists but empty",
+			yaml: `
+otlp_config:
+`,
+			expected: false,
+		},
+		{
+			name: "otlp_config exists but receiver key missing",
+			yaml: `
+otlp_config:
+  other_key: value
+`,
+			expected: false,
+		},
+		{
+			name: "receiver section exists but empty",
+			yaml: `otlp_config:
+  receiver:
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section exists but null",
+			yaml: `otlp_config:
+  receiver: null
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with protocols but empty",
+			yaml: `otlp_config:
+  receiver:
+    protocols:
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with protocols grpc and http empty",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+      http:
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with protocols grpc and http null",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc: null
+      http: null
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with full grpc configuration",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with full http configuration",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+`,
+			expected: true,
+		},
+		{
+			name: "receiver section with both grpc and http configuration",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+`,
+			expected: true,
+		},
+		{
+			name: "empty config with env var setting grpc endpoint",
+			yaml: "",
+			envVars: map[string]string{
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT": "0.0.0.0:9993",
+			},
+			expected: true,
+		},
+		{
+			name: "empty config with env var setting http endpoint",
+			yaml: "",
+			envVars: map[string]string{
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT": "0.0.0.0:9994",
+			},
+			expected: true,
+		},
+		{
+			name: "empty config with multiple env vars",
+			yaml: "",
+			envVars: map[string]string{
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT":          "0.0.0.0:9993",
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT":          "0.0.0.0:9994",
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_MAX_RECV_MSG_SIZE": "4194304",
+			},
+			expected: true,
+		},
+		{
+			name: "config with receiver and env var override",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+`,
+			envVars: map[string]string{
+				"DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT": "0.0.0.0:9994",
+			},
+			expected: true,
+		},
+		{
+			name: "env var for non-receiver otlp config should not enable",
+			yaml: "",
+			envVars: map[string]string{
+				"DD_OTLP_CONFIG_TRACES_ENABLED": "true",
+				"DD_OTLP_CONFIG_LOGS_ENABLED":   "true",
+			},
+			expected: false,
+		},
+		{
+			name: "otlp_config with other sections but no receiver",
+			yaml: `
+otlp_config:
+  traces:
+    enabled: true
+  logs:
+    enabled: true
+`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			// Create mock config
+			cfg := configmock.New(t)
+			pkgconfigsetup.OTLP(cfg)
+
+			// Create temporary file and read config from it
+			if tt.yaml != "" {
+				tmpFile, err := os.CreateTemp("", "test-config-*.yaml")
+				require.NoError(t, err, "Failed to create temp file")
+				defer os.Remove(tmpFile.Name())
+
+				_, err = tmpFile.WriteString(tt.yaml)
+				require.NoError(t, err, "Failed to write YAML to temp file")
+				tmpFile.Close()
+
+				cfg.SetConfigFile(tmpFile.Name())
+				err = cfg.ReadInConfig()
+				require.NoError(t, err, "Failed to read YAML config")
+			}
+
+			result := IsEnabled(cfg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHasSectionEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		section  string
+		expected bool
+	}{
+		{
+			name: "section exists with nested empty map",
+			yaml: `
+otlp_config:
+  receiver:
+    nested:
+`,
+			section:  "receiver",
+			expected: true,
+		},
+		{
+			name: "section exists with deeply nested structure",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+        tls:
+          insecure: true
+`,
+			section:  "receiver",
+			expected: true,
+		},
+		{
+			name: "section with boolean value",
+			yaml: `
+otlp_config:
+  receiver: true
+`,
+			section:  "receiver",
+			expected: true,
+		},
+		{
+			name: "section with string value",
+			yaml: `
+otlp_config:
+  receiver: some_string_value
+`,
+			section:  "receiver",
+			expected: true,
+		},
+		{
+			name: "section with numeric value",
+			yaml: `
+otlp_config:
+  receiver: 12345
+`,
+			section:  "receiver",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			pkgconfigsetup.OTLP(cfg)
+
+			tmpFile, err := os.CreateTemp("", "test-config-*.yaml")
+			require.NoError(t, err, "Failed to create temp file")
+			defer os.Remove(tmpFile.Name())
+
+			_, err = tmpFile.WriteString(tt.yaml)
+			require.NoError(t, err, "Failed to write YAML to temp file")
+			tmpFile.Close()
+
+			cfg.SetConfigFile(tmpFile.Name())
+			err = cfg.ReadInConfig()
+			require.NoError(t, err, "Failed to read YAML config")
+
+			result := hasSection(cfg, tt.section)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsEnabledConsistencyWithReadConfigSection(t *testing.T) {
+	// This test ensures that IsEnabled is consistent with ReadConfigSection behavior
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "receiver section exists but empty",
+			yaml: `
+otlp_config:
+  receiver:
+`,
+		},
+		{
+			name: "receiver section exists but null",
+			yaml: `
+otlp_config:
+  receiver: null
+`,
+		},
+		{
+			name: "receiver section with configuration",
+			yaml: `
+otlp_config:
+  receiver:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			pkgconfigsetup.OTLP(cfg)
+
+			tmpFile, err := os.CreateTemp("", "test-config-*.yaml")
+			require.NoError(t, err, "Failed to create temp file")
+			defer os.Remove(tmpFile.Name())
+
+			_, err = tmpFile.WriteString(tt.yaml)
+			require.NoError(t, err, "Failed to write YAML to temp file")
+			tmpFile.Close()
+
+			cfg.SetConfigFile(tmpFile.Name())
+			err = cfg.ReadInConfig()
+			require.NoError(t, err, "Failed to read YAML config")
+
+			// IsEnabled should return true if ReadConfigSection can find the receiver key
+			isEnabled := IsEnabled(cfg)
+			configSection := ReadConfigSection(cfg, pkgconfigsetup.OTLPSection)
+			_, hasReceiverKey := configSection.ToStringMap()[pkgconfigsetup.OTLPReceiverSubSectionKey]
+
+			assert.Equal(t, hasReceiverKey, isEnabled,
+				"IsEnabled should be consistent with ReadConfigSection's ability to find receiver key")
+		})
+	}
+}

--- a/comp/otelcol/otlp/configcheck/configcheck_test.go
+++ b/comp/otelcol/otlp/configcheck/configcheck_test.go
@@ -54,21 +54,24 @@ otlp_config:
 		},
 		{
 			name: "receiver section exists but empty",
-			yaml: `otlp_config:
+			yaml: `
+otlp_config:
   receiver:
 `,
 			expected: true,
 		},
 		{
 			name: "receiver section exists but null",
-			yaml: `otlp_config:
+			yaml: `
+otlp_config:
   receiver: null
 `,
 			expected: true,
 		},
 		{
 			name: "receiver section with protocols but empty",
-			yaml: `otlp_config:
+			yaml: `
+otlp_config:
   receiver:
     protocols:
 `,

--- a/comp/otelcol/otlp/pipeline_validator_serverless.go
+++ b/comp/otelcol/otlp/pipeline_validator_serverless.go
@@ -11,12 +11,12 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/configcheck"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
 func checkAndUpdateCfg(cfg config.Component, pcfg PipelineConfig, logsAgentChannel chan *message.Message) error {
-	if configcheck.HasLogsSectionEnabled(cfg) {
+	if cfg.GetBool(coreconfig.OTLPLogsEnabled) {
 		pipelineError.Store(fmt.Errorf("Cannot enable OTLP log ingestion for serverless"))
 		return pipelineError.Load()
 	}


### PR DESCRIPTION
### What does this PR do?
Replace the `HasLogsSectionEnabled` function with just checking the config value, and add many tests for the package.

### Motivation
I initially just wanted to add tests, to prove that a future refactor in this package does not break functionality.

However the tests revealed that `HasLogsSectionEnabled` simply doesn't work (it always returns `false`), for two reasons:
- `HasLogsSectionEnabled` uses `hasSection` with `"otlp_config.logs.enabled"`, instead of simply `"logs.enabled"` (eg. `IsEnabled` calls it with `receiver`, not `otlp_config.receiver`)
- `hasSection` only checks **direct** subsections of `otlp_config`, so it can't find `"logs.enabled"` anyway

Also checking the section is useless, the default value for `otlp_config.logs.enabled` is `false`, so just checking the config value is enough.
This is only used in serverless environment to warn about logs not being supported, so probably that no one noticed it wasn't behaving as expected.

### Describe how you validated your changes
CI.

### Additional Notes
I'll move some code around in a follow-up PR to avoid `IsEnabled` depending on otel code, which will remove dependencies in the loader process.