### PR TITLE
[AGENTRUN] Fix RemoteAgentRegistry flakiness

### DIFF
--- a/comp/core/remoteagentregistry/impl/registry_test.go
+++ b/comp/core/remoteagentregistry/impl/registry_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/examples/features/proto/echo"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -89,10 +90,6 @@ func TestGetRegisteredAgentsIdleTimeout(t *testing.T) {
 	require.Equal(t, "Test Agent", agents[0].DisplayName)
 	require.Equal(t, "test-agent", agents[0].SanitizedDisplayName)
 
-	// wait a bit to make sure the remoteAgent gRPC server had the time to start
-	// otherwise it will return the error `grpc: the server has been stopped`
-	time.Sleep(1 * time.Second)
-
 	// Stopping the remote agent should remove it from the registry
 	remoteAgent.Stop()
 	time.Sleep(10 * time.Second)
@@ -156,9 +153,11 @@ type testRemoteAgentServer struct {
 
 	// gRPC embedded
 	server *grpc.Server
+
 	pb.UnimplementedStatusProviderServer
 	pb.UnimplementedFlareProviderServer
 	pb.UnimplementedTelemetryProviderServer
+	echo.UnimplementedEchoServer
 }
 
 func (t *testRemoteAgentServer) GetStatusDetails(context.Context, *pb.GetStatusDetailsRequest) (*pb.GetStatusDetailsResponse, error) {
@@ -180,6 +179,12 @@ func (t *testRemoteAgentServer) GetStatusDetails(context.Context, *pb.GetStatusD
 func (t *testRemoteAgentServer) GetFlareFiles(context.Context, *pb.GetFlareFilesRequest) (*pb.GetFlareFilesResponse, error) {
 	return &pb.GetFlareFilesResponse{
 		Files: t.flareFiles,
+	}, nil
+}
+
+func (t *testRemoteAgentServer) UnaryEcho(_ context.Context, req *echo.EchoRequest) (*echo.EchoResponse, error) {
+	return &echo.EchoResponse{
+		Message: req.Message,
 	}, nil
 }
 
@@ -270,6 +275,11 @@ func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, a
 
 	// Chain interceptors: auth first, then session ID, then delay
 	chainedInterceptor := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// Don't verify session ID for echo requests
+		if _, ok := req.(*echo.EchoRequest); ok {
+			return handler(ctx, req)
+		}
+
 		// First apply auth interceptor
 		authHandler := grpc_auth.UnaryServerInterceptor(grpcutil.StaticAuthInterceptor(ipcComp.GetAuthToken()))
 		return authHandler(ctx, req, info, func(ctx context.Context, req any) (any, error) {
@@ -291,6 +301,9 @@ func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, a
 		provider(server, testServer)
 	}
 
+	// register echo service
+	echo.RegisterEchoServer(server, testServer)
+
 	go func() {
 		err := server.Serve(listener)
 		require.NoError(t, err)
@@ -300,6 +313,14 @@ func buildRemoteAgent(t *testing.T, ipcComp ipc.Component, agentFlavor string, a
 
 	testServer.RegistrationData.APIEndpointURI = listener.Addr().String()
 	testServer.server = server
+
+	// block until the server is started
+	// initializing a dummy echo client to make sure the server is started
+	client, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())))
+	require.NoError(t, err)
+	echoClient := echo.NewEchoClient(client)
+	_, err = echoClient.UnaryEcho(context.Background(), &echo.EchoRequest{}, grpc.WaitForReady(true))
+	require.NoError(t, err)
 
 	return testServer
 }

--- a/comp/core/remoteagentregistry/impl/services_test.go
+++ b/comp/core/remoteagentregistry/impl/services_test.go
@@ -101,7 +101,7 @@ func TestGetTelemetry(t *testing.T) {
 		}
 		return nil
 	}()
-	assert.NotNil(t, bazMetric)
+	require.NotNil(t, bazMetric)
 	assert.Equal(t, bazMetric.GetType(), io_prometheus_client.MetricType_GAUGE)
 	assert.Equal(t, bazMetric.GetMetric()[0].GetGauge().GetValue(), 3.0)
 	assert.Equal(t, bazMetric.GetMetric()[0].GetLabel()[0].GetValue(), "1")


### PR DESCRIPTION
### What does this PR do?

This PR updates the `buildRemoteAgent` function to block execution until its gRPC server is fully initialized and ready to accept requests.

### Motivation

Introducing this blocking mechanism prevents race conditions that previously occurred during some unit test runs.

### Describe how you validated your changes

To validate the change, I simulated a slow gRPC server startup by adding an artificial delay, for example:

```go
	go func() {
		time.Sleep(10 * time.Second)
		err := server.Serve(listener)
		require.NoError(t, err)
	}()
```

Then, I confirmed that all tests still passed successfully.