### PR TITLE
[EBPF] gpu: ensure GPU check is configured even if device event gatherer fails

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -101,11 +101,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, 
 		return err
 	}
 
-	var err error
-	c.deviceEvtGatherer, err = nvidia.NewDeviceEventsGatherer()
-	if err != nil {
-		return fmt.Errorf("failed creating event set gatherer: %w", err)
-	}
+	c.deviceEvtGatherer = nvidia.NewDeviceEventsGatherer()
 
 	// Compute whether we should prefer system-probe process metrics
 	if pkgconfigsetup.SystemProbe().GetBool("gpu_monitoring.enabled") {

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -140,8 +140,7 @@ func TestAllCollectorsWork(t *testing.T) {
 	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled(), testutil.WithMockAllFunctions())
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache := ddnvml.NewDeviceCache()
-	eventsGatherer, err := NewDeviceEventsGatherer()
-	require.NoError(t, err)
+	eventsGatherer := NewDeviceEventsGatherer()
 	require.NoError(t, eventsGatherer.Start())
 	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
 	deps := &CollectorDependencies{DeviceCache: deviceCache, DeviceEventsGatherer: eventsGatherer}

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
@@ -130,7 +129,7 @@ func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
 }
 
 func TestDeviceEventsGatherer_StartShouldFailIfNvmlInitFails(t *testing.T) {
-	if _, err := ddnvml.GetSafeNvmlLib(); err == nil {
+	if _, err := safenvml.GetSafeNvmlLib(); err == nil {
 		t.Skip("NVML library is already initialized, this test relies on the library not being initializable")
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events_test.go
@@ -11,21 +11,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
-	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func TestDeviceEventsGatherer_RegisterBeforeStart(t *testing.T) {
 	device := setupMockDevice(t, nil)
 
-	gatherer, err := NewDeviceEventsGatherer()
-	require.NoError(t, err)
-
+	gatherer := NewDeviceEventsGatherer()
 	assert.Error(t, gatherer.RegisterDevice(device))
 }
 
@@ -37,16 +37,14 @@ func TestDeviceEventsGatherer_RegisterWithUnsupportedEvents(t *testing.T) {
 		return device
 	})
 
-	gatherer, err := NewDeviceEventsGatherer()
-	require.NoError(t, err)
+	gatherer := NewDeviceEventsGatherer()
 	assert.Error(t, gatherer.RegisterDevice(device))
 }
 
 func TestDeviceEventsGatherer_GetWithUnregistered(t *testing.T) {
 	safenvml.WithMockNVML(t, testutil.GetBasicNvmlMock())
 
-	gatherer, err := NewDeviceEventsGatherer()
-	require.NoError(t, err)
+	gatherer := NewDeviceEventsGatherer()
 	require.NoError(t, gatherer.Start())
 	t.Cleanup(func() { require.NoError(t, gatherer.Stop()) })
 
@@ -79,8 +77,7 @@ func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
 		}))
 
 	// create gatherer after lib initialization so that it picks up the mock
-	gatherer, err := NewDeviceEventsGatherer()
-	require.NoError(t, err)
+	gatherer := NewDeviceEventsGatherer()
 	require.NoError(t, gatherer.Start())
 	t.Cleanup(func() { require.NoError(t, gatherer.Stop()) })
 
@@ -130,6 +127,15 @@ func TestDeviceEventsGatherer_RefreshGetSequence(t *testing.T) {
 	events, err = gatherer.GetEvents(uuid)
 	require.NoError(t, err)
 	require.Empty(t, events)
+}
+
+func TestDeviceEventsGatherer_StartShouldFailIfNvmlInitFails(t *testing.T) {
+	if _, err := ddnvml.GetSafeNvmlLib(); err == nil {
+		t.Skip("NVML library is already initialized, this test relies on the library not being initializable")
+	}
+
+	gatherer := NewDeviceEventsGatherer()
+	require.Error(t, gatherer.Start())
 }
 
 type mockDeviceEventsCollectorCache struct {


### PR DESCRIPTION
### What does this PR do?

Ensure that the check configuration does not fail if the DeviceEvents gatherer fails to initialize. 

### Motivation

We recently added support for NVML appearing after the agent starts, but the `Configure()` call was failing because NVML was not present and the check was not getting scheduled.

### Describe how you validated your changes

Added unit test to validate.

### Additional Notes
