### PR TITLE
Clean config setup interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16241,7 +16241,7 @@ New Features
   only updates when containers start/die to save resources
 
 - Add a new option, `force_tls_12`, to the agent configuration to force the
-  TLS version to 1.2 when contactin Datatog.
+  TLS version to 1.2 when contactin Datadog.
 
 - Reno and releasenotes are now mandatory. A test will fail if no
   releasenotes where added/updated to the PR. A 'noreno' label can be added

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -37,7 +37,7 @@ func CheckAndUpgradeConfig() error {
 	}
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.AddConfigPath(defaultpaths.ConfPath)
-	_, err := pkgconfigsetup.LoadWithSecret(ddcfg, secretsnoop.NewComponent().Comp, nil)
+	_, err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil)
 	if err == nil {
 		// was able to read config, check for api key
 		if ddcfg.GetString("api_key") != "" {

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -37,7 +37,7 @@ func CheckAndUpgradeConfig() error {
 	}
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.AddConfigPath(defaultpaths.ConfPath)
-	_, err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil)
+	err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil)
 	if err == nil {
 		// was able to read config, check for api key
 		if ddcfg.GetString("api_key") != "" {

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -56,7 +56,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	cfg := pkgconfigsetup.GlobalConfigBuilder()
 
 	cfg.AddConfigPath(newConfigDir)
-	_, err = pkgconfigsetup.LoadDatatog(cfg, secretsnoop.NewComponent().Comp, nil)
+	err = pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -56,7 +56,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	cfg := pkgconfigsetup.GlobalConfigBuilder()
 
 	cfg.AddConfigPath(newConfigDir)
-	_, err = pkgconfigsetup.LoadWithSecret(cfg, secretsnoop.NewComponent().Comp, nil)
+	_, err = pkgconfigsetup.LoadDatatog(cfg, secretsnoop.NewComponent().Comp, nil)
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/loader/main_nix.go
+++ b/cmd/loader/main_nix.go
@@ -40,7 +40,7 @@ import (
 func main() {
 	cfg := pkgconfigsetup.GlobalConfigBuilder()
 	cfg.SetConfigFile(os.Args[1])
-	_, err := pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
+	err := pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
 	if err != nil {
 		log.Warnf("Failed to load the configuration: %v", err)
 		execOrExit(os.Environ())

--- a/cmd/loader/main_nix.go
+++ b/cmd/loader/main_nix.go
@@ -40,7 +40,7 @@ import (
 func main() {
 	cfg := pkgconfigsetup.GlobalConfigBuilder()
 	cfg.SetConfigFile(os.Args[1])
-	_, err := pkgconfigsetup.LoadDatadogCustom(cfg, "datadog.yaml", secretsnoop.NewComponent().Comp, nil)
+	_, err := pkgconfigsetup.LoadDatadog(cfg, secretsnoop.NewComponent().Comp, nil)
 	if err != nil {
 		log.Warnf("Failed to load the configuration: %v", err)
 		execOrExit(os.Environ())

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -117,7 +117,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 			pkgconfig.SetConfigFile(ddCfg)
 		}
 
-		_, err = pkgconfigsetup.LoadDatadog(pkgconfig, secretsnoop.NewComponent().Comp, nil)
+		err = pkgconfigsetup.LoadDatadog(pkgconfig, secretsnoop.NewComponent().Comp, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -117,7 +117,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 			pkgconfig.SetConfigFile(ddCfg)
 		}
 
-		_, err = pkgconfigsetup.LoadWithSecret(pkgconfig, secretsnoop.NewComponent().Comp, nil)
+		_, err = pkgconfigsetup.LoadDatadog(pkgconfig, secretsnoop.NewComponent().Comp, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -141,7 +141,7 @@ func setup(secretComp secrets.Component, _ mode.Conf, tagger tagger.Component, c
 
 	// The datadog-agent requires Load to be called or it could
 	// panic down the line.
-	_, err := pkgconfigsetup.LoadWithSecret(pkgconfigsetup.Datadog(), secretComp, nil)
+	_, err := pkgconfigsetup.LoadDatadog(pkgconfigsetup.Datadog(), secretComp, nil)
 	if err != nil {
 		log.Debugf("Error loading config: %v\n", err)
 	}

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -141,7 +141,7 @@ func setup(secretComp secrets.Component, _ mode.Conf, tagger tagger.Component, c
 
 	// The datadog-agent requires Load to be called or it could
 	// panic down the line.
-	_, err := pkgconfigsetup.LoadDatadog(pkgconfigsetup.Datadog(), secretComp, nil)
+	err := pkgconfigsetup.LoadDatadog(pkgconfigsetup.Datadog(), secretComp, nil)
 	if err != nil {
 		log.Debugf("Error loading config: %v\n", err)
 	}

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -402,7 +402,7 @@ func loadConfig(secretComp secrets.Component) {
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.SetConfigFile(datadogConfigPath)
 	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
-	if _, err := pkgconfigsetup.LoadDatadog(ddcfg, secretComp, nil); err != nil {
+	if err := pkgconfigsetup.LoadDatadog(ddcfg, secretComp, nil); err != nil {
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -402,7 +402,7 @@ func loadConfig(secretComp secrets.Component) {
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.SetConfigFile(datadogConfigPath)
 	// Load datadog.yaml file into the config, so that metricAgent can pick these configurations
-	if _, err := pkgconfigsetup.LoadWithSecret(ddcfg, secretComp, nil); err != nil {
+	if _, err := pkgconfigsetup.LoadDatadog(ddcfg, secretComp, nil); err != nil {
 		log.Errorf("Error happened when loading configuration from datadog.yaml for metric agent: %s", err)
 	}
 }

--- a/comp/core/config/config.go
+++ b/comp/core/config/config.go
@@ -72,13 +72,11 @@ func newComponent(deps dependencies) (provides, error) {
 
 func newConfig(deps dependencies) (*cfg, error) {
 	config := pkgconfigsetup.GlobalConfigBuilder()
+	warnings := &pkgconfigmodel.Warnings{}
 
-	warnings, err := setupConfig(config, deps.Secret, deps.Params)
+	err := setupConfig(config, deps.Secret, deps.Params)
 	returnErrFct := func(e error) (*cfg, error) {
 		if e != nil && deps.Params.ignoreErrors {
-			if warnings == nil {
-				warnings = &pkgconfigmodel.Warnings{}
-			}
 			warnings.Errors = []error{e}
 			e = nil
 		}

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -19,7 +19,7 @@ import (
 )
 
 // setupConfig loads additional configuration data from yaml files, fleet policies, and command-line options
-func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Component, p Params) (*pkgconfigmodel.Warnings, error) {
+func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Component, p Params) error {
 	confFilePath := p.ConfFilePath
 	configName := p.configName
 	defaultConfPath := p.defaultConfPath
@@ -44,11 +44,11 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 
 	// load extra config file paths
 	if err := config.AddExtraConfigPaths(p.ExtraConfFilePath); err != nil {
-		return nil, err
+		return err
 	}
 
 	// load the configuration
-	warnings, err := pkgconfigsetup.LoadDatatog(config, secretComp, pkgconfigsetup.SystemProbe().GetEnvVars())
+	err := pkgconfigsetup.LoadDatadog(config, secretComp, pkgconfigsetup.SystemProbe().GetEnvVars())
 
 	if err != nil && (!errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) || confFilePath != "") {
 		// special-case permission-denied with a clearer error message
@@ -61,7 +61,7 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 		} else {
 			err = fmt.Errorf("unable to load Datadog config file: %w", err)
 		}
-		return warnings, err
+		return err
 	}
 
 	// Load the remote configuration
@@ -72,12 +72,12 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 		// Main config file
 		err := config.MergeFleetPolicy(path.Join(p.FleetPoliciesDirPath, "datadog.yaml"))
 		if err != nil {
-			return warnings, err
+			return err
 		}
 		if p.configLoadSecurityAgent {
 			err := config.MergeFleetPolicy(path.Join(p.FleetPoliciesDirPath, "security-agent.yaml"))
 			if err != nil {
-				return warnings, err
+				return err
 			}
 		}
 	}
@@ -86,5 +86,5 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 		config.Set(k, v, pkgconfigmodel.SourceCLI)
 	}
 
-	return warnings, nil
+	return nil
 }

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -48,7 +48,7 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, secretComp secrets.Compo
 	}
 
 	// load the configuration
-	warnings, err := pkgconfigsetup.LoadWithSecret(config, secretComp, pkgconfigsetup.SystemProbe().GetEnvVars())
+	warnings, err := pkgconfigsetup.LoadDatatog(config, secretComp, pkgconfigsetup.SystemProbe().GetEnvVars())
 
 	if err != nil && (!errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) || confFilePath != "") {
 		// special-case permission-denied with a clearer error message

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2213,7 +2213,7 @@ func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component,
 		pkgconfigmodel.ApplyOverrideFuncs(config)
 	}()
 
-	err := loadCustom(config, additionalKnownEnvVars)
+	err := loadCustom(config, additionalEnvVars)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			return log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2017,11 +2017,6 @@ func LoadProxyFromEnv(config pkgconfigmodel.ReaderWriter) {
 	}
 }
 
-// LoadWithSecret reads config files and initializes config with decrypted secrets
-func LoadWithSecret(config pkgconfigmodel.Config, secretResolver secrets.Component, additionalEnvVars []string) (*pkgconfigmodel.Warnings, error) {
-	return LoadDatadogCustom(config, "datadog.yaml", secretResolver, additionalEnvVars)
-}
-
 // Merge will merge additional configuration into an existing configuration
 func Merge(configPaths []string, config pkgconfigmodel.Config) error {
 	for _, configPath := range configPaths {
@@ -2207,8 +2202,8 @@ func checkConflictingOptions(config pkgconfigmodel.Config) error {
 	return nil
 }
 
-// LoadDatadogCustom loads the datadog config in the given config
-func LoadDatadogCustom(config pkgconfigmodel.Config, origin string, secretResolver secrets.Component, additionalKnownEnvVars []string) (*pkgconfigmodel.Warnings, error) {
+// LoadDatadog reads config files and initializes config with decrypted secrets
+func LoadDatadog(config pkgconfigmodel.Config, secretResolver secrets.Component, additionalEnvVars []string) (*pkgconfigmodel.Warnings, error) {
 	// Feature detection running in a defer func as it always  need to run (whether config load has been successful or not)
 	// Because some Agents (e.g. trace-agent) will run even if config file does not exist
 	defer func() {
@@ -2230,7 +2225,7 @@ func LoadDatadogCustom(config pkgconfigmodel.Config, origin string, secretResolv
 	// We resolve proxy setting before secrets. This allows setting secrets through DD_PROXY_* env variables
 	LoadProxyFromEnv(config)
 
-	if err := ResolveSecrets(config, secretResolver, origin); err != nil {
+	if err := ResolveSecrets(config, secretResolver, "datadog.yaml"); err != nil {
 		return warnings, err
 	}
 

--- a/pkg/config/setup/config_secret_test.go
+++ b/pkg/config/setup/config_secret_test.go
@@ -159,7 +159,7 @@ func TestProxyWithSecret(t *testing.T) {
 				c.setup(t, config, configPath, resolver)
 			}
 
-			_, err := LoadDatadogCustom(config, "unit_test", resolver, nil)
+			_, err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)

--- a/pkg/config/setup/config_secret_test.go
+++ b/pkg/config/setup/config_secret_test.go
@@ -159,7 +159,7 @@ func TestProxyWithSecret(t *testing.T) {
 				c.setup(t, config, configPath, resolver)
 			}
 
-			_, err := LoadDatadog(config, resolver, nil)
+			err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1197,7 +1197,7 @@ func TestConfigAssignAtPath(t *testing.T) {
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
 
-	err := LoadCustom(config, nil)
+	err := loadCustom(config, nil)
 	assert.NoError(t, err)
 
 	err = configAssignAtPath(config, []string{"secret_backend_command"}, "different")
@@ -1282,7 +1282,7 @@ func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
 
-	err := LoadCustom(config, nil)
+	err := loadCustom(config, nil)
 	assert.NoError(t, err)
 
 	err = configAssignAtPath(config, []string{"secret_backend_command"}, "different")
@@ -1327,7 +1327,7 @@ func TestConfigAssignAtPathSimple(t *testing.T) {
 	os.WriteFile(configPath, testSimpleConf, 0o600)
 	config.SetConfigFile(configPath)
 
-	err := LoadCustom(config, nil)
+	err := loadCustom(config, nil)
 	assert.NoError(t, err)
 
 	err = configAssignAtPath(config, []string{"secret_backend_arguments", "0"}, "password1")
@@ -1383,7 +1383,7 @@ use_proxy_for_cloud_metadata: true
 		"diff_url": "second_value",
 	})
 
-	err := LoadCustom(config, nil)
+	err := loadCustom(config, nil)
 	assert.NoError(t, err)
 
 	err = ResolveSecrets(config, resolver, "unit_test")
@@ -1431,7 +1431,7 @@ additional_endpoints:
 	os.WriteFile(configPath, testIntKeysConf, 0o600)
 	config.SetConfigFile(configPath)
 
-	err := LoadCustom(config, nil)
+	err := loadCustom(config, nil)
 	assert.NoError(t, err)
 
 	err = configAssignAtPath(config, []string{"additional_endpoints", "2"}, "cherry")

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -473,7 +473,7 @@ func TestProxy(t *testing.T) {
 				c.setup(t, config)
 			}
 
-			_, err := LoadDatadog(config, resolver, nil)
+			err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)
@@ -584,7 +584,7 @@ func TestDatabaseMonitoringAurora(t *testing.T) {
 				c.setup(t, config)
 			}
 
-			_, err := LoadDatadog(config, resolver, nil)
+			err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)
@@ -1553,7 +1553,7 @@ flare_stripped_keys:
 	require.NoError(t, err)
 	cfg.SetConfigFile(configPath)
 
-	_, err = LoadDatadog(cfg, secretsmock.New(t), []string{})
+	err = LoadDatadog(cfg, secretsmock.New(t), []string{})
 	require.NoError(t, err)
 
 	stringToScrub := `api_key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -473,7 +473,7 @@ func TestProxy(t *testing.T) {
 				c.setup(t, config)
 			}
 
-			_, err := LoadDatadogCustom(config, "unit_test", resolver, nil)
+			_, err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)
@@ -584,7 +584,7 @@ func TestDatabaseMonitoringAurora(t *testing.T) {
 				c.setup(t, config)
 			}
 
-			_, err := LoadDatadogCustom(config, "unit_test", resolver, nil)
+			_, err := LoadDatadog(config, resolver, nil)
 			require.NoError(t, err)
 
 			c.tests(t, config)
@@ -1116,7 +1116,7 @@ func TestProxyLoadedFromEnvVars(t *testing.T) {
 	t.Setenv("DD_PROXY_HTTP", proxyHTTP)
 	t.Setenv("DD_PROXY_HTTPS", proxyHTTPS)
 
-	LoadWithSecret(conf, secretsmock.New(t), []string{})
+	LoadDatadog(conf, secretsmock.New(t), []string{})
 
 	proxyHTTPConfig := conf.GetString("proxy.http")
 	proxyHTTPSConfig := conf.GetString("proxy.https")
@@ -1136,7 +1136,7 @@ func TestProxyLoadedFromConfigFile(t *testing.T) {
 	os.WriteFile(configTest, []byte("proxy:\n  http: \"http://localhost:1234\"\n  https: \"https://localhost:1234\""), 0o644)
 
 	conf.AddConfigPath(tempDir)
-	LoadWithSecret(conf, secretsmock.New(t), []string{})
+	LoadDatadog(conf, secretsmock.New(t), []string{})
 
 	proxyHTTPConfig := conf.GetString("proxy.http")
 	proxyHTTPSConfig := conf.GetString("proxy.https")
@@ -1159,7 +1159,7 @@ func TestProxyLoadedFromConfigFileAndEnvVars(t *testing.T) {
 	os.WriteFile(configTest, []byte("proxy:\n  http: \"http://localhost:5678\"\n  https: \"http://localhost:5678\""), 0o644)
 
 	conf.AddConfigPath(tempDir)
-	LoadWithSecret(conf, secretsmock.New(t), []string{})
+	LoadDatadog(conf, secretsmock.New(t), []string{})
 
 	proxyHTTPConfig := conf.GetString("proxy.http")
 	proxyHTTPSConfig := conf.GetString("proxy.https")
@@ -1553,7 +1553,7 @@ flare_stripped_keys:
 	require.NoError(t, err)
 	cfg.SetConfigFile(configPath)
 
-	_, err = LoadDatadogCustom(cfg, "test", secretsmock.New(t), []string{})
+	_, err = LoadDatadog(cfg, secretsmock.New(t), []string{})
 	require.NoError(t, err)
 
 	stringToScrub := `api_key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.SetConfigFile(*cfgpath)
-	if _, err := pkgconfigsetup.LoadWithSecret(ddcfg, secretsnoop.NewComponent().Comp, nil); err != nil {
+	if _, err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	ddcfg := pkgconfigsetup.GlobalConfigBuilder()
 	ddcfg.SetConfigFile(*cfgpath)
-	if _, err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil); err != nil {
+	if err := pkgconfigsetup.LoadDatadog(ddcfg, secretsnoop.NewComponent().Comp, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -895,7 +895,7 @@ func setupOptionalDatadogConfigWithDir(t testing.TB, configDir, configFile strin
 		cfg.SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := pkgconfigsetup.LoadWithSecret(cfg, secretsmock.New(t), pkgconfigsetup.SystemProbe().GetEnvVars())
+	_, err := pkgconfigsetup.LoadDatadog(cfg, secretsmock.New(t), pkgconfigsetup.SystemProbe().GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	if err != nil && !errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) {
 		// special-case permission-denied with a clearer error message

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -895,7 +895,7 @@ func setupOptionalDatadogConfigWithDir(t testing.TB, configDir, configFile strin
 		cfg.SetConfigFile(configFile)
 	}
 	// load the configuration
-	_, err := pkgconfigsetup.LoadDatadog(cfg, secretsmock.New(t), pkgconfigsetup.SystemProbe().GetEnvVars())
+	err := pkgconfigsetup.LoadDatadog(cfg, secretsmock.New(t), pkgconfigsetup.SystemProbe().GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
 	if err != nil && !errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) {
 		// special-case permission-denied with a clearer error message

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -44,7 +44,7 @@ func TestStartDoesNotBlock(t *testing.T) {
 		t.Skip("TestStartDoesNotBlock is known to fail on the macOS Gitlab runners because of the already running Agent")
 	}
 	mockConfig := configmock.New(t)
-	pkgconfigsetup.LoadWithSecret(mockConfig, secretsmock.New(t), nil)
+	pkgconfigsetup.LoadDatadog(mockConfig, secretsmock.New(t), nil)
 	metricAgent := &ServerlessMetricAgent{
 		SketchesBucketOffset: time.Second * 10,
 		Tagger:               nooptagger.NewComponent(),

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -68,7 +68,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 	}
 	// load the configuration
 	ddcfg := pkgconfigsetup.Datadog()
-	err := pkgconfigsetup.LoadCustom(cfg, ddcfg.GetEnvVars())
+	err := pkgconfigsetup.LoadSystemProbe(cfg, ddcfg.GetEnvVars())
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			// special-case permission-denied with a clearer error message

--- a/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
+++ b/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     Add a new option, `force_tls_12`, to the agent configuration to force the
-    TLS version to 1.2 when contactin Datadog.
+    TLS version to 1.2 when contacting Datadog.

--- a/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
+++ b/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     Add a new option, `force_tls_12`, to the agent configuration to force the
-    TLS version to 1.2 when contactin Datatog.
+    TLS version to 1.2 when contactin Datadog.


### PR DESCRIPTION
### What does this PR do?

Cleaning config API. This is the first step toward having a single function to load datadog or system-probe configuration instead of scattering the logic across the code base:
* Remove warnings from LoadDatadog
* Make LoadCustom private and introduce LoadSystemProbe
* Rename LoadWithSecret to LoadDatadog and LoadSystemProbe

### Describe how you validated your changes
Running the CI is enough