### PR TITLE
Warn and restore `$BAZEL_REAL`'s exec bit if lost

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -7,6 +7,13 @@ if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != "true" ]; then
   exit 1
 fi
 
+# Restore `bazel`'s executable bit if it was not preserved (observed on macOS after zip extraction)
+if [ ! -x "$BAZEL_REAL" ]; then
+  >&2 echo "🟡 Make bazel executable again"
+  >&2 ls -l "$BAZEL_REAL"
+  chmod +x "$BAZEL_REAL"
+fi
+
 # Not in CI: simply execute `bazel` - done
 if [ -z "${CI_PROJECT_DIR:-}" ]; then
   exec "$BAZEL_REAL" "$@"

--- a/tools/bazel
+++ b/tools/bazel
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Check `bazelisk` properly bootstraps `bazel` or fail with instructions
 if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != "true" ]; then
-  cat >&2 "$(dirname "$0")/bazelisk.md"
+  >&2 cat "$(dirname "$0")/bazelisk.md"
   exit 1
 fi
 
@@ -26,7 +26,7 @@ fi
 # - https://sissource.ethz.ch/sispub/gitlab-ci-euler-image/-/blob/main/entrypoint.sh#L43 for inspiration
 ext_repo_contents_cache=$RUNNER_TEMP_PROJECT_DIR/bazel-repo-contents-cache
 if [ -e "$BAZEL_REPO_CONTENTS_CACHE" ]; then
-  rm >&2 -frv "$ext_repo_contents_cache"
+  >&2 rm -frv "$ext_repo_contents_cache"
   mv "$BAZEL_REPO_CONTENTS_CACHE" "$ext_repo_contents_cache"
 fi
 
@@ -45,7 +45,7 @@ trap '
 
   # Reintegrate `--repo_contents_cache` to original directory
   if [ -e "$ext_repo_contents_cache" ]; then
-    rm >&2 -frv "$BAZEL_REPO_CONTENTS_CACHE"
+    >&2 rm -frv "$BAZEL_REPO_CONTENTS_CACHE"
     mv "$ext_repo_contents_cache" "$BAZEL_REPO_CONTENTS_CACHE"
   fi
 ' EXIT


### PR DESCRIPTION
### Motivation
See: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1172395359#L36
> /Users/ec2-user/[…]/bazelisk/downloads/[…]/bazel: Permission denied

### What does this PR do?
The present change acts as a short-term countermeasure but the `🟡 Make bazel executable again` warning it prints will also allow us to monitor how frequently it happens and whether it's only on macOS runners. (similar to bit flips happening at times?)