### PR TITLE
[EBPF] gpu: add logging limiter and telemetry to nvml refresh errors

### DIFF
--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -10,9 +10,12 @@ package safenvml
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var logLimiter = log.NewLogLimit(20, 10*time.Minute)
 
 // DeviceCache is a cache of GPU devices, with some methods to easily access devices by UUID or index
 type DeviceCache interface {
@@ -81,7 +84,9 @@ func (c *deviceCache) Refresh() error {
 	if lib == nil {
 		var err error
 		if lib, err = GetSafeNvmlLib(); err != nil {
-			log.Warnf("error getting NVML library: %v", err)
+			if logLimiter.ShouldLog() {
+				log.Warnf("error getting NVML library: %v", err)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a log limiter to a log that was spamming a lot in staging when failing to get NVML devices. To handle this case, which ultimately gets propagated to the consumer event handling, we've added an error type to the event error telemetry we already had.

### Motivation

Reduce log noise, improve monitoring.

### Describe how you validated your changes

CI passing.

### Additional Notes
