### PR TITLE
feat(issues): Add a AI automatic triage of issues

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -24,35 +24,176 @@ jobs:
               labels: ["pending"]
             });
 
-  auto_assign_issue:
+  triage:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/datadog/agent-issue-auto-assign:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
-        packages: read
-        issues: write
+      contents: read
+      issues: write
     environment:
       name: main
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Install yq
-      run: |
-        add-apt-repository ppa:rmescandon/yq
-        apt update
-        apt install yq -y
-    - name: Install dda
-      uses: ./.github/actions/install-dda
+
+    - name: Intelligent Issue Triage
+      id: claude
+      uses: anthropics/claude-code-action@ac1a3207f3f00b4a37e2f3a6f0935733c7c64651 # v1.0.0
       with:
-        features: legacy-tasks
-    - name: Assign issue
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        claude_args : --allowedTools "Read,Write,Bash(gh issue edit:*)"
+        prompt: |
+          # Datadog Agent - Intelligent Issue Triage System
+
+          ## Context
+          You are an expert triage system for the Datadog Agent repository. Your job is to analyze this GitHub issue and determine which team should handle it. You have full access to the Datadog Agent codebase and can use all available tools to analyze issues.
+
+          ## Current Issue
+          **Title:** ${{ github.event.issue.title }}
+          **Number:** #${{ github.event.issue.number }}
+          **Author:** @${{ github.event.issue.user.login }}
+          **URL:** ${{ github.event.issue.url }}
+          **Body:**
+          ```
+          ${{ github.event.issue.body }}
+          ```
+
+          ## Analysis Protocol
+          1. **Extract Technical Keywords**: Parse issue for component names, error messages, config keys, file paths
+          2. **Codebase Search**: Use grep/find to locate relevant files and directories
+          3. **Ownership Analysis**: Check CODEOWNERS for team assignments
+          4. **Pattern Matching**: Look for similar historical issues and their team assignments
+          5. **Team Assignment**: Apply the most appropriate team label
+          6. **Documentation**: Comment on the issue explaining the triage decision
+
+          ## Available Teams
+          Extract all the team name labels from the .github/CODEOWNERS file. 
+          If the name of the team is `@DataDog/agent-devx` in the CODEOWNERS file, its associated label will be `team/agent-devx`.
+          Generate all the label names using the example above. 
+          The github team name will be used to retrieve the slack channel once the team has been selected.
+
+          ## Action Items
+          1. Perform thorough analysis using available tools
+          2. Select exactly one team label
+          3. Generate explanatory comment of the choice you did
+          4. If uncertain, apply `team/agent-devx` and request manual review
+          5. Apply the selected labels using the **Apply label** section below
+          6. Retrieve the slack channel associated to the selected team in the tasks/libs/pipeline/github_slack_map.yaml
+          7. Write TEAM, SLACK, CONFIDENCE and EXPLANATION in a local file claude.txt for the next step
+            
+          **IMPORTANT:**
+          - For `team=`, provide ONLY the team name without "team/" prefix (e.g., "container-platform", not "team/container-platform")
+          - Use HIGH confidence if you're very sure, MEDIUM if reasonably sure, LOW if uncertain
+          - If you don't find a corresponding slack channel, use #agent-devx
+          - Keep explanation under 150 characters
+          
+          ## Apply label
+          Use gh issue edit to apply your selected labels
+          DO NOT post any comments explaining your decision
+          DO NOT communicate directly with users
+          If no labels are clearly applicable, do not apply any labels
+          
+          ## Output Format
+          At the end of your analysis, provide a summary in this exact format:
+
+          TEAM:team_name_only
+          SLACK:corresponding_slack_channel_from_the_map
+          CONFIDENCE:HIGH|MEDIUM|LOW
+          EXPLANATION:Brief explanation of why this team was chosen
+
+          Make sure these three lines appear at the very end of your response.
+          Write this exact same content in the local claude.txt file.
+
+          Start your analysis now and ensure you create the GitHub Action outputs.
+
+    - name: Extract label from file
+      id: extract-label
+      run: |
+        if [ -f claude.txt ]; then
+          TEAM=$(grep TEAM claude.txt | cut -d ':' -f2)
+          echo "team=$TEAM" >> $GITHUB_OUTPUT
+          SLACK=$(grep SLACK claude.txt | cut -d ':' -f2)
+          echo "slack=$SLACK" >> $GITHUB_OUTPUT
+          CONFIDENCE=$(grep CONFIDENCE claude.txt | cut -d ':' -f2)
+          echo "confidence=$CONFIDENCE" >> $GITHUB_OUTPUT
+          EXPLANATION=$(grep EXPLANATION claude.txt | cut -d ':' -f2)
+          echo "explanation=$EXPLANATION" >> $GITHUB_OUTPUT
+        else
+          echo "team=unknown" >> $GITHUB_OUTPUT
+          echo "slack=agent-devx" >> $GITHUB_OUTPUT
+          echo "confidence=low" >> $GITHUB_OUTPUT
+          echo "explanation=none" >> $GITHUB_OUTPUT
+        fi
+  
+    - name: Install dependencies
+      run: npm install @slack/web-api
+    
+    - name: Send Slack Message
+      uses: actions/github-script@v7
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
-      run: >-
-        dda inv --dep torch --dep transformers
-        --
-        -e issue.assign-owner -i ${{ github.event.issue.number }}
+        SLACK_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+        TEAM: ${{ steps.extract-label.outputs.team }}
+        SLACK: ${{ steps.extract-label.outputs.slack }}
+        CONFIDENCE: ${{ steps.extract-label.outputs.confidence }}
+        EXPLANATION: ${{ steps.extract-label.outputs.explanation }}
+      with:
+        script: |
+          const { WebClient } = require('@slack/web-api');
+
+          // Get issue details
+          const issue = context.payload.issue;
+          const teamName = process.env.TEAM;
+          const channel = process.env.SLACK;
+          const confidence = process.env.CONFIDENCE;
+          const explanation = process.env.EXPLANATION;
+
+          console.log(`Processing triage for issue #${issue.number} Team: ${teamName}`);
+
+          // Send Slack notification (replicating assign_owner logic from tasks/issue.py)
+          try {
+            const slack = new WebClient(process.env.SLACK_TOKEN);
+
+            // Create confidence emoji
+            const confidenceEmojis = {
+              'HIGH': ':white_check_mark:',
+              'MEDIUM': ':warning:',
+              'LOW': ':question:'
+            };
+            const confidenceEmoji = confidenceEmojis[confidence] || ':robot_face:';
+
+            // Create message (similar format to tasks/issue.py lines 37-43)
+            let message = `:githubstatus_partial_outage: *New Community Issue*
+              ${issue.title} <${issue.html_url}|${context.repo.repo}#${issue.number}>
+
+              ${confidenceEmoji} *Auto-assigned* to \`team/${teamName}\` (Confidence: ${confidence})
+              *Analysis:* ${explanation}
+            `;
+
+            message += "\nYour team was assigned automatically using :claude: analysis.\nPlease redirect if the assignment is incorrect.";
+
+            const response = await slack.chat.postMessage({
+              channel: channel,
+              text: message
+            });
+
+            console.log(`✅ Slack message sent to ${channel} (message ts: ${response.ts})`);
+
+          } catch (error) {
+            console.error(`❌ Failed to send Slack notification: ${error}`);
+
+            // Try to send error notification to default channel
+            try {
+              const slack = new WebClient(process.env.SLACK_TOKEN);
+              await slack.chat.postMessage({
+                channel: '#agent-devx-ops',
+                text: `⚠️ Failed to send triage notification for issue ${issue.html_url}. Team: ${teamName}. Error: ${error.message}`
+              });
+            } catch (fallbackError) {
+              console.error('Failed to send fallback notification:', fallbackError);
+            }
+
+            // Don't fail the job for Slack errors - label was already applied
+            console.log('Label was applied successfully, continuing despite Slack notification failure...');
+          }
+
+          console.log('✅ Triage process completed');


### PR DESCRIPTION
### What does this PR do?
Change the `assign_issue` workflow to rely on LLM instead of a manually generated model:
- Call the [claude-code action](https://github.com/anthropics/claude-code-action) with a dedicated prompt, to generate TEAM, SLACK, CONFIDENCE and EXPLANATION. The action asks the AI agent to make full use of the local clone of the repository + the issue to determine the target team.
- Copy the generated information on a local file for the next step (see [constraints](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#why-doesnt-claude-execute-my-bash-commands))
- Use these information to send a slack message to the concerned team
<img width="791" height="157" alt="image" src="https://github.com/user-attachments/assets/3b945651-eeda-44a6-8020-5a8f7dc05ab8" />


### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1024
The team assignment relies on a model that was [generated](https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/issue/model/actions.py#L8) in 2023. It is outdated as the teams are changing. And this workflow is [broken](https://github.com/DataDog/datadog-agent/actions/workflows/assign_issue.yml) since dda migration.
LLMs are efficient with such task, and the cost impact is limited (see below). And the prompt is not repo-specific so there should be no maintenance on the workflow definition.

### Describe how you validated your changes
I first tried the [gemini workflow](https://github.com/chouetz/datadog-agent/blob/chouetz-patch-2/.github/workflows/gemini-scheduled-triage.yml) which does not use the repo context. I switched to claude and ran several [iterations](https://github.com/chouetz/datadog-agent/actions/workflows/claude-triage.yml) of the workflow on a [test issue](https://github.com/chouetz/datadog-agent/issues/17). The evaluation of the relevance of the LLM had been done with ~10 local queries to the assistant on already assigned issues.

### Additional Notes
- Usage of claude: there are alternative options to use LLM in a github action, for instance [gemini](https://github.com/google-github-actions/run-gemini-cli). The adherence towards a model is low, and switching from one action to another should be simple (just a modification of [these lines](https://github.com/chouetz/datadog-agent/blob/main/.github/workflows/claude-triage.yml#L27-L31)). Claude provides a better summary (see below) compared to gemini
- Cost consideration: According to the summaries generated (scroll down to the end of a [summary](https://github.com/chouetz/datadog-agent/actions/runs/18340536573) to see the cost), each call cost ~0.5$ (using an upper limit of what I've seen on these [executions](https://github.com/chouetz/datadog-agent/actions/workflows/claude-triage.yml)). If we consider [150 issues per year](https://github.com/DataDog/datadog-agent/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20created%3A2024-01-01..2025-01-01), this is completely affordable, and doesn't requires the generation of a local model.
