### PR TITLE
[CONTP-1001] chore(build_tags): remove cel build tag from heroku and iot agent

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -152,7 +152,7 @@ CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = {"clusterchecks", "grpcnotrace", "cel"}
 DOGSTATSD_TAGS = {"containerd", "grpcnotrace", "no_dynamic_plugins", "docker", "kubelet", "podman", "zlib", "zstd"}
 
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
-IOT_AGENT_TAGS = {"grpcnotrace", "jetson", "otlp", "systemd", "zlib", "zstd", "cel"}
+IOT_AGENT_TAGS = {"grpcnotrace", "jetson", "otlp", "systemd", "zlib", "zstd"}
 
 # INSTALLER_TAGS lists the tags needed when building the installer
 INSTALLER_TAGS = {"docker", "ec2", "kubelet"}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -126,6 +126,7 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
         "podman",
         "systemd",
         "trivy",
+        "cel",
     }
 )
 


### PR DESCRIPTION
### What does this PR do?

Removes the `cel` build tag from heroku & iot agent builds.

### Motivation

Customers running heroku & IoT agents don't use workload filtering features and very likely won't need CEL-based filtering either. It is better to remove the feature to reduce agent binary size & memory footprint.

### Describe how you validated your changes

- CI is green ✅ 

### Additional Notes
