### PR TITLE
feat(debugger): split add. endpoints config for debugger and logs intakes

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -318,8 +318,10 @@ type DebuggerProxyConfig struct {
 	DDURL string
 	// APIKey ...
 	APIKey string `json:"-"` // Never marshal this field
-	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
+	// AdditionalEndpoints is a map of additional Datadog sites to API keys for the logs intake.
 	AdditionalEndpoints map[string][]string `json:"-"` // Never marshal this field
+	// AdditionalEndpointsDebugger is a map of additional Datadog sites to API keys for the debugger intake.
+	AdditionalEndpointsDebugger map[string][]string `json:"-"` // Never marshal this field
 }
 
 // SymDBProxyConfig ...


### PR DESCRIPTION
### What does this PR do?

Add dedicated `AdditionalEndpointsDebugger` field to `DebuggerProxyConfig` to support different additional endpoints for debugger intake vs logs intake.

### Motivation

While investigating dual-shipping for both staging and production DCs, I noticed that the format of `AdditionalEndpoints` takes the form: `ddstaging-http-intake.logs.datadoghq.com` instead of the site URL. This means that if we configure `AdditionalEndpoints` today, the logs, diagnostics, and snapshots will be sent to the same endpoint.

With this change we'll be able to define the configuration like:

```
debugger_proxy_config:
  ...
  additional_endpoints:
    - host: ddstaging-http-intake.logs.datadoghq.com
      api_key: KEY
  additional_endpoints_debugger:
    - host: ddstaging-debugger-intake.datadoghq.com/api/v2/debugger
      api_key: KEY
```

### Describe how you validated your changes

Unit tests

### Additional Notes

N/A