### PR TITLE
dyninst/irgen: reduce memory usage for inline funcs

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -966,7 +966,6 @@ func processDwarf(
 		dwarf:               d,
 		subprogramIDAlloc:   idAllocator[ir.SubprogramID]{},
 		abstractSubprograms: make(map[dwarf.Offset]*abstractSubprogram),
-		inlinedSubprograms:  make(map[*dwarf.Entry][]*inlinedSubprogram),
 		pointerSize:         uint8(arch.PointerSize()),
 		typeIndexBuilder:    typeIndexBuilder,
 	}
@@ -976,38 +975,126 @@ func processDwarf(
 		return processedDwarf{}, err
 	}
 
-	// Concrete subprograms are already in v.pendingSubprograms.
-	pending := v.subprograms
+	inlinedSubprograms, err := convertAbstractSubprogramsToPending(
+		v.dwarf,
+		v.abstractSubprograms,
+		v.unitOffsets,
+		v.outOfLineSubprogramOffsets,
+		v.inlineInstances,
+		v.outOfLineInstances,
+		&v.subprogramIDAlloc,
+	)
+	if err != nil {
+		return processedDwarf{}, err
+	}
 
-	// Propagate details from each inlined instance to its abstract origin.
-	inlinedByUnit := iterMapSorted(v.inlinedSubprograms, cmpEntry)
-	for _, inlinedSubs := range inlinedByUnit {
-		for _, inlined := range inlinedSubs {
-			abs, ok := v.abstractSubprograms[inlined.abstractOrigin]
-			if !ok || !abs.issue.IsNone() {
-				continue
-			}
+	if v.goRuntimeInformation == (ir.GoModuledataInfo{}) {
+		return processedDwarf{}, fmt.Errorf("runtime.firstmoduledata not found")
+	}
+	return processedDwarf{
+		pendingSubprograms: append(v.subprograms, inlinedSubprograms...),
+		goModuledataInfo:   v.goRuntimeInformation,
+		interestingTypes:   v.interestingTypes,
+	}, nil
+}
 
-			if inlined.outOfLinePCRanges != nil {
-				// Out-of-line instance.
-				if len(abs.outOfLinePCRanges) != 0 {
-					abs.issue = ir.Issue{
-						Kind:    ir.IssueKindMalformedExecutable,
-						Message: "multiple out-of-line instances of abstract subprogram",
-					}
-				} else {
-					abs.outOfLinePCRanges = inlined.outOfLinePCRanges
+// convertAbstractSubprogramsToPending constructs the pending subprograms for the inlined
+// subprograms stored in the abstractSubprograms map.
+func convertAbstractSubprogramsToPending(
+	d *dwarf.Data,
+	abstractSubprograms map[dwarf.Offset]*abstractSubprogram,
+	unitOffsets []dwarf.Offset,
+	outOfLineSubprogramOffsets []dwarf.Offset,
+	inlineInstances []concreteSubprogramRef,
+	outOfLineInstances []concreteSubprogramRef,
+	idAllocator *idAllocator[ir.SubprogramID],
+) ([]*pendingSubprogram, error) {
+	// Prepare data for enrichment: filter refs without abstract origins and
+	// sort all data by offset to enable incremental advancement through the
+	// DWARF tree.
+	slices.Sort(unitOffsets)
+	slices.Sort(outOfLineSubprogramOffsets)
+	noAbstractOrigin := func(a concreteSubprogramRef) bool {
+		_, ok := abstractSubprograms[a.abstractOrigin]
+		return !ok
+	}
+	inlineInstances = slices.DeleteFunc(inlineInstances, noAbstractOrigin)
+	outOfLineInstances = slices.DeleteFunc(outOfLineInstances, noAbstractOrigin)
+	slices.SortFunc(inlineInstances, concreteSubprogramRef.cmpByOffset)
+	slices.SortFunc(outOfLineInstances, concreteSubprogramRef.cmpByOffset)
+
+	var inlinedInstanceError *inlinedInstanceError
+	for ctx, err := range iterConcreteSubprograms(
+		d, inlineInstances, unitOffsets, outOfLineSubprogramOffsets,
+	) {
+		switch {
+		case errors.As(err, &inlinedInstanceError):
+			abs := abstractSubprograms[inlinedInstanceError.abstractOrigin]
+			if abs.issue.IsNone() {
+				abs.issue = ir.Issue{
+					Kind:    ir.IssueKindInvalidDWARF,
+					Message: inlinedInstanceError.err.Error(),
 				}
-			} else {
-				// Inlined instance.
-				abs.inlinePCRanges = append(abs.inlinePCRanges, inlined.inlinedPCRanges)
 			}
-			abs.inlined = append(abs.inlined, inlined)
+			continue
+		case err != nil:
+			return nil, err
 		}
+		abs := abstractSubprograms[ctx.abstractOrigin]
+		if !abs.issue.IsNone() {
+			continue
+		}
+		ranges := ir.InlinePCRanges{
+			Ranges:     ctx.entryRanges,
+			RootRanges: ctx.rootRanges,
+		}
+		abs.inlined = append(abs.inlined, &inlinedSubprogram{
+			abstractOrigin:  ctx.abstractOrigin,
+			inlinedPCRanges: ranges,
+			variables:       ctx.variables,
+		})
+		abs.inlinePCRanges = append(abs.inlinePCRanges, ranges)
+	}
+
+	for ctx, err := range iterConcreteSubprograms(
+		d, outOfLineInstances, unitOffsets, nil, /* no ranges needed */
+	) {
+		switch {
+		case errors.As(err, &inlinedInstanceError):
+			abs := abstractSubprograms[inlinedInstanceError.abstractOrigin]
+			if abs.issue.IsNone() {
+				abs.issue = ir.Issue{
+					Kind:    ir.IssueKindInvalidDWARF,
+					Message: inlinedInstanceError.err.Error(),
+				}
+			}
+			continue
+		case err != nil:
+			return nil, err
+		}
+		abs := abstractSubprograms[ctx.abstractOrigin]
+		if !abs.issue.IsNone() {
+			continue
+		}
+		if len(abs.outOfLinePCRanges) != 0 {
+			abs.issue = ir.Issue{
+				Kind:    ir.IssueKindMalformedExecutable,
+				Message: "multiple out-of-line instances of abstract subprogram",
+			}
+			continue
+		}
+		outOfLine := &inlinedSubprogram{
+			abstractOrigin:    ctx.abstractOrigin,
+			outOfLinePCRanges: ctx.entryRanges,
+			variables:         ctx.variables,
+		}
+		abs.outOfLinePCRanges = append(abs.outOfLinePCRanges, ctx.entryRanges...)
+		abs.inlined = append(abs.inlined, outOfLine)
 	}
 
 	// Append the abstract sub-programs in deterministic order.
-	abstractSubs := iterMapSorted(v.abstractSubprograms, cmp.Compare)
+	var ret []*pendingSubprogram
+	abstractSubs := iterMapSorted(abstractSubprograms, cmp.Compare)
 	for _, abs := range abstractSubs {
 		// Collect abstract variable DIEs in deterministic order.
 		varVars := make([]*dwarf.Entry, 0, len(abs.variables))
@@ -1021,7 +1108,7 @@ func processDwarf(
 				varVars = append(varVars, abs.variables[k])
 			}
 		}
-		pending = append(pending, &pendingSubprogram{
+		ret = append(ret, &pendingSubprogram{
 			unit:              abs.unit,
 			subprogramEntry:   nil,
 			name:              abs.name,
@@ -1031,19 +1118,266 @@ func processDwarf(
 			variables:         varVars,
 			probesCfgs:        abs.probesCfgs,
 			issue:             abs.issue,
-			id:                v.subprogramIDAlloc.next(),
+			id:                idAllocator.next(),
 			abstract:          true,
 		})
 	}
 
-	if v.goRuntimeInformation == (ir.GoModuledataInfo{}) {
-		return processedDwarf{}, fmt.Errorf("runtime.firstmoduledata not found")
+	return ret, nil
+}
+
+// concreteSubprogramContext is a dwarf entry corresponding to a concrete
+// instance of an inlined subprogram, along with a reader positioned at that
+// entry, the corresponding abstractOrigin, and, if the entry corresponds to
+// an inlined instance, the root pc ranges of the out-of-line subprogram that
+// contains it.
+type concreteSubprogramContext struct {
+	abstractOrigin dwarf.Offset
+	entry          *dwarf.Entry
+	entryRanges    []ir.PCRange
+	reader         *dwarf.Reader
+	rootRanges     [][2]uint64 // nil if entry is an out-of-line instance
+	variables      []*dwarf.Entry
+}
+
+func cmpRange(a, b [2]uint64) int { return cmp.Compare(a[0], b[0]) }
+
+// validateNonOverlappingPCRanges checks that sorted PC ranges do not overlap.
+// Returns an error if any ranges overlap.
+func validateNonOverlappingPCRanges(
+	ranges []ir.PCRange, offset dwarf.Offset, context string,
+) error {
+	for i := 1; i < len(ranges); i++ {
+		if ranges[i-1][1] > ranges[i][0] {
+			return fmt.Errorf(
+				"overlapping pc ranges for %s at %#x: [%#x, %#x) and [%#x, %#x)",
+				context, offset,
+				ranges[i-1][0], ranges[i-1][1], ranges[i][0], ranges[i][1],
+			)
+		}
 	}
-	return processedDwarf{
-		pendingSubprograms: pending,
-		goModuledataInfo:   v.goRuntimeInformation,
-		interestingTypes:   v.interestingTypes,
-	}, nil
+	return nil
+}
+
+type inlinedInstanceError struct {
+	abstractOrigin dwarf.Offset
+	concreteOffset dwarf.Offset
+	err            error
+}
+
+func (e *inlinedInstanceError) Error() string {
+	return fmt.Sprintf(
+		"inlined instance error for abstract origin %#x at offset %#x: %v",
+		e.abstractOrigin, e.concreteOffset, e.err,
+	)
+}
+
+// iterConcreteSubprograms yields concrete subprogram contexts for each
+// element of refs.
+//
+// The function incrementally advances through sorted compile units and concrete
+// subprograms (if any), positioning DWARF readers and loading ranges as needed.
+//
+// Parameters must be sorted by offset:
+//   - refs: sorted by offset, then abstractOrigin
+//   - units: sorted by offset
+//   - concreteSubprograms: sorted by offset (or nil to skip range tracking)
+func iterConcreteSubprograms(
+	d *dwarf.Data,
+	refs []concreteSubprogramRef,
+	units []dwarf.Offset,
+	concreteSubprograms []dwarf.Offset,
+) iter.Seq2[concreteSubprogramContext, error] {
+	var (
+		unitIdx               int
+		concreteSubprogramIdx int
+		currentSubprogram     struct {
+			offset dwarf.Offset
+			entry  *dwarf.Entry
+			ranges [][2]uint64
+		}
+		reader          *dwarf.Reader
+		variableVisitor concreteSubprogramVariableCollector
+	)
+
+	trackConcreteSubprograms := len(concreteSubprograms) > 0
+	if trackConcreteSubprograms {
+		currentSubprogram.offset = concreteSubprograms[0]
+	}
+
+	maybeAdvanceUnitAndReader := func(refOffset dwarf.Offset) error {
+		if reader != nil &&
+			(unitIdx+1 >= len(units) || units[unitIdx+1] > refOffset) {
+			return nil // no advancement needed
+		}
+		found, _ := slices.BinarySearch(units[unitIdx:], refOffset)
+		if found == 0 {
+			return fmt.Errorf("ref %#x precedes first unit", refOffset)
+		}
+		unitIdx += found - 1
+		reader = d.Reader()
+		reader.Seek(units[unitIdx])
+		if _, err := reader.Next(); err != nil {
+			return fmt.Errorf("failed to get next entry: %w", err)
+		}
+		return nil
+	}
+
+	maybeAdvanceRootRanges := func(refOffset dwarf.Offset) error {
+		if !trackConcreteSubprograms {
+			return nil
+		}
+
+		if concreteSubprogramIdx+1 < len(concreteSubprograms) &&
+			concreteSubprograms[concreteSubprogramIdx+1] <= refOffset {
+			found, _ := slices.BinarySearch(
+				concreteSubprograms[concreteSubprogramIdx:], refOffset,
+			)
+			if found == 0 {
+				return fmt.Errorf(
+					"ref %#x precedes first concrete subprogram",
+					refOffset,
+				)
+			}
+			concreteSubprogramIdx += found - 1
+			currentSubprogram.offset = concreteSubprograms[concreteSubprogramIdx]
+			currentSubprogram.entry = nil
+			currentSubprogram.ranges = nil
+		}
+
+		if currentSubprogram.entry == nil {
+			reader.Seek(currentSubprogram.offset)
+			var err error
+			currentSubprogram.entry, err = reader.Next()
+			if err != nil {
+				return fmt.Errorf(
+					"failed to get next concrete subprogram entry: %w",
+					err,
+				)
+			}
+			if currentSubprogram.ranges, err = d.Ranges(
+				currentSubprogram.entry,
+			); err != nil {
+				return fmt.Errorf(
+					"failed to get ranges for concrete subprogram entry: %w",
+					err,
+				)
+			}
+			if len(currentSubprogram.ranges) == 0 {
+				return fmt.Errorf("no ranges for concrete subprogram entry")
+			}
+
+			slices.SortFunc(currentSubprogram.ranges, cmpRange)
+			if err := validateNonOverlappingPCRanges(
+				currentSubprogram.ranges,
+				currentSubprogram.offset,
+				"concrete subprogram",
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return func(yield func(concreteSubprogramContext, error) bool) {
+		for _, ref := range refs {
+			if err := maybeAdvanceUnitAndReader(ref.offset); err != nil {
+				yield(concreteSubprogramContext{}, err)
+				return
+			}
+			if err := maybeAdvanceRootRanges(ref.offset); err != nil {
+				yield(concreteSubprogramContext{}, err)
+				return
+			}
+			reader.Seek(ref.offset)
+			entry, err := reader.Next()
+			if err != nil {
+				yield(concreteSubprogramContext{}, err)
+				return
+			}
+
+			inlinedPCRanges, err := d.Ranges(entry)
+			if err != nil {
+				if !yield(concreteSubprogramContext{}, &inlinedInstanceError{
+					abstractOrigin: ref.abstractOrigin,
+					concreteOffset: ref.offset,
+					err:            err,
+				}) {
+					return
+				}
+				continue
+			}
+			slices.SortFunc(inlinedPCRanges, func(a, b ir.PCRange) int {
+				return cmp.Compare(a[0], b[0])
+			})
+			if err := validateNonOverlappingPCRanges(
+				inlinedPCRanges, entry.Offset, "inlined subroutine",
+			); err != nil {
+				if !yield(concreteSubprogramContext{}, &inlinedInstanceError{
+					abstractOrigin: ref.abstractOrigin,
+					concreteOffset: ref.offset,
+					err:            err,
+				}) {
+					return
+				}
+				continue
+			}
+
+			variableVisitor = concreteSubprogramVariableCollector{me: entry}
+			if err := visitReader(entry, reader, &variableVisitor); err != nil {
+				if !yield(concreteSubprogramContext{}, &inlinedInstanceError{
+					abstractOrigin: ref.abstractOrigin,
+					concreteOffset: ref.offset,
+					err:            err,
+				}) {
+					return
+				}
+				continue
+			}
+			if !yield(concreteSubprogramContext{
+				reader:         reader,
+				rootRanges:     currentSubprogram.ranges,
+				abstractOrigin: ref.abstractOrigin,
+				entry:          entry,
+				entryRanges:    inlinedPCRanges,
+				variables:      variableVisitor.variableEntries,
+			}, nil) {
+				return
+			}
+		}
+	}
+}
+
+// concreteSubprogramVariableCollector is a visitor that collects variable DIEs
+// for a concrete instance of an inlined subprogram.
+type concreteSubprogramVariableCollector struct {
+	me              *dwarf.Entry
+	variableEntries []*dwarf.Entry
+}
+
+func (v *concreteSubprogramVariableCollector) push(
+	entry *dwarf.Entry,
+) (childVisitor visitor, err error) {
+	if entry == v.me {
+		return v, nil
+	}
+	switch entry.Tag {
+	case dwarf.TagFormalParameter, dwarf.TagVariable:
+		v.variableEntries = append(v.variableEntries, entry)
+		return nil, nil
+	case dwarf.TagLexDwarfBlock:
+		return v, nil
+	case dwarf.TagInlinedSubroutine:
+		return nil, nil
+	case dwarf.TagTypedef:
+		return nil, nil
+	default:
+		return v, nil
+	}
+}
+
+func (v *concreteSubprogramVariableCollector) pop(_ *dwarf.Entry, _ visitor) error {
+	return nil
 }
 
 func findUnusedConfigs(
@@ -1118,10 +1452,6 @@ func iterMapSorted[
 			}
 		}
 	}
-}
-
-func cmpEntry(a, b *dwarf.Entry) int {
-	return cmp.Compare(a.Offset, b.Offset)
 }
 
 func completeGoMapType(tc *typeCatalog, t *ir.GoMapType) error {
@@ -1513,6 +1843,21 @@ func populateEventExpressions(
 	return ir.Issue{}
 }
 
+// concreteSubprogramRef is a reference to a concrete instance of an inlined
+// subprogram. It can reference either an inlined instance or an out-of-line
+// instance of the inlined subprogram referenced by the abstract origin.
+type concreteSubprogramRef struct {
+	offset         dwarf.Offset
+	abstractOrigin dwarf.Offset
+}
+
+func (c concreteSubprogramRef) cmpByOffset(b concreteSubprogramRef) int {
+	return cmp.Or(
+		cmp.Compare(c.offset, b.offset),
+		cmp.Compare(c.abstractOrigin, b.abstractOrigin),
+	)
+}
+
 type rootVisitor struct {
 	pointerSize         uint8
 	interests           interests
@@ -1520,10 +1865,37 @@ type rootVisitor struct {
 	subprogramIDAlloc   idAllocator[ir.SubprogramID]
 	subprograms         []*pendingSubprogram
 	abstractSubprograms map[dwarf.Offset]*abstractSubprogram
-	// InlinedSubprograms grouped by the compilation unit entry.
-	inlinedSubprograms map[*dwarf.Entry][]*inlinedSubprogram
-	interestingTypes   []dwarf.Offset
-	typeIndexBuilder   goTypeToOffsetIndexBuilder
+
+	// Unit offsets are used to track the offsets of the top-level compile
+	// units nodes in dwarf.
+	//
+	// This is needed to properly construct DWARF readers in a way that avoids
+	// https://github.com/golang/go/issues/72778 in go 1.24 (where it is still
+	// present).
+	unitOffsets []dwarf.Offset
+
+	// Dwarf offsets of all out-of-line subprograms. These may either be
+	// non-inlined subprograms or out-of-line instances of inlined subprograms.
+	//
+	// This is used to find the root PC ranges for inlined instances of inlined
+	// subprograms.
+	outOfLineSubprogramOffsets []dwarf.Offset
+
+	// All concrete inlined subprogram instances. Note that there can be quite
+	// a large number of these, so we intentionally store just the offsets and
+	// the abstract origin.
+	//
+	// We need to store these because we may not yet have visited the abstract
+	// origin by the time we visit the concrete instance, and without visiting
+	// the abstract origin, we do not know the name, or whether we're interested
+	// in the instance.
+	inlineInstances []concreteSubprogramRef
+	// Similar to inlineInstances, but for out-of-line instances of inlined
+	// subprograms.
+	outOfLineInstances []concreteSubprogramRef
+
+	interestingTypes []dwarf.Offset
+	typeIndexBuilder goTypeToOffsetIndexBuilder
 
 	goRuntimeInformation ir.GoModuledataInfo
 
@@ -1573,6 +1945,7 @@ func (v *rootVisitor) getUnitVisitor(entry *dwarf.Entry) (unitVisitor *unitChild
 			root: v,
 		}
 	}
+	v.unitOffsets = append(v.unitOffsets, entry.Offset)
 	unitVisitor.unit = entry
 	return unitVisitor
 }
@@ -1606,17 +1979,25 @@ func (v *unitChildVisitor) push(
 	// subprograms.
 	switch entry.Tag {
 	case dwarf.TagSubprogram:
+		v.root.outOfLineSubprogramOffsets = append(v.root.outOfLineSubprogramOffsets, entry.Offset)
 		name, ok, err := maybeGetAttr[string](entry, dwarf.AttrName)
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
 			// This is expected to be an out-of-line instance of an abstract program.
-			childVisitor, err = processInlinedSubroutineEntry(v.root, v.unit, true /* outOfLineInstance */, nil, entry)
+			abstractOrigin, err := getAttr[dwarf.Offset](entry, dwarf.AttrAbstractOrigin)
 			if err != nil {
-				return nil, fmt.Errorf("unnamed, non-inline subprogram: %w", err)
+				return nil, fmt.Errorf("failed to get abstract origin for out-of-line instance: %w", err)
 			}
-			return childVisitor, nil
+			v.root.outOfLineInstances = append(v.root.outOfLineInstances, concreteSubprogramRef{
+				offset:         entry.Offset,
+				abstractOrigin: abstractOrigin,
+			})
+
+			return &inlinedSubroutineChildVisitor{
+				root: v.root,
+			}, nil
 		}
 		probesCfgs := v.root.interests.subprograms[name]
 		inline, ok, err := maybeGetAttr[int64](entry, dwarf.AttrInline)
@@ -1641,20 +2022,11 @@ func (v *unitChildVisitor) push(
 			return nil, nil
 		}
 
-		var subprogramPCRanges []ir.PCRange
-		if len(probesCfgs) > 0 {
-			var err error
-			subprogramPCRanges, err = v.root.dwarf.Ranges(entry)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse pc ranges: %w", err)
-			}
-		}
 		return &subprogramChildVisitor{
-			root:                     v.root,
-			subprogramEntry:          entry,
-			unit:                     v.unit,
-			cachedSubprogramPCRanges: subprogramPCRanges,
-			probesCfgs:               probesCfgs,
+			root:            v.root,
+			subprogramEntry: entry,
+			unit:            v.unit,
+			probesCfgs:      probesCfgs,
 		}, nil
 
 	case dwarf.TagUnspecifiedType:
@@ -1841,15 +2213,34 @@ func (v *unitChildVisitor) pop(_ *dwarf.Entry, childVisitor visitor) error {
 			if n, ok, _ := maybeGetAttr[string](t.subprogramEntry, dwarf.AttrName); ok {
 				spName = n
 			}
+			ranges, err := v.root.dwarf.Ranges(t.subprogramEntry)
+			var issue ir.Issue
+			if err != nil {
+				issue = ir.Issue{
+					Kind:    ir.IssueKindInvalidDWARF,
+					Message: err.Error(),
+				}
+			} else {
+				slices.SortFunc(ranges, cmpRange)
+				if err := validateNonOverlappingPCRanges(
+					ranges, t.subprogramEntry.Offset, "subprogram",
+				); err != nil {
+					issue = ir.Issue{
+						Kind:    ir.IssueKindInvalidDWARF,
+						Message: err.Error(),
+					}
+				}
+			}
 			spID := v.root.subprogramIDAlloc.next()
 			v.root.subprograms = append(v.root.subprograms, &pendingSubprogram{
 				unit:              t.unit,
 				subprogramEntry:   t.subprogramEntry,
 				name:              spName,
-				outOfLinePCRanges: t.cachedSubprogramPCRanges,
+				outOfLinePCRanges: ranges,
 				variables:         t.variableEntries,
 				probesCfgs:        t.probesCfgs,
 				id:                spID,
+				issue:             issue,
 			})
 		}
 		return nil
@@ -2379,33 +2770,9 @@ type subprogramChildVisitor struct {
 	root            *rootVisitor
 	unit            *dwarf.Entry
 	subprogramEntry *dwarf.Entry
-	// Cached pc ranges of the subprogram. Calculated on demand from subprogramEntry.
-	cachedSubprogramPCRanges []ir.PCRange
-	probesCfgs               []ir.ProbeDefinition
+	probesCfgs      []ir.ProbeDefinition
 	// Discovery: collect variable DIEs for later materialization.
 	variableEntries []*dwarf.Entry
-}
-
-func (v *subprogramChildVisitor) subprogramPCRanges() ([]ir.PCRange, error) {
-	if v.cachedSubprogramPCRanges != nil {
-		return v.cachedSubprogramPCRanges, nil
-	}
-	ranges, err := v.root.dwarf.Ranges(v.subprogramEntry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse pc ranges: %w", err)
-	}
-	slices.SortFunc(ranges, func(a, b ir.PCRange) int {
-		return cmp.Compare(a[0], b[0])
-	})
-	for i := 1; i < len(ranges); i++ {
-		if ranges[i-1][1] > ranges[i][0] {
-			return nil, fmt.Errorf("overlapping pc ranges for subprogram at 0x%x: [0x%x, 0x%x) and [0x%x, 0x%x)",
-				v.subprogramEntry.Offset,
-				ranges[i-1][0], ranges[i-1][1], ranges[i][0], ranges[i][1])
-		}
-	}
-	v.cachedSubprogramPCRanges = ranges
-	return ranges, nil
 }
 
 func (v *subprogramChildVisitor) push(
@@ -2413,11 +2780,8 @@ func (v *subprogramChildVisitor) push(
 ) (childVisitor visitor, err error) {
 	switch entry.Tag {
 	case dwarf.TagInlinedSubroutine:
-		rootPCRanges, err := v.subprogramPCRanges()
-		if err != nil {
-			return nil, err
-		}
-		return processInlinedSubroutineEntry(v.root, v.unit, false /* outOfLineInstance */, rootPCRanges, entry)
+		v := &inlinedSubroutineChildVisitor{root: v.root}
+		return v.push(entry)
 	case dwarf.TagFormalParameter:
 		fallthrough
 	case dwarf.TagVariable:
@@ -2440,53 +2804,6 @@ func (v *subprogramChildVisitor) push(
 }
 
 func (v *subprogramChildVisitor) pop(_ *dwarf.Entry, _ visitor) error { return nil }
-
-func processInlinedSubroutineEntry(
-	root *rootVisitor,
-	unit *dwarf.Entry,
-	outOfLineInstance bool,
-	rootPCRanges []ir.PCRange,
-	subroutine *dwarf.Entry,
-) (childVisitor visitor, err error) {
-	abstractOrigin, err := getAttr[dwarf.Offset](subroutine, dwarf.AttrAbstractOrigin)
-	if err != nil {
-		return nil, err
-	}
-	ranges, err := root.dwarf.Ranges(subroutine)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse pc ranges %w", err)
-	}
-	slices.SortFunc(ranges, func(a, b ir.PCRange) int {
-		return cmp.Compare(a[0], b[0])
-	})
-	for i := 1; i < len(ranges); i++ {
-		if ranges[i-1][1] > ranges[i][0] {
-			return nil, fmt.Errorf("overlapping pc ranges for inlined subroutine at 0x%x: [0x%x, 0x%x) and [0x%x, 0x%x)",
-				subroutine.Offset,
-				ranges[i-1][0], ranges[i-1][1], ranges[i][0], ranges[i][1])
-		}
-	}
-	sp := &inlinedSubprogram{
-		abstractOrigin: abstractOrigin,
-		rootPCRanges:   rootPCRanges,
-	}
-	if outOfLineInstance {
-		sp.outOfLinePCRanges = ranges
-		rootPCRanges = ranges
-	} else {
-		sp.inlinedPCRanges = ir.InlinePCRanges{
-			Ranges:     ranges,
-			RootRanges: rootPCRanges,
-		}
-	}
-	root.inlinedSubprograms[unit] = append(root.inlinedSubprograms[unit], sp)
-	return &inlinedSubroutineChildVisitor{
-		root:         root,
-		unit:         unit,
-		rootPCRanges: rootPCRanges,
-		sp:           sp,
-	}, nil
-}
 
 func processVariable(
 	unit, entry *dwarf.Entry,
@@ -2544,7 +2861,6 @@ type abstractSubprogram struct {
 	unit       *dwarf.Entry
 	probesCfgs []ir.ProbeDefinition
 	name       string
-	id         ir.SubprogramID
 	// Aggregated ranges from out-of-line and inlined instances.
 	outOfLinePCRanges []ir.PCRange
 	inlinePCRanges    []ir.InlinePCRanges
@@ -2584,15 +2900,11 @@ type inlinedSubprogram struct {
 	// outOfLinePCRanges are set. Otherwise, inlinedPCRanges are set.
 	outOfLinePCRanges []ir.PCRange
 	inlinedPCRanges   ir.InlinePCRanges
-	rootPCRanges      []ir.PCRange
 	variables         []*dwarf.Entry
 }
 
 type inlinedSubroutineChildVisitor struct {
-	root         *rootVisitor
-	unit         *dwarf.Entry
-	rootPCRanges []ir.PCRange
-	sp           *inlinedSubprogram
+	root *rootVisitor
 }
 
 func (v *inlinedSubroutineChildVisitor) push(
@@ -2600,18 +2912,22 @@ func (v *inlinedSubroutineChildVisitor) push(
 ) (childVisitor visitor, err error) {
 	switch entry.Tag {
 	case dwarf.TagInlinedSubroutine:
-		return processInlinedSubroutineEntry(v.root, v.unit, false /* outOfLineInstance */, v.rootPCRanges, entry)
-	case dwarf.TagFormalParameter:
+		abstractOrigin, err := getAttr[dwarf.Offset](entry, dwarf.AttrAbstractOrigin)
+		if err != nil {
+			return nil, err
+		}
+		v.root.inlineInstances = append(v.root.inlineInstances, concreteSubprogramRef{
+			offset:         entry.Offset,
+			abstractOrigin: abstractOrigin,
+		})
 		fallthrough
-	case dwarf.TagVariable:
-		v.sp.variables = append(v.sp.variables, entry)
-		return nil, nil
 	case dwarf.TagLexDwarfBlock:
 		return v, nil
-	case dwarf.TagTypedef:
-		return v, nil
+	case dwarf.TagFormalParameter, dwarf.TagVariable, dwarf.TagTypedef, dwarf.TagLabel:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unexpected tag for inlined subroutine child: %s", entry.Tag)
 	}
-	return nil, fmt.Errorf("unexpected tag for inlined subroutine child: %s", entry.Tag)
 }
 
 func (v *inlinedSubroutineChildVisitor) pop(_ *dwarf.Entry, _ visitor) error {

--- a/pkg/dyninst/irgen/irgen_memory_use_test.go
+++ b/pkg/dyninst/irgen/irgen_memory_use_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package irgen_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime/trace"
+	"strconv"
+	"testing"
+
+	xtrace "golang.org/x/exp/trace"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+const internalEnv = "IRGEN_MEMORY_USE_INTERNAL_TEST"
+const traceOutputEnv = "IRGEN_MEMORY_USE_TRACE_OUTPUT"
+
+// TestIrgenMemoryUse asserts an upper bound on the memory usage of the
+// irgen package to generate an IR program for our sample binary.
+//
+// The way it works is to exec a subprocess that runs with go tracing enabled
+// and has garbage collection set to be extremely aggressive. Then, from this,
+// we can analyze the peak memory usage and assert that it doesn't exceed a
+// certain threshold (determined empirically).
+func TestIrgenMemoryUse(t *testing.T) {
+	dyninsttest.SkipIfKernelNotSupported(t)
+	tmpDir := t.TempDir()
+	traceOutputPath := filepath.Join(tmpDir, "irgen-memory-use-test.trace")
+	env := append(
+		os.Environ(),
+		fmt.Sprintf("%s=true", internalEnv),
+		fmt.Sprintf("%s=%s", traceOutputEnv, traceOutputPath),
+		"--test.run=TestIrgenMemoryUseInternal",
+		"GOGC=1", // aggressive GC, every 1% of memory growth.
+	)
+	cmd := exec.Command(os.Args[0], "--test.run=TestIrgenMemoryUseInternal", "--test.count=1")
+	cmd.Env = env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+	require.FileExists(t, traceOutputPath)
+	f, err := os.Open(traceOutputPath)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	reader, err := xtrace.NewReader(f)
+	require.NoError(t, err)
+	var maxMem uint64
+	const memoryMetricName = "/memory/classes/heap/objects:bytes"
+	for {
+		event, err := reader.ReadEvent()
+		if err != nil {
+			require.ErrorIs(t, err, io.EOF)
+			break
+		}
+		if event.Kind() != xtrace.EventMetric {
+			continue
+		}
+		metric := event.Metric()
+		if metric.Name != memoryMetricName {
+			continue
+		}
+		maxMem = max(maxMem, metric.Value.Uint64())
+	}
+	const maxMemLimit uint64 = 27 * 1024 * 1024 // 27 MiB
+	require.Less(t, maxMem, maxMemLimit,
+		"%s > %s", humanize.IBytes(maxMem), humanize.IBytes(maxMemLimit))
+}
+
+func TestIrgenMemoryUseInternal(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv(internalEnv)); !ok {
+		t.Skip("IRGEN_MEMORY_USE_INTERNAL_TEST is not set")
+	}
+	const prog = "sample"
+	cfg := testprogs.MustGetCommonConfigs(t)[0]
+	binPath := testprogs.MustGetBinary(t, prog, cfg)
+	probes := testprogs.MustGetProbeDefinitions(t, prog)
+
+	traceOutputPath := os.Getenv(traceOutputEnv)
+	require.NotEmpty(t, traceOutputPath)
+	traceOutputDir := filepath.Dir(traceOutputPath)
+	require.DirExists(t, traceOutputDir)
+	traceOutput, err := os.CreateTemp(traceOutputDir, "irgen-memory-use-test-*.trace")
+	traceOutputTmpPath := traceOutput.Name()
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(traceOutputTmpPath) }()
+	trace.Start(traceOutput)
+	diskCache, err := object.NewDiskCache(object.DiskCacheConfig{
+		DirPath:                  t.TempDir(),
+		RequiredDiskSpaceBytes:   10 * 1024 * 1024,  // require 10 MiB free
+		RequiredDiskSpacePercent: 1.0,               // 1% free space
+		MaxTotalBytes:            512 * 1024 * 1024, // 512 MiB max cache size
+	})
+	require.NoError(t, err)
+	irgenOptions := []irgen.Option{
+		irgen.WithOnDiskGoTypeIndexFactory(diskCache),
+		irgen.WithObjectLoader(diskCache),
+	}
+	generator := irgen.NewGenerator(irgenOptions...)
+
+	_, err = generator.GenerateIR(1, binPath, probes)
+	require.NoError(t, err)
+	trace.Stop()
+	require.NoError(t, traceOutput.Close())
+	require.NoError(t, os.Rename(traceOutputTmpPath, traceOutputPath))
+}


### PR DESCRIPTION
### What does this PR do?

Before this change, we stored every parsed concrete instance
of inlined functions and their parsed variables. We generally
weren't interested in most of them, but it was hard to know that
in all cases when we started to parse them.

This changes the approach to instead just create an index over
the concrete instances of inlined functions that takes 1 word
per instance. Then, after we've walked all the dwarf, we can
filter down to the instances we know we care about and then go
and parse their structure.

For the problematic binary we were looking at previously, this
reduces the peak memory usage in the dwarf walking phase from
~900MiB to ~32MiB.

It also speeds up irgen pretty nicely:

```
name                                                      old time/op    new time/op    delta
SnapshotTesting/sample/arch=amd64,toolchain=go1.23.11-14     164ms ± 2%     130ms ± 2%  -20.96%  (p=0.000 n=9+9)
SnapshotTesting/sample/arch=amd64,toolchain=go1.24.3-14      174ms ± 2%     138ms ± 2%  -20.29%  (p=0.000 n=9+10)
SnapshotTesting/sample/arch=amd64,toolchain=go1.25.0-14      186ms ± 2%     138ms ± 2%  -25.79%  (p=0.000 n=8+10)

name                                                      old alloc/op   new alloc/op   delta
SnapshotTesting/sample/arch=amd64,toolchain=go1.23.11-14     109MB ± 0%      88MB ± 0%  -18.78%  (p=0.000 n=10+10)
SnapshotTesting/sample/arch=amd64,toolchain=go1.24.3-14      116MB ± 0%      94MB ± 0%  -18.97%  (p=0.000 n=10+10)
SnapshotTesting/sample/arch=amd64,toolchain=go1.25.0-14      128MB ± 0%      94MB ± 0%  -27.12%  (p=0.000 n=7+10)

name                                                      old allocs/op  new allocs/op  delta
SnapshotTesting/sample/arch=amd64,toolchain=go1.23.11-14     2.53M ± 0%     2.07M ± 0%  -18.31%  (p=0.000 n=9+10)
SnapshotTesting/sample/arch=amd64,toolchain=go1.24.3-14      2.69M ± 0%     2.18M ± 0%  -18.96%  (p=0.000 n=10+10)
SnapshotTesting/sample/arch=amd64,toolchain=go1.25.0-14      2.99M ± 0%     2.15M ± 0%  -28.09%  (p=0.000 n=8+10)
```
#### dyninst/irgen: more eagerly filter inlined instance

We'd expect that on average we see an instance inlined after
we've already examined its abstract origin. If that's the case
then we know definitively whether or not it's actually interesting.

This cuts the memory usage due to these inlined instances by another
factor of around 2.
### Motivation

We've been seeing OOMs on staging from some users and in QA of the current release.

### Describe how you validated your changes

I ran the problematic generation locally and observed a >98% drop in peak heap usage during the relevant stage of processing compared to before this change.

Before:
<img width="2792" height="529" alt="Screenshot from 2025-10-09 01-46-56" src="https://github.com/user-attachments/assets/8a14a7f6-b5da-414f-aad2-083c22641c13" />
After:
<img width="2792" height="529" alt="Screenshot from 2025-10-09 02-29-16" src="https://github.com/user-attachments/assets/fdd803f0-585e-40b8-ac79-da58ce14a1d3" />

I also added an automated test that captures an execution trace of the execution of the code on a test program and asserts the max heap size is bounded.

### Additional Notes
Fixes https://datadoghq.atlassian.net/browse/DEBUG-4561