### PR TITLE
[workloadfilter]: Compile CEL Rules

### DIFF
--- a/comp/core/workloadfilter/catalog/container.go
+++ b/comp/core/workloadfilter/catalog/container.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
@@ -18,53 +17,53 @@ import (
 )
 
 // LegacyContainerMetricsProgram creates a program for filtering container metrics
-func LegacyContainerMetricsProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerMetricsProgram"
-	include := config.GetStringSlice("container_include_metrics")
-	exclude := config.GetStringSlice("container_exclude_metrics")
+	include := filterConfig.ContainerIncludeMetrics
+	exclude := filterConfig.ContainerExcludeMetrics
 	return createFromOldFilters(programName, include, exclude, workloadfilter.ContainerType, logger)
 }
 
 // LegacyContainerLogsProgram creates a program for filtering container logs
-func LegacyContainerLogsProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerLogsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerLogsProgram"
-	include := config.GetStringSlice("container_include_logs")
-	exclude := config.GetStringSlice("container_exclude_logs")
+	include := filterConfig.ContainerIncludeLogs
+	exclude := filterConfig.ContainerExcludeLogs
 	return createFromOldFilters(programName, include, exclude, workloadfilter.ContainerType, logger)
 }
 
 // LegacyContainerACExcludeProgram creates a program for excluding containers via legacy `AC` filters
-func LegacyContainerACExcludeProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerACExcludeProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerACExcludeProgram"
-	exclude := config.GetStringSlice("ac_exclude")
+	exclude := filterConfig.ACExclude
 	return createFromOldFilters(programName, nil, exclude, workloadfilter.ContainerType, logger)
 }
 
 // LegacyContainerACIncludeProgram creates a program for including containers via legacy `AC` filters
-func LegacyContainerACIncludeProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerACIncludeProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerACIncludeProgram"
-	include := config.GetStringSlice("ac_include")
+	include := filterConfig.ACInclude
 	return createFromOldFilters(programName, include, nil, workloadfilter.ContainerType, logger)
 }
 
 // LegacyContainerGlobalProgram creates a program for filtering container globally
-func LegacyContainerGlobalProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerGlobalProgram"
-	include := config.GetStringSlice("container_include")
-	exclude := config.GetStringSlice("container_exclude")
+	include := filterConfig.ContainerInclude
+	exclude := filterConfig.ContainerExclude
 	return createFromOldFilters(programName, include, exclude, workloadfilter.ContainerType, logger)
 }
 
 // LegacyContainerSBOMProgram creates a program for filtering container SBOMs
-func LegacyContainerSBOMProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyContainerSBOMProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyContainerSBOMProgram"
-	include := config.GetStringSlice("sbom.container_image.container_include")
-	exclude := config.GetStringSlice("sbom.container_image.container_exclude")
+	include := filterConfig.SBOMContainerInclude
+	exclude := filterConfig.SBOMContainerExclude
 	return createFromOldFilters(programName, include, exclude, workloadfilter.ContainerType, logger)
 }
 
 // ContainerPausedProgram creates a program for filtering paused containers
-func ContainerPausedProgram(_ config.Component, logger log.Component) program.FilterProgram {
+func ContainerPausedProgram(_ *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "ContainerPausedProgram"
 	var initErrors []error
 
@@ -94,4 +93,32 @@ func ContainerPausedProgram(_ config.Component, logger log.Component) program.Fi
 		},
 		InitializationErrors: initErrors,
 	}
+}
+
+// ContainerCELMetricsProgram creates a program for filtering container metrics via CEL rules
+func ContainerCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ContainerCELMetricsProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ContainerType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ContainerType, logger)
+}
+
+// ContainerCELLogsProgram creates a program for filtering container logs via CEL rules
+func ContainerCELLogsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ContainerCELLogsProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductLogs, workloadfilter.ContainerType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ContainerType, logger)
+}
+
+// ContainerCELSBOMProgram creates a program for filtering container SBOMs via CEL rules
+func ContainerCELSBOMProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ContainerCELSBOMProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductSBOM, workloadfilter.ContainerType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ContainerType, logger)
+}
+
+// ContainerCELGlobalProgram creates a program for filtering containers globally via CEL rules
+func ContainerCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ContainerCELGlobalProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.ContainerType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ContainerType, logger)
 }

--- a/comp/core/workloadfilter/catalog/filter_config.go
+++ b/comp/core/workloadfilter/catalog/filter_config.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package catalog
+
+import (
+	"errors"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/impl/parse"
+)
+
+// FilterConfig holds all configuration values needed for filter initialization
+type FilterConfig struct {
+	// Legacy container filters
+	ContainerInclude        []string
+	ContainerExclude        []string
+	ContainerIncludeMetrics []string
+	ContainerExcludeMetrics []string
+	ContainerIncludeLogs    []string
+	ContainerExcludeLogs    []string
+
+	// Legacy AC filters
+	ACInclude []string
+	ACExclude []string
+
+	// Pause container settings
+	ExcludePauseContainer     bool
+	SBOMExcludePauseContainer bool
+
+	// SBOM container filtering
+	SBOMContainerInclude []string
+	SBOMContainerExclude []string
+
+	// Process filtering settings
+	ProcessBlacklistPatterns []string
+
+	// CEL workload filter rules (pre-parsed)
+	CELProductRules map[workloadfilter.Product]map[workloadfilter.ResourceType][]string
+}
+
+// NewFilterConfig creates a FilterConfig from the agent config
+func NewFilterConfig(cfg config.Component) (*FilterConfig, error) {
+	rawCfg, loadErr := loadCELConfig(cfg)
+	if loadErr != nil {
+		return nil, loadErr
+	}
+
+	celProductRules, celParseErrors := parse.GetProductConfigs(rawCfg)
+	if celParseErrors != nil {
+		return nil, errors.Join(celParseErrors...)
+	}
+
+	var processBlacklistPatterns []string
+	if cfg.IsConfigured("process_config.blacklist_patterns") {
+		processBlacklistPatterns = cfg.GetStringSlice("process_config.blacklist_patterns")
+	}
+
+	return &FilterConfig{
+		// Legacy container filters
+		ContainerInclude:        cfg.GetStringSlice("container_include"),
+		ContainerExclude:        cfg.GetStringSlice("container_exclude"),
+		ContainerIncludeMetrics: cfg.GetStringSlice("container_include_metrics"),
+		ContainerExcludeMetrics: cfg.GetStringSlice("container_exclude_metrics"),
+		ContainerIncludeLogs:    cfg.GetStringSlice("container_include_logs"),
+		ContainerExcludeLogs:    cfg.GetStringSlice("container_exclude_logs"),
+
+		// Legacy AC filters
+		ACInclude: cfg.GetStringSlice("ac_include"),
+		ACExclude: cfg.GetStringSlice("ac_exclude"),
+
+		// Pause container settings
+		ExcludePauseContainer:     cfg.GetBool("exclude_pause_container"),
+		SBOMExcludePauseContainer: cfg.GetBool("sbom.container_image.exclude_pause_container"),
+
+		// SBOM container filtering
+		SBOMContainerInclude: cfg.GetStringSlice("sbom.container_image.container_include"),
+		SBOMContainerExclude: cfg.GetStringSlice("sbom.container_image.container_exclude"),
+
+		// Process filtering settings
+		ProcessBlacklistPatterns: processBlacklistPatterns,
+
+		// CEL workload filter rules (pre-parsed)
+		CELProductRules: celProductRules,
+	}, nil
+}
+
+// GetCELRulesForProduct returns the CEL rules for a specific product and resource type
+func (fc *FilterConfig) GetCELRulesForProduct(product workloadfilter.Product, resourceType workloadfilter.ResourceType) string {
+	if fc.CELProductRules == nil {
+		return ""
+	}
+
+	if productMap, exists := fc.CELProductRules[product]; exists {
+		if ruleSlice, exists := productMap[resourceType]; exists {
+			return strings.Join(ruleSlice, " || ")
+		}
+	}
+
+	return ""
+}
+
+// GetLegacyContainerInclude returns the appropriate container include list with fallback to AC include
+func (fc *FilterConfig) GetLegacyContainerInclude() []string {
+	if len(fc.ContainerInclude) > 0 {
+		return fc.ContainerInclude
+	}
+	return fc.ACInclude
+}
+
+// GetLegacyContainerExclude returns the appropriate container exclude list with fallback to AC exclude
+func (fc *FilterConfig) GetLegacyContainerExclude() []string {
+	if len(fc.ContainerExclude) > 0 {
+		return fc.ContainerExclude
+	}
+	return fc.ACExclude
+}
+
+// loadCELConfig loads CEL workload exclude configuration
+func loadCELConfig(cfg config.Component) ([]workloadfilter.RuleBundle, error) {
+	var celConfig []workloadfilter.RuleBundle
+
+	// First try the standard UnmarshalKey method (input defined in datadog.yaml)
+	err := cfg.UnmarshalKey("cel_workload_exclude", &celConfig)
+	if err == nil {
+		return celConfig, nil
+	}
+
+	// Fallback: try to get raw value and unmarshal manually
+	rawValue := cfg.GetString("cel_workload_exclude")
+	if rawValue == "" {
+		return nil, nil
+	}
+
+	// handles both yaml and json input
+	err = yaml.Unmarshal([]byte(rawValue), &celConfig)
+	if err == nil {
+		return celConfig, nil
+	}
+
+	return nil, err
+}

--- a/comp/core/workloadfilter/catalog/filter_config_test.go
+++ b/comp/core/workloadfilter/catalog/filter_config_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build cel
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestNewFilterConfig_CELFallback(t *testing.T) {
+	t.Run("successful unmarshal - no fallback needed", func(t *testing.T) {
+
+		mockConfig := configmock.New(t)
+
+		// Set up valid CEL config that should unmarshal successfully
+		celConfig := []workloadfilter.RuleBundle{
+			{
+				Products: []workloadfilter.Product{workloadfilter.ProductMetrics},
+				Rules: map[workloadfilter.ResourceType][]string{
+					workloadfilter.ContainerType: {"container.name == 'test'"},
+				},
+			},
+		}
+		mockConfig.SetWithoutSource("cel_workload_exclude", celConfig)
+
+		filterConfig, err := NewFilterConfig(mockConfig)
+		require.NoError(t, err)
+		assert.NotNil(t, filterConfig)
+		assert.NotNil(t, filterConfig.CELProductRules)
+		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
+	})
+
+	t.Run("unmarshal fails but YAML string fallback succeeds", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+
+		// Set up YAML string like what would come from configuration files
+		yamlConfig := `- products:
+  - metrics
+  rules:
+    kube_services:
+    - service.name == 'yaml-service'
+    pods:
+    - pod.namespace == 'yaml-ns'
+    containers:
+    - container.name == 'yaml-test'`
+		mockConfig.SetWithoutSource("cel_workload_exclude", yamlConfig)
+
+		filterConfig, err := NewFilterConfig(mockConfig)
+		require.NoError(t, err)
+		assert.NotNil(t, filterConfig)
+		assert.NotNil(t, filterConfig.CELProductRules)
+		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
+
+		containerRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ContainerType)
+		assert.Equal(t, "container.name == 'yaml-test'", containerRules)
+		podRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.PodType)
+		assert.Equal(t, "pod.namespace == 'yaml-ns'", podRules)
+		serviceRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ServiceType)
+		assert.Equal(t, "service.name == 'yaml-service'", serviceRules)
+	})
+
+	t.Run("unmarshal fails but JSON string fallback succeeds", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+		jsonConfig := `[
+			{
+				"products": ["metrics"],
+				"rules": {
+					"kube_services": ["service.name == 'test-service'"],
+					"pods": ["pod.namespace == 'test-ns'"],
+					"containers": ["container.name == 'json-test'"]
+				}
+			}
+		]`
+		mockConfig.SetWithoutSource("cel_workload_exclude", jsonConfig)
+
+		filterConfig, err := NewFilterConfig(mockConfig)
+		require.NoError(t, err)
+		assert.NotNil(t, filterConfig)
+		assert.NotNil(t, filterConfig.CELProductRules)
+		assert.Contains(t, filterConfig.CELProductRules, workloadfilter.ProductMetrics)
+
+		containerRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ContainerType)
+		assert.Equal(t, "container.name == 'json-test'", containerRules)
+		podRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.PodType)
+		assert.Equal(t, "pod.namespace == 'test-ns'", podRules)
+		serviceRules := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ServiceType)
+		assert.Equal(t, "service.name == 'test-service'", serviceRules)
+	})
+
+	t.Run("both unmarshal and fallback fail", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+		mockConfig.SetWithoutSource("cel_workload_exclude", "invalid string data")
+
+		filterConfig, err := NewFilterConfig(mockConfig)
+		assert.Error(t, err)
+		assert.Nil(t, filterConfig)
+	})
+
+	t.Run("no cel_workload_exclude config", func(t *testing.T) {
+		mockConfig := configmock.New(t)
+
+		filterConfig, err := NewFilterConfig(mockConfig)
+		require.NoError(t, err)
+		assert.NotNil(t, filterConfig)
+		assert.Empty(t, filterConfig.CELProductRules)
+	})
+}

--- a/comp/core/workloadfilter/catalog/kube_service.go
+++ b/comp/core/workloadfilter/catalog/kube_service.go
@@ -7,33 +7,37 @@
 package catalog
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 )
 
 // LegacyServiceMetricsProgram creates a program for filtering service metrics
-func LegacyServiceMetricsProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyServiceMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyServiceMetricsProgram"
-	include := config.GetStringSlice("container_include_metrics")
-	exclude := config.GetStringSlice("container_exclude_metrics")
+	include := filterConfig.ContainerIncludeMetrics
+	exclude := filterConfig.ContainerExcludeMetrics
 	return createFromOldFilters(programName, include, exclude, workloadfilter.ServiceType, logger)
 }
 
 // LegacyServiceGlobalProgram creates a program for filtering services globally
-func LegacyServiceGlobalProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyServiceGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyServiceGlobalProgram"
-
-	includeList := config.GetStringSlice("container_include")
-	excludeList := config.GetStringSlice("container_exclude")
-	if len(includeList) == 0 {
-		// fallback and support legacy "ac_include" config
-		includeList = config.GetStringSlice("ac_include")
-	}
-	if len(excludeList) == 0 {
-		// fallback and support legacy "ac_exclude" config
-		excludeList = config.GetStringSlice("ac_exclude")
-	}
+	includeList := filterConfig.GetLegacyContainerInclude()
+	excludeList := filterConfig.GetLegacyContainerExclude()
 	return createFromOldFilters(programName, includeList, excludeList, workloadfilter.ServiceType, logger)
+}
+
+// ServiceCELMetricsProgram creates a program for filtering services metrics via CEL rules
+func ServiceCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ServiceCELMetricsProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ServiceType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ServiceType, logger)
+}
+
+// ServiceCELGlobalProgram creates a program for filtering services globally via CEL rules
+func ServiceCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
+	programName := "ServiceCELGlobalProgram"
+	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.ServiceType)
+	return createCELExcludeProgram(programName, rule, workloadfilter.ServiceType, logger)
 }

--- a/comp/core/workloadfilter/catalog/process.go
+++ b/comp/core/workloadfilter/catalog/process.go
@@ -10,14 +10,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 )
 
 // LegacyProcessExcludeProgram creates a regex-based program for filtering processes based on legacy disallowlist patterns
-func LegacyProcessExcludeProgram(config config.Component, logger log.Component) program.FilterProgram {
+func LegacyProcessExcludeProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
 	programName := "LegacyProcessExcludeProgram"
 	var initErrors []error
 
@@ -29,7 +28,7 @@ func LegacyProcessExcludeProgram(config config.Component, logger log.Component) 
 		return process.GetCmdline()
 	}
 
-	processPatterns := config.GetStringSlice("process_config.blacklist_patterns")
+	processPatterns := filterConfig.ProcessBlacklistPatterns
 	if len(processPatterns) == 0 {
 		return &program.RegexProgram{
 			Name:                 programName,

--- a/comp/core/workloadfilter/catalog/utils_nocel.go
+++ b/comp/core/workloadfilter/catalog/utils_nocel.go
@@ -31,3 +31,8 @@ func createFromOldFilters(name string, include, exclude []string, _ workloadfilt
 		InitializationErrors: initErrors,
 	}
 }
+
+// createCELExcludeProgram is a stub to allow compilation without CEL support.
+func createCELExcludeProgram(_ string, _ string, _ workloadfilter.ResourceType, _ log.Component) program.FilterProgram {
+	return nil
+}

--- a/comp/core/workloadfilter/impl/filter.go
+++ b/comp/core/workloadfilter/impl/filter.go
@@ -7,13 +7,14 @@
 package workloadfilterimpl
 
 import (
+	"os"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
 	coretelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/catalog"
-	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 )
@@ -22,16 +23,18 @@ import (
 type filterProgramFactory struct {
 	once    sync.Once
 	program program.FilterProgram
-	factory func(cfg config.Component, logger log.Component) program.FilterProgram
+	factory func(filterConfig *catalog.FilterConfig, logger logcomp.Component) program.FilterProgram
 }
 
 // workloadfilterStore is the implementation of the workloadfilterStore component.
 type workloadfilterStore struct {
 	config              config.Component
-	log                 log.Component
+	log                 logcomp.Component
 	telemetry           coretelemetry.Component
 	programFactoryStore map[workloadfilter.ResourceType]map[int]*filterProgramFactory
 	selection           *filterSelection
+	// Pre-built filter configuration with all parsed values
+	filterConfig *catalog.FilterConfig
 }
 
 // Requires defines the dependencies of the filter component.
@@ -39,7 +42,7 @@ type Requires struct {
 	compdef.In
 
 	Config    config.Component
-	Log       log.Component
+	Log       logcomp.Component
 	Telemetry coretelemetry.Component
 }
 
@@ -64,7 +67,7 @@ func NewComponent(req Requires) (Provides, error) {
 
 var _ workloadfilter.Component = (*workloadfilterStore)(nil)
 
-func (f *workloadfilterStore) registerFactory(resourceType workloadfilter.ResourceType, programType int, factory func(cfg config.Component, logger log.Component) program.FilterProgram) {
+func (f *workloadfilterStore) registerFactory(resourceType workloadfilter.ResourceType, programType int, factory func(filterConfig *catalog.FilterConfig, logger logcomp.Component) program.FilterProgram) {
 	if f.programFactoryStore[resourceType] == nil {
 		f.programFactoryStore[resourceType] = make(map[int]*filterProgramFactory)
 	}
@@ -89,27 +92,37 @@ func (f *workloadfilterStore) getProgram(resourceType workloadfilter.ResourceTyp
 	}
 
 	factory.once.Do(func() {
-		factory.program = factory.factory(f.config, f.log)
+		factory.program = factory.factory(f.filterConfig, f.log)
 	})
 
 	return factory.program
 }
 
-func newFilter(cfg config.Component, logger log.Component, telemetry coretelemetry.Component) (workloadfilter.Component, error) {
+func newFilter(cfg config.Component, logger logcomp.Component, telemetry coretelemetry.Component) (workloadfilter.Component, error) {
+	filterConfig, configErr := catalog.NewFilterConfig(cfg)
+	if configErr != nil {
+		logger.Criticalf("failed to parse 'cel_workload_exclude' filters. Provided value: \n%s\nError: %v", cfg.Get("cel_workload_exclude"), configErr)
+		logger.Flush()
+		os.Exit(1)
+	}
+
 	filter := &workloadfilterStore{
 		config:              cfg,
 		log:                 logger,
 		telemetry:           telemetry,
 		programFactoryStore: make(map[workloadfilter.ResourceType]map[int]*filterProgramFactory),
 		selection:           newFilterSelection(cfg),
+		filterConfig:        filterConfig,
 	}
 
 	genericADProgram := catalog.AutodiscoveryAnnotations()
 	genericADMetricsProgram := catalog.AutodiscoveryMetricsAnnotations()
 	genericADLogsProgram := catalog.AutodiscoveryLogsAnnotations()
-	genericADProgramFactory := func(_ config.Component, _ log.Component) program.FilterProgram { return genericADProgram }
-	genericADMetricsProgramFactory := func(_ config.Component, _ log.Component) program.FilterProgram { return genericADMetricsProgram }
-	genericADLogsProgramFactory := func(_ config.Component, _ log.Component) program.FilterProgram { return genericADLogsProgram }
+	genericADProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return genericADProgram }
+	genericADMetricsProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram {
+		return genericADMetricsProgram
+	}
+	genericADLogsProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return genericADLogsProgram }
 
 	// Container Filters
 	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.LegacyContainerMetrics), catalog.LegacyContainerMetricsProgram)
@@ -124,11 +137,19 @@ func newFilter(cfg config.Component, logger log.Component, telemetry coretelemet
 	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerADAnnotationsLogs), genericADLogsProgramFactory)
 	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerPaused), catalog.ContainerPausedProgram)
 
+	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerCELMetrics), catalog.ContainerCELMetricsProgram)
+	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerCELLogs), catalog.ContainerCELLogsProgram)
+	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerCELSBOM), catalog.ContainerCELSBOMProgram)
+	filter.registerFactory(workloadfilter.ContainerType, int(workloadfilter.ContainerCELGlobal), catalog.ContainerCELGlobalProgram)
+
 	// Service Filters
 	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.LegacyServiceGlobal), catalog.LegacyServiceGlobalProgram)
 	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.LegacyServiceMetrics), catalog.LegacyServiceMetricsProgram)
 	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.ServiceADAnnotations), genericADProgramFactory)
 	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.ServiceADAnnotationsMetrics), genericADMetricsProgramFactory)
+
+	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.ServiceCELMetrics), catalog.ServiceCELMetricsProgram)
+	filter.registerFactory(workloadfilter.ServiceType, int(workloadfilter.ServiceCELGlobal), catalog.ServiceCELGlobalProgram)
 
 	// Endpoints Filters
 	filter.registerFactory(workloadfilter.EndpointType, int(workloadfilter.LegacyEndpointGlobal), catalog.LegacyEndpointsGlobalProgram)
@@ -136,10 +157,16 @@ func newFilter(cfg config.Component, logger log.Component, telemetry coretelemet
 	filter.registerFactory(workloadfilter.EndpointType, int(workloadfilter.EndpointADAnnotations), genericADProgramFactory)
 	filter.registerFactory(workloadfilter.EndpointType, int(workloadfilter.EndpointADAnnotationsMetrics), genericADMetricsProgramFactory)
 
+	filter.registerFactory(workloadfilter.EndpointType, int(workloadfilter.EndpointCELMetrics), catalog.EndpointCELMetricsProgram)
+	filter.registerFactory(workloadfilter.EndpointType, int(workloadfilter.EndpointCELGlobal), catalog.EndpointCELGlobalProgram)
+
 	// Pod Filters
 	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.LegacyPod), catalog.LegacyPodProgram)
 	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodADAnnotations), genericADProgramFactory)
 	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodADAnnotationsMetrics), genericADMetricsProgramFactory)
+
+	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodCELMetrics), catalog.PodCELMetricsProgram)
+	filter.registerFactory(workloadfilter.PodType, int(workloadfilter.PodCELGlobal), catalog.PodCELGlobalProgram)
 
 	// Process Filters
 	filter.registerFactory(workloadfilter.ProcessType, int(workloadfilter.LegacyProcessExcludeList), catalog.LegacyProcessExcludeProgram)


### PR DESCRIPTION
### What does this PR do?

This PR compiles the CEL programs provided via `cel_workload_exclude` configuration on the Agent. Gracefully kills the Agent process if parsing/compiling of the rules fail.

### Motivation

CONTP-992

### Describe how you validated your changes

CI and Unit Tests

### Additional Notes

When spinning up the Agent with an invalid definition like `cel_workload_filter: invalid-input`, you will see the following error in the agent logs while it is sent into CrashLoopBackoff:

```
2025-10-10 16:02:53 UTC | CRITICAL | (comp/core/workloadfilter/impl/filter.go:104 in newFilter) | failed to parse 'cel_workload_exclude' filters. Provided value:
invalid-input
Errors: decoding failed due to the following error(s):

        '[0]' expected a map or struct, got "string"
```

```
2025-10-10 16:06:47 UTC | CRITICAL | (comp/core/workloadfilter/impl/filter.go:104 in newFilter) | failed to parse 'cel_workload_exclude' filters. Provided value:
[map[products:[bad_product] rules:map[kube_services:[true] pods:[false]]] map[products:[logs sbom] rules:map[containers:[container.name != 'this']]]]
Errors: unsupported product for CEL workload filtering: bad_product
```

```
2025-10-10 16:07:35 UTC | CRITICAL | (comp/core/workloadfilter/impl/filter.go:104 in newFilter) | failed to parse 'cel_workload_exclude' filters. Provided value:
        [map[products:[metrics] rules:map[kube_services:[true] pods-typo:[false]]] map[products:[logs sbom] rules:map[containers:[container.name != 'this']]]]
        Errors: unsupported resource type for CEL workload filtering: pods-typo
        unsupported resource type for CEL workload filtering on metrics product: pods-typo
```

```
2025-10-10 16:09:07 UTC | CRITICAL | (comp/core/workloadfilter/catalog/utils.go:169 in createCELExcludeProgram) | failed to compile 'PodCELMetricsProgram' from 'cel_workload_exclude' filters: ERROR: <input>:1:1: undeclared reference to 'pods' (in container '')
         | pods.badkey != 101
         | ^
```

Note: is it slightly easier to define this configuration option via the `datadog.yaml` file. The config component is also expecting an `[]interface{}` which is different than providing the value directly as a string into the environment. This leads to issues with unmarshalling which leads to implement fallback using yaml.unmarshal directly

```
datadog:
  kubelet:
    tlsVerify: false
agents:
  useConfigMap: true
  customAgentConfig:
    cel_workload_exclude:
      - products: ["metrics"]
        rules:
          kube_services: ["true"]
          pods: ["false"]
      - products: ["logs", "sbom"]
        rules:
          containers: ["container.name != 'this'"]
```