### PR TITLE
remove TestDNSCacheTelemetry flake

### DIFF
--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 var disableAutomaticExpiration = 1 * time.Hour

--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -141,7 +141,6 @@ func TestDNSCacheExpiration(t *testing.T) {
 }
 
 func TestDNSCacheTelemetry(t *testing.T) {
-	flake.Mark(t)
 	cacheTelemetry.lookups.Delete()
 	cacheTelemetry.resolved.Delete()
 	cacheTelemetry.length.Set(0)


### PR DESCRIPTION
### What does this PR do?
Removes flake from `TestDNSCacheTelemetry`

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1723


### Describe how you validated your changes
removes a flake marker.

### Additional Notes
I am removing this to see what happens. Want to see where this tests actually fails.