### PR TITLE
chore(fleet): Remove .installed_by_pkg.txt

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -102,12 +102,6 @@ build do
             command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
             command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
 
-            # The prerm and preinst scripts of the package will use this list to detect which files
-            # have been setup by the installer, this way, on removal, we'll be able to delete only files
-            # which have not been created by the package.
-            command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.installed_by_pkg.txt"
-            command "find . -path './embedded/lib/python*/site-packages/*' >> #{install_dir}/embedded/.installed_by_pkg.txt", cwd: install_dir
-
             # removing the doc from the embedded folder to reduce package size by ~3MB
             delete "#{install_dir}/embedded/share/doc"
 

--- a/pkg/fleet/installer/packages/integrations/integrations.go
+++ b/pkg/fleet/installer/packages/integrations/integrations.go
@@ -114,46 +114,15 @@ func RemoveCustomIntegrations(ctx context.Context, installPath string) (err erro
 	span, _ := telemetry.StartSpanFromContext(ctx, "remove_custom_integrations")
 	defer func() { span.Finish(err) }()
 
-	if _, err := os.Stat(filepath.Join(installPath, "embedded/.installed_by_pkg.txt")); err != nil {
-		if os.IsNotExist(err) {
-			return nil // No-op
-		}
-		return err
-	}
-
-	fmt.Println("Removing integrations installed with the 'agent integration' command")
-
 	// Use an in-memory map to store all integration paths
 	allIntegrations, err := getAllIntegrations(installPath)
 	if err != nil {
 		return err
 	}
 
-	// Read the list of installed files
-	installedByPkg, err := os.ReadFile(filepath.Join(installPath, "embedded", ".installed_by_pkg.txt"))
-	if err != nil {
-		return err
-	}
-
-	// Create a set of paths installed by the package
-	installedByPkgSet := make(map[string]struct{})
-	for _, line := range strings.Split(string(installedByPkg), "\n") {
-		if line != "" {
-			// Make sure the path is absolute so we can compare apples to apples
-			if !filepath.IsAbs(line) && !strings.HasPrefix(line, "#") {
-				line = filepath.Join(installPath, line)
-			}
-			installedByPkgSet[line] = struct{}{}
-		}
-	}
-
-	// Remove paths that are in allIntegrations but not in installedByPkgSet
 	for _, path := range allIntegrations {
-		if _, exists := installedByPkgSet[path]; !exists {
-			// Remove if it was not installed by the package.
-			if err := os.RemoveAll(path); err != nil {
-				return err
-			}
+		if err := os.RemoveAll(path); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/fleet/installer/packages/integrations/integrations_test.go
+++ b/pkg/fleet/installer/packages/integrations/integrations_test.go
@@ -62,21 +62,6 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		f.Close()
 	}
 
-	installedByPkgPath := filepath.Join(dir, "embedded", ".installed_by_pkg.txt")
-	content := `# DO NOT REMOVE/MODIFY - used by package removal tasks
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt
-./embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json
-`
-	if err := os.WriteFile(installedByPkgPath, []byte(content), 0644); err != nil {
-		t.Fatalf("failed to create .installed_by_pkg.txt: %v", err)
-	}
-
 	if err := RemoveCustomIntegrations(context.TODO(), dir); err != nil {
 		t.Fatalf("RemoveCustomIntegrations failed: %v", err)
 	}
@@ -90,18 +75,9 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/WHEEL",
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/entry_points.txt",
 		"embedded/lib/python3.12/site-packages/botocore-1.38.8.dist-info/direct_url.json",
-		// In the .installed_by_pkg.txt
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt",
-		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json",
 	}
 
 	removed := []string{
-		// Not in the .installed_by_pkg.txt
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/INSTALLER",
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/METADATA",
 		"embedded/lib/python3.12/site-packages/datadog_redisdb-5.0.0.dist-info/RECORD",
@@ -113,6 +89,13 @@ func TestRemoveCustomIntegrations(t *testing.T) {
 		"embedded/lib/python3.8/site-packages/datadog_checks/__pycache__/errors.cpython-312.pyc",
 		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/__init__.cpython-312.pyc",
 		"embedded/lib/python3.8/site-packages/datadog_checks/base/__pycache__/agent.cpython-312.pyc",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/INSTALLER",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/METADATA",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/RECORD",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/REQUESTED",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/WHEEL",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/entry_points.txt",
+		"embedded/lib/python3.12/site-packages/datadog_activemq-5.0.0.dist-info/direct_url.json",
 	}
 
 	for _, relPath := range removed {


### PR DESCRIPTION
### What does this PR do?
Removes unused `.installed_by_pkg.txt` file, which is ~1MB. Files written into it will be removed by the package manager anyway.

### Motivation
Size offset for https://github.com/DataDog/datadog-agent/pull/41312

### Describe how you validated your changes

### Additional Notes
