### PR TITLE
Make `bazel.bat` work regardless of source line endings

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -1,5 +1,6 @@
-﻿@echo off
-setlocal EnableExtensions EnableDelayedExpansion
+@echo off & setlocal EnableDelayedExpansion & if not defined bb (set "bb=%TEMP%\%~n0-%RANDOM%.bat" & more "%~f0" >"!bb!" & call "!bb!" %* & set "rc=!errorlevel!" & del /q "!bb!" & exit /b !rc!)
+:: Above one-liner copies the present script to a temporary file with normalized Windows line endings and executes it.
+:: Works regardless of actual source line endings because the pseudo-shebang is interpreted before the first newline.
 
 rem Check `bazelisk` properly bootstraps `bazel` or fail with instructions
 if not defined BAZEL_REAL (

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -1,4 +1,4 @@
-@echo off & setlocal EnableDelayedExpansion & if not defined bb (set "bb=%TEMP%\%~n0-%RANDOM%.bat" & more "%~f0" >"!bb!" & call "!bb!" %* & set "rc=!errorlevel!" & del /q "!bb!" & exit /b !rc!)
+@echo off & setlocal EnableDelayedExpansion & if not defined bb (set "bb=%TEMP%\%~n0-%RANDOM%.bat" & more /e /p "%~f0" >"!bb!" & call "!bb!" %* & set "rc=!errorlevel!" & del /q "!bb!" & exit /b !rc!)
 :: Above one-liner copies the present script to a temporary file with normalized Windows line endings and executes it.
 :: Works regardless of actual source line endings because the pseudo-shebang is interpreted before the first newline.
 


### PR DESCRIPTION
_This PR got reverted by #42006._

### Motivation
<img width="656" height="216" alt="image" src="https://github.com/user-attachments/assets/22ecc777-b710-4f9f-bc48-88025191018f" />

We're lucky it has been working out of the box in CI but, while iterating over [ABLD-174](https://datadoghq.atlassian.net/browse/ABLD-174), I [too](https://github.com/DataDog/datadog-agent/pull/41170#issue-3443560195) realized how painful it was to work from/to my Linux host and a Windows VM, because `tools/bazel.bat` are checked out differently on POSIX and Windows OSes depending on current Git core settings such as `autocrlf` and `eol` or `.gitattributes` [tweaks](https://github.com/DataDog/datadog-agent/pull/41170#discussion_r2372390220).

### What does this PR do?
<img width="656" height="216" alt="image" src="https://github.com/user-attachments/assets/1f66fff7-82ce-444c-af3b-d249c728d413" />

Given there's no shebang-like feature in `.bat` files, the present change consists in emulating it with a one-liner[^1] that copies the script to a temporary file with normalized Windows line endings (CR-LF), then executes it.

As line endings no longer matter, the source file may be accessed simultaneously (shared drive/folder, bind mount) from POSIX and Windows OSes, edited from either side, and properly recognized by the Windows command interpreter (no need for tweaking Git settings or any extra processing).

### Describe how you validated your changes
Used it frequently over past few days to address various `bazel` issues on Windows.

### Additional Notes
[^1]: it works because it's interpreted **before the first newline** is encountered.

[ABLD-174]: https://datadoghq.atlassian.net/browse/ABLD-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ