### PR TITLE
feat(dda): Pin local action to hash

### DIFF
--- a/.github/workflows/add_reviewer_bot_pr.yml
+++ b/.github/workflows/add_reviewer_bot_pr.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/assess_permissions.yml
+++ b/.github/workflows/assess_permissions.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks legacy-github
 
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks legacy-github
 

--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -68,7 +68,7 @@ jobs:
           go-version: ${{ inputs.go_version }}
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/chase_for_qa_cards.yml
+++ b/.github/workflows/chase_for_qa_cards.yml
@@ -22,7 +22,7 @@ jobs:
         ref: ${{ github.head_ref }}
         persist-credentials: false
     - name: Install dda
-      uses: ./.github/actions/install-dda
+      uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
       with:
         features: legacy-tasks legacy-github legacy-release
     - name: Chase for QA cards

--- a/.github/workflows/chase_release_managers.yml
+++ b/.github/workflows/chase_release_managers.yml
@@ -22,7 +22,7 @@ jobs:
         ref: ${{ github.head_ref }}
         persist-credentials: false
     - name: Install dda
-      uses: ./.github/actions/install-dda
+      uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
       with:
         features: legacy-tasks
     - name: Chase release managers

--- a/.github/workflows/code_review_complexity.yml
+++ b/.github/workflows/code_review_complexity.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Check code review complexity

--- a/.github/workflows/collector-generate-and-update.yml
+++ b/.github/workflows/collector-generate-and-update.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: .go-version
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 
@@ -88,7 +88,7 @@ jobs:
           token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/create_release_schedule.yml
+++ b/.github/workflows/create_release_schedule.yml
@@ -27,7 +27,7 @@ jobs:
         ref: ${{ github.head_ref }}
         persist-credentials: false
     - name: Install dda
-      uses: ./.github/actions/install-dda
+      uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
       with:
         features: legacy-tasks
     - name: Create release schedule

--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -61,7 +61,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 
@@ -104,7 +104,7 @@ jobs:
           ref: ${{ inputs.base_branch || 'main' }}
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install dda
-      uses: ./.github/actions/install-dda
+      uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
       with:
         features: legacy-tasks
 

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Set label on external contributor PRs

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: ".go-version"
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Go mod tidy

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Auto assign team label
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Check release note
@@ -99,7 +99,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Check qa/[done|no-code-change] labels are not set together
@@ -117,7 +117,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Check agent telemetry metric list
@@ -132,7 +132,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Ask for code reviews

--- a/.github/workflows/report-merged-pr.yml
+++ b/.github/workflows/report-merged-pr.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
 

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
 
     - name: Install dda
-      uses: ./.github/actions/install-dda
+      uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
       with:
         features: legacy-tasks
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           go-version-file: ".go-version"
       - name: Install dda
-        uses: ./.github/actions/install-dda
+        uses: DataDog/datadog-agent/.github/actions/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1
         with:
           features: legacy-tasks
       - name: Update every golang.org/x/... package

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -67,7 +67,7 @@ arch=$(/usr/bin/uname -m)
 curl_retries=(--retry 2)
 
 # Cleanup tmp files used for installation
-rm -f /tmp/install-ddagent/system-wide
+rm -f /tmp/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1gent/system-wide
 
 function find_latest_patch_version_for() {
     major_minor="$1"
@@ -142,8 +142,8 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
 fi
 
 if [ "$systemdaemon_install" != false ]; then
-  mkdir -p /tmp/install-ddagent
-  touch /tmp/install-ddagent/system-wide
+  mkdir -p /tmp/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1gent
+  touch /tmp/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1gent/system-wide
 fi
 
 macos_full_version=$(sw_vers -productVersion)

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -107,7 +107,7 @@ if [ ! -e "$CONF_DIR/datadog.yaml" ]; then
 fi
 
 # Start the tray icon app only when not in system-wide installation
-if [ ! -f "/tmp/install-ddagent/system-wide" ]; then
+if [ ! -f "/tmp/install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1gent/system-wide" ]; then
   # Create the tray icon app launchctl service
   sudo -Hu "$INSTALL_USER" cp -vf "$CONF_DIR/com.datadoghq.gui.plist.example" "$USER_HOME/Library/LaunchAgents/com.datadoghq.gui.plist"
   sudo -Hu "$INSTALL_USER" launchctl load -w "$USER_HOME/Library/LaunchAgents/com.datadoghq.agent.plist"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1461,7 +1461,7 @@ def get_kmt_or_alien_stack(ctx, stack, vms, alien_vms):
         "verbose": "Enable full output of all commands executed",
         "arch": "Architecture to build the system-probe for",
         "layout": "Path to file specifying the expected layout on the target VMs",
-        "override_agent": "Assume that the datadog-agent has been installed with `kmt.install-ddagent`, and replace the system-probe binary in its package with a local build. This also overrides the configuration files as defined in tasks/kernel-matrix-testing/build-layout.json",
+        "override_agent": "Assume that the datadog-agent has been installed with `kmt.install-dda@efcd8852af4c4797b065f0653bdfd4852d2144c1gent`, and replace the system-probe binary in its package with a local build. This also overrides the configuration files as defined in tasks/kernel-matrix-testing/build-layout.json",
     }
 )
 def build(


### PR DESCRIPTION
### What does this PR do?
Pin the local `install-dda` action to a hash from main

### Motivation
Enable the `force actions pinned by hash` in the github repository configuration
<img width="454" height="61" alt="image" src="https://github.com/user-attachments/assets/865fef6d-0c74-4dee-aab0-1326c67f4b98" />
This is currently [not possible](https://github.com/DataDog/datadog-agent/actions/runs/18348157083) because this internal action is not pinned

### Describe how you validated your changes
Waiting for the CI to pass

### Additional Notes
