### PR TITLE
windows: rm `./tools/windows/DatadogAgentInstallScript/.gitattributes` as unused

### DIFF
--- a/tools/windows/DatadogAgentInstallScript/.gitattributes
+++ b/tools/windows/DatadogAgentInstallScript/.gitattributes
@@ -1,5 +1,0 @@
-# PowerShell test files should use UTF-16 encoding
-# NOTE: non-ascii encoding is incompatible with eol=crlf
-Test-Update-DatadogAgentConfig.ps1 text eol=lf working-tree-encoding=utf-16
-testlib.ps1 text eol=lf working-tree-encoding=utf-16
-Run-Tests.ps1 text eol=lf working-tree-encoding=utf-16


### PR DESCRIPTION
### What does this PR do?

All the files affected by this gitattributes file have been removed in https://github.com/DataDog/datadog-agent/pull/40477, let's remove this now unused file.

### Motivation

### Describe how you validated your changes

### Additional Notes
