### PR TITLE
[CWS] make the security agent aware of the direct sender mode

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1083,6 +1083,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", true)
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
+	config.BindEnvAndSetDefault("runtime_security_config.direct_send_from_system_probe", false)
 
 	// trace-agent's evp_proxy
 	config.BindEnv("evp_proxy_config.enabled")              //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'

--- a/pkg/security/agent/start.go
+++ b/pkg/security/agent/start.go
@@ -23,9 +23,13 @@ import (
 
 // StartRuntimeSecurity starts runtime security
 func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, compression compression.Component) (*RuntimeSecurityAgent, error) {
-	enabled := config.GetBool("runtime_security_config.enabled")
-	if !enabled {
+	if !config.GetBool("runtime_security_config.enabled") {
 		log.Info("Datadog runtime security agent disabled by config")
+		return nil, nil
+	}
+
+	if config.GetBool("runtime_security_config.direct_send_from_system_probe") {
+		log.Info("Datadog runtime security agent disabled because CWS is running in full system-probe mode")
 		return nil, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

In single container mode we suggest customers to use the following command
```
docker run -e DD_RUNTIME_SECURITY_CONFIG_ENABLED=true [...] datadog/agent
```

with this command, the enablement of CWS (runtime security) is going to be forwarded to both the security agent and the system-probe and thus enable the CWS part in the security agent.

The goal of this PR is to allow:
```
docker run -e DD_RUNTIME_SECURITY_CONFIG_ENABLED=true -e DD_RUNTIME_SECURITY_CONFIG_DIRECT_SEND_FROM_SYSTEM_PROBE=true [...] datadog/agent
```

to correctly configure:
- the system-probe sending data directly to the backend (this exists today already)
- the security agent to not enable the CWS part, and if CSPM is disabled to shut down directly

### Motivation

### Describe how you validated your changes

### Additional Notes
