### PR TITLE
Create new package for validating logic of DI/LD Expression language AST

### DIFF
--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -69,10 +69,10 @@ func Parse(dslJSON []byte) (Expr, error) {
 	}
 	pooled := getPooledDecoder(dslJSON)
 	defer pooled.put()
-	decoder := pooled.decoder
+	dec := pooled.decoder
 
 	// Ensure we have a JSON object
-	objStart, err := decoder.ReadToken()
+	objStart, err := dec.ReadToken()
 	if err != nil {
 		return nil, fmt.Errorf("parse error: failed to read token: %w", err)
 	}
@@ -81,7 +81,7 @@ func Parse(dslJSON []byte) (Expr, error) {
 	}
 
 	// Read the operation key
-	key, err := decoder.ReadToken()
+	key, err := dec.ReadToken()
 	if err != nil {
 		return nil, fmt.Errorf("parse error: failed to read operation key: %w", err)
 	}
@@ -92,32 +92,45 @@ func Parse(dslJSON []byte) (Expr, error) {
 	operation := key.String()
 	switch operation {
 	case "ref":
-		return parseRefExpr(decoder)
+		// Read the ref value
+		val, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
+		}
+		if kind := val.Kind(); kind != '"' {
+			return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
+		}
+
+		refValue := val.String()
+		if refValue == "" {
+			return nil, fmt.Errorf("parse error: ref value cannot be empty")
+		}
+
+		// Read the closing brace
+		endObj, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+		}
+		if kind := endObj.Kind(); kind != '}' {
+			return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+		}
+
+		return &RefExpr{Ref: refValue}, nil
 	default:
 		// Read the argument for unsupported operations
-		arg, err := decoder.ReadToken()
+		arg, err := dec.ReadToken()
 		if err != nil {
 			return nil, fmt.Errorf("parse error: failed to read argument: %w", err)
 		}
 
-		// Extract the argument value before reading more tokens
-		var argument jsontext.Value
-		switch arg.Kind() {
-		case '"':
-			argument = jsontext.Value(arg.String())
-		case 'n':
-			argument = jsontext.Value(nil)
-		case 't', 'f':
-			argument = jsontext.Value(arg.String())
-		case '0':
-			// For numbers in unsupported expressions, store as string
-			argument = jsontext.Value(arg.String())
-		default:
-			argument = jsontext.Value(arg.String())
+		// Extract the argument value before the token gets voided
+		var argValue jsontext.Value
+		if arg.Kind() != 'n' { // not null
+			argValue = jsontext.Value(arg.String())
 		}
 
 		// Read the closing brace
-		endObj, err := decoder.ReadToken()
+		endObj, err := dec.ReadToken()
 		if err != nil {
 			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
 		}
@@ -127,36 +140,9 @@ func Parse(dslJSON []byte) (Expr, error) {
 
 		return &UnsupportedExpr{
 			operation: operation,
-			argument:  argument,
+			argument:  argValue,
 		}, nil
 	}
-}
-
-func parseRefExpr(dec *jsontext.Decoder) (*RefExpr, error) {
-	// Read the value token
-	val, err := dec.ReadToken()
-	if err != nil {
-		return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
-	}
-	if kind := val.Kind(); kind != '"' {
-		return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
-	}
-
-	refValue := val.String()
-	if refValue == "" {
-		return nil, fmt.Errorf("parse error: ref value cannot be empty")
-	}
-
-	// Read the closing brace
-	endObj, err := dec.ReadToken()
-	if err != nil {
-		return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
-	}
-	if kind := endObj.Kind(); kind != '}' {
-		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
-	}
-
-	return &RefExpr{Ref: refValue}, nil
 }
 
 // IsSupported returns true if the expression uses only supported DSL features.

--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package exprlang provides utilities for parsing and working with expressions
+// in the expression language of the dynamic instrumentation and live debugger products.
+package exprlang
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// Expr represents an expression in the DSL.
+type Expr interface {
+	expr() // marker method
+}
+
+// RefExpr represents a reference to a variable.
+type RefExpr struct {
+	Ref string
+}
+
+func (re *RefExpr) expr() {}
+
+// UnsupportedExpr represents an expression type that is not yet supported.
+type UnsupportedExpr struct {
+	operation string
+	argument  jsontext.Value
+}
+
+func (ue *UnsupportedExpr) expr() {}
+
+// Parse parses a DSL JSON expression into a strongly-typed AST node.
+func Parse(dslJSON []byte) (Expr, error) {
+	if len(dslJSON) == 0 {
+		return nil, fmt.Errorf("parse error: empty DSL expression")
+	}
+	dec := jsontext.NewDecoder(bytes.NewReader(dslJSON))
+	// Ensure we have a JSON object
+	objStart, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read token: %w", err)
+	}
+	if kind := objStart.Kind(); kind != '{' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected {", objStart, kind)
+	}
+
+	// Read the operation key
+	key, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read operation key: %w", err)
+	}
+	if kind := key.Kind(); kind != '"' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got key token %v (%v), expected string", key, kind)
+	}
+
+	operation := key.String()
+	switch operation {
+	case "ref":
+		return parseRefExpr(dec)
+	default:
+		// Read the argument for unsupported operations
+		arg, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read argument: %w", err)
+		}
+
+		// Extract the argument value before reading more tokens
+		var argument jsontext.Value
+		switch arg.Kind() {
+		case '"':
+			argument = jsontext.Value(arg.String())
+		case 'n':
+			argument = jsontext.Value(nil)
+		case 't', 'f':
+			argument = jsontext.Value(arg.String())
+		case '0':
+			// For numbers in unsupported expressions, store as string
+			argument = jsontext.Value(arg.String())
+		default:
+			argument = jsontext.Value(arg.String())
+		}
+
+		// Read the closing brace
+		endObj, err := dec.ReadToken()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+		}
+		if kind := endObj.Kind(); kind != '}' {
+			return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+		}
+
+		return &UnsupportedExpr{
+			operation: operation,
+			argument:  argument,
+		}, nil
+	}
+}
+
+func parseRefExpr(dec *jsontext.Decoder) (*RefExpr, error) {
+	// Read the value token
+	val, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read ref value: %w", err)
+	}
+	if kind := val.Kind(); kind != '"' {
+		return nil, fmt.Errorf("parse error: malformed ref: got value token %v (%v), expected string", val, kind)
+	}
+
+	refValue := val.String()
+	if refValue == "" {
+		return nil, fmt.Errorf("parse error: ref value cannot be empty")
+	}
+
+	// Read the closing brace
+	endObj, err := dec.ReadToken()
+	if err != nil {
+		return nil, fmt.Errorf("parse error: failed to read closing brace: %w", err)
+	}
+	if kind := endObj.Kind(); kind != '}' {
+		return nil, fmt.Errorf("parse error: malformed DSL: got token %v (%v), expected }", endObj, kind)
+	}
+
+	return &RefExpr{Ref: refValue}, nil
+}
+
+// IsSupported returns true if the expression uses only supported DSL features.
+func IsSupported(expr Expr) bool {
+	switch expr.(type) {
+	case *RefExpr:
+		return true
+	case *UnsupportedExpr:
+		return false
+	default:
+		return false
+	}
+}

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package exprlang
+
+import (
+	"testing"
+
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		wantExpr  Expr
+		wantError bool
+	}{
+		{
+			name:  "valid ref expression",
+			input: `{"ref": "s"}`,
+			wantExpr: &RefExpr{
+				Ref: "s",
+			},
+		},
+		{
+			name:  "valid ref with complex variable name",
+			input: `{"ref": "myVariable123"}`,
+			wantExpr: &RefExpr{
+				Ref: "myVariable123",
+			},
+		},
+		{
+			name:      "empty ref value",
+			input:     `{"ref": ""}`,
+			wantError: true,
+		},
+		{
+			name:  "unsupported instruction with string arg",
+			input: `{"foo": "bar"}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "foo",
+				argument:  jsontext.Value("bar"),
+			},
+		},
+		{
+			name:  "unsupported instruction with number arg",
+			input: `{"add": 42}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "add",
+				argument:  jsontext.Value("42"),
+			},
+		},
+		{
+			name:  "unsupported instruction with bool arg",
+			input: `{"enabled": true}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "enabled",
+				argument:  jsontext.Value(jsontext.True.String()),
+			},
+		},
+		{
+			name:  "unsupported instruction with null arg",
+			input: `{"value": null}`,
+			wantExpr: &UnsupportedExpr{
+				operation: "value",
+				argument:  nil,
+			},
+		},
+		{
+			name:      "empty expression",
+			input:     `{}`,
+			wantError: true,
+		},
+		{
+			name:      "malformed JSON",
+			input:     `{"ref": "}`,
+			wantError: true,
+		},
+		{
+			name:      "not an object",
+			input:     `"ref"`,
+			wantError: true,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "ref with non-string value",
+			input:     `{"ref": 123}`,
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := Parse([]byte(tc.input))
+
+			if tc.wantError {
+				require.Error(t, err)
+				require.Nil(t, expr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantExpr, expr)
+			}
+		})
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	testCases := []struct {
+		name          string
+		expr          Expr
+		wantSupported bool
+	}{
+		{
+			name:          "ref expression is supported",
+			expr:          &RefExpr{Ref: "s"},
+			wantSupported: true,
+		},
+		{
+			name:          "unsupported expression",
+			expr:          &UnsupportedExpr{operation: "foo", argument: jsontext.Value("bar")},
+			wantSupported: false,
+		},
+		{
+			name:          "nil expression",
+			expr:          nil,
+			wantSupported: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			supported := IsSupported(tc.expr)
+			require.Equal(t, tc.wantSupported, supported)
+		})
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple_ref",
+			input: `{"ref": "s"}`,
+		},
+		{
+			name:  "long_ref",
+			input: `{"ref": "thisIsAVeryLongVariableNameThatMightBeUsedInRealWorld"}`,
+		},
+		{
+			name:  "unsupported_string",
+			input: `{"add": "someValue"}`,
+		},
+		{
+			name:  "unsupported_number",
+			input: `{"multiply": 42}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		input := []byte(tc.input)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				expr, err := Parse(input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = expr
+			}
+		})
+	}
+}
+
+// BenchmarkParseParallel tests performance under concurrent load
+func BenchmarkParseParallel(b *testing.B) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple_ref",
+			input: `{"ref": "s"}`,
+		},
+		{
+			name:  "unsupported_string",
+			input: `{"add": "someValue"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		input := []byte(tc.input)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					expr, err := Parse(input)
+					if err != nil {
+						b.Fatal(err)
+					}
+					_ = expr
+				}
+			})
+		})
+	}
+}

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -8,166 +8,258 @@
 package exprlang
 
 import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
+	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/stretchr/testify/require"
 )
 
-func TestParse(t *testing.T) {
-	testCases := []struct {
-		name      string
-		input     string
-		wantExpr  Expr
-		wantError bool
-	}{
-		{
-			name:  "valid ref expression",
-			input: `{"ref": "s"}`,
-			wantExpr: &RefExpr{
-				Ref: "s",
-			},
-		},
-		{
-			name:  "valid ref with complex variable name",
-			input: `{"ref": "myVariable123"}`,
-			wantExpr: &RefExpr{
-				Ref: "myVariable123",
-			},
-		},
-		{
-			name:      "empty ref value",
-			input:     `{"ref": ""}`,
-			wantError: true,
-		},
-		{
-			name:  "unsupported instruction with string arg",
-			input: `{"foo": "bar"}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "foo",
-				argument:  jsontext.Value("bar"),
-			},
-		},
-		{
-			name:  "unsupported instruction with number arg",
-			input: `{"add": 42}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "add",
-				argument:  jsontext.Value("42"),
-			},
-		},
-		{
-			name:  "unsupported instruction with bool arg",
-			input: `{"enabled": true}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "enabled",
-				argument:  jsontext.Value(jsontext.True.String()),
-			},
-		},
-		{
-			name:  "unsupported instruction with null arg",
-			input: `{"value": null}`,
-			wantExpr: &UnsupportedExpr{
-				operation: "value",
-				argument:  nil,
-			},
-		},
-		{
-			name:      "empty expression",
-			input:     `{}`,
-			wantError: true,
-		},
-		{
-			name:      "malformed JSON",
-			input:     `{"ref": "}`,
-			wantError: true,
-		},
-		{
-			name:      "not an object",
-			input:     `"ref"`,
-			wantError: true,
-		},
-		{
-			name:      "empty input",
-			input:     "",
-			wantError: true,
-		},
-		{
-			name:      "ref with non-string value",
-			input:     `{"ref": 123}`,
-			wantError: true,
-		},
+//go:embed testdata
+var testdataFS embed.FS
+
+var testCases = []struct {
+	name  string
+	input string
+}{
+	{
+		name:  "valid ref expression",
+		input: `{"ref": "s"}`,
+	},
+	{
+		name:  "valid ref with complex variable name",
+		input: `{"ref": "myVariable123"}`,
+	},
+	{
+		name:  "empty ref value",
+		input: `{"ref": ""}`,
+	},
+	{
+		name:  "unsupported instruction with string arg",
+		input: `{"foo": "bar"}`,
+	},
+	{
+		name:  "unsupported instruction with number arg",
+		input: `{"add": 42}`,
+	},
+	{
+		name:  "unsupported instruction with bool arg",
+		input: `{"enabled": true}`,
+	},
+	{
+		name:  "unsupported instruction with null arg",
+		input: `{"value": null}`,
+	},
+	{
+		name:  "empty expression",
+		input: `{}`,
+	},
+	{
+		name:  "malformed JSON",
+		input: `{"ref": "}`,
+	},
+	{
+		name:  "not an object",
+		input: `"ref"`,
+	},
+	{
+		name:  "empty input",
+		input: "",
+	},
+	{
+		name:  "ref with non-string value",
+		input: `{"ref": 123}`,
+	},
+	// Test simple references (supported)
+	{name: "ref hits", input: `{"ref": "hits"}`},
+	{name: "ref @it", input: `{"ref": "@it"}`},
+	{name: "ref @value", input: `{"ref": "@value"}`},
+	{name: "ref @key", input: `{"ref": "@key"}`},
+	// Test unsupported operations with simple values
+	{name: "isDefined", input: `{"isDefined": "foobar"}`},
+	{name: "not with bool", input: `{"not": true}`},
+	// Nested/complex structures (will fail to parse with current simple parser)
+	// The current parser only handles single-level {"operation": value} structures
+	{name: "len of ref", input: `{"len": {"ref": "payload"}}`},
+	{name: "len of getmember", input: `{"len": {"getmember": [{"ref": "self"}, "collectionField"]}}`},
+	{name: "getmember", input: `{"getmember": [{"ref": "self"}, "name"]}`},
+	{name: "nested getmember", input: `{"getmember": [{"getmember": [{"ref": "self"}, "field1"]}, "name"]}`},
+	{name: "index array", input: `{"index": [{"ref": "arr"}, 1]}`},
+	{name: "index dict", input: `{"index": [{"ref": "dict"}, "world"]}`},
+	{name: "contains", input: `{"contains": [{"ref": "payload"}, "hello"]}`},
+	{name: "eq with bool", input: `{"eq": [{"ref": "hits"}, true]}`},
+	{name: "eq with null", input: `{"eq": [{"ref": "hits"}, null]}`},
+	{name: "substring", input: `{"substring": [{"ref": "payload"}, 4, 7]}`},
+	{name: "any with isEmpty", input: `{"any": [{"ref": "collection"}, {"isEmpty": {"ref": "@it"}}]}`},
+	{name: "any with @value", input: `{"any": [{"ref": "coll"}, {"isEmpty": {"ref": "@value"}}]}`},
+	{name: "any with @key", input: `{"any": [{"ref": "coll"}, {"isEmpty": {"ref": "@key"}}]}`},
+	{name: "startsWith", input: `{"startsWith": [{"ref": "local_string"}, "hello"]}`},
+	{name: "filter", input: `{"filter": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]}`},
+	{name: "matches", input: `{"matches": [{"ref": "payload"}, "[0-9]+"]}`},
+	{name: "or", input: `{"or": [{"ref": "bar"}, {"ref": "foo"}]}`},
+	{name: "and", input: `{"and": [{"ref": "bar"}, {"ref": "foo"}]}`},
+	{name: "instanceof", input: `{"instanceof": [{"ref": "bar"}, "int"]}`},
+	{name: "isEmpty", input: `{"isEmpty": {"ref": "empty_str"}}`},
+	{name: "ne", input: `{"ne": [1, 2]}`},
+	{name: "gt", input: `{"gt": [2, 1]}`},
+	{name: "ge", input: `{"ge": [2, 1]}`},
+	{name: "lt", input: `{"lt": [1, 2]}`},
+	{name: "le", input: `{"le": [1, 2]}`},
+	{name: "all", input: `{"all": [{"ref": "collection"}, {"not": {"isEmpty": {"ref": "@it"}}}]}`},
+	{name: "endsWith", input: `{"endsWith": [{"ref": "local_string"}, "world!"]}`},
+	{name: "len of filter", input: `{"len": {"filter": [{"ref": "collection"}, {"gt": [{"ref": "@it"}, 1]}]}}`},
+	{name: "deeply nested getmember", input: `{"getmember": [{"getmember": [{"getmember": [{"ref": "self"}, "field1"]}, "field2"]}, "name"]}`},
+	{name: "any with nested ops", input: `{"any": [{"getmember": [{"ref": "self"}, "collectionField"]}, {"startsWith": [{"getmember": [{"ref": "@it"}, "name"]}, "foo"]}]}`},
+	{name: "and with eq and gt", input: `{"and": [{"eq": [{"ref": "hits"}, 42]}, {"gt": [{"len": {"ref": "payload"}}, 5]}]}`},
+	{name: "index of filter", input: `{"index": [{"filter": [{"ref": "collection"}, {"gt": [{"ref": "@it"}, 2]}]}, 0]}`},
+	{name: "count", input: `{"count": {"ref": "payload"}}`},
+	{name: "substring negative", input: `{"substring": [{"ref": "s"}, -5, -1]}`},
+	{name: "nested filter with any", input: `{"len": {"filter": [{"ref": "collection"}, {"any": [{"ref": "@it"}, {"eq": [{"ref": "@it"}, 1]}]}]}}`},
+	// Test literal values (these should also fail - not objects)
+	{name: "literal int", input: `42`},
+	{name: "literal bool", input: `true`},
+}
+
+// exprResult represents the result of parsing an expression for storage in JSON.
+type exprResult struct {
+	Type      string          `json:"type"`          // "ref", "unsupported", or "error"
+	Ref       string          `json:"ref,omitempty"` // Ref value (used for ref expressions)
+	Operation string          `json:"operation"`
+	Argument  json.RawMessage `json:"argument,omitempty"` // Raw json argument (used for unsupported expressions)
+	Error     string          `json:"error"`
+}
+
+func exprToResult(expr Expr, err error) exprResult {
+	if err != nil {
+		return exprResult{Type: "error", Error: err.Error()}
 	}
+	switch e := expr.(type) {
+	case *RefExpr:
+		return exprResult{Type: "ref", Ref: e.Ref}
+	case *UnsupportedExpr:
+		return exprResult{Type: "unsupported", Operation: e.Operation, Argument: json.RawMessage(e.Argument)}
+	default:
+		return exprResult{Type: "error", Error: "unknown expression type"}
+	}
+}
+
+// sanitizeTestName converts a test name to a safe filename by replacing spaces
+// and special characters.
+func sanitizeTestName(testName string) string {
+	// Replace spaces with underscores
+	name := strings.ReplaceAll(testName, " ", "_")
+	// Replace @ with "at"
+	name = strings.ReplaceAll(name, "@", "at")
+	// Remove other special characters that might cause issues
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\\", "_")
+	return name
+}
+
+func getExpectedOutputFilename(testName string) string {
+	return filepath.Join("testdata", sanitizeTestName(testName)+".json")
+}
+
+func loadExpectedOutput(testName string) (exprResult, error) {
+	filename := getExpectedOutputFilename(testName)
+	content, err := testdataFS.ReadFile(filename)
+	if err != nil {
+		return exprResult{}, fmt.Errorf("reading %s: %w", filename, err)
+	}
+	var result exprResult
+	if err := json.Unmarshal(content, &result); err != nil {
+		return exprResult{}, fmt.Errorf("unmarshalling %s: %w", filename, err)
+	}
+	return result, nil
+}
+
+func saveActualOutput(testName string, result exprResult) error {
+	filename := getExpectedOutputFilename(testName)
+	outputDir := filepath.Dir(filename)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("error creating testdata directory: %w", err)
+	}
+
+	marshaled, err := jsonv2.Marshal(
+		result,
+		jsontext.WithIndent("  "),
+		jsontext.EscapeForHTML(false),
+		jsontext.EscapeForJS(false),
+	)
+	if err != nil {
+		return fmt.Errorf("error marshalling result: %w", err)
+	}
+
+	baseName := filepath.Base(filename)
+	tmpFile, err := os.CreateTemp(outputDir, "."+baseName+".*.tmp.json")
+	if err != nil {
+		return fmt.Errorf("error creating temp output file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := io.Copy(tmpFile, bytes.NewReader(marshaled)); err != nil {
+		return fmt.Errorf("error writing temp output: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing temp output: %w", err)
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		return fmt.Errorf("error renaming temp output: %w", err)
+	}
+	return nil
+}
+
+func TestParse(t *testing.T) {
+	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := Parse([]byte(tc.input))
+			actualResult := exprToResult(expr, err)
 
-			if tc.wantError {
-				require.Error(t, err)
-				require.Nil(t, expr)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.wantExpr, expr)
+			if rewrite {
+				// In rewrite mode, save the actual output
+				if saveErr := saveActualOutput(tc.name, actualResult); saveErr != nil {
+					t.Logf("error saving actual output for test %s: %v", tc.name, saveErr)
+				} else {
+					t.Logf("output saved to: %s", getExpectedOutputFilename(tc.name))
+				}
+				return
+			}
+
+			// Load expected output from JSON and compare
+			expectedResult, loadErr := loadExpectedOutput(tc.name)
+			require.NoError(t, loadErr, "failed to load expected output for test %s", tc.name)
+
+			// Compare results
+			require.Equal(t, expectedResult.Type, actualResult.Type, "expression type mismatch")
+			require.Equal(t, expectedResult.Operation, actualResult.Operation, "operation mismatch")
+			require.Equal(t, expectedResult.Error, actualResult.Error, "error mismatch")
+			switch expr.(type) {
+			case *RefExpr:
+				require.Equal(t, expectedResult.Ref, actualResult.Ref, "ref value mismatch")
+			case *UnsupportedExpr:
+				if expectedResult.Argument == nil {
+					require.Equal(t, json.RawMessage("null"), actualResult.Argument, "argument mismatch")
+				} else {
+					require.JSONEq(t, string(expectedResult.Argument), string(actualResult.Argument), "argument mismatch")
+				}
 			}
 		})
 	}
 }
 
-func TestIsSupported(t *testing.T) {
-	testCases := []struct {
-		name          string
-		expr          Expr
-		wantSupported bool
-	}{
-		{
-			name:          "ref expression is supported",
-			expr:          &RefExpr{Ref: "s"},
-			wantSupported: true,
-		},
-		{
-			name:          "unsupported expression",
-			expr:          &UnsupportedExpr{operation: "foo", argument: jsontext.Value("bar")},
-			wantSupported: false,
-		},
-		{
-			name:          "nil expression",
-			expr:          nil,
-			wantSupported: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			supported := IsSupported(tc.expr)
-			require.Equal(t, tc.wantSupported, supported)
-		})
-	}
-}
-
 func BenchmarkParse(b *testing.B) {
-	testCases := []struct {
-		name  string
-		input string
-	}{
-		{
-			name:  "simple_ref",
-			input: `{"ref": "s"}`,
-		},
-		{
-			name:  "long_ref",
-			input: `{"ref": "thisIsAVeryLongVariableNameThatMightBeUsedInRealWorld"}`,
-		},
-		{
-			name:  "unsupported_string",
-			input: `{"add": "someValue"}`,
-		},
-		{
-			name:  "unsupported_number",
-			input: `{"multiply": 42}`,
-		},
-	}
-
 	for _, tc := range testCases {
 		input := []byte(tc.input)
 
@@ -180,40 +272,6 @@ func BenchmarkParse(b *testing.B) {
 				}
 				_ = expr
 			}
-		})
-	}
-}
-
-// BenchmarkParseParallel tests performance under concurrent load
-func BenchmarkParseParallel(b *testing.B) {
-	testCases := []struct {
-		name  string
-		input string
-	}{
-		{
-			name:  "simple_ref",
-			input: `{"ref": "s"}`,
-		},
-		{
-			name:  "unsupported_string",
-			input: `{"add": "someValue"}`,
-		},
-	}
-
-	for _, tc := range testCases {
-		input := []byte(tc.input)
-
-		b.Run(tc.name, func(b *testing.B) {
-			b.ReportAllocs()
-			b.RunParallel(func(pb *testing.PB) {
-				for pb.Next() {
-					expr, err := Parse(input)
-					if err != nil {
-						b.Fatal(err)
-					}
-					_ = expr
-				}
-			})
 		})
 	}
 }

--- a/pkg/dyninst/exprlang/testdata/.gitkeep
+++ b/pkg/dyninst/exprlang/testdata/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the testdata directory is not empty
+

--- a/pkg/dyninst/exprlang/testdata/all.json
+++ b/pkg/dyninst/exprlang/testdata/all.json
@@ -1,0 +1,17 @@
+{
+  "type": "unsupported",
+  "operation": "all",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "not": {
+        "isEmpty": {
+          "ref": "@it"
+        }
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/and.json
+++ b/pkg/dyninst/exprlang/testdata/and.json
@@ -1,0 +1,13 @@
+{
+  "type": "unsupported",
+  "operation": "and",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    {
+      "ref": "foo"
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/and_with_eq_and_gt.json
+++ b/pkg/dyninst/exprlang/testdata/and_with_eq_and_gt.json
@@ -1,0 +1,25 @@
+{
+  "type": "unsupported",
+  "operation": "and",
+  "argument": [
+    {
+      "eq": [
+        {
+          "ref": "hits"
+        },
+        42
+      ]
+    },
+    {
+      "gt": [
+        {
+          "len": {
+            "ref": "payload"
+          }
+        },
+        5
+      ]
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_atkey.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_atkey.json
@@ -1,0 +1,15 @@
+{
+  "type": "unsupported",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "coll"
+    },
+    {
+      "isEmpty": {
+        "ref": "@key"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_atvalue.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_atvalue.json
@@ -1,0 +1,15 @@
+{
+  "type": "unsupported",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "coll"
+    },
+    {
+      "isEmpty": {
+        "ref": "@value"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_isEmpty.json
@@ -1,0 +1,15 @@
+{
+  "type": "unsupported",
+  "operation": "any",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "isEmpty": {
+        "ref": "@it"
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/any_with_nested_ops.json
+++ b/pkg/dyninst/exprlang/testdata/any_with_nested_ops.json
@@ -1,0 +1,28 @@
+{
+  "type": "unsupported",
+  "operation": "any",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "ref": "self"
+        },
+        "collectionField"
+      ]
+    },
+    {
+      "startsWith": [
+        {
+          "getmember": [
+            {
+              "ref": "@it"
+            },
+            "name"
+          ]
+        },
+        "foo"
+      ]
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/contains.json
+++ b/pkg/dyninst/exprlang/testdata/contains.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "contains",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    "hello"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/count.json
+++ b/pkg/dyninst/exprlang/testdata/count.json
@@ -1,0 +1,8 @@
+{
+  "type": "unsupported",
+  "operation": "count",
+  "argument": {
+    "ref": "payload"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/deeply_nested_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/deeply_nested_getmember.json
@@ -1,0 +1,21 @@
+{
+  "type": "unsupported",
+  "operation": "getmember",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "getmember": [
+            {
+              "ref": "self"
+            },
+            "field1"
+          ]
+        },
+        "field2"
+      ]
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/empty_expression.json
+++ b/pkg/dyninst/exprlang/testdata/empty_expression.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: malformed DSL: got key token } (}), expected string"
+}

--- a/pkg/dyninst/exprlang/testdata/empty_input.json
+++ b/pkg/dyninst/exprlang/testdata/empty_input.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: empty DSL expression"
+}

--- a/pkg/dyninst/exprlang/testdata/empty_ref_value.json
+++ b/pkg/dyninst/exprlang/testdata/empty_ref_value.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: ref value cannot be empty"
+}

--- a/pkg/dyninst/exprlang/testdata/endsWith.json
+++ b/pkg/dyninst/exprlang/testdata/endsWith.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "endsWith",
+  "argument": [
+    {
+      "ref": "local_string"
+    },
+    "world!"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/eq_with_bool.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_bool.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "eq",
+  "argument": [
+    {
+      "ref": "hits"
+    },
+    true
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/eq_with_null.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_null.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "eq",
+  "argument": [
+    {
+      "ref": "hits"
+    },
+    null
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/filter.json
+++ b/pkg/dyninst/exprlang/testdata/filter.json
@@ -1,0 +1,17 @@
+{
+  "type": "unsupported",
+  "operation": "filter",
+  "argument": [
+    {
+      "ref": "collection"
+    },
+    {
+      "not": {
+        "isEmpty": {
+          "ref": "@it"
+        }
+      }
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ge.json
+++ b/pkg/dyninst/exprlang/testdata/ge.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "operation": "ge",
+  "argument": [
+    2,
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/getmember.json
+++ b/pkg/dyninst/exprlang/testdata/getmember.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "getmember",
+  "argument": [
+    {
+      "ref": "self"
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/gt.json
+++ b/pkg/dyninst/exprlang/testdata/gt.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "operation": "gt",
+  "argument": [
+    2,
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_array.json
+++ b/pkg/dyninst/exprlang/testdata/index_array.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "index",
+  "argument": [
+    {
+      "ref": "arr"
+    },
+    1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_dict.json
+++ b/pkg/dyninst/exprlang/testdata/index_dict.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "index",
+  "argument": [
+    {
+      "ref": "dict"
+    },
+    "world"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/index_of_filter.json
+++ b/pkg/dyninst/exprlang/testdata/index_of_filter.json
@@ -1,0 +1,23 @@
+{
+  "type": "unsupported",
+  "operation": "index",
+  "argument": [
+    {
+      "filter": [
+        {
+          "ref": "collection"
+        },
+        {
+          "gt": [
+            {
+              "ref": "@it"
+            },
+            2
+          ]
+        }
+      ]
+    },
+    0
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/instanceof.json
+++ b/pkg/dyninst/exprlang/testdata/instanceof.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "instanceof",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    "int"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/isDefined.json
+++ b/pkg/dyninst/exprlang/testdata/isDefined.json
@@ -1,0 +1,6 @@
+{
+  "type": "unsupported",
+  "operation": "isDefined",
+  "argument": "foobar",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/isEmpty.json
@@ -1,0 +1,8 @@
+{
+  "type": "unsupported",
+  "operation": "isEmpty",
+  "argument": {
+    "ref": "empty_str"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/le.json
+++ b/pkg/dyninst/exprlang/testdata/le.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "operation": "le",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_filter.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_filter.json
@@ -1,0 +1,20 @@
+{
+  "type": "unsupported",
+  "operation": "len",
+  "argument": {
+    "filter": [
+      {
+        "ref": "collection"
+      },
+      {
+        "gt": [
+          {
+            "ref": "@it"
+          },
+          1
+        ]
+      }
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_getmember.json
@@ -1,0 +1,13 @@
+{
+  "type": "unsupported",
+  "operation": "len",
+  "argument": {
+    "getmember": [
+      {
+        "ref": "self"
+      },
+      "collectionField"
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/len_of_ref.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_ref.json
@@ -1,0 +1,8 @@
+{
+  "type": "unsupported",
+  "operation": "len",
+  "argument": {
+    "ref": "payload"
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/literal_bool.json
+++ b/pkg/dyninst/exprlang/testdata/literal_bool.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: malformed DSL: got token true (true), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/literal_int.json
+++ b/pkg/dyninst/exprlang/testdata/literal_int.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: malformed DSL: got token 42 (number), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/lt.json
+++ b/pkg/dyninst/exprlang/testdata/lt.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "operation": "lt",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/malformed_JSON.json
+++ b/pkg/dyninst/exprlang/testdata/malformed_JSON.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: failed to read ref value: jsontext: unexpected EOF within \"/ref\" after offset 10"
+}

--- a/pkg/dyninst/exprlang/testdata/matches.json
+++ b/pkg/dyninst/exprlang/testdata/matches.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "matches",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    "[0-9]+"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ne.json
+++ b/pkg/dyninst/exprlang/testdata/ne.json
@@ -1,0 +1,9 @@
+{
+  "type": "unsupported",
+  "operation": "ne",
+  "argument": [
+    1,
+    2
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
+++ b/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
@@ -1,0 +1,27 @@
+{
+  "type": "unsupported",
+  "operation": "len",
+  "argument": {
+    "filter": [
+      {
+        "ref": "collection"
+      },
+      {
+        "any": [
+          {
+            "ref": "@it"
+          },
+          {
+            "eq": [
+              {
+                "ref": "@it"
+              },
+              1
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/nested_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/nested_getmember.json
@@ -1,0 +1,16 @@
+{
+  "type": "unsupported",
+  "operation": "getmember",
+  "argument": [
+    {
+      "getmember": [
+        {
+          "ref": "self"
+        },
+        "field1"
+      ]
+    },
+    "name"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/not_an_object.json
+++ b/pkg/dyninst/exprlang/testdata/not_an_object.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: malformed DSL: got token ref (string), expected {"
+}

--- a/pkg/dyninst/exprlang/testdata/not_with_bool.json
+++ b/pkg/dyninst/exprlang/testdata/not_with_bool.json
@@ -1,0 +1,6 @@
+{
+  "type": "unsupported",
+  "operation": "not",
+  "argument": true,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/or.json
+++ b/pkg/dyninst/exprlang/testdata/or.json
@@ -1,0 +1,13 @@
+{
+  "type": "unsupported",
+  "operation": "or",
+  "argument": [
+    {
+      "ref": "bar"
+    },
+    {
+      "ref": "foo"
+    }
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atit.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atit.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "@it",
+  "operation": "",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atkey.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atkey.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "@key",
+  "operation": "",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_atvalue.json
+++ b/pkg/dyninst/exprlang/testdata/ref_atvalue.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "@value",
+  "operation": "",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_hits.json
+++ b/pkg/dyninst/exprlang/testdata/ref_hits.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "hits",
+  "operation": "",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/ref_with_non-string_value.json
+++ b/pkg/dyninst/exprlang/testdata/ref_with_non-string_value.json
@@ -1,0 +1,5 @@
+{
+  "type": "error",
+  "operation": "",
+  "error": "parse error: malformed ref: got value token 123 (number), expected string"
+}

--- a/pkg/dyninst/exprlang/testdata/startsWith.json
+++ b/pkg/dyninst/exprlang/testdata/startsWith.json
@@ -1,0 +1,11 @@
+{
+  "type": "unsupported",
+  "operation": "startsWith",
+  "argument": [
+    {
+      "ref": "local_string"
+    },
+    "hello"
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/substring.json
+++ b/pkg/dyninst/exprlang/testdata/substring.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "operation": "substring",
+  "argument": [
+    {
+      "ref": "payload"
+    },
+    4,
+    7
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/substring_negative.json
+++ b/pkg/dyninst/exprlang/testdata/substring_negative.json
@@ -1,0 +1,12 @@
+{
+  "type": "unsupported",
+  "operation": "substring",
+  "argument": [
+    {
+      "ref": "s"
+    },
+    -5,
+    -1
+  ],
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported instruction with null arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported instruction with null arg.json
@@ -1,0 +1,5 @@
+{
+  "type": "unsupported",
+  "operation": "value",
+  "argument": null
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_bool_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_bool_arg.json
@@ -1,0 +1,6 @@
+{
+  "type": "unsupported",
+  "operation": "enabled",
+  "argument": true,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_null_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_null_arg.json
@@ -1,0 +1,5 @@
+{
+  "type": "unsupported",
+  "operation": "value",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_number_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_number_arg.json
@@ -1,0 +1,6 @@
+{
+  "type": "unsupported",
+  "operation": "add",
+  "argument": 42,
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_string_arg.json
+++ b/pkg/dyninst/exprlang/testdata/unsupported_instruction_with_string_arg.json
@@ -1,0 +1,6 @@
+{
+  "type": "unsupported",
+  "operation": "foo",
+  "argument": "bar",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/valid_ref_expression.json
+++ b/pkg/dyninst/exprlang/testdata/valid_ref_expression.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "s",
+  "operation": "",
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/valid_ref_with_complex_variable_name.json
+++ b/pkg/dyninst/exprlang/testdata/valid_ref_with_complex_variable_name.json
@@ -1,0 +1,6 @@
+{
+  "type": "ref",
+  "ref": "myVariable123",
+  "operation": "",
+  "error": ""
+}


### PR DESCRIPTION
### What does this PR do?

Creates the `dyninst/exprlang` package which lays the foundation for supporting the live debugger expression language. The package parses the dsl JSON message received from remote config, validates it is supported, and will provide utility for using it such as collecting all variables referenced in the ast.

### Motivation

Supporting expression language.

### Describe how you validated your changes

Added tests

### Additional Notes
