### PR TITLE
[kubernetes/kubelet] Delete ForceGetLocalPodList from interface

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -327,12 +327,6 @@ func (ku *KubeUtil) GetLocalPodListWithMetadata(ctx context.Context) (*PodList, 
 	return ku.getLocalPodList(ctx)
 }
 
-// ForceGetLocalPodList reset podList cache and call GetLocalPodList
-func (ku *KubeUtil) ForceGetLocalPodList(ctx context.Context) (*PodList, error) {
-	ResetCache()
-	return ku.GetLocalPodListWithMetadata(ctx)
-}
-
 // GetLocalStatsSummary returns node and pod stats from kubelet
 func (ku *KubeUtil) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
 	data, code, err := ku.QueryKubelet(ctx, kubeletStatsSummary)

--- a/pkg/util/kubernetes/kubelet/kubelet_interface.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_interface.go
@@ -20,7 +20,6 @@ type KubeUtilInterface interface {
 	GetNodename(ctx context.Context) (string, error)
 	GetLocalPodList(ctx context.Context) ([]*Pod, error)
 	GetLocalPodListWithMetadata(ctx context.Context) (*PodList, error)
-	ForceGetLocalPodList(ctx context.Context) (*PodList, error)
 	QueryKubelet(ctx context.Context, path string) ([]byte, int, error)
 	GetRawConnectionInfo() map[string]string
 	GetRawMetrics(ctx context.Context) ([]byte, error)

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
@@ -25,7 +25,6 @@ type KubeUtilInterface interface {
 	GetNodename(ctx context.Context) (string, error)
 	GetLocalPodList(ctx context.Context) ([]*Pod, error)
 	GetLocalPodListWithMetadata(ctx context.Context) (*PodList, error)
-	ForceGetLocalPodList(ctx context.Context) (*PodList, error)
 	QueryKubelet(ctx context.Context, path string) ([]byte, int, error)
 	GetRawConnectionInfo() map[string]string
 	GetRawMetrics(ctx context.Context) ([]byte, error)

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -702,7 +702,7 @@ func (suite *KubeletTestSuite) TestPodListNoExpire() {
 	require.NotNil(suite.T(), kubeutil)
 	kubelet.dropRequests() // Throwing away first GETs
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
 	require.Len(suite.T(), pods.Items, 4)
@@ -742,7 +742,7 @@ func (suite *KubeletTestSuite) TestPodListExpire() {
 		return t
 	}
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
 	require.Len(suite.T(), pods.Items, 3)
@@ -791,7 +791,7 @@ func (suite *KubeletTestSuite) TestContainerEnvVars() {
 	kubeutil := suite.getCustomKubeUtil()
 	kubelet.dropRequests() // Throwing away first GETs
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
 
@@ -841,7 +841,7 @@ func (suite *KubeletTestSuite) TestPodListWithNullPod() {
 	kubeutil := suite.getCustomKubeUtil()
 	kubelet.dropRequests() // Throwing away first GETs
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
 	require.Len(suite.T(), pods.Items, 1)
@@ -870,7 +870,7 @@ func (suite *KubeletTestSuite) TestPodListOnKubeletInit() {
 	kubeutil := suite.getCustomKubeUtil()
 	kubelet.dropRequests() // Throwing away first GETs
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.NotNil(suite.T(), err)
 	require.Nil(suite.T(), pods)
 }
@@ -894,7 +894,7 @@ func (suite *KubeletTestSuite) TestPodListWithPersistentVolumeClaim() {
 	kubeutil := suite.getCustomKubeUtil()
 	kubelet.dropRequests() // Throwing away first GETs
 
-	pods, err := kubeutil.ForceGetLocalPodList(ctx)
+	pods, err := kubeutil.GetLocalPodListWithMetadata(ctx)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
 	require.Len(suite.T(), pods.Items, 9)


### PR DESCRIPTION
### What does this PR do?

This PR deletes the `ForceGetLocalPodList` function from the kubelet client interface.
The function cleared the cache before getting the pod list and it was used only in a few test, but those tests already call a setup function that resets the kubelet cache, so this code was not needed.

### Describe how you validated your changes

CI
