### PR TITLE
Retry APM requests on 429s

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -419,7 +419,7 @@ func (s *sender) do(req *http.Request) error {
 
 // isRetriable reports whether the give HTTP status code should be retried.
 func isRetriable(code int) bool {
-	if code == http.StatusRequestTimeout {
+	if code == http.StatusRequestTimeout || code == http.StatusTooManyRequests {
 		return true
 	}
 	// 5xx errors can be retried

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -68,6 +68,7 @@ func TestIsRetriable(t *testing.T) {
 		404: false,
 		408: true,
 		409: false,
+		429: true,
 		500: true,
 		503: true,
 		505: true,

--- a/pkg/trace/writer/testserver_test.go
+++ b/pkg/trace/writer/testserver_test.go
@@ -141,7 +141,7 @@ func TestTestServer(t *testing.T) {
 
 		assert.Equal(6, ts.Total())
 		assert.Equal(2, ts.Accepted())
-		assert.Equal(2, ts.Failed())
-		assert.Equal(2, ts.Retried())
+		assert.Equal(0, ts.Failed())
+		assert.Equal(4, ts.Retried())
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Make 429s (Too Many Requests) retriable.

### Motivation

### Describe how you validated your changes

### Additional Notes
