### PR TITLE
Update Traceroute library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.71.0-rc.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f
-	github.com/DataDog/datadog-traceroute v0.1.26
+	github.com/DataDog/datadog-traceroute v0.1.28
 	github.com/DataDog/dd-trace-go/v2 v2.2.2
 	github.com/DataDog/ebpf-manager v0.7.14
 	github.com/DataDog/go-libddwaf/v4 v4.3.2

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f h1:O+Ls4K2v4lQpGum7yYWM3aRZ3vJ/Ibvk/Ma/NqXwtWI=
 github.com/DataDog/datadog-operator/api v0.0.0-20251002125833-f01ea1d12a3f/go.mod h1:E+dFku5SVIXDUj6apiBdDAzrUOR3xLz1bMgUOGjRAVQ=
-github.com/DataDog/datadog-traceroute v0.1.26 h1:Gom3/Hs562ai8HYdv9LTrgAc+Za7ixVbRCHmy3d3Rv4=
-github.com/DataDog/datadog-traceroute v0.1.26/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
+github.com/DataDog/datadog-traceroute v0.1.28 h1:aakZepsIXOy0kcDNHkiHMnbIVn0cY8it6gzx/8+rmmU=
+github.com/DataDog/datadog-traceroute v0.1.28/go.mod h1:PU0w0AsVMEapWPgaqXEtBuDUlPQGlnHsaADsXVMKMts=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251001104144-35a0daaf10ff h1:ebg53sL4WZzIqazsg7P39quwG7bc9tEr9tXOU5Y5ZzI=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251001104144-35a0daaf10ff/go.mod h1:inkKXnNcJR5TNK8CvXcxybKj9J878mj4+4Ri9cziHbE=
 github.com/DataDog/dd-trace-go/v2 v2.2.2 h1:t7RCS6et5z+xrvM9dqUPtCGoNOWTj0pcApzbktMZi2k=

--- a/test/new-e2e/tests/netpath/network-path-integration/fixtures/network_path_windows.yaml
+++ b/test/new-e2e/tests/netpath/network-path-integration/fixtures/network_path_windows.yaml
@@ -1,6 +1,7 @@
 instances:
   - hostname: api.datadoghq.eu
     protocol: TCP
+    tcp_method: sack # verify we support sack
     port: 443
   - hostname: 8.8.8.8
     protocol: UDP
@@ -9,7 +10,7 @@ instances:
   - hostname: 8.8.8.8
     protocol: TCP
     port: 443
-    tcp_method: syn_socket
+    tcp_method: syn_socket # verify we support syn with raw sockets
   - hostname: 1.1.1.1
     protocol: TCP
     port: 443


### PR DESCRIPTION
### What does this PR do?
Update traceroute to dependency to `v0.1.28`. This fixes an bug with running SACK traceroute on windows devices.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1899

### Describe how you validated your changes
Adds to existing e2e test a sack traceroute. Manually tested on windows VM.


### Additional Notes
