### PR TITLE
[DJM support] Manual multiline detection for stack traces

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -47,10 +47,13 @@ var (
 			AutoMultiLineDetection: true,
 		},
 		{
-			Type:                   "file",
-			Path:                   "/databricks/driver/logs/stdout",
-			Source:                 "driver_stdout",
-			Service:                "databricks",
+			Type:    "file",
+			Path:    "/databricks/driver/logs/stdout",
+			Source:  "driver_stdout",
+			Service: "databricks",
+			LogProcessingRules: []config.LogProcessingRule{
+				{Type: "multi_line", Name: "logger_multiline", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
+			},
 			AutoMultiLineDetection: true,
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Use the same manual multiline detection for stack traces rule as we have for EMR in Databricks.

### Motivation

Capture dbt stack traces in 1 log instead of having the stack traces broken up with 1 log per line of the stack trace

### Describe how you validated your changes

### Additional Notes
