### PR TITLE
fix(installer): Use right permissions for config files

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -152,7 +152,7 @@ func (o *Operations) Apply(rootPath string) error {
 			return err
 		}
 	}
-	err = os.WriteFile(filepath.Join(rootPath, deploymentIDFile), []byte(o.DeploymentID), 0644)
+	err = os.WriteFile(filepath.Join(rootPath, deploymentIDFile), []byte(o.DeploymentID), 0640)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (a *FileOperation) apply(root *os.Root) error {
 		if err != nil {
 			return err
 		}
-		file, err := root.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+		file, err := root.OpenFile(path, os.O_RDWR|os.O_CREATE, 0640)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?
During config upgrades new files are created with permission 644, it should be 640

### Motivation

### Describe how you validated your changes

### Additional Notes
