### PR TITLE
Add an Omnibus builder helper to run commands from the original datadog-agent source root

### DIFF
--- a/omnibus/config/software/bzip2.rb
+++ b/omnibus/config/software/bzip2.rb
@@ -32,8 +32,7 @@ version("1.0.8") { source sha256: "ab5a03176ee106d3f0fa90e381da478ddae405918153c
 source url: "https://fossies.org/linux/misc/#{name}-#{version}.tar.gz"
 
 build do
-  command "bazelisk run -- @bzip2//:install --destdir='#{install_dir}/embedded'", \
-    cwd: "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent"
+  command_on_repo_root "bazelisk run -- @bzip2//:install --destdir='#{install_dir}/embedded'"
 
   # The version of bzip2 we use doesn't create a pkgconfig file,
   # we add it here manually (needed at least by the Python build)

--- a/omnibus/config/software/zlib.rb
+++ b/omnibus/config/software/zlib.rb
@@ -21,6 +21,5 @@ build do
   license "Zlib"
   license_file "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
 
-  command "bazelisk run -- @zlib//:install --destdir='#{install_dir}/embedded'", \
-	cwd: "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent"
+  command_on_repo_root "bazelisk run -- @zlib//:install --destdir='#{install_dir}/embedded'"
 end

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -100,4 +100,15 @@ module Omnibus
     expose :inspect_binary
     expose :sign_file
   end
+
+  # Open the Builder class to allow adding custom DSL methods
+  class Builder
+    #
+    # Runs a command from the root of the datadog-agent repository
+    #
+    def command_on_repo_root(*args, **kwargs)
+      command *args, **kwargs, cwd: File.join(Omnibus::Config.project_root, "..")
+    end
+    expose :command_on_repo_root
+  end
 end


### PR DESCRIPTION
### What does this PR do?

Adds an Omnibus builder helper to have a single way to invoke `command` from the root of the original datadog-agent source.

### Motivation

Avoid repeating the same `cwd: "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent"` everywhere, moving that to a single source of truth.

### Describe how you validated your changes

Build passing should suffice.

### Additional Notes

This may arguably be a bit too "magical" in the sense that it relies on how Ruby classes can be reopened for adding methods to it, in a way that it may make things not as easily discoverable (how the new `command_on_repo_root` DSL method becomes available can be mysterious for people not familiar with both Ruby and Omnibus).

If deemed too magical I'm fine with turning this into a helper that simply returns the repo root such that we can simply add `cwd: repo_root` to those `command`s (💭 and that might also be more reusable, too?).

