### PR TITLE
[AGNTLOG-327] Fix tailer memory leak and premature halting for Logs fingerprinting

### DIFF
--- a/pkg/logs/launchers/file/launcher_test.go
+++ b/pkg/logs/launchers/file/launcher_test.go
@@ -1278,7 +1278,6 @@ func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForTruncatedU
 	// Get initial tailer and verify rotation detection works
 	tailer, found := s.tailers.Get(getScanKey(suite.testPath, suite.source))
 	suite.True(found, "tailer should be found")
-	initialTailerCount := s.tailers.Count()
 
 	// Simulate rotation: truncate file to empty (fingerprint becomes 0)
 	suite.Nil(suite.testFile.Truncate(0))
@@ -1294,10 +1293,12 @@ func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForTruncatedU
 	// Now test the launcher's behavior: it should NOT create a new tailer for the undersized file
 	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
 
-	// Verify no new tailer was created for the undersized file
-	// The old tailer should be removed but no new one should be created
-	afterScanCount := s.tailers.Count()
-	suite.Equal(initialTailerCount-1, afterScanCount, "No new tailer should be created for undersized file after rotation")
+	// Verify the behavior when file is truncated to undersized:
+	// - Old tailer should be removed from active tailers
+	// - Old tailer should be added to rotatedTailers to finish draining
+	// - No new tailer should be created for the undersized file
+	suite.Equal(0, s.tailers.Count(), "No active tailers should remain when file truncates to undersized")
+	suite.Equal(1, len(s.rotatedTailers), "Rotated tailer should remain tracked while draining")
 }
 
 func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForRotatedUndersizedFile() {
@@ -1337,7 +1338,6 @@ func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForRotatedUnd
 	// Get initial tailer and verify rotation detection works
 	tailer, found := s.tailers.Get(getScanKey(suite.testPath, suite.source))
 	suite.True(found, "tailer should be found")
-	initialTailerCount := s.tailers.Count()
 
 	// Simulate file rotation: move current file to .1 and create a new empty file
 	rotatedPath := suite.testPath + ".1"
@@ -1357,10 +1357,12 @@ func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForRotatedUnd
 	// Now test the launcher's behavior: it should NOT create a new tailer for the undersized file
 	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
 
-	// Verify no new tailer was created for the undersized file
-	// The old tailer should be removed but no new one should be created
-	afterScanCount := s.tailers.Count() + len(s.rotatedTailers)
-	suite.Equal(initialTailerCount, afterScanCount, "No new tailer should be created for undersized file after rotation")
+	// Verify the behavior when file rotates to undersized:
+	// - Old tailer should be removed from active tailers (because new file is undersized and won't be tailed)
+	// - Old tailer should be added to rotatedTailers to finish draining
+	// - No new tailer should be created for the undersized file
+	suite.Equal(0, s.tailers.Count(), "No active tailers should remain when file rotates to undersized")
+	suite.Equal(1, len(s.rotatedTailers), "Rotated tailer should remain tracked while draining")
 
 	// Clean up the rotated file
 	os.Remove(rotatedPath)
@@ -1368,4 +1370,148 @@ func (suite *BaseLauncherTestSuite) TestLauncherDoesNotCreateTailerForRotatedUnd
 
 func getScanKey(path string, source *sources.LogSource) string {
 	return filetailer.NewFile(path, source, false).GetScanKey()
+}
+
+// TestRotatedTailersNotStoppedDuringScan tests that rotated tailers are not stopped during scan
+func (suite *BaseLauncherTestSuite) TestRotatedTailersNotStoppedDuringScan() {
+	suite.s.cleanup()
+	mockConfig := configmock.New(suite.T())
+	mockConfig.SetWithoutSource("logs_config.close_timeout", 1) // seconds
+
+	sleepDuration := 20 * time.Millisecond
+	fc := flareController.NewFlareController()
+
+	// Create fingerprint config for this test
+	fingerprintConfig := types.FingerprintConfig{
+		FingerprintStrategy: types.FingerprintStrategyByteChecksum,
+		Count:               5,
+		CountToSkip:         0,
+		MaxBytes:            10000,
+	}
+
+	s := NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "byte_checksum", fc, suite.tagger, fingerprintConfig)
+	s.pipelineProvider = suite.pipelineProvider
+	s.registry = auditorMock.NewMockRegistry()
+	s.activeSources = append(s.activeSources, suite.source)
+	status.Clear()
+	status.InitStatus(mockConfig, util.CreateSources([]*sources.LogSource{suite.source}))
+	defer status.Clear()
+
+	// Create initial file with content
+	_, err := suite.testFile.WriteString("initial content\n")
+	suite.Nil(err)
+	suite.Nil(suite.testFile.Sync())
+
+	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
+
+	// Read the message
+	msg := <-suite.outputChan
+	suite.Equal("initial content", string(msg.GetContent()))
+
+	// Rotate the file
+	rotatedPath := suite.testPath + ".1"
+	err = os.Rename(suite.testPath, rotatedPath)
+	suite.Nil(err)
+
+	newFile, err := os.Create(suite.testPath)
+	suite.Nil(err)
+	_, err = newFile.WriteString("new content\n")
+	suite.Nil(err)
+	newFile.Close()
+
+	// Scan detects rotation
+	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
+
+	// After rotation, we should have:
+	// - 1 active tailer (for the new file)
+	// - 1 rotated tailer (still draining the old file)
+	suite.Equal(1, s.tailers.Count(), "Should have 1 active tailer")
+	suite.Equal(1, len(s.rotatedTailers), "Should have 1 rotated tailer")
+
+	// Change the source path to simulate the file no longer matching
+	// This should normally cause the tailer to be stopped, but rotated tailers should be skipped
+	s.activeSources = []*sources.LogSource{}
+
+	// Scan again - the rotated tailer should NOT be stopped
+	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
+
+	// Clean up
+	os.Remove(rotatedPath)
+}
+
+// TestRestartTailerAfterFileRotationRemovesTailer tests that restartTailerAfterFileRotation removes the old tailer
+func (suite *BaseLauncherTestSuite) TestRestartTailerAfterFileRotationRemovesTailer() {
+	suite.s.cleanup()
+	mockConfig := configmock.New(suite.T())
+	mockConfig.SetWithoutSource("logs_config.close_timeout", 1) // seconds
+
+	sleepDuration := 20 * time.Millisecond
+	fc := flareController.NewFlareController()
+
+	// Create fingerprint config for this test
+	fingerprintConfig := types.FingerprintConfig{
+		FingerprintStrategy: types.FingerprintStrategyByteChecksum,
+		Count:               5,
+		CountToSkip:         0,
+		MaxBytes:            10000,
+	}
+
+	s := NewLauncher(suite.openFilesLimit, sleepDuration, false, 10*time.Second, "byte_checksum", fc, suite.tagger, fingerprintConfig)
+	s.pipelineProvider = suite.pipelineProvider
+	s.registry = auditorMock.NewMockRegistry()
+	s.activeSources = append(s.activeSources, suite.source)
+	status.Clear()
+	status.InitStatus(mockConfig, util.CreateSources([]*sources.LogSource{suite.source}))
+	defer status.Clear()
+
+	// Create initial file
+	_, err := suite.testFile.WriteString("line1\n")
+	suite.Nil(err)
+	suite.Nil(suite.testFile.Sync())
+
+	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
+
+	// Read the message
+	msg := <-suite.outputChan
+	suite.Equal("line1", string(msg.GetContent()))
+
+	// Get initial tailer
+	initialTailer, _ := s.tailers.Get(getScanKey(suite.testPath, suite.source))
+	suite.NotNil(initialTailer)
+
+	// Simulate rotation
+	rotatedPath := suite.testPath + ".1"
+	err = os.Rename(suite.testPath, rotatedPath)
+	suite.Nil(err)
+
+	// Create new file
+	newFile, err := os.Create(suite.testPath)
+	suite.Nil(err)
+	_, err = newFile.WriteString("line2\n")
+	suite.Nil(err)
+	newFile.Close()
+
+	// Scan to detect rotation
+	s.resolveActiveTailers(suite.s.fileProvider.FilesToTail(context.Background(), suite.s.validatePodContainerID, suite.s.activeSources, suite.s.registry))
+
+	// After rotation:
+	// - The old tailer should be removed from the active container
+	// - The old tailer should be in rotatedTailers list
+	// - A new tailer should be in the active container
+	suite.Equal(1, s.tailers.Count(), "Should have 1 active tailer")
+	suite.Equal(1, len(s.rotatedTailers), "Should have 1 rotated tailer")
+
+	newTailer, found := s.tailers.Get(getScanKey(suite.testPath, suite.source))
+	suite.True(found, "New tailer should be in active container")
+	suite.True(initialTailer != newTailer, "New tailer should be different from initial tailer")
+
+	// The old tailer should be in rotatedTailers
+	suite.True(initialTailer == s.rotatedTailers[0], "Old tailer should be in rotatedTailers list")
+
+	// Read the new message
+	msg = <-suite.outputChan
+	suite.Equal("line2", string(msg.GetContent()))
+
+	// Clean up
+	os.Remove(rotatedPath)
 }

--- a/pkg/logs/launchers/file/position.go
+++ b/pkg/logs/launchers/file/position.go
@@ -39,7 +39,7 @@ func Position(registry auditor.Registry, identifier string, mode config.TailingM
 				// If fingerprint computation fails, assume fingerprints don't align to be safe
 				fingerprintsAlign = true
 			} else {
-				fingerprintsAlign = prevFingerprint.Value == newFingerprint.Value
+				fingerprintsAlign = prevFingerprint.Equals(newFingerprint)
 			}
 		}
 	}
@@ -61,6 +61,9 @@ func Position(registry auditor.Registry, identifier string, mode config.TailingM
 				whence = io.SeekStart
 			}
 		}
+	case !fingerprintsAlign && value != "":
+		// Fingerprints don't align (rotation detected), start from beginning regardless of mode
+		offset, whence = 0, io.SeekStart
 	case mode == config.Beginning:
 		offset, whence = 0, io.SeekStart
 	case mode == config.End:

--- a/pkg/logs/tailers/file/fingerprint_test.go
+++ b/pkg/logs/tailers/file/fingerprint_test.go
@@ -861,6 +861,13 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	tailer := suite.createTailer()
 	fingerprinter := NewFingerprinter(*config)
 
+	// Initialize osFile and fullpath for DidRotate() filesystem checks
+	osFile, err := os.Open(suite.testPath)
+	suite.Nil(err)
+	defer osFile.Close()
+	tailer.osFile = osFile
+	tailer.fullpath = suite.testPath
+
 	// Compute initial fingerprint
 	initialFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.NotNil(initialFingerprint)
@@ -879,7 +886,9 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	suite.Nil(err)
 	suite.False(rotated, "Should not detect rotation on an unchanged file")
 
-	// 3. Truncate the file, which simulates a rotation. This should be detected.
+	// 3. Truncate the file, which simulates a rotation.
+	// valid -> invalid triggers filesystem check.
+	// filesystem check returns false (no rotation detected).
 	suite.T().Log("Truncating file to simulate rotation")
 	suite.Nil(suite.testFile.Truncate(0))
 	_, err = suite.testFile.Seek(0, 0)
@@ -887,7 +896,7 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	suite.Nil(suite.testFile.Sync())
 	rotated, err = tailer.DidRotateViaFingerprint(fingerprinter)
 	suite.Nil(err)
-	suite.True(rotated, "Should detect rotation after truncation")
+	suite.False(rotated, "Truncation not detected via filesystem check when lastReadOffset=0")
 
 	// 4. Simulate a full file replacement (e.g. logrotate with 'create' directive).
 	suite.T().Log("Simulating file replacement with different content")
@@ -898,6 +907,14 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	// We 're-arm' the tailer, as if the launcher had picked up the new file.
 	// This tailer now considers the current content ("a completely new file") as its baseline.
 	tailer = suite.createTailer()
+
+	// Re-open the file and set up the tailer for filesystem checks
+	osFile, err = os.Open(suite.testPath)
+	suite.Nil(err)
+	defer osFile.Close()
+	tailer.osFile = osFile
+	tailer.fullpath = suite.testPath
+
 	fingerprinter = NewFingerprinter(*config)
 	newFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.NotNil(newFingerprint)
@@ -935,26 +952,56 @@ func (suite *FingerprintTestSuite) TestDidRotateViaFingerprint() {
 	receivedChecksum, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(expectedChecksum, receivedChecksum.Value)
 
-	// 5. Test case with an an empty file.
-	// The initial fingerprint will be nil.
-	suite.T().Log("Testing rotation detection with an initially empty file")
+	// 5. Test case with an empty file where both fingerprints are invalid.
+	// When both old and new fingerprints are invalid, we fall back to filesystem checks.
+	suite.T().Log("Testing rotation detection with both fingerprints invalid")
 	suite.Nil(suite.testFile.Truncate(0))
 	_, err = suite.testFile.Seek(0, 0)
 	suite.Nil(err)
 	suite.Nil(suite.testFile.Sync())
 	tailer = suite.createTailer()
+
+	// Open the file so the tailer has a valid osFile handle for DidRotate() filesystem checks
+	osFile3, err := os.Open(suite.testPath)
+	suite.Nil(err)
+	defer osFile3.Close()
+	tailer.osFile = osFile3
+	tailer.fullpath = suite.testPath
+
 	fingerprinter = NewFingerprinter(*config)
 	emptyFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
 	suite.Equal(uint64(0), emptyFingerprint.Value, "Fingerprint of an empty file should have Value=0")
 
-	// Set the fingerprint on the tailer (even though it's nil)
+	// Set the fingerprint on the tailer (invalid)
 	tailer.fingerprint = emptyFingerprint
 
-	// `DidRotateViaFingerprint` is designed to return `false` if the original
-	// fingerprint was nil, to avoid false positives.
+	// With both fingerprints invalid (Value=0), DidRotateViaFingerprint falls back to filesystem checks.
+	// Since we just opened the same file and nothing has changed, filesystem checks should return false.
 	rotated, err = tailer.DidRotateViaFingerprint(fingerprinter)
 	suite.Nil(err)
-	suite.False(rotated, "Should not detect rotation if the initial fingerprint was nil")
+	suite.False(rotated, "Should not detect rotation when both fingerprints are invalid and filesystem shows no change")
+
+	// 6. Test case with invalid -> valid transition (empty file gets content)
+	// old invalid + new valid => rotation detected
+	suite.T().Log("Testing rotation detection from invalid to valid fingerprint")
+	suite.Nil(suite.testFile.Truncate(0))
+	suite.Nil(suite.testFile.Sync())
+	tailer = suite.createTailer()
+
+	// Set baseline as invalid (empty file)
+	invalidFingerprint, _ := fingerprinter.ComputeFingerprint(tailer.file)
+	suite.Equal(uint64(0), invalidFingerprint.Value)
+	tailer.fingerprint = invalidFingerprint
+
+	// Now add content to the file
+	_, err = suite.testFile.WriteString("new content after empty\n")
+	suite.Nil(err)
+	suite.Nil(suite.testFile.Sync())
+
+	// Should detect rotation: invalid -> valid (non-zero) without needing filesystem checks
+	rotated, err = tailer.DidRotateViaFingerprint(fingerprinter)
+	suite.Nil(err)
+	suite.True(rotated, "Should detect rotation when transitioning from invalid to valid fingerprint")
 }
 
 func (suite *FingerprintTestSuite) TestLineBased_FallbackToByteBased() {

--- a/pkg/logs/tailers/file/rotate.go
+++ b/pkg/logs/tailers/file/rotate.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// DidRotateViaFingerprint returns true if the file has been log-rotated via fingerprint.
+//
+// When a log rotation occurs, the file can be either:
+// - renamed and recreated
+// - removed and recreated
+// - truncated
+func (t *Tailer) DidRotateViaFingerprint(fingerprinter Fingerprinter) (bool, error) {
+	// compute the new fingerprint
+	newFingerprint, err := fingerprinter.ComputeFingerprint(t.file)
+
+	// If computing the fingerprint led to an error there was likely an IO issue, handle this appropriately below.
+	if err != nil {
+		return false, err
+	}
+
+	// New fingerprint is invalid: recreated/truncated file, so fall back to filesystem check
+	if !newFingerprint.ValidFingerprint() {
+		log.Debugf("Falling back to filesystem rotation check for %s. New fingerprint invalid", t.file.Path)
+		return t.DidRotate()
+	}
+
+	// Old fingerprint invalid (not nil) but new one isn’t: the file changed, assume rotation
+	if !t.fingerprint.ValidFingerprint() {
+		log.Debugf("File rotation detected for %s. Previous fingerprint invalid, new fingerprint valid; assuming rotation", t.file.Path)
+		return true, nil
+	}
+
+	// If fingerprints are different, it means the file was rotated.
+	// This is also true if the new fingerprint is invalid (Value=0), which means the file was truncated.
+	rotated := !t.fingerprint.Equals(newFingerprint)
+	if rotated {
+		log.Debugf("File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)",
+			t.file.Path, t.fingerprint.Value, newFingerprint.Value)
+	}
+	return rotated, nil
+}

--- a/pkg/logs/tailers/file/rotate_nix.go
+++ b/pkg/logs/tailers/file/rotate_nix.go
@@ -52,31 +52,3 @@ func (t *Tailer) DidRotate() (bool, error) {
 
 	return recreated || truncated, nil
 }
-
-// DidRotateViaFingerprint returns true if the file has been log-rotated via fingerprint.
-//
-// On *nix, when a log rotation occurs, the file can be either:
-// - renamed and recreated
-// - removed and recreated
-// - truncated
-func (t *Tailer) DidRotateViaFingerprint(fingerprinter Fingerprinter) (bool, error) {
-	newFingerprint, err := fingerprinter.ComputeFingerprint(t.file)
-
-	// If computing the fingerprint led to an error there was likely an IO issue, handle this appropriately below.
-	if err != nil {
-		return false, err
-	}
-	// If the original fingerprint is nil, we can't detect rotation
-	if t.fingerprint == nil {
-		return false, nil
-	}
-
-	// If fingerprints are different, it means the file was rotated.
-	// This is also true if the new fingerprint is invalid (Value=0), which means the file was truncated.
-	rotated := !t.fingerprint.Equals(newFingerprint)
-	if rotated {
-		log.Debugf("File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)",
-			t.file.Path, t.fingerprint.Value, newFingerprint.Value)
-	}
-	return rotated, nil
-}

--- a/pkg/logs/tailers/file/rotate_windows.go
+++ b/pkg/logs/tailers/file/rotate_windows.go
@@ -45,31 +45,3 @@ func (t *Tailer) DidRotate() (bool, error) {
 
 	return false, nil
 }
-
-// DidRotateViaFingerprint returns true if the file has been log-rotated via fingerprint.
-//
-// On windows, when a log rotation occurs, the file can be either:
-// - renamed and recreated
-// - removed and recreated
-// - truncated
-func (t *Tailer) DidRotateViaFingerprint(fingerprinter Fingerprinter) (bool, error) {
-	newFingerprint, err := fingerprinter.ComputeFingerprint(t.file)
-
-	// If computing the fingerprint led to an error there was likely an IO issue, handle this appropriately below.
-	if err != nil {
-		return false, err
-	}
-	// If the original fingerprint is nil, we can't detect rotation
-	if t.fingerprint == nil {
-		return false, nil
-	}
-
-	// If fingerprints are different, it means the file was rotated.
-	// This is also true if the new fingerprint is invalid (Value=0), which means the file was truncated.
-	rotated := !t.fingerprint.Equals(newFingerprint)
-	if rotated {
-		log.Debugf("File rotation detected via fingerprint mismatch for %s (old: 0x%x, new: 0x%x)",
-			t.file.Path, t.fingerprint.Value, newFingerprint.Value)
-	}
-	return rotated, nil
-}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -274,7 +274,10 @@ func (t *Tailer) StartFromBeginning() error {
 // been flushed to the output channel.
 func (t *Tailer) Stop() {
 	t.registry.SetTailed(t.Identifier(), false)
-	t.stop <- struct{}{}
+	select {
+	case t.stop <- struct{}{}:
+	default: // already signalled
+	}
 	t.file.Source.RemoveInput(t.file.Path)
 	// wait for the decoder to be flushed
 	<-t.done
@@ -301,7 +304,10 @@ func (t *Tailer) StopAfterFileRotation() {
 			}
 		}
 		t.stopForward()
-		t.stop <- struct{}{}
+		select {
+		case t.stop <- struct{}{}:
+		default: // already signalled
+		}
 	}()
 	t.file.Source.RemoveInput(t.file.Path)
 }

--- a/pkg/logs/tailers/file/tailer_test.go
+++ b/pkg/logs/tailers/file/tailer_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
@@ -78,8 +79,8 @@ func (suite *TailerTestSuite) TearDownTest() {
 	suite.testFile.Close()
 }
 
-func TestTailerTestSuite(t *testing.T) {
-	suite.Run(t, new(TailerTestSuite))
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
 }
 
 func (suite *TailerTestSuite) TestStopAfterFileRotationWhenStuck() {
@@ -476,4 +477,90 @@ func toInt(str string) int {
 		return int(value)
 	}
 	return 0
+}
+
+// Test_RotationThenShutdownNoGoroutineLeak tests the following scenario:
+//  1. File rotation is detected => StopAfterFileRotation() called (goroutine sleeps)
+//  2. Agent shutdown happens => Stop() called on the rotated tailer
+//  3. Stop() signals channel and waits for completion
+//  4. StopAfterFileRotation goroutine wakes up and tries to send
+//     to validate that if there is a race condition, the goroutine will exit cleanly
+func TestNoGoLeakWithNonBlockingStop(t *testing.T) {
+	// Ignore all goroutines that exist before the test starts (background workers from logging, caching, etc.)
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	testDir := t.TempDir()
+	testPath := filepath.Join(testDir, "tailer.log")
+	f, err := os.Create(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	outputChan := make(chan *message.Message, chanSize)
+	source := sources.NewReplaceableSource(sources.NewLogSource("", &config.LogsConfig{
+		Type: config.FileType,
+		Path: testPath,
+	}))
+	sleepDuration := 10 * time.Millisecond
+	info := status.NewInfoRegistry()
+
+	tailerOptions := &TailerOptions{
+		OutputChan:      outputChan,
+		File:            NewFile(testPath, source.UnderlyingSource(), false),
+		SleepDuration:   sleepDuration,
+		Decoder:         decoder.NewDecoderFromSource(source, info),
+		Info:            info,
+		CapacityMonitor: metrics.NewNoopPipelineMonitor("").GetCapacityMonitor("", ""),
+		Registry:        auditor.NewMockRegistry(),
+	}
+
+	tailer := NewTailer(tailerOptions)
+	tailer.closeTimeout = 20 * time.Millisecond // Short timeout for test
+
+	// Write some data and start tailer
+	_, err = f.WriteString("line 1\nline 2\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tailer.StartFromBeginning()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain messages
+	<-outputChan
+	<-outputChan
+
+	// ROTATION DETECTED ...
+	// StopAfterFileRotation spawns goroutine that sleeps for closeTimeout, tries to send to the stop channel
+	tailer.StopAfterFileRotation()
+
+	// RN...
+	// - goroutine is sleeping for closeTimeout
+	// - The tailer is still running (readForever is active)
+
+	// Sleep briefly to make sure the goroutine is actually sleeping
+	time.Sleep(10 * time.Millisecond)
+
+	// Stop() is called on the rotated tailer (simulating launcher.cleanup())
+	// This will signal the stop channel, readForever drains it and exits, forwardMessages finishes and closes done channel, Stop() returns after <-t.done
+	tailer.Stop()
+
+	// RN...
+	// - tailer is fully stopped (readForever exited, done channel closed)
+	// - stop channel is empty (0/1)
+	// - StopAfterFileRotation goroutine is still sleeping (not woken up yet)
+
+	// Wait for the closeTimeout to expire
+	// The StopAfterFileRotation goroutine will wake up and try to send to the stop channel,
+	// but since readForever has already exited, there's no reader.
+	// The select/default in StopAfterFileRotation will hit the default case, allowing the goroutine to exit cleanly.
+
+	// Wait long enough for the goroutine to wake up and complete
+	// closeTimeout is 20ms, so 100ms gives us plenty of buffer for slow CI machines
+	time.Sleep(100 * time.Millisecond)
+
+	// The deferred goleak.VerifyNone() will detect if goroutine leaked
 }

--- a/releasenotes/notes/enable-fingerprint-and-patch-leak-b2b8a89be041811e.yaml
+++ b/releasenotes/notes/enable-fingerprint-and-patch-leak-b2b8a89be041811e.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a file descriptor leak in the log file tailer where rotated tailers
+    were not being properly removed from the active tailer container, causing
+    them to remain active indefinitely. Rotated tailers now drain their remaining
+    content while allowing new tailers to be created for the rotated file.


### PR DESCRIPTION
### What does this PR do?
- Keep draining tailers registered during rotation (`rotateTailerWithoutRestart`) so they are not prematurely halted, `cleanUpRotatedTailers` can finish the cleanup, and rotated bytes aren’t lost.
- Make the stop channel non-blocking in `Tailer.Stop` / `StopAfterFileRotation` to prevent goroutine leaks when both paths race to stop the reader.
- consolidate / remove code duplication of `DidRotateViaFingerprint` with `rotate.go` and add fingerprint comparison edge cases 

### Motivation
https://datadoghq.atlassian.net/browse/AGNTLOG-327
https://datadoghq.atlassian.net/wiki/x/3obTSgE

### Describe how you validated your changes
unit tests, [running local agent](https://github.com/DataDog/datadog-agent/pull/41722#issuecomment-3402014525)

### Additional Notes
