### PR TITLE
[EBPF-840] update(corechecks/gpu/nvidia): support nspid tag in all metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/base.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base.go
@@ -9,6 +9,7 @@ package nvidia
 
 import (
 	"fmt"
+
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/hashicorp/go-multierror"
 )

--- a/pkg/collector/corechecks/gpu/nvidia/base_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base_test.go
@@ -9,10 +9,6 @@ package nvidia
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -22,7 +18,6 @@ import (
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func setupMockDeviceWithLibOpts(t *testing.T, customize func(device *mock.Device) *mock.Device, extraLibOpts ...testutil.NvmlMockOption) ddnvml.Device {
@@ -59,21 +54,6 @@ func setupMockDeviceWithLibOpts(t *testing.T, customize func(device *mock.Device
 // If customize is provided, allows overriding specific device functions.
 func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Device) ddnvml.Device {
 	return setupMockDeviceWithLibOpts(t, customize)
-}
-
-func setupFakeProcTaskStatus(t *testing.T, pid, tid uint32, nspid uint32) {
-	hostRoot := os.Getenv("HOST_PROC") // set by TestMain
-	require.Equal(t, hostRoot, kernel.ProcFSRoot())
-
-	dirPath := filepath.Join(
-		hostRoot,
-		strconv.FormatUint(uint64(pid), 10),
-		"task",
-		strconv.FormatUint(uint64(tid), 10))
-	require.NoError(t, os.MkdirAll(dirPath, os.ModePerm))
-
-	content := fmt.Sprintf("Pid: %d\nNSpid: %d\n", tid, nspid)
-	require.NoError(t, os.WriteFile(filepath.Join(dirPath, "status"), []byte(content), os.ModePerm))
 }
 
 func TestNewBaseCollector(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/base_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/base_test.go
@@ -9,6 +9,10 @@ package nvidia
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -18,6 +22,7 @@ import (
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func setupMockDeviceWithLibOpts(t *testing.T, customize func(device *mock.Device) *mock.Device, extraLibOpts ...testutil.NvmlMockOption) ddnvml.Device {
@@ -54,6 +59,21 @@ func setupMockDeviceWithLibOpts(t *testing.T, customize func(device *mock.Device
 // If customize is provided, allows overriding specific device functions.
 func setupMockDevice(t *testing.T, customize func(device *mock.Device) *mock.Device) ddnvml.Device {
 	return setupMockDeviceWithLibOpts(t, customize)
+}
+
+func setupFakeProcTaskStatus(t *testing.T, pid, tid uint32, nspid uint32) {
+	hostRoot := os.Getenv("HOST_PROC") // set by TestMain
+	require.Equal(t, hostRoot, kernel.ProcFSRoot())
+
+	dirPath := filepath.Join(
+		hostRoot,
+		strconv.FormatUint(uint64(pid), 10),
+		"task",
+		strconv.FormatUint(uint64(tid), 10))
+	require.NoError(t, os.MkdirAll(dirPath, os.ModePerm))
+
+	content := fmt.Sprintf("Pid: %d\nNSpid: %d\n", tid, nspid)
+	require.NoError(t, os.WriteFile(filepath.Join(dirPath, "status"), []byte(content), os.ModePerm))
 }
 
 func TestNewBaseCollector(t *testing.T) {

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -92,6 +92,8 @@ type CollectorDependencies struct {
 	DeviceEventsGatherer *DeviceEventsGatherer
 	// SystemProbeCache is a (optional) cache of the latest metrics obtained from system probe
 	SystemProbeCache *SystemProbeCache
+	// NsPidCache is a cache used for the resolution of nspids of processes
+	NsPidCache *NsPidCache
 }
 
 // BuildCollectors returns a set of collectors that can be used to collect metrics from NVML.
@@ -124,7 +126,7 @@ func buildCollectors(devices []ddnvml.Device, deps *CollectorDependencies, build
 	if deps.SystemProbeCache != nil {
 		log.Info("GPU monitoring probe is enabled in system-probe, creating ebpf collectors for all devices")
 		for _, dev := range devices {
-			spCollector, err := newEbpfCollector(dev, deps.SystemProbeCache)
+			spCollector, err := newEbpfCollector(dev, deps.NsPidCache, deps.SystemProbeCache)
 			if err != nil {
 				log.Warnf("failed to create system-probe collector for device %s: %s", dev.GetDeviceInfo().UUID, err)
 				continue

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -41,7 +41,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	deviceCache := ddnvml.NewDeviceCache()
 	devices, err := deviceCache.AllPhysicalDevices()
 	require.NoError(t, err)
-	deps := &CollectorDependencies{}
+	deps := &CollectorDependencies{NsPidCache: &NsPidCache{}}
 	collectors, err := buildCollectors(devices, deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestAllCollectorsWork(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, eventsGatherer.Stop()) })
 	devices, err := deviceCache.AllPhysicalDevices()
 	require.NoError(t, err)
-	deps := &CollectorDependencies{DeviceEventsGatherer: eventsGatherer}
+	deps := &CollectorDependencies{DeviceEventsGatherer: eventsGatherer, NsPidCache: &NsPidCache{}}
 	collectors, err := BuildCollectors(devices, deps)
 	require.NoError(t, err)
 	require.NotNil(t, collectors)

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -114,7 +114,7 @@ func testCollectWithInvalidCache(t *testing.T) {
 	dev := createMockDevice(t, testutil.DefaultGpuUUID)
 	cache := NewSystemProbeCache()
 
-	collector, err := newEbpfCollector(dev, cache)
+	collector, err := newEbpfCollector(dev, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -143,7 +143,7 @@ func testCollectWithSingleActiveProcess(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -211,7 +211,7 @@ func testCollectWithMultipleActiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -255,7 +255,7 @@ func testCollectWithInactiveProcesses(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	// First collect with process 123
@@ -328,7 +328,7 @@ func testCollectFiltersByDeviceUUID(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()
@@ -392,7 +392,7 @@ func testCollectAggregatesPidTagsForLimits(t *testing.T) {
 		},
 	})
 
-	collector, err := newEbpfCollector(device, cache)
+	collector, err := newEbpfCollector(device, &NsPidCache{}, cache)
 	require.NoError(t, err)
 
 	metrics, err := collector.Collect()

--- a/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling_test.go
@@ -54,7 +54,7 @@ func TestNewSampleCollector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockDevice := setupMockDevice(t, tt.customSetup)
 
-			collector, err := newSamplingCollector(mockDevice, nil)
+			collector, err := newSamplingCollector(mockDevice, &CollectorDependencies{NsPidCache: &NsPidCache{}})
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -112,12 +112,12 @@ func TestCollectProcessUtilization(t *testing.T) {
 			originalFactory := sampleAPIFactory
 			defer func() { sampleAPIFactory = originalFactory }()
 
-			sampleAPIFactory = func() []apiCallInfo {
+			sampleAPIFactory = func(nsPidCache *NsPidCache) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_utilization",
 						Handler: func(device safenvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-							return processUtilizationSample(device, lastTimestamp)
+							return processUtilizationSample(device, lastTimestamp, nsPidCache)
 						},
 					},
 				}
@@ -130,7 +130,7 @@ func TestCollectProcessUtilization(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice, nil)
+			collector, err := newSamplingCollector(mockDevice, &CollectorDependencies{NsPidCache: &NsPidCache{}})
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()
@@ -168,12 +168,12 @@ func TestCollectProcessUtilization_Error(t *testing.T) {
 			originalFactory := sampleAPIFactory
 			defer func() { sampleAPIFactory = originalFactory }()
 
-			sampleAPIFactory = func() []apiCallInfo {
+			sampleAPIFactory = func(nsPidCache *NsPidCache) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_utilization",
 						Handler: func(device safenvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-							return processUtilizationSample(device, lastTimestamp)
+							return processUtilizationSample(device, lastTimestamp, nsPidCache)
 						},
 					},
 				}
@@ -190,7 +190,7 @@ func TestCollectProcessUtilization_Error(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice, nil)
+			collector, err := newSamplingCollector(mockDevice, &CollectorDependencies{NsPidCache: &NsPidCache{}})
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()
@@ -242,12 +242,12 @@ func TestProcessUtilizationTimestampUpdate(t *testing.T) {
 			originalFactory := sampleAPIFactory
 			defer func() { sampleAPIFactory = originalFactory }()
 
-			sampleAPIFactory = func() []apiCallInfo {
+			sampleAPIFactory = func(nsPidCache *NsPidCache) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_utilization",
 						Handler: func(device safenvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-							return processUtilizationSample(device, lastTimestamp)
+							return processUtilizationSample(device, lastTimestamp, nsPidCache)
 						},
 					},
 				}
@@ -267,7 +267,7 @@ func TestProcessUtilizationTimestampUpdate(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice, nil)
+			collector, err := newSamplingCollector(mockDevice, &CollectorDependencies{NsPidCache: &NsPidCache{}})
 			require.NoError(t, err)
 
 			bc := collector.(*baseCollector)
@@ -356,12 +356,12 @@ func TestProcessUtilization_SmActiveCalculation(t *testing.T) {
 			originalFactory := sampleAPIFactory
 			defer func() { sampleAPIFactory = originalFactory }()
 
-			sampleAPIFactory = func() []apiCallInfo {
+			sampleAPIFactory = func(nsPidCache *NsPidCache) []apiCallInfo {
 				return []apiCallInfo{
 					{
 						Name: "process_utilization",
 						Handler: func(device safenvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-							return processUtilizationSample(device, lastTimestamp)
+							return processUtilizationSample(device, lastTimestamp, nsPidCache)
 						},
 					},
 				}
@@ -374,7 +374,7 @@ func TestProcessUtilization_SmActiveCalculation(t *testing.T) {
 				return device
 			})
 
-			collector, err := newSamplingCollector(mockDevice, nil)
+			collector, err := newSamplingCollector(mockDevice, &CollectorDependencies{NsPidCache: &NsPidCache{}})
 			require.NoError(t, err)
 
 			processMetrics, err := collector.Collect()

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -78,19 +78,18 @@ func nvlinkSample(device ddnvml.Device) ([]Metric, uint64, error) {
 }
 
 // processMemorySample handles process memory usage collection logic
-func processMemorySample(device ddnvml.Device) ([]Metric, uint64, error) {
+func processMemorySample(device ddnvml.Device, nsPidCache *NsPidCache) ([]Metric, uint64, error) {
 	procs, err := device.GetComputeRunningProcesses()
 
-	var nsPids nsPidCache
 	var processMetrics []Metric
 	var allPidTags []string
 
 	if err == nil {
-		// Create PID tag for this process, and add NS PID if available
+		// Create PID tag for this process
 		for _, proc := range procs {
-			pidTags := []string{fmt.Sprintf("pid:%d", proc.Pid)}
-			if nsPid := nsPids.getHostPidNsPid(proc.Pid); nsPid != 0 {
-				pidTags = append(pidTags, fmt.Sprintf("nspid:%d", nsPid))
+			pidTags := []string{
+				fmt.Sprintf("pid:%d", proc.Pid),
+				fmt.Sprintf("nspid:%d", nsPidCache.GetNsPidOrHostPid(proc.Pid, true)),
 			}
 			allPidTags = append(allPidTags, pidTags...)
 
@@ -118,7 +117,7 @@ func processMemorySample(device ddnvml.Device) ([]Metric, uint64, error) {
 }
 
 // createStatelessAPIs creates API call definitions for all stateless metrics on demand
-func createStatelessAPIs() []apiCallInfo {
+func createStatelessAPIs(nsPidCache *NsPidCache) []apiCallInfo {
 	apis := []apiCallInfo{
 		// Memory collector APIs
 		{
@@ -387,7 +386,7 @@ func createStatelessAPIs() []apiCallInfo {
 		{
 			Name: "process_memory_usage",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				return processMemorySample(device)
+				return processMemorySample(device, nsPidCache)
 			},
 		},
 		// NVLink collector APIs
@@ -405,6 +404,6 @@ func createStatelessAPIs() []apiCallInfo {
 var statelessAPIFactory = createStatelessAPIs
 
 // newStatelessCollector creates a collector that consolidates all stateless collector types
-func newStatelessCollector(device ddnvml.Device, _ *CollectorDependencies) (Collector, error) {
-	return NewBaseCollector(stateless, device, statelessAPIFactory())
+func newStatelessCollector(device ddnvml.Device, deps *CollectorDependencies) (Collector, error) {
+	return NewBaseCollector(stateless, device, statelessAPIFactory(deps.NsPidCache))
 }


### PR DESCRIPTION
### What does this PR do?

This attempts resolving the nspid of processes when collecting GPU monitoring metrics, and attaching it as a tag when available.

### Motivation

This is helpful during aggregations for distinguishing the pid of processes within their containers from their host pid.

### Describe how you validated your changes

### Additional Notes
