### PR TITLE
[BARX-1031] Prevent version regression of "stable" release candidate tags 

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -134,11 +134,11 @@ qa_installer_script*                   @DataDog/agent-delivery
 
 # Deploy containers and tags
 deploy_containers*                     @Datadog/agent-delivery
+deploy_latest_rc_only                  @Datadog/agent-delivery
 deploy_mutable_image_tags*             @Datadog/agent-delivery
 deploy_mutable_cws_instrumentation_tags*     @Datadog/agent-delivery
 deploy_mutable_dca_tags*               @Datadog/agent-delivery
 deploy_mutable_ot_standalone_tags*     @Datadog/agent-delivery
-deploy_latest_rc_only                  @Datadog/agent-delivery
 
 # Deploy CWS instrumentation
 deploy_containers-cws-instrumentation* @DataDog/agent-security

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -138,6 +138,7 @@ deploy_mutable_image_tags*             @Datadog/agent-delivery
 deploy_mutable_cws_instrumentation_tags*     @Datadog/agent-delivery
 deploy_mutable_dca_tags*               @Datadog/agent-delivery
 deploy_mutable_ot_standalone_tags*     @Datadog/agent-delivery
+deploy_latest_rc_only                  @Datadog/agent-delivery
 
 # Deploy CWS instrumentation
 deploy_containers-cws-instrumentation* @DataDog/agent-security

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -6,24 +6,8 @@ deploy_latest_rc_only:
   rules:
     !reference [.on_deploy_rc]
   dependencies: []
-  script: |
-    # 1. list all tags
-    # 2. clean result and print only the tags
-    all_tags=$(git ls-remote --tags origin \
-      | awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}')
-
-    # 3. sort and retrieve latest tag
-    latest_tag=$(echo -e "$all_tags\n$CI_COMMIT_TAG" | sort -V | tail -n1)
-
-    echo "latest tag $latest_tag"
-    echo "current tag $CI_COMMIT_TAG"
-    if [[ $latest_tag != $CI_COMMIT_TAG ]];
-    then
-      echo "Newer RC tag exists - skipping job."
-      exit 1
-    fi
-    echo "No newer RC tag found - safe to proceed."
-
+  script:
+    - ./tools/ci/check_latest_rc.sh
 
 .deploy_mutable_image_tags_base:
   extends: .docker_publish_job_definition

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -7,24 +7,26 @@ deploy_latest_rc_only:
     !reference [.on_deploy_rc]
   dependencies: []
   script: |
-      tag = $CI_COMMIT_TAG
-      minor=$(echo "$tag" | cut -d. -f2)
-      patch=$(echo "$tag" | cut -d. -f3 | cut -d- -f1)
+    # 1. list all tags
+    # 2. clean result and print only the tags
+    all_tags=$(git ls-remote --tags origin \
+      | awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}')
 
-      # 1. list all tags
-      # 2. clean result and print only the tags
-      # 3. filter and print tags newer than the current one
-      # 4. detect if any tags were printed
-      if git ls-remote --tags origin \
-        | awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}' \
-        | awk -F'[.-]' -v cur_minor="$minor" -v cur_patch="$patch" \
-          '($2>cur_minor)||($2==cur_minor && $3>cur_patch)' \
-        | grep -q .
-      then
-        echo "Newer RC tag exists - skipping job."
-        exit 1
-      fi
-      echo "No newer RC tag found - safe to proceed."
+    # 3. append current tag to results
+    all_tags=$(echo -e "$all_tags\n$CI_COMMIT_TAG")
+
+    # 4. sort and retrieve latest tag
+    latest_tag=$(echo "$all_tags" | sort -V | tail -n1)
+
+    echo "latest tag $latest_tag"
+    echo "current tag $CI_COMMIT_TAG"
+    if [[ $latest_tag != $CI_COMMIT_TAG ]];
+    then
+      echo "Newer RC tag exists - skipping job."
+      exit 1
+    fi
+    echo "No newer RC tag found - safe to proceed."
+
 
 .deploy_mutable_image_tags_base:
   extends: .docker_publish_job_definition

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -3,6 +3,8 @@
 
 deploy_latest_rc_only:
   stage: deploy_mutable_image_tags
+  rules:
+    !reference [.on_deploy_rc]
   dependencies: []
   script: |
       tag = $CI_COMMIT_TAG
@@ -28,9 +30,6 @@ deploy_latest_rc_only:
   extends: .docker_publish_job_definition
   stage: deploy_mutable_image_tags
   dependencies: []
-  needs:
-    - job: deploy_latest_rc_only
-      artifacts: false
   before_script:
     - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
     - export IMG_TAG_REFERENCE=${AGENT_REPOSITORY}:${VERSION}${SUFFIX}
@@ -57,6 +56,8 @@ deploy_mutable_image_tags-a7-rc:
   needs:
     - job: deploy_containers-a7
       artifacts: false
+    - job: deploy_latest_rc_only
+      artifacts: false
   parallel:
     matrix:
       - SUFFIX:
@@ -73,6 +74,8 @@ deploy_mutable_image_tags-a7-win-only-rc:
     !reference [.on_deploy_rc]
   needs:
     - job: deploy_containers-a7-win-only
+      artifacts: false
+    - job: deploy_latest_rc_only
       artifacts: false
   parallel:
     matrix:
@@ -97,6 +100,8 @@ deploy_mutable_image_tags-a7-full-rc:
   needs:
     - job: deploy_containers-a7-full
       artifacts: false
+    - job: deploy_latest_rc_only
+      artifacts: false
   parallel:
     matrix:
       - SUFFIX: ["-full"]
@@ -107,6 +112,8 @@ deploy_mutable_image_tags-a7-fips-rc:
     !reference [.on_deploy_rc]
   needs:
     - job: deploy_containers-a7-fips
+      artifacts: false
+    - job: deploy_latest_rc_only
       artifacts: false
   parallel:
     matrix:

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -12,11 +12,8 @@ deploy_latest_rc_only:
     all_tags=$(git ls-remote --tags origin \
       | awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}')
 
-    # 3. append current tag to results
-    all_tags=$(echo -e "$all_tags\n$CI_COMMIT_TAG")
-
-    # 4. sort and retrieve latest tag
-    latest_tag=$(echo "$all_tags" | sort -V | tail -n1)
+    # 3. sort and retrieve latest tag
+    latest_tag=$(echo -e "$all_tags\n$CI_COMMIT_TAG" | sort -V | tail -n1)
 
     echo "latest tag $latest_tag"
     echo "current tag $CI_COMMIT_TAG"

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -1,10 +1,36 @@
 # deploy mutable image tags stage
 # Contains jobs which deploy Agent 7 related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
 
+deploy_latest_rc_only:
+  stage: deploy_mutable_image_tags
+  dependencies: []
+  script: |
+      tag = $CI_COMMIT_TAG
+      minor=$(echo "$tag" | cut -d. -f2)
+      patch=$(echo "$tag" | cut -d. -f3 | cut -d- -f1)
+
+      # 1. list all tags
+      # 2. clean result and print only the tags
+      # 3. filter and print tags newer than the current one
+      # 4. detect if any tags were printed
+      if git ls-remote --tags origin \
+        | awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}' \
+        | awk -F'[.-]' -v cur_minor="$minor" -v cur_patch="$patch" \
+          '($2>cur_minor)||($2==cur_minor && $3>cur_patch)' \
+        | grep -q .
+      then
+        echo "Newer RC tag exists - skipping job."
+        exit 1
+      fi
+      echo "No newere RC tag found - safe to proceed."
+
 .deploy_mutable_image_tags_base:
   extends: .docker_publish_job_definition
   stage: deploy_mutable_image_tags
   dependencies: []
+  needs:
+    - job: deploy_latest_rc_only
+      artifacts: false
   before_script:
     - VERSION="$(dda inv -- agent.version --url-safe --pipeline-id $PARENT_PIPELINE_ID)" || exit $?
     - export IMG_TAG_REFERENCE=${AGENT_REPOSITORY}:${VERSION}${SUFFIX}

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -22,7 +22,7 @@ deploy_latest_rc_only:
         echo "Newer RC tag exists - skipping job."
         exit 1
       fi
-      echo "No newere RC tag found - safe to proceed."
+      echo "No newer RC tag found - safe to proceed."
 
 .deploy_mutable_image_tags_base:
   extends: .docker_publish_job_definition

--- a/tools/ci/check_latest_rc.sh
+++ b/tools/ci/check_latest_rc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# 1. list all tags
+# 2. clean result and print only the tags
+all_tags=$(git ls-remote --tags origin \
+	| awk -F/ -v major="7" '$3 ~ ("^"major"\\.[0-9]+\\.[0-9]+-rc\\.[0-9]+$"){print $3}')
+
+# 3. sort and retrieve latest tag
+latest_tag=$(echo -e "$all_tags\n$CI_COMMIT_TAG" | sort -V | tail -n1)
+
+echo "latest tag $latest_tag"
+echo "current tag $CI_COMMIT_TAG"
+if [[ $latest_tag != $CI_COMMIT_TAG ]];
+then
+	echo "Newer RC tag exists - skipping job."
+	exit 1
+fi
+echo "No newer RC tag found - safe to proceed."


### PR DESCRIPTION
### What does this PR do?

Only deploy mutable rc image tags (i.e. `7-rc-full`) if the rc tag is the latest tag.

The job `deploy_latest_rc_only` is added as a dependency to jobs that deploy mutable rc image tags. The `deploy_latest_rc_only` job works by listing current tags in git and checking if the current tag (`CI_COMMIT_TAG`) is the latest tag. 

For example, if the current tag is `7.67.0-rc.3` and there is a tag for `7.68.0-rc.1` the job will fail and none of the mutable image tags will be deployed.

### Motivation

https://datadoghq.atlassian.net/browse/BARX-1031

### Describe how you validated your changes

### Additional Notes
