### PR TITLE
Disable support for external libs when building libpcap

### DIFF
--- a/omnibus/config/software/libpcap.rb
+++ b/omnibus/config/software/libpcap.rb
@@ -30,6 +30,12 @@ build do
     "--disable-bluetooth",
     "--disable-dbus",
     "--disable-rdma",
+    "--without-dag",
+    "--without-dpdk",
+    "--without-libnl",
+    "--without-septel",
+    "--without-snf",
+    "--without-turbocap",
   ]
   configure(*configure_options, env: env)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -744,6 +744,12 @@ def build_libpcap(ctx):
                 "--disable-bluetooth",
                 "--disable-dbus",
                 "--disable-rdma",
+                "--without-dag",
+                "--without-dpdk",
+                "--without-libnl",
+                "--without-septel",
+                "--without-snf",
+                "--without-turbocap",
             ]
             ctx.run(f"./configure {' '.join(config_opts)}")
             ctx.run("make install")


### PR DESCRIPTION
### What does this PR do?

Libpcap will build with support for a few external libs if these are autodetected by `configure`.
Let's explicitly disable these optional libs as `system-probe` doesn't need them.

### Motivation

Allow building libpcap statically when one of these libs is already installed on the system where the build happens.

### Describe how you validated your changes

### Additional Notes
