### PR TITLE
[pkg/util] Ensure that EC2 mock metadata server is up before running assertions

### DIFF
--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -113,14 +113,14 @@ func TestGetInstanceID(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "i-0123456789abcdef0"
 	val, err := GetInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
 	// the internal cache is populated now, should return the cached value even if API errors out
 	responseCode = http.StatusInternalServerError
 	val, err = GetInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
@@ -128,7 +128,7 @@ func TestGetInstanceID(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "i-aaaaaaaaaaaaaaaaa"
 	val, err = GetInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 }
@@ -160,14 +160,14 @@ func TestGetLegacyResolutionInstanceID(t *testing.T) {
 	// API successful, should return API result
 	responseCode = http.StatusOK
 	val, err = GetLegacyResolutionInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
 	// the internal cache is populated now, should return the cached value even if API errors out
 	responseCode = http.StatusInternalServerError
 	val, err = GetLegacyResolutionInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 
@@ -175,7 +175,7 @@ func TestGetLegacyResolutionInstanceID(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "i-aaaaaaaaaaaaaaaaa"
 	val, err = GetLegacyResolutionInstanceID(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 }
@@ -279,14 +279,14 @@ func TestGetHostname(t *testing.T) {
 	// API successful, should return hostname
 	responseCode = http.StatusOK
 	val, err = GetHostname(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
 	// the internal cache is populated now, should return the cached hostname even if API errors out
 	responseCode = http.StatusInternalServerError
 	val, err = GetHostname(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
@@ -294,7 +294,7 @@ func TestGetHostname(t *testing.T) {
 	responseCode = http.StatusOK
 	expected = "ip-20-20-20-20.ec2.internal"
 	val, err = GetHostname(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -108,6 +108,7 @@ func TestGetInstanceID(t *testing.T) {
 	conf := configmock.New(t)
 	defer resetPackageVars()
 	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
+	setupDMIForEC2(t)
 
 	// API successful, should return API result
 	responseCode = http.StatusOK


### PR DESCRIPTION
### What does this PR do?

Code now waits up to a second for the mock server to be properly
available before proceeding with invocation of the EC2 instance
identification code (which was a bit flaky).

### Motivation

Flaky test

### Describe how you validated your changes

Local testing

### Additional Notes
AGENTRUN-752
