### PR TITLE
[CWS] fix TestSBOM to always use the v2 collector

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -820,7 +820,6 @@ func genTestConfigs(t testing.TB, cfgDir string, opts testOpts) (*emconfig.Confi
 		"RuntimeSecurityEnabled":                     runtimeSecurityEnabled,
 		"SBOMEnabled":                                opts.enableSBOM,
 		"HostSBOMEnabled":                            opts.enableHostSBOM,
-		"SBOMUseV2Collector":                         opts.sbomUseV2Collector,
 		"EBPFLessEnabled":                            ebpfLessEnabled,
 		"FIMEnabled":                                 opts.enableFIM, // should only be enabled/disabled on windows
 		"NetworkIngressEnabled":                      opts.networkIngressEnabled,

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -129,7 +129,6 @@ runtime_security_config:
     enabled: {{ .SBOMEnabled }}
     host:
       enabled: {{ .HostSBOMEnabled }}
-    use_v2_collector: {{ .SBOMUseV2Collector }}
   activity_dump:
     enabled: {{ .EnableActivityDump }}
     syscall_monitor:

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -25,16 +25,6 @@ import (
 )
 
 func TestSBOM(t *testing.T) {
-	t.Run("with v1 collector", func(t *testing.T) {
-		testSBOMWithCollector(t, false)
-	})
-
-	t.Run("with v2 collector", func(t *testing.T) {
-		testSBOMWithCollector(t, true)
-	})
-}
-
-func testSBOMWithCollector(t *testing.T, useV2collector bool) {
 	SkipIfNotAvailable(t)
 
 	kv, err := kernel.NewKernelVersion()
@@ -62,7 +52,7 @@ func testSBOMWithCollector(t *testing.T, useV2collector bool) {
 				`&& process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 	}
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true, enableHostSBOM: true, sbomUseV2Collector: useV2collector}))
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true, enableHostSBOM: true}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -56,7 +56,6 @@ type testOpts struct {
 	disableRuntimeSecurity                     bool
 	enableSBOM                                 bool
 	enableHostSBOM                             bool
-	sbomUseV2Collector                         bool
 	preStartCallback                           func(test *testModule)
 	tagger                                     tags.Tagger
 	ruleMatchHandler                           func(*testModule, *model.Event, *rules.Rule)


### PR DESCRIPTION
### What does this PR do?

The SBOM v1 collector has been removed, the test should only the v2 now.

### Motivation

### Describe how you validated your changes

### Additional Notes
