### PR TITLE
usm: http: Use correct clock for incomplete transaction timeout

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 )
@@ -113,12 +114,16 @@ func (b *incompleteBuffer) Add(tx Transaction) {
 	}
 }
 
-func (b *incompleteBuffer) Flush(now time.Time) []Transaction {
+func (b *incompleteBuffer) Flush(time.Time) []Transaction {
 	var (
 		joined   []Transaction
 		previous = b.data
-		nowUnix  = now.UnixNano()
 	)
+
+	nowUnix, err := ebpf.NowNanoseconds()
+	if err != nil {
+		nowUnix = 0
+	}
 
 	b.data = make(map[types.ConnectionKey]*txParts)
 	for key, parts := range previous {


### PR DESCRIPTION
## Summary
- Fix incomplete HTTP transaction timeout to use monotonic clock instead of wall clock
- Changes `incompleteBuffer.Flush()` to use `ebpf.NowNanoseconds()` (monotonic CLOCK_MONOTONIC) instead of `time.Time` parameter (wall clock)
- Ensures consistent timeout behavior unaffected by system time changes

## Test plan

Load test
* [plain http](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=pr-41790-http-haproxy-base&tpl_var_client-service%5B0%5D=golang-k6-client-http&tpl_var_compare_agent-env%5B0%5D=pr-41790-http-haproxy-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm2&tpl_var_server-service%5B0%5D=golang-httpbin&from_ts=1760107735740&to_ts=1760185134582&live=false)
* [openssl http](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=pr-41790-http-openssl-base&tpl_var_client-service%5B0%5D=python-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=pr-41790-http-openssl-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm3&tpl_var_server-service%5B0%5D=python-httpbin-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1760107735740&to_ts=1760185134582&live=false)
* [go tls http](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=false&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=pr-41790-http-go-tls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=pr-41790-http-go-tls-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm3&tpl_var_server-service%5B0%5D=golang-httpbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1760107735740&to_ts=1760185134582&live=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)