### PR TITLE
Update the pr-commenter task to delete when force-delete is set

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -336,6 +336,9 @@ def pr_commenter(
         with open(body_file) as f:
             body = f.read()
 
+    if force_delete:
+        delete = True
+
     if not body and not delete:
         return
 


### PR DESCRIPTION
### What does this PR do?
Update the pr-commenter task to delete when force-delete is set.

### Motivation
The package-deps-diff job uses the `--force-delete` flag without the `--delete` flag, which results in silently not deleting the comment. 
