### PR TITLE
pkg/dyninst: Check dwarf entry field with AttrVarParam to check if a value is a return

### DIFF
--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -7,6 +7,8 @@
 
 package ir
 
+import "fmt"
+
 // ProgramID is a ID corresponding to an instance of a Program.  It is used to
 // identify messages from this program as they are communicated over the ring
 // buffer.
@@ -101,6 +103,30 @@ type Subprogram struct {
 	Variables []*Variable
 }
 
+// VariableRole is the role of a variable within a subprogram.
+type VariableRole uint8
+
+// VariableRole values.
+const (
+	_ VariableRole = iota
+	VariableRoleParameter
+	VariableRoleReturn
+	VariableRoleLocal
+)
+
+func (vr VariableRole) String() string {
+	switch vr {
+	case VariableRoleParameter:
+		return "Parameter"
+	case VariableRoleReturn:
+		return "Return"
+	case VariableRoleLocal:
+		return "Local"
+	default:
+		return fmt.Sprintf("VariableRole(%d)", vr)
+	}
+}
+
 // Variable represents a variable or parameter in the subprogram.
 type Variable struct {
 	// Name is the name of the variable.
@@ -111,10 +137,8 @@ type Variable struct {
 	// Sorted by low limit of their ranges. Note the ranges might overlap,
 	// in case of variables inlined multiple times in the same parent subprogram.
 	Locations []Location
-	// IsParameter is true if the variable is a parameter.
-	IsParameter bool
-	// IsReturn is true if this variable is a return value.
-	IsReturn bool
+	// Role is the role of the variable within the subprogram.
+	Role VariableRole
 }
 
 // PCRange is the range of PC values that will be probed.

--- a/pkg/dyninst/irgen/abi.go
+++ b/pkg/dyninst/irgen/abi.go
@@ -122,7 +122,7 @@ func augmentReturnLocationsFromABI(
 	argRegs := &registerState{}
 	var argStackSize int32
 	for _, v := range subprogram.Variables {
-		if !v.IsParameter || v.IsReturn {
+		if v.Role != ir.VariableRoleParameter {
 			continue
 		}
 
@@ -153,7 +153,7 @@ func augmentReturnLocationsFromABI(
 	resultRegs := &registerState{} // reset per ABI step 4
 	var resultStackSize int32
 	for _, v := range subprogram.Variables {
-		if !v.IsReturn {
+		if v.Role != ir.VariableRoleReturn {
 			continue
 		}
 

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.23.11.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 10 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 93 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x4a8085..0x4a8134
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.24.3.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 9 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 98 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x4aa2a5..0x4aa354
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=amd64,toolchain=go1.25.0.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 9 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 99 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x4b0985..0x4b0a34
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.23.11.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 10 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 94 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xb7528..0xb75d0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.24.3.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 9 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 99 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xb7558..0xb75f0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/fault.arch=arm64,toolchain=go1.25.0.yaml
@@ -35,8 +35,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 9 GoStringHeaderType string
           Locations:
@@ -52,8 +51,7 @@ Subprograms:
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 100 PointerType *int
           Locations:
@@ -61,8 +59,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xba088..0xba110
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 103 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd59836..0xd59a5c
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd59848..0xd59881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 107 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd5997a..0xd59a5c
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd59b20..0xd59be5]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 220

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 108 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd313d6..0xd315f9
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd313e8..0xd31421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 112 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd31512..0xd315f9
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd316c0..0xd31785]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 251

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.25.0.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 110 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd363b6..0xd365d9
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd363c8..0xd36401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 114 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd364f2..0xd365d9
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd366a0..0xd36765]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 103 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x8dff94..0x8e0170
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 105 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8dffa8..0x8dffd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 107 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8e0098..0x8e0170
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8e0250..0x8e0310]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 220

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 108 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x8a0cf4..0x8a0ec0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 110 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8a0d08..0x8a0d38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 112 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8a0df0..0x8a0ec0
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8a0f90..0x8a1040]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 251

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.25.0.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 110 PointerType *net/http.Request
           Locations:
@@ -80,15 +79,13 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x8599d0..0x859b80
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: span
           Type: 112 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8599e4..0x859a14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&buf'
           Type: 114 PointerType *bytes.Buffer
           Locations:
@@ -96,8 +93,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x859ab8..0x859b80
               Pieces: [{Size: 8, Op: {CfaOffset: -120}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x859c50..0x859cf0]
@@ -112,8 +108,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 103 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd28a56..0xd28c90
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 105 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd28bb1..0xd28c90
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -112,8 +109,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd28d60..0xd28e25]
@@ -128,8 +124,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 108 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcfc6b6..0xcfc8f0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 110 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcfc809..0xcfc8f0
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -112,8 +109,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xcfc9c0..0xcfca85]
@@ -128,8 +124,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 165

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.25.0.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 110 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd04ed6..0xd05110
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 112 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd05029..0xd05110
               Pieces: [{Size: 8, Op: {CfaOffset: -136}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -112,8 +109,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0xd051e0..0xd052a5]
@@ -128,8 +124,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 103 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x8ad8c4..0x8adab0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 105 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8ad9d0..0x8adab0
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 107 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -112,8 +109,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x8adb90..0x8adc50]
@@ -128,8 +124,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 39

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 108 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x86c164..0x86c340
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 110 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x86c268..0x86c340
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 112 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -112,8 +109,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x86c410..0x86c4c0]
@@ -128,8 +124,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 165

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.25.0.yaml
@@ -71,8 +71,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: r
           Type: 110 PointerType *net/http.Request
           Locations:
@@ -80,8 +79,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x82b150..0x82b320
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: '&buf'
           Type: 112 PointerType *bytes.Buffer
           Locations:
@@ -89,8 +87,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x82b258..0x82b320
               Pieces: [{Size: 8, Op: {CfaOffset: -128}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: span
           Type: 114 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
@@ -106,8 +103,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 2
       Name: main.LookAtTheRequest
       OutOfLinePCRanges: [0x82b3f0..0x82b490]
@@ -122,8 +118,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 63

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0xd02e00..0xd02e01
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xd02e20..0xd02e21]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0xd02e20..0xd02e21
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xd02e40..0xd02e41]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0xd02e40..0xd02e41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xd02e60..0xd02e61]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0xd02e60..0xd02e61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xd02e80..0xd02e81]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0xd02e80..0xd02e81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xd02ea0..0xd02ea1]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0xd02ea0..0xd02ea1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xd02ec0..0xd02ec1]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0xd02ec0..0xd02ec1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xd02ee0..0xd02ee1]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0xd02ee0..0xd02ee1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xd02f00..0xd02f01]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0xd02f00..0xd02f01
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xd02f20..0xd02f21]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0xd02f20..0xd02f21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xd02f40..0xd02f41]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0xd02f40..0xd02f41
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xd02f60..0xd02f61]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0xd02f60..0xd02f61
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xd02f80..0xd02f81]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0xd02f80..0xd02f81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0xd02fa0..0xd02fa1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0xd02fc0..0xd02fc1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0xd02fe0..0xd02fe1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xd03000..0xd03001]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0xd03000..0xd03001
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0xd03020..0xd03021]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0xd03020..0xd03021
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0xd03040..0xd03041]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0xd03040..0xd03041
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xd03080..0xd03081]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0xd03080..0xd03081
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xd03400..0xd03401]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0xd03400..0xd03401
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xd03420..0xd03421]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0xd03420..0xd03421
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xd03440..0xd03441]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0xd03440..0xd03441
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xd03460..0xd03461]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0xd03460..0xd03461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xd03480..0xd03481]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0xd03480..0xd03481
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xd034a0..0xd034a1]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0xd034a0..0xd034a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xd034c0..0xd034c1]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0xd034c0..0xd034c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xd034e0..0xd034e1]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0xd034e0..0xd034e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xd03500..0xd03501]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0xd03500..0xd03501
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xd03520..0xd03521]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0xd03520..0xd03521
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xd03540..0xd03541]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0xd03540..0xd03541
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xd03560..0xd03561]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0xd03560..0xd03561
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xd03580..0xd03581]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0xd03580..0xd03581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xd035a0..0xd035a1]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0xd035a0..0xd035a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xd035c0..0xd035c1]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0xd035c0..0xd035c1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xd035e0..0xd035e1]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0xd035e0..0xd035e1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xd03740..0xd0375f]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0xd03800..0xd03801]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0xd03800..0xd03801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0xd03820..0xd03821]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0xd03820..0xd03821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0xd039a0..0xd039a1]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0xd039c0..0xd039c1]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0xd039c0..0xd039c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0xd03b20..0xd03b21]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0xd03b20..0xd03b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0xd03b40..0xd03b41]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0xd03b40..0xd03b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0xd03b60..0xd03b61]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0xd03b60..0xd03b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0xd03b80..0xd03b81]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0xd03b80..0xd03b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0xd03ba0..0xd03dea]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd03d58..0xd03d6f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 9 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
             - Range: 0xd03d58..0xd03dea
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
             - Range: 0xd03d6f..0xd03dea
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xd04240..0xd04345]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xd04360..0xd043c3]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0xd04360..0xd0438d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xd047a0..0xd04828]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0xd047a0..0xd047b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xd04840..0xd04905]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0xd04840..0xd04856
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 BaseType int
           Locations:
             - Range: 0xd04840..0xd04867
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd04867..0xd04905
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xd04920..0xd04982]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0xd04920..0xd0493a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xd049a0..0xd04aae]
@@ -3569,8 +3514,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
             - Range: 0xd04a20..0xd04a34
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 9 BaseType int
           Locations:
@@ -3580,8 +3524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0xd04a20..0xd04a2f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0xd04ac0..0xd04ac6]
@@ -3592,8 +3535,7 @@ Subprograms:
           Locations:
             - Range: 0xd04ac0..0xd04ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -3601,8 +3543,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd04ac5..0xd04ac6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xd04ae0..0xd04b23]
@@ -3613,8 +3554,7 @@ Subprograms:
           Locations:
             - Range: 0xd04ae0..0xd04b23
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -3624,8 +3564,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd04b1e..0xd04b23
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0xd04dc0..0xd04dc1]
@@ -3640,8 +3579,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0xd04de0..0xd04e46]
@@ -3662,8 +3600,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
@@ -3677,8 +3614,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd04e26..0xd04e46
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0xd04e60..0xd04e61]
@@ -3693,8 +3629,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0xd04e80..0xd04ed4]
@@ -3705,8 +3640,7 @@ Subprograms:
           Locations:
             - Range: 0xd04e80..0xd04ea6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
@@ -3720,8 +3654,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd04ebe..0xd04ed4
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0xd04ee0..0xd04ee1]
@@ -3736,8 +3669,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xd05540..0xd05541]
@@ -3748,8 +3680,7 @@ Subprograms:
           Locations:
             - Range: 0xd05540..0xd05541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xd05560..0xd05561]
@@ -3760,8 +3691,7 @@ Subprograms:
           Locations:
             - Range: 0xd05560..0xd05561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd05580..0xd05581]
@@ -3772,8 +3702,7 @@ Subprograms:
           Locations:
             - Range: 0xd05580..0xd05581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd055a0..0xd055a1]
@@ -3784,8 +3713,7 @@ Subprograms:
           Locations:
             - Range: 0xd055a0..0xd055a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd055c0..0xd055c1]
@@ -3796,8 +3724,7 @@ Subprograms:
           Locations:
             - Range: 0xd055c0..0xd055c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xd055e0..0xd055e1]
@@ -3808,8 +3735,7 @@ Subprograms:
           Locations:
             - Range: 0xd055e0..0xd055e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd05600..0xd05601]
@@ -3820,8 +3746,7 @@ Subprograms:
           Locations:
             - Range: 0xd05600..0xd05601
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd05620..0xd05621]
@@ -3832,8 +3757,7 @@ Subprograms:
           Locations:
             - Range: 0xd05620..0xd05621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd05640..0xd05641]
@@ -3844,8 +3768,7 @@ Subprograms:
           Locations:
             - Range: 0xd05640..0xd05641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xd05660..0xd05661]
@@ -3856,8 +3779,7 @@ Subprograms:
           Locations:
             - Range: 0xd05660..0xd05661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd05680..0xd05681]
@@ -3868,8 +3790,7 @@ Subprograms:
           Locations:
             - Range: 0xd05680..0xd05681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd056a0..0xd056a1]
@@ -3880,8 +3801,7 @@ Subprograms:
           Locations:
             - Range: 0xd056a0..0xd056a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd056c0..0xd056c1]
@@ -3892,8 +3812,7 @@ Subprograms:
           Locations:
             - Range: 0xd056c0..0xd056c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd056e0..0xd056e1]
@@ -3904,8 +3823,7 @@ Subprograms:
           Locations:
             - Range: 0xd056e0..0xd056e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xd05700..0xd05701]
@@ -3916,8 +3834,7 @@ Subprograms:
           Locations:
             - Range: 0xd05700..0xd05701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xd05720..0xd05721]
@@ -3928,8 +3845,7 @@ Subprograms:
           Locations:
             - Range: 0xd05720..0xd05721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xd05740..0xd05741]
@@ -3940,8 +3856,7 @@ Subprograms:
           Locations:
             - Range: 0xd05740..0xd05741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xd05760..0xd05761]
@@ -3952,8 +3867,7 @@ Subprograms:
           Locations:
             - Range: 0xd05760..0xd05761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xd05780..0xd05781]
@@ -3964,8 +3878,7 @@ Subprograms:
           Locations:
             - Range: 0xd05780..0xd05781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xd057a0..0xd057a1]
@@ -3976,8 +3889,7 @@ Subprograms:
           Locations:
             - Range: 0xd057a0..0xd057a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xd057c0..0xd057c1]
@@ -3988,8 +3900,7 @@ Subprograms:
           Locations:
             - Range: 0xd057c0..0xd057c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xd057e0..0xd057e1]
@@ -4000,8 +3911,7 @@ Subprograms:
           Locations:
             - Range: 0xd057e0..0xd057e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0xd05800..0xd05801]
@@ -4012,8 +3922,7 @@ Subprograms:
           Locations:
             - Range: 0xd05800..0xd05801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xd06f40..0xd06f41]
@@ -4024,22 +3933,19 @@ Subprograms:
           Locations:
             - Range: 0xd06f40..0xd06f41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xd06f40..0xd06f41
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 16 BaseType float32
           Locations:
             - Range: 0xd06f40..0xd06f41
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xd07100..0xd07101]
@@ -4050,29 +3956,25 @@ Subprograms:
           Locations:
             - Range: 0xd07100..0xd07101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xd07100..0xd07101
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
             - Range: 0xd07100..0xd07101
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 15 BaseType uint
           Locations:
             - Range: 0xd07100..0xd07101
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
@@ -4082,8 +3984,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0xd07320..0xd07321]
@@ -4094,8 +3995,7 @@ Subprograms:
           Locations:
             - Range: 0xd07320..0xd07321
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xd074e0..0xd074e1]
@@ -4106,8 +4006,7 @@ Subprograms:
           Locations:
             - Range: 0xd074e0..0xd074e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xd07500..0xd07501]
@@ -4122,8 +4021,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xd07520..0xd07521]
@@ -4134,8 +4032,7 @@ Subprograms:
           Locations:
             - Range: 0xd07520..0xd07521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xd07540..0xd07541]
@@ -4146,8 +4043,7 @@ Subprograms:
           Locations:
             - Range: 0xd07540..0xd07541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xd07580..0xd07581]
@@ -4158,8 +4054,7 @@ Subprograms:
           Locations:
             - Range: 0xd07580..0xd07581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xd07660..0xd07661]
@@ -4170,8 +4065,7 @@ Subprograms:
           Locations:
             - Range: 0xd07660..0xd07661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xd076a0..0xd076a1]
@@ -4182,15 +4076,13 @@ Subprograms:
           Locations:
             - Range: 0xd076a0..0xd076a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 15 BaseType uint
           Locations:
             - Range: 0xd076a0..0xd076a1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0xd076e0..0xd076e1]
@@ -4201,8 +4093,7 @@ Subprograms:
           Locations:
             - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xd07be0..0xd07c52]
@@ -4213,8 +4104,7 @@ Subprograms:
           Locations:
             - Range: 0xd07be0..0xd07bf2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4224,8 +4114,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07c3c..0xd07c52
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4233,8 +4122,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07c05..0xd07c52
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xd07c60..0xd07cf5]
@@ -4247,8 +4135,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07c7a..0xd07cf5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 93 PointerType *int
           Locations:
@@ -4258,8 +4145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07cdc..0xd07cf5
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
@@ -4267,8 +4153,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07c9c..0xd07cf5
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xd07d00..0xd07dde]
@@ -4279,8 +4164,7 @@ Subprograms:
           Locations:
             - Range: 0xd07d00..0xd07d62
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4290,13 +4174,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd07dc5..0xd07dde
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd07d00..0xd07dde, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
@@ -4304,8 +4186,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd07d67..0xd07dde
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
@@ -4313,8 +4194,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
             - Range: 0xd07d67..0xd07dde
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xd07de0..0xd07e3b]
@@ -4325,8 +4205,7 @@ Subprograms:
           Locations:
             - Range: 0xd07de0..0xd07df9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
@@ -4348,8 +4227,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd07e26..0xd07e3b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xd07e40..0xd07f86]
@@ -4388,15 +4266,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0xd07e40..0xd07e8f
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
@@ -4434,8 +4310,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd07f5a..0xd07f86
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
@@ -4473,15 +4348,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xd07f5a..0xd07f86
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
             - Range: 0xd07ed7..0xd07ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xd07fa0..0xd08194]
@@ -4508,8 +4381,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
@@ -4547,22 +4419,19 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0816d..0xd08194
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
             - Range: 0xd0808a..0xd08090
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
             - Range: 0xd08045..0xd08064
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xd081a0..0xd08305]
@@ -4595,8 +4464,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
             - Range: 0xd082c8..0xd08305
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
@@ -4618,8 +4486,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0829c..0xd08305
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
@@ -4657,8 +4524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xd0829b..0xd08305
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xd08320..0xd083af]
@@ -4669,8 +4535,7 @@ Subprograms:
           Locations:
             - Range: 0xd08320..0xd08331
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4680,8 +4545,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08396..0xd083af
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xd083c0..0xd08489]
@@ -4692,8 +4556,7 @@ Subprograms:
           Locations:
             - Range: 0xd083c0..0xd08413
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4703,8 +4566,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08470..0xd08489
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
@@ -4714,8 +4576,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08470..0xd08489
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xd084a0..0xd08568]
@@ -4728,8 +4589,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd084e5..0xd08568
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4739,8 +4599,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
@@ -4750,8 +4609,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -4761,8 +4619,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd0854f..0xd08568
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xd08580..0xd085fe]
@@ -4777,8 +4634,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
@@ -4788,8 +4644,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
@@ -4799,8 +4654,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
@@ -4810,8 +4664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4821,8 +4674,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
@@ -4832,8 +4684,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4843,8 +4694,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
@@ -4854,8 +4704,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd085f2..0xd085fe
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xd08600..0xd086f5]
@@ -4864,78 +4713,63 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
@@ -4945,8 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xd086e6..0xd086f5
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
@@ -4956,8 +4789,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xd086e6..0xd086f5
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xd08700..0xd08773]
@@ -4966,13 +4798,11 @@ Subprograms:
         - Name: ~r0
           Type: 89 BaseType complex64
           Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 90 BaseType complex128
           Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xd08780..0xd08825]
@@ -4987,8 +4817,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xd08814..0xd08825
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xd08840..0xd088ba]
@@ -5003,8 +4832,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xd088ae..0xd088ba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xd088c0..0xd08918]
@@ -5019,8 +4847,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0890c..0xd08918
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xd08920..0xd08973]
@@ -5035,8 +4862,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd08967..0xd08973
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xd08980..0xd089e7]
@@ -5045,8 +4871,7 @@ Subprograms:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0xd08980..0xd089e7, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xd08a00..0xd08a9a]
@@ -5061,8 +4886,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
@@ -5072,8 +4896,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5083,8 +4906,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
@@ -5094,8 +4916,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
@@ -5105,8 +4926,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
@@ -5116,8 +4936,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
@@ -5127,8 +4946,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
@@ -5138,8 +4956,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5149,8 +4966,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xd08a8b..0xd08a9a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xd08aa0..0xd08b45]
@@ -5165,8 +4981,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xd08b35..0xd08b45
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xd08b60..0xd08bd9]
@@ -5181,13 +4996,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5197,13 +5010,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5217,8 +5028,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xd08bcd..0xd08bd9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xd08be0..0xd08c5a]
@@ -5233,8 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xd08c4e..0xd08c5a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xd08c60..0xd08cbb]
@@ -5243,8 +5052,7 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08c60..0xd08cbb, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xd08cc0..0xd08d27]
@@ -5253,13 +5061,11 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float32
           Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xd08d40..0xd08d9d]
@@ -5274,8 +5080,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd08d91..0xd08d9d
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5285,8 +5090,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd08d91..0xd08d9d
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xd08da0..0xd08f05]
@@ -5297,8 +5101,7 @@ Subprograms:
           Locations:
             - Range: 0xd08da0..0xd08f05
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5308,8 +5111,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xd08ef4..0xd08f05
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xd08f20..0xd08ff2]
@@ -5320,8 +5122,7 @@ Subprograms:
           Locations:
             - Range: 0xd08f20..0xd08ff2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
@@ -5331,8 +5132,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xd08fe3..0xd08ff2
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xd09000..0xd0923a]
@@ -5343,15 +5143,13 @@ Subprograms:
           Locations:
             - Range: 0xd09000..0xd0923a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
             - Range: 0xd09000..0xd0923a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5361,8 +5159,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xd0922b..0xd0923a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xd09240..0xd094cf]
@@ -5375,8 +5172,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5384,8 +5180,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
@@ -5393,8 +5188,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
@@ -5402,8 +5196,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd092b0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
@@ -5411,8 +5204,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
@@ -5420,8 +5212,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
@@ -5429,8 +5220,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
@@ -5438,8 +5228,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
@@ -5447,8 +5236,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
             - Range: 0xd092f0..0xd094cf
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
@@ -5458,8 +5246,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xd09463..0xd094cf
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xd094e0..0xd097ac]
@@ -5472,8 +5259,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5481,8 +5267,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
@@ -5490,8 +5275,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
@@ -5499,8 +5283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xd09542..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
@@ -5508,8 +5291,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
@@ -5517,8 +5299,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
@@ -5526,8 +5307,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
@@ -5535,8 +5315,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xd0958b..0xd097ac
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5546,8 +5325,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5557,8 +5335,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xd0972c..0xd097ac
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xd097c0..0xd0984c]
@@ -5569,8 +5346,7 @@ Subprograms:
           Locations:
             - Range: 0xd097c0..0xd0984c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5580,8 +5356,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
@@ -5591,8 +5366,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5602,8 +5376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xd0983d..0xd0984c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xd09860..0xd0994a]
@@ -5614,15 +5387,13 @@ Subprograms:
           Locations:
             - Range: 0xd09860..0xd0994a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
             - Range: 0xd09860..0xd0994a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5632,8 +5403,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09937..0xd0994a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
@@ -5643,8 +5413,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xd09937..0xd0994a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xd09960..0xd09a2b]
@@ -5655,8 +5424,7 @@ Subprograms:
           Locations:
             - Range: 0xd09960..0xd09a2b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5666,8 +5434,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09a1b..0xd09a2b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
@@ -5677,15 +5444,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xd09a1b..0xd09a2b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
             - Range: 0xd099e6..0xd09a2b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xd09a40..0xd09ae6]
@@ -5694,8 +5459,7 @@ Subprograms:
         - Name: a
           Type: 248 ArrayType [0]int
           Locations: [{Range: 0xd09a40..0xd09ae6, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5707,8 +5471,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xd09ac2..0xd09ae6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5718,8 +5481,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xd09acd..0xd09ae6
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
@@ -5729,8 +5491,7 @@ Subprograms:
               Pieces: []
             - Range: 0xd09acd..0xd09ae6
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xd09fe0..0xd09fe1]
@@ -5747,8 +5508,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0a000..0xd0a001]
@@ -5765,8 +5525,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd0a020..0xd0a021]
@@ -5783,8 +5542,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xd0a040..0xd0a041]
@@ -5801,15 +5559,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0xd0a040..0xd0a041
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd0a060..0xd0a061]
@@ -5826,15 +5582,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0xd0a060..0xd0a061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xd0a080..0xd0a081]
@@ -5851,15 +5605,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0xd0a080..0xd0a081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xd0a0a0..0xd0a0a1]
@@ -5876,8 +5628,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xd0a0c0..0xd0a0c1]
@@ -5888,8 +5639,7 @@ Subprograms:
           Locations:
             - Range: 0xd0a0c0..0xd0a0c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
@@ -5901,15 +5651,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 15 BaseType uint
           Locations:
             - Range: 0xd0a0c0..0xd0a0c1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
@@ -5926,8 +5674,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0a100..0xd0a101]
@@ -5944,8 +5691,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xd0a120..0xd0a121]
@@ -5962,8 +5708,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0xd0a460..0xd0a4b2]
@@ -5982,8 +5727,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xd0a4a6..0xd0a4b2
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0xd0a4c0..0xd0a4c1]
@@ -5998,8 +5742,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xd0a4e0..0xd0a4e1]
@@ -6014,8 +5757,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
@@ -6025,8 +5767,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
@@ -6036,8 +5777,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xd0a500..0xd0a51f]
@@ -6060,8 +5800,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xd0a520..0xd0a521]
@@ -6072,8 +5811,7 @@ Subprograms:
           Locations:
             - Range: 0xd0a520..0xd0a521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xd0a540..0xd0a541]
@@ -6084,8 +5822,7 @@ Subprograms:
           Locations:
             - Range: 0xd0a540..0xd0a541
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xd0a560..0xd0a561]
@@ -6100,8 +5837,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xd0a580..0xd0a581]
@@ -6116,8 +5852,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
@@ -6132,8 +5867,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xd0a700..0xd0a701]
@@ -6144,8 +5878,7 @@ Subprograms:
           Locations:
             - Range: 0xd0a700..0xd0a701
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xd0a720..0xd0a73f]
@@ -6168,8 +5901,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0xd0a860..0xd0a883]
@@ -6194,8 +5926,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xd0a9e0..0xd0a9e1]
@@ -6204,8 +5935,7 @@ Subprograms:
         - Name: e
           Type: 312 StructureType main.emptyStruct
           Locations: [{Range: 0xd0a9e0..0xd0a9e1, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xd0aa00..0xd0aa01]
@@ -6216,8 +5946,7 @@ Subprograms:
           Locations:
             - Range: 0xd0aa00..0xd0aa01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04600..0xd04662]
@@ -6246,8 +5975,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xd04920..0xd0493a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6281,8 +6009,7 @@ Subprograms:
           Locations:
             - Range: 0xd04ac0..0xd04ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6299,8 +6026,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
             - Range: 0xd04b8c..0xd04cc5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 132

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4120..0xcd4121
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd4140..0xcd4141]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4140..0xcd4141
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xcd4160..0xcd4161]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4160..0xcd4161
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd4180..0xcd4181]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4180..0xcd4181
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xcd41a0..0xcd41a1]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0xcd41a0..0xcd41a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xcd41c0..0xcd41c1]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0xcd41c0..0xcd41c1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xcd41e0..0xcd41e1]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0xcd41e0..0xcd41e1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xcd4200..0xcd4201]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4200..0xcd4201
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xcd4220..0xcd4221]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4220..0xcd4221
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xcd4240..0xcd4241]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4240..0xcd4241
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xcd4260..0xcd4261]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4260..0xcd4261
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xcd4280..0xcd4281]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4280..0xcd4281
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0xcd42a0..0xcd42a1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0xcd42c0..0xcd42c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0xcd42e0..0xcd42e1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xcd4300..0xcd4301]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4300..0xcd4301
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xcd4320..0xcd4321]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4320..0xcd4321
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0xcd4340..0xcd4341]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4340..0xcd4341
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0xcd4360..0xcd4361]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4360..0xcd4361
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xcd43a0..0xcd43a1]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0xcd43a0..0xcd43a1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xcd4720..0xcd4721]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4720..0xcd4721
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd4740..0xcd4741]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4740..0xcd4741
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xcd4760..0xcd4761]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4760..0xcd4761
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd4780..0xcd4781]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4780..0xcd4781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xcd47a0..0xcd47a1]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0xcd47a0..0xcd47a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xcd47c0..0xcd47c1]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0xcd47c0..0xcd47c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xcd47e0..0xcd47e1]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0xcd47e0..0xcd47e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xcd4800..0xcd4801]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4800..0xcd4801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xcd4820..0xcd4821]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4820..0xcd4821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd4840..0xcd4841]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4840..0xcd4841
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xcd4860..0xcd4861]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4860..0xcd4861
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xcd4880..0xcd4881]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4880..0xcd4881
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xcd48a0..0xcd48a1]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0xcd48a0..0xcd48a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xcd48c0..0xcd48c1]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0xcd48c0..0xcd48c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xcd48e0..0xcd48e1]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0xcd48e0..0xcd48e1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xcd4900..0xcd4901]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4900..0xcd4901
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xcd4a60..0xcd4a7f]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0xcd4b20..0xcd4b21]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4b20..0xcd4b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0xcd4b40..0xcd4b41]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4b40..0xcd4b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0xcd4cc0..0xcd4cc1]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0xcd4ce0..0xcd4ce1]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4ce0..0xcd4ce1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0xcd4e40..0xcd4e41]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4e40..0xcd4e41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0xcd4e60..0xcd4e61]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4e60..0xcd4e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0xcd4e80..0xcd4e81]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4e80..0xcd4e81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0xcd4ea0..0xcd4ea1]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0xcd4ea0..0xcd4ea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0xcd4ec0..0xcd510a]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd5078..0xcd508f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 7 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
             - Range: 0xcd5078..0xcd510a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
             - Range: 0xcd508f..0xcd510a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xcd5560..0xcd5665]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xcd5680..0xcd56e3]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5680..0xcd56ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xcd5ac0..0xcd5b48]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5ac0..0xcd5ad5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xcd5b60..0xcd5c25]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0xcd5b60..0xcd5b76
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
             - Range: 0xcd5b60..0xcd5b87
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd5b87..0xcd5c25
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcd5c40..0xcd5ca2]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5c40..0xcd5c5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcd5cc0..0xcd5dce]
@@ -3569,8 +3514,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
             - Range: 0xcd5d40..0xcd5d54
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -3580,8 +3524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0xcd5d40..0xcd5d4f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcd5de0..0xcd5de6]
@@ -3592,8 +3535,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5de0..0xcd5de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3601,8 +3543,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcd5de5..0xcd5de6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xcd5e00..0xcd5e43]
@@ -3613,8 +3554,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5e00..0xcd5e43
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3624,8 +3564,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd5e3e..0xcd5e43
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0xcd60e0..0xcd60e1]
@@ -3640,8 +3579,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0xcd6100..0xcd6166]
@@ -3662,8 +3600,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3677,8 +3614,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd6146..0xcd6166
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0xcd6180..0xcd6181]
@@ -3693,8 +3629,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0xcd61a0..0xcd61f4]
@@ -3705,8 +3640,7 @@ Subprograms:
           Locations:
             - Range: 0xcd61a0..0xcd61c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3720,8 +3654,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd61de..0xcd61f4
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0xcd6200..0xcd6201]
@@ -3736,8 +3669,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcd6860..0xcd6861]
@@ -3748,8 +3680,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6860..0xcd6861
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcd6880..0xcd6881]
@@ -3760,8 +3691,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6880..0xcd6881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd68a0..0xcd68a1]
@@ -3772,8 +3702,7 @@ Subprograms:
           Locations:
             - Range: 0xcd68a0..0xcd68a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd68c0..0xcd68c1]
@@ -3784,8 +3713,7 @@ Subprograms:
           Locations:
             - Range: 0xcd68c0..0xcd68c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd68e0..0xcd68e1]
@@ -3796,8 +3724,7 @@ Subprograms:
           Locations:
             - Range: 0xcd68e0..0xcd68e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd6900..0xcd6901]
@@ -3808,8 +3735,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6900..0xcd6901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd6920..0xcd6921]
@@ -3820,8 +3746,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6920..0xcd6921
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd6940..0xcd6941]
@@ -3832,8 +3757,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6940..0xcd6941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd6960..0xcd6961]
@@ -3844,8 +3768,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6960..0xcd6961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd6980..0xcd6981]
@@ -3856,8 +3779,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6980..0xcd6981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd69a0..0xcd69a1]
@@ -3868,8 +3790,7 @@ Subprograms:
           Locations:
             - Range: 0xcd69a0..0xcd69a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd69c0..0xcd69c1]
@@ -3880,8 +3801,7 @@ Subprograms:
           Locations:
             - Range: 0xcd69c0..0xcd69c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd69e0..0xcd69e1]
@@ -3892,8 +3812,7 @@ Subprograms:
           Locations:
             - Range: 0xcd69e0..0xcd69e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd6a00..0xcd6a01]
@@ -3904,8 +3823,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6a00..0xcd6a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcd6a20..0xcd6a21]
@@ -3916,8 +3834,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6a20..0xcd6a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcd6a40..0xcd6a41]
@@ -3928,8 +3845,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6a40..0xcd6a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcd6a60..0xcd6a61]
@@ -3940,8 +3856,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6a60..0xcd6a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcd6a80..0xcd6a81]
@@ -3952,8 +3867,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6a80..0xcd6a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcd6aa0..0xcd6aa1]
@@ -3964,8 +3878,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6aa0..0xcd6aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcd6ac0..0xcd6ac1]
@@ -3976,8 +3889,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6ac0..0xcd6ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xcd6ae0..0xcd6ae1]
@@ -3988,8 +3900,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6ae0..0xcd6ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xcd6b00..0xcd6b01]
@@ -4000,8 +3911,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6b00..0xcd6b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0xcd6b20..0xcd6b21]
@@ -4012,8 +3922,7 @@ Subprograms:
           Locations:
             - Range: 0xcd6b20..0xcd6b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xcd8420..0xcd8421]
@@ -4024,22 +3933,19 @@ Subprograms:
           Locations:
             - Range: 0xcd8420..0xcd8421
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd8420..0xcd8421
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
             - Range: 0xcd8420..0xcd8421
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcd85e0..0xcd85e1]
@@ -4050,29 +3956,25 @@ Subprograms:
           Locations:
             - Range: 0xcd85e0..0xcd85e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xcd85e0..0xcd85e1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 10 BaseType int32
           Locations:
             - Range: 0xcd85e0..0xcd85e1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 16 BaseType uint
           Locations:
             - Range: 0xcd85e0..0xcd85e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
@@ -4082,8 +3984,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0xcd8800..0xcd8801]
@@ -4094,8 +3995,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8800..0xcd8801
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcd89c0..0xcd89c1]
@@ -4106,8 +4006,7 @@ Subprograms:
           Locations:
             - Range: 0xcd89c0..0xcd89c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
@@ -4122,8 +4021,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
@@ -4134,8 +4032,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a00..0xcd8a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
@@ -4146,8 +4043,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a20..0xcd8a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
@@ -4158,8 +4054,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
@@ -4170,8 +4065,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b40..0xcd8b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
@@ -4182,15 +4076,13 @@ Subprograms:
           Locations:
             - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 16 BaseType uint
           Locations:
             - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
@@ -4201,8 +4093,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xcd9020..0xcd9092]
@@ -4213,8 +4104,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9020..0xcd9032
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4224,8 +4114,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd907c..0xcd9092
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4233,8 +4122,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9045..0xcd9092
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcd90a0..0xcd912f]
@@ -4247,8 +4135,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd90ba..0xcd912f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 98 PointerType *int
           Locations:
@@ -4258,8 +4145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9115..0xcd912f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
@@ -4267,8 +4153,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd90d9..0xcd912f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcd9140..0xcd921e]
@@ -4279,8 +4164,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9140..0xcd91a2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4290,13 +4174,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9205..0xcd921e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9140..0xcd921e, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
@@ -4304,8 +4186,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd91a7..0xcd921e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
@@ -4313,8 +4194,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
             - Range: 0xcd91a7..0xcd921e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcd9220..0xcd927b]
@@ -4325,8 +4205,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9220..0xcd9239
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
@@ -4348,8 +4227,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd9266..0xcd927b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xcd9280..0xcd93c6]
@@ -4388,15 +4266,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0xcd9280..0xcd92c3
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
@@ -4434,8 +4310,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd939a..0xcd93c6
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
@@ -4473,15 +4348,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcd939a..0xcd93c6
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0xcd92cb..0xcd92d1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xcd93e0..0xcd95d4]
@@ -4508,8 +4381,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
@@ -4547,22 +4419,19 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd95ad..0xcd95d4
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0xcd94ca..0xcd94d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
             - Range: 0xcd9485..0xcd94a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xcd95e0..0xcd973d]
@@ -4595,8 +4464,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
             - Range: 0xcd9706..0xcd973d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
@@ -4618,8 +4486,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcd96da..0xcd973d
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
@@ -4657,8 +4524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcd96d9..0xcd973d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcd9740..0xcd97cf]
@@ -4669,8 +4535,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9740..0xcd9751
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4680,8 +4545,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd97b6..0xcd97cf
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xcd97e0..0xcd98a9]
@@ -4692,8 +4556,7 @@ Subprograms:
           Locations:
             - Range: 0xcd97e0..0xcd9833
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4703,8 +4566,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9890..0xcd98a9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4714,8 +4576,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9890..0xcd98a9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xcd98c0..0xcd9985]
@@ -4728,8 +4589,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9905..0xcd9985
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4739,8 +4599,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4750,8 +4609,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -4761,8 +4619,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd996c..0xcd9985
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xcd99a0..0xcd9a1e]
@@ -4777,8 +4634,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
@@ -4788,8 +4644,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
@@ -4799,8 +4654,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
@@ -4810,8 +4664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4821,8 +4674,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
@@ -4832,8 +4684,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4843,8 +4694,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
@@ -4854,8 +4704,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcd9a12..0xcd9a1e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xcd9a20..0xcd9b17]
@@ -4864,78 +4713,63 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
@@ -4945,8 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xcd9b08..0xcd9b17
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
@@ -4956,8 +4789,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcd9b08..0xcd9b17
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xcd9b20..0xcd9b93]
@@ -4966,13 +4798,11 @@ Subprograms:
         - Name: ~r0
           Type: 94 BaseType complex64
           Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 95 BaseType complex128
           Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xcd9ba0..0xcd9c45]
@@ -4987,8 +4817,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xcd9c34..0xcd9c45
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xcd9c60..0xcd9cda]
@@ -5003,8 +4832,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcd9cce..0xcd9cda
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xcd9ce0..0xcd9d38]
@@ -5019,8 +4847,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9d2c..0xcd9d38
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xcd9d40..0xcd9d93]
@@ -5035,8 +4862,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcd9d87..0xcd9d93
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xcd9da0..0xcd9e07]
@@ -5045,8 +4871,7 @@ Subprograms:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0xcd9da0..0xcd9e07, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xcd9e20..0xcd9eba]
@@ -5061,8 +4886,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5072,8 +4896,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5083,8 +4906,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
@@ -5094,8 +4916,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
@@ -5105,8 +4926,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
@@ -5116,8 +4936,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
@@ -5127,8 +4946,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
@@ -5138,8 +4956,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5149,8 +4966,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcd9eab..0xcd9eba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xcd9ec0..0xcd9f65]
@@ -5165,8 +4981,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xcd9f55..0xcd9f65
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xcd9f80..0xcd9ff9]
@@ -5181,13 +4996,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5197,13 +5010,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5217,8 +5028,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcd9fed..0xcd9ff9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xcda000..0xcda07a]
@@ -5233,8 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcda06e..0xcda07a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xcda080..0xcda0db]
@@ -5243,8 +5052,7 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda080..0xcda0db, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xcda0e0..0xcda147]
@@ -5253,13 +5061,11 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float32
           Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xcda160..0xcda1bd]
@@ -5274,8 +5080,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda1b1..0xcda1bd
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5285,8 +5090,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcda1b1..0xcda1bd
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xcda1c0..0xcda345]
@@ -5297,8 +5101,7 @@ Subprograms:
           Locations:
             - Range: 0xcda1c0..0xcda345
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5308,8 +5111,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xcda334..0xcda345
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xcda360..0xcda432]
@@ -5320,8 +5122,7 @@ Subprograms:
           Locations:
             - Range: 0xcda360..0xcda432
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
@@ -5331,8 +5132,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcda423..0xcda432
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xcda440..0xcda67a]
@@ -5343,15 +5143,13 @@ Subprograms:
           Locations:
             - Range: 0xcda440..0xcda67a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
             - Range: 0xcda440..0xcda67a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5361,8 +5159,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xcda66b..0xcda67a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xcda680..0xcda90f]
@@ -5375,8 +5172,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5384,8 +5180,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5393,8 +5188,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcda71a..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5402,8 +5196,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcda6f0..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5411,8 +5204,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5420,8 +5212,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5429,8 +5220,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5438,8 +5228,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -5447,8 +5236,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
             - Range: 0xcda730..0xcda90f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
@@ -5458,8 +5246,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcda8a3..0xcda90f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xcda920..0xcdabec]
@@ -5472,8 +5259,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5481,8 +5267,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5490,8 +5275,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcda9b5..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5499,8 +5283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcda982..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5508,8 +5291,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5517,8 +5299,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5526,8 +5307,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5535,8 +5315,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcda9cb..0xcdabec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5546,8 +5325,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5557,8 +5335,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xcdab6c..0xcdabec
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xcdac00..0xcdac8c]
@@ -5569,8 +5346,7 @@ Subprograms:
           Locations:
             - Range: 0xcdac00..0xcdac8c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5580,8 +5356,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5591,8 +5366,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5602,8 +5376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdac7d..0xcdac8c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xcdaca0..0xcdad8e]
@@ -5614,15 +5387,13 @@ Subprograms:
           Locations:
             - Range: 0xcdaca0..0xcdad8e
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
             - Range: 0xcdaca0..0xcdad8e
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5632,8 +5403,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdad7f..0xcdad8e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
@@ -5643,8 +5413,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xcdad7f..0xcdad8e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xcdada0..0xcdae6b]
@@ -5655,8 +5424,7 @@ Subprograms:
           Locations:
             - Range: 0xcdada0..0xcdae6b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5666,8 +5434,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdae5b..0xcdae6b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
@@ -5677,15 +5444,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdae5b..0xcdae6b
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdae26..0xcdae6b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xcdae80..0xcdaf26]
@@ -5694,8 +5459,7 @@ Subprograms:
         - Name: a
           Type: 251 ArrayType [0]int
           Locations: [{Range: 0xcdae80..0xcdaf26, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5707,8 +5471,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xcdaefa..0xcdaf26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5718,8 +5481,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdaf0d..0xcdaf26
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
@@ -5729,8 +5491,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcdaf0d..0xcdaf26
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdb420..0xcdb421]
@@ -5747,8 +5508,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdb440..0xcdb441]
@@ -5765,8 +5525,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdb460..0xcdb461]
@@ -5783,8 +5542,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdb480..0xcdb481]
@@ -5801,15 +5559,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdb480..0xcdb481
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
@@ -5826,15 +5582,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdb4a0..0xcdb4a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
@@ -5851,15 +5605,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdb4c0..0xcdb4c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcdb4e0..0xcdb4e1]
@@ -5876,8 +5628,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcdb500..0xcdb501]
@@ -5888,8 +5639,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb500..0xcdb501
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
@@ -5901,15 +5651,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 16 BaseType uint
           Locations:
             - Range: 0xcdb500..0xcdb501
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdb520..0xcdb521]
@@ -5926,8 +5674,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdb540..0xcdb541]
@@ -5944,8 +5691,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xcdb560..0xcdb561]
@@ -5962,8 +5708,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0xcdb8a0..0xcdb8f2]
@@ -5982,8 +5727,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdb8e6..0xcdb8f2
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0xcdb900..0xcdb901]
@@ -5998,8 +5742,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcdb920..0xcdb921]
@@ -6014,8 +5757,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6025,8 +5767,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6036,8 +5777,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xcdb940..0xcdb95f]
@@ -6060,8 +5800,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xcdb960..0xcdb961]
@@ -6072,8 +5811,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb960..0xcdb961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcdb980..0xcdb981]
@@ -6084,8 +5822,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb980..0xcdb981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xcdb9a0..0xcdb9a1]
@@ -6100,8 +5837,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcdb9c0..0xcdb9c1]
@@ -6116,8 +5852,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
@@ -6132,8 +5867,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xcdbb40..0xcdbb41]
@@ -6144,8 +5878,7 @@ Subprograms:
           Locations:
             - Range: 0xcdbb40..0xcdbb41
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xcdbb60..0xcdbb7f]
@@ -6168,8 +5901,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0xcdbca0..0xcdbcc3]
@@ -6194,8 +5926,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xcdbe20..0xcdbe21]
@@ -6204,8 +5935,7 @@ Subprograms:
         - Name: e
           Type: 315 StructureType main.emptyStruct
           Locations: [{Range: 0xcdbe20..0xcdbe21, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xcdbe40..0xcdbe41]
@@ -6216,8 +5946,7 @@ Subprograms:
           Locations:
             - Range: 0xcdbe40..0xcdbe41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5920..0xcd5982]
@@ -6246,8 +5975,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xcd5c40..0xcd5c5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6281,8 +6009,7 @@ Subprograms:
           Locations:
             - Range: 0xcd5de0..0xcd5de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6299,8 +6026,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
             - Range: 0xcd5eac..0xcd5fe5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 137

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a20..0xcd8a21
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a40..0xcd8a41
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd8a80..0xcd8a81]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8a80..0xcd8a81
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8aa0..0xcd8aa1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0xcd8ac0..0xcd8ac1]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8ac0..0xcd8ac1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0xcd8ae0..0xcd8ae1]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8ae0..0xcd8ae1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0xcd8b00..0xcd8b01]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b00..0xcd8b01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0xcd8b20..0xcd8b21]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b20..0xcd8b21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b40..0xcd8b41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0xcd8b60..0xcd8b61]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b60..0xcd8b61
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0xcd8ba0..0xcd8ba1]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8ba0..0xcd8ba1
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0xcd8be0..0xcd8be1]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8be0..0xcd8be1
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8c00..0xcd8c01
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0xcd8c20..0xcd8c21]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8c20..0xcd8c21
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0xcd8c40..0xcd8c41]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8c40..0xcd8c41
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0xcd8c60..0xcd8c61]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8c60..0xcd8c61
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0xcd8ca0..0xcd8ca1]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0xcd8ca0..0xcd8ca1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0xcd9020..0xcd9021]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9020..0xcd9021
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0xcd9040..0xcd9041]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9040..0xcd9041
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0xcd9060..0xcd9061]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9060..0xcd9061
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0xcd9080..0xcd9081]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9080..0xcd9081
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0xcd90a0..0xcd90a1]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0xcd90a0..0xcd90a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0xcd90c0..0xcd90c1]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0xcd90c0..0xcd90c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0xcd90e0..0xcd90e1]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0xcd90e0..0xcd90e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0xcd9100..0xcd9101]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9100..0xcd9101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0xcd9120..0xcd9121]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9120..0xcd9121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0xcd9140..0xcd9141]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9140..0xcd9141
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0xcd9160..0xcd9161]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9160..0xcd9161
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0xcd9180..0xcd9181]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9180..0xcd9181
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0xcd91a0..0xcd91a1]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0xcd91a0..0xcd91a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0xcd91c0..0xcd91c1]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0xcd91c0..0xcd91c1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0xcd91e0..0xcd91e1]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0xcd91e0..0xcd91e1
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0xcd9200..0xcd9201]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9200..0xcd9201
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0xcd9360..0xcd937f]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0xcd9420..0xcd9421]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9420..0xcd9421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0xcd9440..0xcd9441]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9440..0xcd9441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0xcd95c0..0xcd95c1]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0xcd95e0..0xcd95e1]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0xcd95e0..0xcd95e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0xcd9740..0xcd9741]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9740..0xcd9741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0xcd9760..0xcd9761]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9760..0xcd9761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0xcd9780..0xcd9781]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9780..0xcd9781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0xcd97a0..0xcd97a1]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0xcd97a0..0xcd97a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0xcd97c0..0xcd9a0a]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcd9978..0xcd998f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 7 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
             - Range: 0xcd9978..0xcd9a0a
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
             - Range: 0xcd998f..0xcd9a0a
               Pieces: [{Size: 8, Op: {CfaOffset: -192}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0xcd9e40..0xcd9f45]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0xcd9f60..0xcd9fc3]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0xcd9f60..0xcd9f8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0xcda3a0..0xcda428]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0xcda3a0..0xcda3b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0xcda440..0xcda505]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0xcda440..0xcda456
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
             - Range: 0xcda440..0xcda467
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda467..0xcda505
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0xcda520..0xcda582]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0xcda520..0xcda53a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0xcda5a0..0xcda6a5]
@@ -3569,8 +3514,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
             - Range: 0xcda615..0xcda629
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -3580,8 +3524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0xcda615..0xcda624
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0xcda6c0..0xcda6c6]
@@ -3592,8 +3535,7 @@ Subprograms:
           Locations:
             - Range: 0xcda6c0..0xcda6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3601,8 +3543,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcda6c5..0xcda6c6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0xcda6e0..0xcda723]
@@ -3613,8 +3554,7 @@ Subprograms:
           Locations:
             - Range: 0xcda6e0..0xcda723
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3624,8 +3564,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcda71e..0xcda723
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0xcda9c0..0xcda9c1]
@@ -3640,8 +3579,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0xcda9e0..0xcdaa46]
@@ -3662,8 +3600,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3677,8 +3614,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdaa26..0xcdaa46
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0xcdaa60..0xcdaa61]
@@ -3693,8 +3629,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0xcdaa80..0xcdaad4]
@@ -3705,8 +3640,7 @@ Subprograms:
           Locations:
             - Range: 0xcdaa80..0xcdaaa6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3720,8 +3654,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdaabe..0xcdaad4
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0xcdaae0..0xcdaae1]
@@ -3736,8 +3669,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0xcdb0e0..0xcdb0e1]
@@ -3748,8 +3680,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb0e0..0xcdb0e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0xcdb100..0xcdb101]
@@ -3760,8 +3691,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb100..0xcdb101
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcdb120..0xcdb121]
@@ -3772,8 +3702,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb120..0xcdb121
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcdb140..0xcdb141]
@@ -3784,8 +3713,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb140..0xcdb141
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcdb160..0xcdb161]
@@ -3796,8 +3724,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb160..0xcdb161
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0xcdb180..0xcdb181]
@@ -3808,8 +3735,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb180..0xcdb181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcdb1a0..0xcdb1a1]
@@ -3820,8 +3746,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb1a0..0xcdb1a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcdb1c0..0xcdb1c1]
@@ -3832,8 +3757,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb1c0..0xcdb1c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcdb1e0..0xcdb1e1]
@@ -3844,8 +3768,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb1e0..0xcdb1e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0xcdb200..0xcdb201]
@@ -3856,8 +3779,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb200..0xcdb201
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcdb220..0xcdb221]
@@ -3868,8 +3790,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb220..0xcdb221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcdb240..0xcdb241]
@@ -3880,8 +3801,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb240..0xcdb241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcdb260..0xcdb261]
@@ -3892,8 +3812,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb260..0xcdb261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcdb280..0xcdb281]
@@ -3904,8 +3823,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb280..0xcdb281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcdb2a0..0xcdb2a1]
@@ -3916,8 +3834,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb2a0..0xcdb2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcdb2c0..0xcdb2c1]
@@ -3928,8 +3845,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb2c0..0xcdb2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcdb2e0..0xcdb2e1]
@@ -3940,8 +3856,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb2e0..0xcdb2e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0xcdb300..0xcdb301]
@@ -3952,8 +3867,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb300..0xcdb301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0xcdb320..0xcdb321]
@@ -3964,8 +3878,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb320..0xcdb321
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0xcdb340..0xcdb341]
@@ -3976,8 +3889,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb340..0xcdb341
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0xcdb360..0xcdb361]
@@ -3988,8 +3900,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb360..0xcdb361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0xcdb380..0xcdb381]
@@ -4000,8 +3911,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb380..0xcdb381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0xcdb3a0..0xcdb3a1]
@@ -4012,8 +3922,7 @@ Subprograms:
           Locations:
             - Range: 0xcdb3a0..0xcdb3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0xcdcca0..0xcdcca1]
@@ -4024,22 +3933,19 @@ Subprograms:
           Locations:
             - Range: 0xcdcca0..0xcdcca1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xcdcca0..0xcdcca1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 18 BaseType float32
           Locations:
             - Range: 0xcdcca0..0xcdcca1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcdce60..0xcdce61]
@@ -4050,29 +3956,25 @@ Subprograms:
           Locations:
             - Range: 0xcdce60..0xcdce61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0xcdce60..0xcdce61
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 10 BaseType int32
           Locations:
             - Range: 0xcdce60..0xcdce61
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 17 BaseType uint
           Locations:
             - Range: 0xcdce60..0xcdce61
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
@@ -4082,8 +3984,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0xcdd080..0xcdd081]
@@ -4094,8 +3995,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd080..0xcdd081
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcdd220..0xcdd221]
@@ -4106,8 +4006,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd220..0xcdd221
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcdd240..0xcdd241]
@@ -4122,8 +4021,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcdd260..0xcdd261]
@@ -4134,8 +4032,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd260..0xcdd261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcdd280..0xcdd281]
@@ -4146,8 +4043,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd280..0xcdd281
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
@@ -4158,8 +4054,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd2c0..0xcdd2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
@@ -4170,8 +4065,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd3a0..0xcdd3a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
@@ -4182,15 +4076,13 @@ Subprograms:
           Locations:
             - Range: 0xcdd3e0..0xcdd3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 17 BaseType uint
           Locations:
             - Range: 0xcdd3e0..0xcdd3e1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0xcdd420..0xcdd421]
@@ -4201,8 +4093,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xcdd860..0xcdd8d2]
@@ -4213,8 +4104,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd860..0xcdd872
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4224,8 +4114,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd8bc..0xcdd8d2
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4233,8 +4122,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd885..0xcdd8d2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcdd8e0..0xcdd96f]
@@ -4247,8 +4135,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd8fa..0xcdd96f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
@@ -4258,8 +4145,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd955..0xcdd96f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
@@ -4267,8 +4153,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdd919..0xcdd96f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcdd980..0xcdda5e]
@@ -4279,8 +4164,7 @@ Subprograms:
           Locations:
             - Range: 0xcdd980..0xcdd9e2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4290,13 +4174,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdda45..0xcdda5e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcdd980..0xcdda5e, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
@@ -4304,8 +4186,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdd9e7..0xcdda5e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
@@ -4313,8 +4194,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
             - Range: 0xcdd9e7..0xcdda5e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcdda60..0xcddabb]
@@ -4325,8 +4205,7 @@ Subprograms:
           Locations:
             - Range: 0xcdda60..0xcdda79
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
@@ -4348,8 +4227,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddaa6..0xcddabb
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xcddac0..0xcddc06]
@@ -4388,15 +4266,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0xcddac0..0xcddb03
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
@@ -4434,8 +4310,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddbda..0xcddc06
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
@@ -4473,15 +4348,13 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcddbda..0xcddc06
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0xcddb0b..0xcddb11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xcddc20..0xcdde0e]
@@ -4508,8 +4381,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
@@ -4547,22 +4419,19 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcdddeb..0xcdde0e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0xcddcc0..0xcddcc6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
             - Range: 0xcddd05..0xcddd24
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xcdde20..0xcddf74]
@@ -4595,8 +4464,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
             - Range: 0xcddf38..0xcddf74
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
@@ -4618,8 +4486,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xcddf0a..0xcddf74
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
@@ -4657,8 +4524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcddf09..0xcddf74
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcddf80..0xcde00f]
@@ -4669,8 +4535,7 @@ Subprograms:
           Locations:
             - Range: 0xcddf80..0xcddf91
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4680,8 +4545,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcddff6..0xcde00f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xcde020..0xcde0e9]
@@ -4692,8 +4556,7 @@ Subprograms:
           Locations:
             - Range: 0xcde020..0xcde071
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4703,8 +4566,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde0d0..0xcde0e9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4714,8 +4576,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde0d0..0xcde0e9
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xcde100..0xcde1c7]
@@ -4728,8 +4589,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde145..0xcde1c7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4739,8 +4599,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4750,8 +4609,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -4761,8 +4619,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde1ae..0xcde1c7
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xcde1e0..0xcde25e]
@@ -4777,8 +4634,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
@@ -4788,8 +4644,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
@@ -4799,8 +4654,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
@@ -4810,8 +4664,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4821,8 +4674,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
@@ -4832,8 +4684,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4843,8 +4694,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
@@ -4854,8 +4704,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcde252..0xcde25e
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xcde260..0xcde357]
@@ -4864,78 +4713,63 @@ Subprograms:
         - Name: ~r0
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
@@ -4945,8 +4779,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
             - Range: 0xcde348..0xcde357
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
@@ -4956,8 +4789,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0xcde348..0xcde357
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xcde360..0xcde3d3]
@@ -4966,13 +4798,11 @@ Subprograms:
         - Name: ~r0
           Type: 96 BaseType complex64
           Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 97 BaseType complex128
           Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xcde3e0..0xcde485]
@@ -4987,8 +4817,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
             - Range: 0xcde474..0xcde485
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xcde4a0..0xcde51a]
@@ -5003,8 +4832,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcde50e..0xcde51a
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xcde520..0xcde578]
@@ -5019,8 +4847,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde56c..0xcde578
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xcde580..0xcde5d3]
@@ -5035,8 +4862,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcde5c7..0xcde5d3
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xcde5e0..0xcde647]
@@ -5045,8 +4871,7 @@ Subprograms:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0xcde5e0..0xcde647, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xcde660..0xcde6fa]
@@ -5061,8 +4886,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5072,8 +4896,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5083,8 +4906,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
@@ -5094,8 +4916,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
@@ -5105,8 +4926,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
@@ -5116,8 +4936,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
@@ -5127,8 +4946,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
@@ -5138,8 +4956,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5149,8 +4966,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcde6eb..0xcde6fa
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xcde700..0xcde7a5]
@@ -5165,8 +4981,7 @@ Subprograms:
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
             - Range: 0xcde795..0xcde7a5
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xcde7c0..0xcde839]
@@ -5181,13 +4996,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5197,13 +5010,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5217,8 +5028,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
             - Range: 0xcde82d..0xcde839
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xcde840..0xcde8ba]
@@ -5233,8 +5043,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
             - Range: 0xcde8ae..0xcde8ba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xcde8c0..0xcde91b]
@@ -5243,8 +5052,7 @@ Subprograms:
         - Name: ~r0
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde8c0..0xcde91b, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xcde920..0xcde987]
@@ -5253,13 +5061,11 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float32
           Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xcde9a0..0xcde9fd]
@@ -5274,8 +5080,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcde9f1..0xcde9fd
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5285,8 +5090,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcde9f1..0xcde9fd
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xcdea00..0xcdeb85]
@@ -5297,8 +5101,7 @@ Subprograms:
           Locations:
             - Range: 0xcdea00..0xcdeb85
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5308,8 +5111,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
             - Range: 0xcdeb74..0xcdeb85
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xcdeba0..0xcdec72]
@@ -5320,8 +5122,7 @@ Subprograms:
           Locations:
             - Range: 0xcdeba0..0xcdec72
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
@@ -5331,8 +5132,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdec63..0xcdec72
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xcdec80..0xcdeeba]
@@ -5343,15 +5143,13 @@ Subprograms:
           Locations:
             - Range: 0xcdec80..0xcdeeba
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
             - Range: 0xcdec80..0xcdeeba
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5361,8 +5159,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
             - Range: 0xcdeeab..0xcdeeba
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xcdeec0..0xcdf14f]
@@ -5375,8 +5172,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5384,8 +5180,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5393,8 +5188,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdef5a..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5402,8 +5196,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcdef30..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5411,8 +5204,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5420,8 +5212,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5429,8 +5220,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5438,8 +5228,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -5447,8 +5236,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
             - Range: 0xcdef70..0xcdf14f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
@@ -5458,8 +5246,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
             - Range: 0xcdf0e3..0xcdf14f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xcdf160..0xcdf42c]
@@ -5472,8 +5259,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5481,8 +5267,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5490,8 +5275,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdf1f5..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5499,8 +5283,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0xcdf1c2..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5508,8 +5291,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5517,8 +5299,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5526,8 +5307,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5535,8 +5315,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
             - Range: 0xcdf20b..0xcdf42c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5546,8 +5325,7 @@ Subprograms:
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5557,8 +5335,7 @@ Subprograms:
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
             - Range: 0xcdf3ac..0xcdf42c
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xcdf440..0xcdf4cc]
@@ -5569,8 +5346,7 @@ Subprograms:
           Locations:
             - Range: 0xcdf440..0xcdf4cc
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5580,8 +5356,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5591,8 +5366,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5602,8 +5376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0xcdf4bd..0xcdf4cc
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xcdf4e0..0xcdf5cf]
@@ -5614,15 +5387,13 @@ Subprograms:
           Locations:
             - Range: 0xcdf4e0..0xcdf5cf
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
             - Range: 0xcdf4e0..0xcdf5cf
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5632,8 +5403,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf5c0..0xcdf5cf
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
@@ -5643,8 +5413,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
             - Range: 0xcdf5c0..0xcdf5cf
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xcdf5e0..0xcdf6ac]
@@ -5655,8 +5424,7 @@ Subprograms:
           Locations:
             - Range: 0xcdf5e0..0xcdf6ac
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5666,8 +5434,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf69d..0xcdf6ac
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
@@ -5677,15 +5444,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
             - Range: 0xcdf69d..0xcdf6ac
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdf666..0xcdf6ac
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xcdf6c0..0xcdf766]
@@ -5694,8 +5459,7 @@ Subprograms:
         - Name: a
           Type: 253 ArrayType [0]int
           Locations: [{Range: 0xcdf6c0..0xcdf766, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5707,8 +5471,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xcdf73a..0xcdf766
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5718,8 +5481,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xcdf74d..0xcdf766
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
@@ -5729,8 +5491,7 @@ Subprograms:
               Pieces: []
             - Range: 0xcdf74d..0xcdf766
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdfc40..0xcdfc41]
@@ -5747,8 +5508,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdfc60..0xcdfc61]
@@ -5765,8 +5525,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
@@ -5783,8 +5542,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
@@ -5801,15 +5559,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdfca0..0xcdfca1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
@@ -5826,15 +5582,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdfcc0..0xcdfcc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
@@ -5851,15 +5605,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0xcdfce0..0xcdfce1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
@@ -5876,8 +5628,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcdfd20..0xcdfd21]
@@ -5888,8 +5639,7 @@ Subprograms:
           Locations:
             - Range: 0xcdfd20..0xcdfd21
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
@@ -5901,15 +5651,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 17 BaseType uint
           Locations:
             - Range: 0xcdfd20..0xcdfd21
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
@@ -5926,8 +5674,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
@@ -5944,8 +5691,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xcdfd80..0xcdfd81]
@@ -5962,8 +5708,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0xce00c0..0xce0112]
@@ -5982,8 +5727,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0xce0106..0xce0112
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0xce0120..0xce0121]
@@ -5998,8 +5742,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xce0140..0xce0141]
@@ -6014,8 +5757,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6025,8 +5767,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6036,8 +5777,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xce0160..0xce017f]
@@ -6060,8 +5800,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xce0180..0xce0181]
@@ -6072,8 +5811,7 @@ Subprograms:
           Locations:
             - Range: 0xce0180..0xce0181
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce01a0..0xce01a1]
@@ -6084,8 +5822,7 @@ Subprograms:
           Locations:
             - Range: 0xce01a0..0xce01a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xce01c0..0xce01c1]
@@ -6100,8 +5837,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xce01e0..0xce01e1]
@@ -6116,8 +5852,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xce0200..0xce0201]
@@ -6132,8 +5867,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xce0360..0xce0361]
@@ -6144,8 +5878,7 @@ Subprograms:
           Locations:
             - Range: 0xce0360..0xce0361
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xce0380..0xce039f]
@@ -6168,8 +5901,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0xce04c0..0xce04e3]
@@ -6194,8 +5926,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xce0640..0xce0641]
@@ -6204,8 +5935,7 @@ Subprograms:
         - Name: e
           Type: 317 StructureType main.emptyStruct
           Locations: [{Range: 0xce0640..0xce0641, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xce0660..0xce0661]
@@ -6216,8 +5946,7 @@ Subprograms:
           Locations:
             - Range: 0xce0660..0xce0661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda200..0xcda262]
@@ -6246,8 +5975,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
             - Range: 0xcda520..0xcda53a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6281,8 +6009,7 @@ Subprograms:
           Locations:
             - Range: 0xcda6c0..0xcda6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6299,8 +6026,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
             - Range: 0xcda78c..0xcda8c5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 139

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0x88c240..0x88c250
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x88c250..0x88c260]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0x88c250..0x88c260
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x88c260..0x88c270]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0x88c260..0x88c270
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x88c270..0x88c280]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0x88c270..0x88c280
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x88c280..0x88c290]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0x88c280..0x88c290
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x88c290..0x88c2a0]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0x88c290..0x88c2a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2a0..0x88c2b0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2b0..0x88c2c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2c0..0x88c2d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2d0..0x88c2e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2e0..0x88c2f0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x88c2f0..0x88c300]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0x88c2f0..0x88c300
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x88c300..0x88c310]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0x88c300..0x88c310
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x88c310..0x88c320]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0x88c310..0x88c320
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x88c320..0x88c330]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0x88c320..0x88c330
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x88c330..0x88c340]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0x88c330..0x88c340
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x88c340..0x88c350]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0x88c340..0x88c350
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0x88c350..0x88c360]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0x88c350..0x88c360
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0x88c360..0x88c370]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0x88c360..0x88c370
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x88c380..0x88c390]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0x88c380..0x88c390
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x88c6b0..0x88c6c0]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0x88c6b0..0x88c6c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x88c6c0..0x88c6d0]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0x88c6c0..0x88c6d0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x88c6d0..0x88c6e0]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0x88c6d0..0x88c6e0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x88c6e0..0x88c6f0]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0x88c6e0..0x88c6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x88c6f0..0x88c700]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0x88c6f0..0x88c700
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x88c700..0x88c710]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0x88c700..0x88c710
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x88c710..0x88c720]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0x88c710..0x88c720
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x88c720..0x88c730]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0x88c720..0x88c730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x88c730..0x88c740]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0x88c730..0x88c740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x88c740..0x88c750]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0x88c740..0x88c750
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x88c750..0x88c760]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0x88c750..0x88c760
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x88c760..0x88c770]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0x88c760..0x88c770
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x88c770..0x88c780]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0x88c770..0x88c780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x88c780..0x88c790]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0x88c780..0x88c790
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x88c790..0x88c7a0]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0x88c790..0x88c7a0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x88c7a0..0x88c7b0]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0x88c7a0..0x88c7b0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x88c8b0..0x88c8d0]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0x88c980..0x88c990]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0x88c980..0x88c990
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x88c990..0x88c9a0]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0x88c990..0x88c9a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0x88cb30..0x88cb40]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0x88cb40..0x88cb50]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0x88cb40..0x88cb50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0x88cc90..0x88cca0]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0x88cc90..0x88cca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0x88cca0..0x88ccb0]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0x88cca0..0x88ccb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0x88ccb0..0x88ccc0]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0x88ccb0..0x88ccc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0x88ccc0..0x88ccd0]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0x88ccc0..0x88ccd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0x88ccd0..0x88ced0]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88ce48..0x88ce58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 9 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
             - Range: 0x88ce44..0x88ced0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
             - Range: 0x88ce58..0x88ced0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x88d250..0x88d340]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x88d340..0x88d3c0]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0x88d340..0x88d378
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x88d780..0x88d810]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0x88d780..0x88d7b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x88d810..0x88d8e0]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0x88d810..0x88d82c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 BaseType int
           Locations:
             - Range: 0x88d810..0x88d83c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88d83c..0x88d8e0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x88d8e0..0x88d960]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0x88d8e0..0x88d904
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x88d960..0x88da80]
@@ -3569,8 +3514,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0x88d9e8..0x88d9fc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 9 BaseType int
           Locations:
@@ -3580,8 +3524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
             - Range: 0x88d9e8..0x88d9f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0x88da80..0x88da90]
@@ -3592,8 +3535,7 @@ Subprograms:
           Locations:
             - Range: 0x88da80..0x88da88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -3603,8 +3545,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88da89..0x88da90
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x88da90..0x88daf0]
@@ -3615,8 +3556,7 @@ Subprograms:
           Locations:
             - Range: 0x88da90..0x88daf0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -3626,8 +3566,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x88dad9..0x88daf0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0x88dd30..0x88dd40]
@@ -3642,8 +3581,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0x88dd40..0x88ddb0]
@@ -3664,8 +3602,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
@@ -3679,8 +3616,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x88dd85..0x88ddb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0x88ddb0..0x88ddc0]
@@ -3695,8 +3631,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0x88ddc0..0x88de30]
@@ -3707,8 +3642,7 @@ Subprograms:
           Locations:
             - Range: 0x88ddc0..0x88ddf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
@@ -3722,8 +3656,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x88de05..0x88de30
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0x88de30..0x88de40]
@@ -3738,8 +3671,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x88e3e0..0x88e3f0]
@@ -3750,8 +3682,7 @@ Subprograms:
           Locations:
             - Range: 0x88e3e0..0x88e3f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x88e3f0..0x88e400]
@@ -3762,8 +3693,7 @@ Subprograms:
           Locations:
             - Range: 0x88e3f0..0x88e400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x88e400..0x88e410]
@@ -3774,8 +3704,7 @@ Subprograms:
           Locations:
             - Range: 0x88e400..0x88e410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x88e410..0x88e420]
@@ -3786,8 +3715,7 @@ Subprograms:
           Locations:
             - Range: 0x88e410..0x88e420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x88e420..0x88e430]
@@ -3798,8 +3726,7 @@ Subprograms:
           Locations:
             - Range: 0x88e420..0x88e430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x88e430..0x88e440]
@@ -3810,8 +3737,7 @@ Subprograms:
           Locations:
             - Range: 0x88e430..0x88e440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x88e440..0x88e450]
@@ -3822,8 +3748,7 @@ Subprograms:
           Locations:
             - Range: 0x88e440..0x88e450
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x88e450..0x88e460]
@@ -3834,8 +3759,7 @@ Subprograms:
           Locations:
             - Range: 0x88e450..0x88e460
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x88e460..0x88e470]
@@ -3846,8 +3770,7 @@ Subprograms:
           Locations:
             - Range: 0x88e460..0x88e470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x88e470..0x88e480]
@@ -3858,8 +3781,7 @@ Subprograms:
           Locations:
             - Range: 0x88e470..0x88e480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x88e480..0x88e490]
@@ -3870,8 +3792,7 @@ Subprograms:
           Locations:
             - Range: 0x88e480..0x88e490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x88e490..0x88e4a0]
@@ -3882,8 +3803,7 @@ Subprograms:
           Locations:
             - Range: 0x88e490..0x88e4a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x88e4a0..0x88e4b0]
@@ -3894,8 +3814,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4a0..0x88e4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x88e4b0..0x88e4c0]
@@ -3906,8 +3825,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4b0..0x88e4c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x88e4c0..0x88e4d0]
@@ -3918,8 +3836,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4c0..0x88e4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x88e4d0..0x88e4e0]
@@ -3930,8 +3847,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4d0..0x88e4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x88e4e0..0x88e4f0]
@@ -3942,8 +3858,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4e0..0x88e4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x88e4f0..0x88e500]
@@ -3954,8 +3869,7 @@ Subprograms:
           Locations:
             - Range: 0x88e4f0..0x88e500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x88e500..0x88e510]
@@ -3966,8 +3880,7 @@ Subprograms:
           Locations:
             - Range: 0x88e500..0x88e510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x88e510..0x88e520]
@@ -3978,8 +3891,7 @@ Subprograms:
           Locations:
             - Range: 0x88e510..0x88e520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x88e520..0x88e530]
@@ -3990,8 +3902,7 @@ Subprograms:
           Locations:
             - Range: 0x88e520..0x88e530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x88e530..0x88e540]
@@ -4002,8 +3913,7 @@ Subprograms:
           Locations:
             - Range: 0x88e530..0x88e540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0x88e540..0x88e550]
@@ -4014,8 +3924,7 @@ Subprograms:
           Locations:
             - Range: 0x88e540..0x88e550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x88f8b0..0x88f8c0]
@@ -4026,22 +3935,19 @@ Subprograms:
           Locations:
             - Range: 0x88f8b0..0x88f8c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x88f8b0..0x88f8c0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 16 BaseType float32
           Locations:
             - Range: 0x88f8b0..0x88f8c0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x88f990..0x88f9a0]
@@ -4052,29 +3958,25 @@ Subprograms:
           Locations:
             - Range: 0x88f990..0x88f9a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x88f990..0x88f9a0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 13 BaseType int32
           Locations:
             - Range: 0x88f990..0x88f9a0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 12 BaseType uint
           Locations:
             - Range: 0x88f990..0x88f9a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
@@ -4084,8 +3986,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0x88fb30..0x88fb40]
@@ -4096,8 +3997,7 @@ Subprograms:
           Locations:
             - Range: 0x88fb30..0x88fb40
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x88fcd0..0x88fce0]
@@ -4108,8 +4008,7 @@ Subprograms:
           Locations:
             - Range: 0x88fcd0..0x88fce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x88fce0..0x88fcf0]
@@ -4124,8 +4023,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x88fcf0..0x88fd00]
@@ -4136,8 +4034,7 @@ Subprograms:
           Locations:
             - Range: 0x88fcf0..0x88fd00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x88fd00..0x88fd10]
@@ -4148,8 +4045,7 @@ Subprograms:
           Locations:
             - Range: 0x88fd00..0x88fd10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x88fd20..0x88fd30]
@@ -4160,8 +4056,7 @@ Subprograms:
           Locations:
             - Range: 0x88fd20..0x88fd30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x88fd90..0x88fda0]
@@ -4172,8 +4067,7 @@ Subprograms:
           Locations:
             - Range: 0x88fd90..0x88fda0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x88fdb0..0x88fdc0]
@@ -4184,15 +4078,13 @@ Subprograms:
           Locations:
             - Range: 0x88fdb0..0x88fdc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 12 BaseType uint
           Locations:
             - Range: 0x88fdb0..0x88fdc0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0x88fdd0..0x88fde0]
@@ -4203,8 +4095,7 @@ Subprograms:
           Locations:
             - Range: 0x88fdd0..0x88fde0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x8901e0..0x890260]
@@ -4215,8 +4106,7 @@ Subprograms:
           Locations:
             - Range: 0x8901e0..0x8901fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4226,8 +4116,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x89023d..0x890260
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4235,8 +4124,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890208..0x890260
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x890260..0x890300]
@@ -4249,8 +4137,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890284..0x890300
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
@@ -4260,8 +4147,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8902dd..0x890300
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
@@ -4269,8 +4155,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8902a4..0x890300
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x890300..0x8903d0]
@@ -4281,8 +4166,7 @@ Subprograms:
           Locations:
             - Range: 0x890300..0x890358
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4292,13 +4176,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8903b1..0x8903d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x890300..0x8903d0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
@@ -4306,8 +4188,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x89035c..0x8903d0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
@@ -4315,8 +4196,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
             - Range: 0x89035c..0x8903d0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x8903d0..0x890450]
@@ -4327,8 +4207,7 @@ Subprograms:
           Locations:
             - Range: 0x8903d0..0x8903f4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
@@ -4350,8 +4229,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x89042d..0x890450
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x890450..0x8905d0]
@@ -4390,15 +4268,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0x890450..0x8904a4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
@@ -4436,8 +4312,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8905a1..0x8905d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
@@ -4475,15 +4350,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x8905a1..0x8905d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
             - Range: 0x890504..0x89050c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x8905d0..0x8907d0]
@@ -4510,8 +4383,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
@@ -4549,22 +4421,19 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8907a9..0x8907d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
             - Range: 0x8906bc..0x8906c4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
             - Range: 0x89066c..0x890688
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x8907d0..0x890940]
@@ -4597,8 +4466,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
             - Range: 0x890904..0x890940
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
@@ -4620,8 +4488,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x8908cd..0x890940
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
@@ -4659,8 +4526,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
             - Range: 0x8908cc..0x890940
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x890940..0x8909e0]
@@ -4671,8 +4537,7 @@ Subprograms:
           Locations:
             - Range: 0x890940..0x89095c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4682,8 +4547,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8909b9..0x8909e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x8909e0..0x890ab0]
@@ -4694,8 +4558,7 @@ Subprograms:
           Locations:
             - Range: 0x8909e0..0x890a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
@@ -4705,8 +4568,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890a85..0x890ab0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
@@ -4716,8 +4578,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890a85..0x890ab0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x890ab0..0x890b80]
@@ -4730,8 +4591,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890af0..0x890b80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -4741,8 +4601,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
@@ -4752,8 +4611,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -4763,8 +4621,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x890b55..0x890b80
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x890b80..0x890c10]
@@ -4779,8 +4636,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
@@ -4790,8 +4646,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
@@ -4801,8 +4656,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
@@ -4812,8 +4666,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4823,8 +4676,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
@@ -4834,8 +4686,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4845,8 +4696,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
@@ -4856,8 +4706,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x890bf1..0x890c10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x890c10..0x890cd0]
@@ -4866,83 +4715,67 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
@@ -4952,8 +4785,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x890cad..0x890cd0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x890cd0..0x890d50]
@@ -4962,13 +4794,11 @@ Subprograms:
         - Name: ~r0
           Type: 90 BaseType complex64
           Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 91 BaseType complex128
           Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x890d50..0x890e20]
@@ -5003,8 +4833,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x890e05..0x890e20
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x890e20..0x890eb0]
@@ -5019,8 +4848,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x890e91..0x890eb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x890eb0..0x890f20]
@@ -5035,8 +4863,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x890f05..0x890f20
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x890f20..0x890f90]
@@ -5051,8 +4878,7 @@ Subprograms:
               Pieces: []
             - Range: 0x890f71..0x890f90
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x890f90..0x891010]
@@ -5061,8 +4887,7 @@ Subprograms:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0x890f90..0x891010, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x891010..0x8910b0]
@@ -5077,8 +4902,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
@@ -5088,8 +4912,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5099,8 +4922,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
@@ -5110,8 +4932,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
@@ -5121,8 +4942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
@@ -5132,8 +4952,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
@@ -5143,8 +4962,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
@@ -5154,8 +4972,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5169,8 +4986,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x89108d..0x8910b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x8910b0..0x891190]
@@ -5207,8 +5023,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x891175..0x891190
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x891190..0x891220]
@@ -5223,13 +5038,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x891190..0x891220, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5239,13 +5052,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
           Locations: [{Range: 0x891190..0x891220, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5259,8 +5070,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x891201..0x891220
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x891220..0x8912b0]
@@ -5275,8 +5085,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x891291..0x8912b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x8912b0..0x891320]
@@ -5285,8 +5094,7 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float64
           Locations: [{Range: 0x8912b0..0x891320, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x891320..0x8913a0]
@@ -5295,13 +5103,11 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float32
           Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
           Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x8913a0..0x891410]
@@ -5316,8 +5122,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8913f9..0x891410
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5327,8 +5132,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x8913f9..0x891410
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x891410..0x8915f0]
@@ -5403,8 +5207,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5434,8 +5237,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x891589..0x8915f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x8915f0..0x8916c0]
@@ -5446,8 +5248,7 @@ Subprograms:
           Locations:
             - Range: 0x8915f0..0x8916c0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
@@ -5457,8 +5258,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x8916a5..0x8916c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x8916c0..0x891920]
@@ -5533,15 +5333,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
             - Range: 0x8916c0..0x891920
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5571,8 +5369,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x8918b1..0x891920
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x891920..0x891b10]
@@ -5585,8 +5382,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5594,8 +5390,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
@@ -5603,8 +5398,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
@@ -5612,8 +5406,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
@@ -5621,8 +5414,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
@@ -5630,8 +5422,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
@@ -5639,8 +5430,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
@@ -5648,8 +5438,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
@@ -5657,8 +5446,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0x891998..0x891b10
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
@@ -5668,8 +5456,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x891aad..0x891b10
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x891b10..0x891d50]
@@ -5682,8 +5469,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5691,8 +5477,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
@@ -5700,8 +5485,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
@@ -5709,8 +5493,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
@@ -5718,8 +5501,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
@@ -5727,8 +5509,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
@@ -5736,8 +5517,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
@@ -5745,8 +5525,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x891b98..0x891d50
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
@@ -5762,8 +5541,7 @@ Subprograms:
                   Op: {CfaOffset: 72}
                 - Size: 8
                   Op: {CfaOffset: 80}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
@@ -5793,8 +5571,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x891ce1..0x891d50
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x891d50..0x891df0]
@@ -5805,8 +5582,7 @@ Subprograms:
           Locations:
             - Range: 0x891d50..0x891df0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5816,8 +5592,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
@@ -5827,8 +5602,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
@@ -5838,8 +5612,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x891dcd..0x891df0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x891df0..0x891ed0]
@@ -5850,15 +5623,13 @@ Subprograms:
           Locations:
             - Range: 0x891df0..0x891ed0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
             - Range: 0x891df0..0x891ed0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5868,8 +5639,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891eb1..0x891ed0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
@@ -5879,8 +5649,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x891eb1..0x891ed0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x891ed0..0x891fa0]
@@ -5891,8 +5660,7 @@ Subprograms:
           Locations:
             - Range: 0x891ed0..0x891fa0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5902,8 +5670,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x891f7d..0x891fa0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
@@ -5913,15 +5680,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x891f7d..0x891fa0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
             - Range: 0x891f50..0x891fa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x891fa0..0x892050]
@@ -5930,8 +5695,7 @@ Subprograms:
         - Name: a
           Type: 248 ArrayType [0]int
           Locations: [{Range: 0x891fa0..0x892050, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
@@ -5943,8 +5707,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x892018..0x892050
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
@@ -5954,8 +5717,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x892025..0x892050
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
@@ -5965,8 +5727,7 @@ Subprograms:
               Pieces: []
             - Range: 0x892025..0x892050
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x8924c0..0x8924d0]
@@ -5983,8 +5744,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x8924d0..0x8924e0]
@@ -6001,8 +5761,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x8924e0..0x8924f0]
@@ -6019,8 +5778,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x8924f0..0x892500]
@@ -6037,15 +5795,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0x8924f0..0x892500
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x892500..0x892510]
@@ -6062,15 +5818,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0x892500..0x892510
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x892510..0x892520]
@@ -6087,15 +5841,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 9 BaseType int
           Locations:
             - Range: 0x892510..0x892520
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x892520..0x892530]
@@ -6112,8 +5864,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x892530..0x892540]
@@ -6124,8 +5875,7 @@ Subprograms:
           Locations:
             - Range: 0x892530..0x892540
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
@@ -6137,15 +5887,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 12 BaseType uint
           Locations:
             - Range: 0x892530..0x892540
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x892540..0x892550]
@@ -6162,8 +5910,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x892550..0x892560]
@@ -6180,8 +5927,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x892560..0x892570]
@@ -6198,8 +5944,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0x892840..0x8928b0]
@@ -6218,8 +5963,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x89288d..0x8928b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0x8928b0..0x8928c0]
@@ -6234,8 +5978,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x8928c0..0x8928d0]
@@ -6250,8 +5993,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
@@ -6261,8 +6003,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
@@ -6272,8 +6013,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x8928d0..0x8928f0]
@@ -6296,8 +6036,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x8928f0..0x892900]
@@ -6308,8 +6047,7 @@ Subprograms:
           Locations:
             - Range: 0x8928f0..0x892900
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x892900..0x892910]
@@ -6320,8 +6058,7 @@ Subprograms:
           Locations:
             - Range: 0x892900..0x892910
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x892910..0x892920]
@@ -6336,8 +6073,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x892920..0x892930]
@@ -6352,8 +6088,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x892930..0x892940]
@@ -6368,8 +6103,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x892a80..0x892a90]
@@ -6380,8 +6114,7 @@ Subprograms:
           Locations:
             - Range: 0x892a80..0x892a90
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x892a90..0x892ab0]
@@ -6404,8 +6137,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0x892b80..0x892ba0]
@@ -6430,8 +6162,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x892c80..0x892c90]
@@ -6440,8 +6171,7 @@ Subprograms:
         - Name: e
           Type: 312 StructureType main.emptyStruct
           Locations: [{Range: 0x892c80..0x892c90, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x892c90..0x892ca0]
@@ -6452,8 +6182,7 @@ Subprograms:
           Locations:
             - Range: 0x892c90..0x892ca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d5e0..0x88d650]
@@ -6482,8 +6211,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x88d8e0..0x88d904
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6517,8 +6245,7 @@ Subprograms:
           Locations:
             - Range: 0x88da80..0x88da88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6535,8 +6262,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
             - Range: 0x88db38..0x88dc40
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 132

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0x849980..0x849990
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x849990..0x8499a0]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0x849990..0x8499a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x8499a0..0x8499b0]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0x8499a0..0x8499b0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x8499b0..0x8499c0]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0x8499b0..0x8499c0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x8499c0..0x8499d0]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0x8499c0..0x8499d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x8499d0..0x8499e0]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0x8499d0..0x8499e0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x8499e0..0x8499f0]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0x8499e0..0x8499f0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x8499f0..0x849a00]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0x8499f0..0x849a00
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x849a00..0x849a10]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0x849a00..0x849a10
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x849a10..0x849a20]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0x849a10..0x849a20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x849a20..0x849a30]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0x849a20..0x849a30
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x849a30..0x849a40]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0x849a30..0x849a40
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x849a40..0x849a50]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0x849a40..0x849a50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x849a50..0x849a60]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0x849a50..0x849a60
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x849a60..0x849a70]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0x849a60..0x849a70
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x849a70..0x849a80]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0x849a70..0x849a80
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x849a80..0x849a90]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0x849a80..0x849a90
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0x849a90..0x849aa0]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0x849a90..0x849aa0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0x849aa0..0x849ab0]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0x849aa0..0x849ab0
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x849ac0..0x849ad0]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0x849ac0..0x849ad0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x849df0..0x849e00]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0x849df0..0x849e00
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x849e00..0x849e10]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0x849e00..0x849e10
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x849e10..0x849e20]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0x849e10..0x849e20
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x849e20..0x849e30]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0x849e20..0x849e30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x849e30..0x849e40]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0x849e30..0x849e40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x849e40..0x849e50]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0x849e40..0x849e50
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x849e50..0x849e60]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0x849e50..0x849e60
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x849e60..0x849e70]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0x849e60..0x849e70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x849e70..0x849e80]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0x849e70..0x849e80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x849e80..0x849e90]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0x849e80..0x849e90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x849e90..0x849ea0]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0x849e90..0x849ea0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x849ea0..0x849eb0]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0x849ea0..0x849eb0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x849eb0..0x849ec0]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0x849eb0..0x849ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x849ec0..0x849ed0]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0x849ec0..0x849ed0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x849ed0..0x849ee0]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0x849ed0..0x849ee0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x849ee0..0x849ef0]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0x849ee0..0x849ef0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x849ff0..0x84a010]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0x84a0c0..0x84a0d0]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0x84a0c0..0x84a0d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x84a0d0..0x84a0e0]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0x84a0d0..0x84a0e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0x84a270..0x84a280]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0x84a280..0x84a290]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0x84a280..0x84a290
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0x84a3d0..0x84a3e0]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0x84a3d0..0x84a3e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0x84a3e0..0x84a3f0]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0x84a3e0..0x84a3f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0x84a3f0..0x84a400]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0x84a3f0..0x84a400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0x84a400..0x84a410]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0x84a400..0x84a410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0x84a410..0x84a610]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84a580..0x84a590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 7 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
             - Range: 0x84a57c..0x84a610
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
             - Range: 0x84a590..0x84a610
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x84a990..0x84aa60]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x84aa60..0x84aae0]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0x84aa60..0x84aa98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x84aea0..0x84af30]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0x84aea0..0x84aed8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x84af30..0x84aff0]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0x84af30..0x84af4c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
             - Range: 0x84af30..0x84af5c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84af5c..0x84aff0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x84aff0..0x84b070]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0x84aff0..0x84b014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x84b070..0x84b190]
@@ -3569,8 +3514,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
             - Range: 0x84b0f8..0x84b10c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -3580,8 +3524,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
             - Range: 0x84b0f8..0x84b108
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0x84b190..0x84b1a0]
@@ -3592,8 +3535,7 @@ Subprograms:
           Locations:
             - Range: 0x84b190..0x84b198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3603,8 +3545,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84b199..0x84b1a0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x84b1a0..0x84b200]
@@ -3615,8 +3556,7 @@ Subprograms:
           Locations:
             - Range: 0x84b1a0..0x84b200
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3626,8 +3566,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84b1e9..0x84b200
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0x84b430..0x84b440]
@@ -3642,8 +3581,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0x84b440..0x84b4b0]
@@ -3664,8 +3602,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3679,8 +3616,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84b485..0x84b4b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0x84b4b0..0x84b4c0]
@@ -3695,8 +3631,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0x84b4c0..0x84b530]
@@ -3707,8 +3642,7 @@ Subprograms:
           Locations:
             - Range: 0x84b4c0..0x84b4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3722,8 +3656,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84b505..0x84b530
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0x84b530..0x84b540]
@@ -3738,8 +3671,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x84bae0..0x84baf0]
@@ -3750,8 +3682,7 @@ Subprograms:
           Locations:
             - Range: 0x84bae0..0x84baf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x84baf0..0x84bb00]
@@ -3762,8 +3693,7 @@ Subprograms:
           Locations:
             - Range: 0x84baf0..0x84bb00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84bb00..0x84bb10]
@@ -3774,8 +3704,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb00..0x84bb10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84bb10..0x84bb20]
@@ -3786,8 +3715,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb10..0x84bb20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x84bb20..0x84bb30]
@@ -3798,8 +3726,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb20..0x84bb30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x84bb30..0x84bb40]
@@ -3810,8 +3737,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb30..0x84bb40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x84bb40..0x84bb50]
@@ -3822,8 +3748,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb40..0x84bb50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x84bb50..0x84bb60]
@@ -3834,8 +3759,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb50..0x84bb60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x84bb60..0x84bb70]
@@ -3846,8 +3770,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb60..0x84bb70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x84bb70..0x84bb80]
@@ -3858,8 +3781,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb70..0x84bb80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x84bb80..0x84bb90]
@@ -3870,8 +3792,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb80..0x84bb90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x84bb90..0x84bba0]
@@ -3882,8 +3803,7 @@ Subprograms:
           Locations:
             - Range: 0x84bb90..0x84bba0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x84bba0..0x84bbb0]
@@ -3894,8 +3814,7 @@ Subprograms:
           Locations:
             - Range: 0x84bba0..0x84bbb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x84bbb0..0x84bbc0]
@@ -3906,8 +3825,7 @@ Subprograms:
           Locations:
             - Range: 0x84bbb0..0x84bbc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x84bbc0..0x84bbd0]
@@ -3918,8 +3836,7 @@ Subprograms:
           Locations:
             - Range: 0x84bbc0..0x84bbd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x84bbd0..0x84bbe0]
@@ -3930,8 +3847,7 @@ Subprograms:
           Locations:
             - Range: 0x84bbd0..0x84bbe0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x84bbe0..0x84bbf0]
@@ -3942,8 +3858,7 @@ Subprograms:
           Locations:
             - Range: 0x84bbe0..0x84bbf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x84bbf0..0x84bc00]
@@ -3954,8 +3869,7 @@ Subprograms:
           Locations:
             - Range: 0x84bbf0..0x84bc00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x84bc00..0x84bc10]
@@ -3966,8 +3880,7 @@ Subprograms:
           Locations:
             - Range: 0x84bc00..0x84bc10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x84bc10..0x84bc20]
@@ -3978,8 +3891,7 @@ Subprograms:
           Locations:
             - Range: 0x84bc10..0x84bc20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x84bc20..0x84bc30]
@@ -3990,8 +3902,7 @@ Subprograms:
           Locations:
             - Range: 0x84bc20..0x84bc30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x84bc30..0x84bc40]
@@ -4002,8 +3913,7 @@ Subprograms:
           Locations:
             - Range: 0x84bc30..0x84bc40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0x84bc40..0x84bc50]
@@ -4014,8 +3924,7 @@ Subprograms:
           Locations:
             - Range: 0x84bc40..0x84bc50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x84d060..0x84d070]
@@ -4026,22 +3935,19 @@ Subprograms:
           Locations:
             - Range: 0x84d060..0x84d070
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x84d060..0x84d070
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 17 BaseType float32
           Locations:
             - Range: 0x84d060..0x84d070
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x84d140..0x84d150]
@@ -4052,29 +3958,25 @@ Subprograms:
           Locations:
             - Range: 0x84d140..0x84d150
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x84d140..0x84d150
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
             - Range: 0x84d140..0x84d150
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 10 BaseType uint
           Locations:
             - Range: 0x84d140..0x84d150
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
@@ -4084,8 +3986,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0x84d2e0..0x84d2f0]
@@ -4096,8 +3997,7 @@ Subprograms:
           Locations:
             - Range: 0x84d2e0..0x84d2f0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x84d480..0x84d490]
@@ -4108,8 +4008,7 @@ Subprograms:
           Locations:
             - Range: 0x84d480..0x84d490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x84d490..0x84d4a0]
@@ -4124,8 +4023,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x84d4a0..0x84d4b0]
@@ -4136,8 +4034,7 @@ Subprograms:
           Locations:
             - Range: 0x84d4a0..0x84d4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x84d4b0..0x84d4c0]
@@ -4148,8 +4045,7 @@ Subprograms:
           Locations:
             - Range: 0x84d4b0..0x84d4c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
@@ -4160,8 +4056,7 @@ Subprograms:
           Locations:
             - Range: 0x84d4d0..0x84d4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x84d540..0x84d550]
@@ -4172,8 +4067,7 @@ Subprograms:
           Locations:
             - Range: 0x84d540..0x84d550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x84d560..0x84d570]
@@ -4184,15 +4078,13 @@ Subprograms:
           Locations:
             - Range: 0x84d560..0x84d570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
             - Range: 0x84d560..0x84d570
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0x84d580..0x84d590]
@@ -4203,8 +4095,7 @@ Subprograms:
           Locations:
             - Range: 0x84d580..0x84d590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x84d8c0..0x84d940]
@@ -4215,8 +4106,7 @@ Subprograms:
           Locations:
             - Range: 0x84d8c0..0x84d8dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4226,8 +4116,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d91d..0x84d940
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4235,8 +4124,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d8e8..0x84d940
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x84d940..0x84d9e0]
@@ -4249,8 +4137,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d964..0x84d9e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
@@ -4260,8 +4147,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d9b9..0x84d9e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
@@ -4269,8 +4155,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84d980..0x84d9e0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x84d9e0..0x84dab0]
@@ -4281,8 +4166,7 @@ Subprograms:
           Locations:
             - Range: 0x84d9e0..0x84da38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4292,13 +4176,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84da91..0x84dab0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84d9e0..0x84dab0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
@@ -4306,8 +4188,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84da3c..0x84dab0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
@@ -4315,8 +4196,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
             - Range: 0x84da3c..0x84dab0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x84dab0..0x84db30]
@@ -4327,8 +4207,7 @@ Subprograms:
           Locations:
             - Range: 0x84dab0..0x84dad4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
@@ -4350,8 +4229,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84db0d..0x84db30
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x84db30..0x84dcb0]
@@ -4390,15 +4268,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0x84db30..0x84db74
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
@@ -4436,8 +4312,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84dc81..0x84dcb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
@@ -4475,15 +4350,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x84dc81..0x84dcb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0x84db80..0x84db88
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x84dcb0..0x84deb0]
@@ -4510,8 +4383,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
@@ -4549,22 +4421,19 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84de85..0x84deb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0x84dd98..0x84dda0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
             - Range: 0x84dd48..0x84dd64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x84deb0..0x84e010]
@@ -4597,8 +4466,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
             - Range: 0x84dfe0..0x84e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
@@ -4620,8 +4488,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84dfa9..0x84e010
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
@@ -4659,8 +4526,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
             - Range: 0x84dfa8..0x84e010
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x84e010..0x84e0b0]
@@ -4671,8 +4537,7 @@ Subprograms:
           Locations:
             - Range: 0x84e010..0x84e02c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4682,8 +4547,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e089..0x84e0b0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x84e0b0..0x84e180]
@@ -4694,8 +4558,7 @@ Subprograms:
           Locations:
             - Range: 0x84e0b0..0x84e100
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4705,8 +4568,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e155..0x84e180
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4716,8 +4578,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e155..0x84e180
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x84e180..0x84e240]
@@ -4730,8 +4591,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e1c0..0x84e240
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4741,8 +4601,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4752,8 +4611,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -4763,8 +4621,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e221..0x84e240
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x84e240..0x84e2d0]
@@ -4779,8 +4636,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
@@ -4790,8 +4646,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
@@ -4801,8 +4656,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
@@ -4812,8 +4666,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4823,8 +4676,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
@@ -4834,8 +4686,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4845,8 +4696,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
@@ -4856,8 +4706,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84e2b1..0x84e2d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x84e2d0..0x84e390]
@@ -4866,83 +4715,67 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
@@ -4952,8 +4785,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x84e36d..0x84e390
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x84e390..0x84e410]
@@ -4962,13 +4794,11 @@ Subprograms:
         - Name: ~r0
           Type: 95 BaseType complex64
           Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 96 BaseType complex128
           Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x84e410..0x84e4e0]
@@ -5003,8 +4833,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84e4c5..0x84e4e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x84e4e0..0x84e570]
@@ -5019,8 +4848,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x84e551..0x84e570
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x84e570..0x84e5e0]
@@ -5035,8 +4863,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e5c5..0x84e5e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x84e5e0..0x84e650]
@@ -5051,8 +4878,7 @@ Subprograms:
               Pieces: []
             - Range: 0x84e631..0x84e650
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x84e650..0x84e6d0]
@@ -5061,8 +4887,7 @@ Subprograms:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0x84e650..0x84e6d0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x84e6d0..0x84e770]
@@ -5077,8 +4902,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5088,8 +4912,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5099,8 +4922,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
@@ -5110,8 +4932,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
@@ -5121,8 +4942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
@@ -5132,8 +4952,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
@@ -5143,8 +4962,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
@@ -5154,8 +4972,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5169,8 +4986,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84e74d..0x84e770
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x84e770..0x84e850]
@@ -5207,8 +5023,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x84e835..0x84e850
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x84e850..0x84e8e0]
@@ -5223,13 +5038,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5239,13 +5052,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5259,8 +5070,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x84e8c1..0x84e8e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x84e8e0..0x84e970]
@@ -5275,8 +5085,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x84e951..0x84e970
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x84e970..0x84e9e0]
@@ -5285,8 +5094,7 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e970..0x84e9e0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x84e9e0..0x84ea60]
@@ -5295,13 +5103,11 @@ Subprograms:
         - Name: ~r0
           Type: 17 BaseType float32
           Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x84ea60..0x84ead0]
@@ -5316,8 +5122,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84eab9..0x84ead0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5327,8 +5132,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84eab9..0x84ead0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x84ead0..0x84ec90]
@@ -5403,8 +5207,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5434,8 +5237,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84ec49..0x84ec90
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x84ec90..0x84ed60]
@@ -5446,8 +5248,7 @@ Subprograms:
           Locations:
             - Range: 0x84ec90..0x84ed60
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
@@ -5457,8 +5258,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x84ed45..0x84ed60
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x84ed60..0x84ef90]
@@ -5533,15 +5333,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
             - Range: 0x84ed60..0x84ef90
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5571,8 +5369,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84ef51..0x84ef90
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x84ef90..0x84f160]
@@ -5585,8 +5382,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5594,8 +5390,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84eff4..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5603,8 +5398,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5612,8 +5406,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5621,8 +5414,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5630,8 +5422,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5639,8 +5430,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5648,8 +5438,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -5657,8 +5446,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0x84f008..0x84f160
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
@@ -5668,8 +5456,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x84f119..0x84f160
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x84f160..0x84f370]
@@ -5682,8 +5469,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5691,8 +5477,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84f1d4..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5700,8 +5485,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5709,8 +5493,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5718,8 +5501,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5727,8 +5509,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5736,8 +5517,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5745,8 +5525,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x84f1e8..0x84f370
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5762,8 +5541,7 @@ Subprograms:
                   Op: {CfaOffset: 72}
                 - Size: 8
                   Op: {CfaOffset: 80}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
@@ -5793,8 +5571,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x84f32d..0x84f370
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x84f370..0x84f410]
@@ -5805,8 +5582,7 @@ Subprograms:
           Locations:
             - Range: 0x84f370..0x84f410
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5816,8 +5592,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5827,8 +5602,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5838,8 +5612,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x84f3ed..0x84f410
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x84f410..0x84f4f0]
@@ -5850,15 +5623,13 @@ Subprograms:
           Locations:
             - Range: 0x84f410..0x84f4f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
             - Range: 0x84f410..0x84f4f0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5868,8 +5639,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f4d5..0x84f4f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
@@ -5879,8 +5649,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x84f4d5..0x84f4f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x84f4f0..0x84f5c0]
@@ -5891,8 +5660,7 @@ Subprograms:
           Locations:
             - Range: 0x84f4f0..0x84f5c0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5902,8 +5670,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f59d..0x84f5c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
@@ -5913,15 +5680,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x84f59d..0x84f5c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x84f570..0x84f5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x84f5c0..0x84f660]
@@ -5930,8 +5695,7 @@ Subprograms:
         - Name: a
           Type: 251 ArrayType [0]int
           Locations: [{Range: 0x84f5c0..0x84f660, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5943,8 +5707,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x84f624..0x84f660
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5954,8 +5717,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x84f641..0x84f660
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
@@ -5965,8 +5727,7 @@ Subprograms:
               Pieces: []
             - Range: 0x84f641..0x84f660
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x84fac0..0x84fad0]
@@ -5983,8 +5744,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x84fad0..0x84fae0]
@@ -6001,8 +5761,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x84fae0..0x84faf0]
@@ -6019,8 +5778,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x84faf0..0x84fb00]
@@ -6037,15 +5795,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x84faf0..0x84fb00
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x84fb00..0x84fb10]
@@ -6062,15 +5818,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x84fb00..0x84fb10
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x84fb10..0x84fb20]
@@ -6087,15 +5841,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x84fb10..0x84fb20
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x84fb20..0x84fb30]
@@ -6112,8 +5864,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x84fb30..0x84fb40]
@@ -6124,8 +5875,7 @@ Subprograms:
           Locations:
             - Range: 0x84fb30..0x84fb40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
@@ -6137,15 +5887,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 10 BaseType uint
           Locations:
             - Range: 0x84fb30..0x84fb40
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x84fb40..0x84fb50]
@@ -6162,8 +5910,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x84fb50..0x84fb60]
@@ -6180,8 +5927,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x84fb60..0x84fb70]
@@ -6198,8 +5944,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0x84fe40..0x84feb0]
@@ -6218,8 +5963,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x84fe8d..0x84feb0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0x84feb0..0x84fec0]
@@ -6234,8 +5978,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x84fec0..0x84fed0]
@@ -6250,8 +5993,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6261,8 +6003,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6272,8 +6013,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x84fed0..0x84fef0]
@@ -6296,8 +6036,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x84fef0..0x84ff00]
@@ -6308,8 +6047,7 @@ Subprograms:
           Locations:
             - Range: 0x84fef0..0x84ff00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x84ff00..0x84ff10]
@@ -6320,8 +6058,7 @@ Subprograms:
           Locations:
             - Range: 0x84ff00..0x84ff10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x84ff10..0x84ff20]
@@ -6336,8 +6073,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x84ff20..0x84ff30]
@@ -6352,8 +6088,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x84ff30..0x84ff40]
@@ -6368,8 +6103,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x850080..0x850090]
@@ -6380,8 +6114,7 @@ Subprograms:
           Locations:
             - Range: 0x850080..0x850090
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x850090..0x8500b0]
@@ -6404,8 +6137,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0x850180..0x8501a0]
@@ -6430,8 +6162,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x850280..0x850290]
@@ -6440,8 +6171,7 @@ Subprograms:
         - Name: e
           Type: 315 StructureType main.emptyStruct
           Locations: [{Range: 0x850280..0x850290, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x850290..0x8502a0]
@@ -6452,8 +6182,7 @@ Subprograms:
           Locations:
             - Range: 0x850290..0x8502a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84ad00..0x84ad70]
@@ -6482,8 +6211,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x84aff0..0x84b014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6517,8 +6245,7 @@ Subprograms:
           Locations:
             - Range: 0x84b190..0x84b198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6535,8 +6262,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
             - Range: 0x84b248..0x84b350
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 137

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -2823,8 +2823,7 @@ Subprograms:
           Locations:
             - Range: 0x806290..0x8062a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.testRuneArray
       OutOfLinePCRanges: [0x8062a0..0x8062b0]
@@ -2835,8 +2834,7 @@ Subprograms:
           Locations:
             - Range: 0x8062a0..0x8062b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.testStringArray
       OutOfLinePCRanges: [0x8062b0..0x8062c0]
@@ -2847,8 +2845,7 @@ Subprograms:
           Locations:
             - Range: 0x8062b0..0x8062c0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.testBoolArray
       OutOfLinePCRanges: [0x8062c0..0x8062d0]
@@ -2859,8 +2856,7 @@ Subprograms:
           Locations:
             - Range: 0x8062c0..0x8062d0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.testIntArray
       OutOfLinePCRanges: [0x8062d0..0x8062e0]
@@ -2871,8 +2867,7 @@ Subprograms:
           Locations:
             - Range: 0x8062d0..0x8062e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.testInt8Array
       OutOfLinePCRanges: [0x8062e0..0x8062f0]
@@ -2883,8 +2878,7 @@ Subprograms:
           Locations:
             - Range: 0x8062e0..0x8062f0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.testInt16Array
       OutOfLinePCRanges: [0x8062f0..0x806300]
@@ -2895,8 +2889,7 @@ Subprograms:
           Locations:
             - Range: 0x8062f0..0x806300
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.testInt32Array
       OutOfLinePCRanges: [0x806300..0x806310]
@@ -2907,8 +2900,7 @@ Subprograms:
           Locations:
             - Range: 0x806300..0x806310
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.testInt64Array
       OutOfLinePCRanges: [0x806310..0x806320]
@@ -2919,8 +2911,7 @@ Subprograms:
           Locations:
             - Range: 0x806310..0x806320
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.testUintArray
       OutOfLinePCRanges: [0x806320..0x806330]
@@ -2931,8 +2922,7 @@ Subprograms:
           Locations:
             - Range: 0x806320..0x806330
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 11
       Name: main.testUint8Array
       OutOfLinePCRanges: [0x806330..0x806340]
@@ -2943,8 +2933,7 @@ Subprograms:
           Locations:
             - Range: 0x806330..0x806340
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 12
       Name: main.testUint16Array
       OutOfLinePCRanges: [0x806340..0x806350]
@@ -2955,8 +2944,7 @@ Subprograms:
           Locations:
             - Range: 0x806340..0x806350
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.testUint32Array
       OutOfLinePCRanges: [0x806350..0x806360]
@@ -2967,8 +2955,7 @@ Subprograms:
           Locations:
             - Range: 0x806350..0x806360
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.testUint64Array
       OutOfLinePCRanges: [0x806360..0x806370]
@@ -2979,8 +2966,7 @@ Subprograms:
           Locations:
             - Range: 0x806360..0x806370
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
       OutOfLinePCRanges: [0x806370..0x806380]
@@ -2991,8 +2977,7 @@ Subprograms:
           Locations:
             - Range: 0x806370..0x806380
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
       OutOfLinePCRanges: [0x806380..0x806390]
@@ -3003,8 +2988,7 @@ Subprograms:
           Locations:
             - Range: 0x806380..0x806390
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
       OutOfLinePCRanges: [0x806390..0x8063a0]
@@ -3015,8 +2999,7 @@ Subprograms:
           Locations:
             - Range: 0x806390..0x8063a0
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
       OutOfLinePCRanges: [0x8063a0..0x8063b0]
@@ -3027,8 +3010,7 @@ Subprograms:
           Locations:
             - Range: 0x8063a0..0x8063b0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
       OutOfLinePCRanges: [0x8063b0..0x8063c0]
@@ -3039,8 +3021,7 @@ Subprograms:
           Locations:
             - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
       OutOfLinePCRanges: [0x8063d0..0x8063e0]
@@ -3051,8 +3032,7 @@ Subprograms:
           Locations:
             - Range: 0x8063d0..0x8063e0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 21
       Name: main.testSingleByte
       OutOfLinePCRanges: [0x806700..0x806710]
@@ -3063,8 +3043,7 @@ Subprograms:
           Locations:
             - Range: 0x806700..0x806710
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 22
       Name: main.testSingleRune
       OutOfLinePCRanges: [0x806710..0x806720]
@@ -3075,8 +3054,7 @@ Subprograms:
           Locations:
             - Range: 0x806710..0x806720
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 23
       Name: main.testSingleBool
       OutOfLinePCRanges: [0x806720..0x806730]
@@ -3087,8 +3065,7 @@ Subprograms:
           Locations:
             - Range: 0x806720..0x806730
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 24
       Name: main.testSingleInt
       OutOfLinePCRanges: [0x806730..0x806740]
@@ -3099,8 +3076,7 @@ Subprograms:
           Locations:
             - Range: 0x806730..0x806740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
       OutOfLinePCRanges: [0x806740..0x806750]
@@ -3111,8 +3087,7 @@ Subprograms:
           Locations:
             - Range: 0x806740..0x806750
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
       OutOfLinePCRanges: [0x806750..0x806760]
@@ -3123,8 +3098,7 @@ Subprograms:
           Locations:
             - Range: 0x806750..0x806760
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
       OutOfLinePCRanges: [0x806760..0x806770]
@@ -3135,8 +3109,7 @@ Subprograms:
           Locations:
             - Range: 0x806760..0x806770
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
       OutOfLinePCRanges: [0x806770..0x806780]
@@ -3147,8 +3120,7 @@ Subprograms:
           Locations:
             - Range: 0x806770..0x806780
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 29
       Name: main.testSingleUint
       OutOfLinePCRanges: [0x806780..0x806790]
@@ -3159,8 +3131,7 @@ Subprograms:
           Locations:
             - Range: 0x806780..0x806790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
       OutOfLinePCRanges: [0x806790..0x8067a0]
@@ -3171,8 +3142,7 @@ Subprograms:
           Locations:
             - Range: 0x806790..0x8067a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
       OutOfLinePCRanges: [0x8067a0..0x8067b0]
@@ -3183,8 +3153,7 @@ Subprograms:
           Locations:
             - Range: 0x8067a0..0x8067b0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
       OutOfLinePCRanges: [0x8067b0..0x8067c0]
@@ -3195,8 +3164,7 @@ Subprograms:
           Locations:
             - Range: 0x8067b0..0x8067c0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
       OutOfLinePCRanges: [0x8067c0..0x8067d0]
@@ -3207,8 +3175,7 @@ Subprograms:
           Locations:
             - Range: 0x8067c0..0x8067d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
       OutOfLinePCRanges: [0x8067d0..0x8067e0]
@@ -3219,8 +3186,7 @@ Subprograms:
           Locations:
             - Range: 0x8067d0..0x8067e0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
       OutOfLinePCRanges: [0x8067e0..0x8067f0]
@@ -3231,8 +3197,7 @@ Subprograms:
           Locations:
             - Range: 0x8067e0..0x8067f0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
       OutOfLinePCRanges: [0x8067f0..0x806800]
@@ -3243,8 +3208,7 @@ Subprograms:
           Locations:
             - Range: 0x8067f0..0x806800
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 37
       Name: main.testBigStruct
       OutOfLinePCRanges: [0x8068f0..0x806900]
@@ -3267,8 +3231,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
       OutOfLinePCRanges: [0x8069b0..0x8069c0]
@@ -3279,8 +3242,7 @@ Subprograms:
           Locations:
             - Range: 0x8069b0..0x8069c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
       OutOfLinePCRanges: [0x8069c0..0x8069d0]
@@ -3291,8 +3253,7 @@ Subprograms:
           Locations:
             - Range: 0x8069c0..0x8069d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
       OutOfLinePCRanges: [0x806b30..0x806b40]
@@ -3309,8 +3270,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
       OutOfLinePCRanges: [0x806b40..0x806b50]
@@ -3321,8 +3281,7 @@ Subprograms:
           Locations:
             - Range: 0x806b40..0x806b50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
       OutOfLinePCRanges: [0x806c90..0x806ca0]
@@ -3333,8 +3292,7 @@ Subprograms:
           Locations:
             - Range: 0x806c90..0x806ca0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
       OutOfLinePCRanges: [0x806ca0..0x806cb0]
@@ -3345,8 +3303,7 @@ Subprograms:
           Locations:
             - Range: 0x806ca0..0x806cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 44
       Name: main.testStringType1
       OutOfLinePCRanges: [0x806cb0..0x806cc0]
@@ -3357,8 +3314,7 @@ Subprograms:
           Locations:
             - Range: 0x806cb0..0x806cc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 45
       Name: main.testStringType2
       OutOfLinePCRanges: [0x806cc0..0x806cd0]
@@ -3369,8 +3325,7 @@ Subprograms:
           Locations:
             - Range: 0x806cc0..0x806cd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
       OutOfLinePCRanges: [0x806cd0..0x806eb0]
@@ -3383,8 +3338,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x806e28..0x806e38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: a
           Type: 7 BaseType int
           Locations:
@@ -3398,8 +3352,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
             - Range: 0x806e24..0x806eb0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -3419,8 +3372,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
             - Range: 0x806e38..0x806eb0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 47
       Name: main.testEsotericStack
       OutOfLinePCRanges: [0x8071e0..0x8072a0]
@@ -3489,8 +3441,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
       OutOfLinePCRanges: [0x8072a0..0x807310]
@@ -3501,8 +3452,7 @@ Subprograms:
           Locations:
             - Range: 0x8072a0..0x8072d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
       OutOfLinePCRanges: [0x8076b0..0x807740]
@@ -3513,8 +3463,7 @@ Subprograms:
           Locations:
             - Range: 0x8076b0..0x8076e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
       OutOfLinePCRanges: [0x807740..0x807800]
@@ -3525,15 +3474,13 @@ Subprograms:
           Locations:
             - Range: 0x807740..0x80775c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 7 BaseType int
           Locations:
             - Range: 0x807740..0x80776c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 7 BaseType int
           Locations:
@@ -3541,8 +3488,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80776c..0x807800
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 51
       Name: main.testInlinedBBA
       OutOfLinePCRanges: [0x807800..0x807870]
@@ -3553,8 +3499,7 @@ Subprograms:
           Locations:
             - Range: 0x807800..0x807824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
       OutOfLinePCRanges: [0x807870..0x807980]
@@ -3567,8 +3512,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8078f8..0x807900
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -3576,8 +3520,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8078f8..0x8078fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 53
       Name: main.testFrameless
       OutOfLinePCRanges: [0x807980..0x807990]
@@ -3588,8 +3531,7 @@ Subprograms:
           Locations:
             - Range: 0x807980..0x807988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3599,8 +3541,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x807989..0x807990
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 54
       Name: main.testFramelessArray
       OutOfLinePCRanges: [0x807990..0x8079e0]
@@ -3611,8 +3552,7 @@ Subprograms:
           Locations:
             - Range: 0x807990..0x8079e0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -3622,8 +3562,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x8079d1..0x8079e0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 55
       Name: main.testInterface
       OutOfLinePCRanges: [0x807bf0..0x807c00]
@@ -3638,8 +3577,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 56
       Name: main.testAny
       OutOfLinePCRanges: [0x807c00..0x807c60]
@@ -3660,8 +3598,7 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3675,8 +3612,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x807c41..0x807c60
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 57
       Name: main.testError
       OutOfLinePCRanges: [0x807c60..0x807c70]
@@ -3691,8 +3627,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
       OutOfLinePCRanges: [0x807c70..0x807cd0]
@@ -3703,8 +3638,7 @@ Subprograms:
           Locations:
             - Range: 0x807c70..0x807c9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
@@ -3718,8 +3652,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x807cb1..0x807cd0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 59
       Name: main.testStructWithAny
       OutOfLinePCRanges: [0x807cd0..0x807ce0]
@@ -3734,8 +3667,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
       OutOfLinePCRanges: [0x808220..0x808230]
@@ -3746,8 +3678,7 @@ Subprograms:
           Locations:
             - Range: 0x808220..0x808230
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
       OutOfLinePCRanges: [0x808230..0x808240]
@@ -3758,8 +3689,7 @@ Subprograms:
           Locations:
             - Range: 0x808230..0x808240
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x808240..0x808250]
@@ -3770,8 +3700,7 @@ Subprograms:
           Locations:
             - Range: 0x808240..0x808250
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x808250..0x808260]
@@ -3782,8 +3711,7 @@ Subprograms:
           Locations:
             - Range: 0x808250..0x808260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0x808260..0x808270]
@@ -3794,8 +3722,7 @@ Subprograms:
           Locations:
             - Range: 0x808260..0x808270
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 65
       Name: main.testSmallMap
       OutOfLinePCRanges: [0x808270..0x808280]
@@ -3806,8 +3733,7 @@ Subprograms:
           Locations:
             - Range: 0x808270..0x808280
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0x808280..0x808290]
@@ -3818,8 +3744,7 @@ Subprograms:
           Locations:
             - Range: 0x808280..0x808290
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
       OutOfLinePCRanges: [0x808290..0x8082a0]
@@ -3830,8 +3755,7 @@ Subprograms:
           Locations:
             - Range: 0x808290..0x8082a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
       OutOfLinePCRanges: [0x8082a0..0x8082b0]
@@ -3842,8 +3766,7 @@ Subprograms:
           Locations:
             - Range: 0x8082a0..0x8082b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 69
       Name: main.testMapMassive
       OutOfLinePCRanges: [0x8082b0..0x8082c0]
@@ -3854,8 +3777,7 @@ Subprograms:
           Locations:
             - Range: 0x8082b0..0x8082c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 70
       Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x8082c0..0x8082d0]
@@ -3866,8 +3788,7 @@ Subprograms:
           Locations:
             - Range: 0x8082c0..0x8082d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0x8082d0..0x8082e0]
@@ -3878,8 +3799,7 @@ Subprograms:
           Locations:
             - Range: 0x8082d0..0x8082e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0x8082e0..0x8082f0]
@@ -3890,8 +3810,7 @@ Subprograms:
           Locations:
             - Range: 0x8082e0..0x8082f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 73
       Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x8082f0..0x808300]
@@ -3902,8 +3821,7 @@ Subprograms:
           Locations:
             - Range: 0x8082f0..0x808300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 74
       Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x808300..0x808310]
@@ -3914,8 +3832,7 @@ Subprograms:
           Locations:
             - Range: 0x808300..0x808310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 75
       Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x808310..0x808320]
@@ -3926,8 +3843,7 @@ Subprograms:
           Locations:
             - Range: 0x808310..0x808320
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 76
       Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0x808320..0x808330]
@@ -3938,8 +3854,7 @@ Subprograms:
           Locations:
             - Range: 0x808320..0x808330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
       OutOfLinePCRanges: [0x808330..0x808340]
@@ -3950,8 +3865,7 @@ Subprograms:
           Locations:
             - Range: 0x808330..0x808340
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
       OutOfLinePCRanges: [0x808340..0x808350]
@@ -3962,8 +3876,7 @@ Subprograms:
           Locations:
             - Range: 0x808340..0x808350
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
       OutOfLinePCRanges: [0x808350..0x808360]
@@ -3974,8 +3887,7 @@ Subprograms:
           Locations:
             - Range: 0x808350..0x808360
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
       OutOfLinePCRanges: [0x808360..0x808370]
@@ -3986,8 +3898,7 @@ Subprograms:
           Locations:
             - Range: 0x808360..0x808370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
       OutOfLinePCRanges: [0x808370..0x808380]
@@ -3998,8 +3909,7 @@ Subprograms:
           Locations:
             - Range: 0x808370..0x808380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
       OutOfLinePCRanges: [0x808380..0x808390]
@@ -4010,8 +3920,7 @@ Subprograms:
           Locations:
             - Range: 0x808380..0x808390
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
       OutOfLinePCRanges: [0x809750..0x809760]
@@ -4022,22 +3931,19 @@ Subprograms:
           Locations:
             - Range: 0x809750..0x809760
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x809750..0x809760
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 18 BaseType float32
           Locations:
             - Range: 0x809750..0x809760
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x809830..0x809840]
@@ -4048,29 +3954,25 @@ Subprograms:
           Locations:
             - Range: 0x809830..0x809840
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
             - Range: 0x809830..0x809840
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 12 BaseType int32
           Locations:
             - Range: 0x809830..0x809840
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 10 BaseType uint
           Locations:
             - Range: 0x809830..0x809840
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 9 GoStringHeaderType string
           Locations:
@@ -4080,8 +3982,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 85
       Name: main.testChannel
       OutOfLinePCRanges: [0x8099d0..0x8099e0]
@@ -4092,8 +3993,7 @@ Subprograms:
           Locations:
             - Range: 0x8099d0..0x8099e0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 86
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x809b50..0x809b60]
@@ -4104,8 +4004,7 @@ Subprograms:
           Locations:
             - Range: 0x809b50..0x809b60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 87
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x809b60..0x809b70]
@@ -4120,8 +4019,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 88
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x809b70..0x809b80]
@@ -4132,8 +4030,7 @@ Subprograms:
           Locations:
             - Range: 0x809b70..0x809b80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 89
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x809b80..0x809b90]
@@ -4144,8 +4041,7 @@ Subprograms:
           Locations:
             - Range: 0x809b80..0x809b90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 90
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x809ba0..0x809bb0]
@@ -4156,8 +4052,7 @@ Subprograms:
           Locations:
             - Range: 0x809ba0..0x809bb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 91
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x809c10..0x809c20]
@@ -4168,8 +4063,7 @@ Subprograms:
           Locations:
             - Range: 0x809c10..0x809c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 92
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x809c30..0x809c40]
@@ -4180,15 +4074,13 @@ Subprograms:
           Locations:
             - Range: 0x809c30..0x809c40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
             - Range: 0x809c30..0x809c40
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 93
       Name: main.testCycle
       OutOfLinePCRanges: [0x809c50..0x809c60]
@@ -4199,8 +4091,7 @@ Subprograms:
           Locations:
             - Range: 0x809c50..0x809c60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 94
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x809f60..0x809fe0]
@@ -4211,8 +4102,7 @@ Subprograms:
           Locations:
             - Range: 0x809f60..0x809f7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4222,8 +4112,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x809fb9..0x809fe0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4231,8 +4120,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x809f88..0x809fe0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 95
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x809fe0..0x80a080]
@@ -4245,8 +4133,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a004..0x80a080
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
@@ -4256,8 +4143,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a055..0x80a080
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
@@ -4265,8 +4151,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a020..0x80a080
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 96
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x80a080..0x80a150]
@@ -4277,8 +4162,7 @@ Subprograms:
           Locations:
             - Range: 0x80a080..0x80a0d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4288,13 +4172,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a125..0x80a150
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a080..0x80a150, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
@@ -4302,8 +4184,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a0d8..0x80a150
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
@@ -4311,8 +4192,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
             - Range: 0x80a0d8..0x80a150
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 97
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x80a150..0x80a1d0]
@@ -4323,8 +4203,7 @@ Subprograms:
           Locations:
             - Range: 0x80a150..0x80a174
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
@@ -4346,8 +4225,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a1a9..0x80a1d0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 98
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x80a1d0..0x80a340]
@@ -4380,15 +4258,13 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: failed
           Type: 4 BaseType bool
           Locations:
             - Range: 0x80a1d0..0x80a214
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
@@ -4426,8 +4302,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a315..0x80a340
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
@@ -4465,15 +4340,13 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x80a315..0x80a340
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0x80a220..0x80a228
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 99
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x80a340..0x80a520]
@@ -4500,8 +4373,7 @@ Subprograms:
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
@@ -4539,22 +4411,19 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a4f9..0x80a520
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
             - Range: 0x80a3cc..0x80a3d4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
             - Range: 0x80a418..0x80a434
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 100
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x80a520..0x80a670]
@@ -4587,8 +4456,7 @@ Subprograms:
                   Op: {CfaOffset: 16}
             - Range: 0x80a63c..0x80a670
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
@@ -4610,8 +4478,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80a605..0x80a670
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
@@ -4649,8 +4516,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
             - Range: 0x80a604..0x80a670
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 101
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x80a670..0x80a700]
@@ -4661,8 +4527,7 @@ Subprograms:
           Locations:
             - Range: 0x80a670..0x80a68c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4672,8 +4537,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a6e1..0x80a700
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 102
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x80a700..0x80a7c0]
@@ -4684,8 +4548,7 @@ Subprograms:
           Locations:
             - Range: 0x80a700..0x80a74c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
@@ -4695,8 +4558,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a799..0x80a7c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4706,8 +4568,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a799..0x80a7c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 103
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x80a7c0..0x80a880]
@@ -4720,8 +4581,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a7fc..0x80a880
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -4731,8 +4591,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
@@ -4742,8 +4601,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -4753,8 +4611,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80a85d..0x80a880
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 104
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x80a880..0x80a910]
@@ -4769,8 +4626,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
@@ -4780,8 +4636,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
@@ -4791,8 +4646,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
@@ -4802,8 +4656,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
@@ -4813,8 +4666,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
@@ -4824,8 +4676,7 @@ Subprograms:
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
@@ -4835,8 +4686,7 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
@@ -4846,8 +4696,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80a8ed..0x80a910
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 105
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x80a910..0x80a9c0]
@@ -4856,83 +4705,67 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r9
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r10
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r11
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r12
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r13
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r14
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
           Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
@@ -4942,8 +4775,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
             - Range: 0x80a9a9..0x80a9c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 106
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x80a9c0..0x80aa40]
@@ -4952,13 +4784,11 @@ Subprograms:
         - Name: ~r0
           Type: 97 BaseType complex64
           Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 98 BaseType complex128
           Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 107
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x80aa40..0x80ab00]
@@ -4993,8 +4823,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80aadd..0x80ab00
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 108
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x80ab00..0x80ab80]
@@ -5009,8 +4838,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x80ab69..0x80ab80
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 109
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x80ab80..0x80abf0]
@@ -5025,8 +4853,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80abd1..0x80abf0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 110
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x80abf0..0x80ac60]
@@ -5041,8 +4868,7 @@ Subprograms:
               Pieces: []
             - Range: 0x80ac3d..0x80ac60
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 111
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x80ac60..0x80ace0]
@@ -5051,8 +4877,7 @@ Subprograms:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0x80ac60..0x80ace0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 112
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x80ace0..0x80ad70]
@@ -5067,8 +4892,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5078,8 +4902,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5089,8 +4912,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
@@ -5100,8 +4922,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
@@ -5111,8 +4932,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
@@ -5122,8 +4942,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
@@ -5133,8 +4952,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
@@ -5144,8 +4962,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5159,8 +4976,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80ad59..0x80ad70
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 113
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x80ad70..0x80ae40]
@@ -5197,8 +5013,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
             - Range: 0x80ae1d..0x80ae40
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 114
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x80ae40..0x80aed0]
@@ -5213,13 +5028,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5229,13 +5042,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
           Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5249,8 +5060,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
             - Range: 0x80aead..0x80aed0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 115
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x80aed0..0x80af50]
@@ -5265,8 +5075,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
             - Range: 0x80af39..0x80af50
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 116
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x80af50..0x80afc0]
@@ -5275,8 +5084,7 @@ Subprograms:
         - Name: ~r0
           Type: 16 BaseType float64
           Locations: [{Range: 0x80af50..0x80afc0, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 117
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x80afc0..0x80b030]
@@ -5285,13 +5093,11 @@ Subprograms:
         - Name: ~r0
           Type: 18 BaseType float32
           Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
           Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 118
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x80b030..0x80b0a0]
@@ -5306,8 +5112,7 @@ Subprograms:
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b085..0x80b0a0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
@@ -5317,8 +5122,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b085..0x80b0a0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 119
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x80b0a0..0x80b230]
@@ -5415,8 +5219,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5446,8 +5249,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b1e9..0x80b230
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 120
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x80b230..0x80b2f0]
@@ -5458,8 +5260,7 @@ Subprograms:
           Locations:
             - Range: 0x80b230..0x80b2f0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
@@ -5469,8 +5270,7 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x80b2d9..0x80b2f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 121
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x80b2f0..0x80b500]
@@ -5567,15 +5367,13 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
             - Range: 0x80b2f0..0x80b500
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5605,8 +5403,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b4b5..0x80b500
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 122
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x80b500..0x80b6a0]
@@ -5619,8 +5416,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5628,8 +5424,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b564..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5637,8 +5432,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80b56c..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5646,8 +5440,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5655,8 +5448,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5664,8 +5456,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5673,8 +5464,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5682,8 +5472,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
@@ -5691,8 +5480,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
             - Range: 0x80b574..0x80b6a0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
@@ -5702,8 +5490,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
             - Range: 0x80b65d..0x80b6a0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 123
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x80b6a0..0x80b890]
@@ -5716,8 +5503,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5725,8 +5511,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b714..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
@@ -5734,8 +5519,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80b71c..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
@@ -5743,8 +5527,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
@@ -5752,8 +5535,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
@@ -5761,8 +5543,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
@@ -5770,8 +5551,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
@@ -5779,8 +5559,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
             - Range: 0x80b724..0x80b890
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
@@ -5796,8 +5575,7 @@ Subprograms:
                   Op: {CfaOffset: 72}
                 - Size: 8
                   Op: {CfaOffset: 80}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
@@ -5827,8 +5605,7 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
             - Range: 0x80b849..0x80b890
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 124
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x80b890..0x80b920]
@@ -5839,8 +5616,7 @@ Subprograms:
           Locations:
             - Range: 0x80b890..0x80b920
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5850,8 +5626,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
@@ -5861,8 +5636,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
@@ -5872,8 +5646,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
             - Range: 0x80b901..0x80b920
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 125
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x80b920..0x80b9f0]
@@ -5884,15 +5657,13 @@ Subprograms:
           Locations:
             - Range: 0x80b920..0x80b9f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
             - Range: 0x80b920..0x80b9f0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5902,8 +5673,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80b9d5..0x80b9f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
@@ -5913,8 +5683,7 @@ Subprograms:
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
             - Range: 0x80b9d5..0x80b9f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 126
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x80b9f0..0x80bab0]
@@ -5925,8 +5694,7 @@ Subprograms:
           Locations:
             - Range: 0x80b9f0..0x80bab0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5936,8 +5704,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80ba91..0x80bab0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
@@ -5947,15 +5714,13 @@ Subprograms:
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
             - Range: 0x80ba91..0x80bab0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x80ba68..0x80bab0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 127
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x80bab0..0x80bb50]
@@ -5964,8 +5729,7 @@ Subprograms:
         - Name: a
           Type: 253 ArrayType [0]int
           Locations: [{Range: 0x80bab0..0x80bb50, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
@@ -5977,8 +5741,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x80bb0c..0x80bb50
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
@@ -5988,8 +5751,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x80bb29..0x80bb50
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
@@ -5999,8 +5761,7 @@ Subprograms:
               Pieces: []
             - Range: 0x80bb29..0x80bb50
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 128
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x80bf80..0x80bf90]
@@ -6017,8 +5778,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 129
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80bf90..0x80bfa0]
@@ -6035,8 +5795,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 130
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80bfa0..0x80bfb0]
@@ -6053,8 +5812,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 131
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x80bfb0..0x80bfc0]
@@ -6071,15 +5829,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x80bfb0..0x80bfc0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 132
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80bfc0..0x80bfd0]
@@ -6096,15 +5852,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x80bfc0..0x80bfd0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 133
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
@@ -6121,15 +5875,13 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: a
           Type: 7 BaseType int
           Locations:
             - Range: 0x80bfd0..0x80bfe0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 134
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x80bfe0..0x80bff0]
@@ -6146,8 +5898,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 135
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x80bff0..0x80c000]
@@ -6158,8 +5909,7 @@ Subprograms:
           Locations:
             - Range: 0x80bff0..0x80c000
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
@@ -6171,15 +5921,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: x
           Type: 10 BaseType uint
           Locations:
             - Range: 0x80bff0..0x80c000
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 136
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x80c000..0x80c010]
@@ -6196,8 +5944,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 137
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80c010..0x80c020]
@@ -6214,8 +5961,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 138
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x80c020..0x80c030]
@@ -6232,8 +5978,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 139
       Name: main.stackC
       OutOfLinePCRanges: [0x80c2d0..0x80c330]
@@ -6252,8 +5997,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
             - Range: 0x80c319..0x80c330
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 140
       Name: main.testSingleString
       OutOfLinePCRanges: [0x80c330..0x80c340]
@@ -6268,8 +6012,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 141
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80c340..0x80c350]
@@ -6284,8 +6027,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6295,8 +6037,7 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
@@ -6306,8 +6047,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 142
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x80c350..0x80c360]
@@ -6330,8 +6070,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 143
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x80c360..0x80c370]
@@ -6342,8 +6081,7 @@ Subprograms:
           Locations:
             - Range: 0x80c360..0x80c370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 144
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80c370..0x80c380]
@@ -6354,8 +6092,7 @@ Subprograms:
           Locations:
             - Range: 0x80c370..0x80c380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 145
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x80c380..0x80c390]
@@ -6370,8 +6107,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 146
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80c390..0x80c3a0]
@@ -6386,8 +6122,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 147
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x80c3a0..0x80c3b0]
@@ -6402,8 +6137,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 148
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x80c4e0..0x80c4f0]
@@ -6414,8 +6148,7 @@ Subprograms:
           Locations:
             - Range: 0x80c4e0..0x80c4f0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 149
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x80c4f0..0x80c500]
@@ -6438,8 +6171,7 @@ Subprograms:
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 150
       Name: main.testStruct
       OutOfLinePCRanges: [0x80c5a0..0x80c5c0]
@@ -6464,8 +6196,7 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 151
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x80c670..0x80c680]
@@ -6474,8 +6205,7 @@ Subprograms:
         - Name: e
           Type: 317 StructureType main.emptyStruct
           Locations: [{Range: 0x80c670..0x80c680, Pieces: []}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 152
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x80c680..0x80c690]
@@ -6486,8 +6216,7 @@ Subprograms:
           Locations:
             - Range: 0x80c680..0x80c690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 153
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807520..0x807590]
@@ -6516,8 +6245,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
             - Range: 0x807800..0x807824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 154
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
@@ -6551,8 +6279,7 @@ Subprograms:
           Locations:
             - Range: 0x807980..0x807988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 158
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
@@ -6569,8 +6296,7 @@ Subprograms:
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
             - Range: 0x807a28..0x807b20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 139

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0x4a6100..0x4a6119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4a6180..0x4a61f1]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4a6200..0x4a627a]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4a6280..0x4a62e7]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0x4a6280..0x4a62e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4a6300..0x4a637a]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4a6380..0x4a63e7]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0x4a6380..0x4a63e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4a6400..0x4a6401]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0x4a6400..0x4a6401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4a64e0..0x4a6536]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0x4a64e0..0x4a650d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4a6540..0x4a65fb]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a6573..0x4a65fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0x4a6600..0x4a6653]
@@ -405,13 +396,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a682f..0x4a6845
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: m
           Type: 120 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
           Locations: [{Range: 0x4a6660..0x4a6845, Pieces: []}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4a6420..0x4a6482]
@@ -426,8 +415,7 @@ Subprograms:
               Pieces: []
             - Range: 0x4a6420..0x4a6439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -440,8 +428,7 @@ Subprograms:
           Locations:
             - Range: 0x4a601f..0x4a606b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -454,8 +441,7 @@ Subprograms:
           Locations:
             - Range: 0x4a6090..0x4a60ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 125

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0x4a8100..0x4a8119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4a8180..0x4a81f1]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4a8200..0x4a827a]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4a8280..0x4a82e7]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0x4a8280..0x4a82e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4a8300..0x4a837a]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4a8380..0x4a83e7]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0x4a8380..0x4a83e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4a8400..0x4a8401]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0x4a8400..0x4a8401
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4a84e0..0x4a8536]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0x4a84e0..0x4a850d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4a8540..0x4a85fb]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a8573..0x4a85fb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0x4a8600..0x4a8653]
@@ -405,8 +396,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4a883d..0x4a884f
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4a8420..0x4a8482]
@@ -421,8 +411,7 @@ Subprograms:
               Pieces: []
             - Range: 0x4a8420..0x4a8439
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -435,8 +424,7 @@ Subprograms:
           Locations:
             - Range: 0x4a801f..0x4a806b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -449,8 +437,7 @@ Subprograms:
           Locations:
             - Range: 0x4a8090..0x4a80ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 123

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0x4ae700..0x4ae719
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0x4ae780..0x4ae7f1]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0x4ae800..0x4ae87a]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0x4ae880..0x4ae8e7]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0x4ae880..0x4ae8e7
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0x4ae900..0x4ae97a]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0x4ae980..0x4ae9e7]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0x4ae980..0x4ae9e7
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0x4aea00..0x4aea01]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0x4aea00..0x4aea01
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0x4aeae0..0x4aeb36]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0x4aeae0..0x4aeb0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0x4aeb40..0x4aebfb]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4aeb73..0x4aebfb
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0x4aec00..0x4aec53]
@@ -405,8 +396,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0x4aee45..0x4aee57
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0x4aea20..0x4aea82]
@@ -421,8 +411,7 @@ Subprograms:
               Pieces: []
             - Range: 0x4aea20..0x4aea39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -435,8 +424,7 @@ Subprograms:
           Locations:
             - Range: 0x4ae61f..0x4ae66b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -449,8 +437,7 @@ Subprograms:
           Locations:
             - Range: 0x4ae690..0x4ae6ca
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 125

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0xb5410..0xb5430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb5480..0xb5500]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb5500..0xb5590]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb5590..0xb5610]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0xb5590..0xb5610
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb5610..0xb56a0]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb56a0..0xb5720]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0xb56a0..0xb5720
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb5720..0xb5730]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0xb5720..0xb5730
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb57f0..0xb5860]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0xb57f0..0xb5828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb5860..0xb5920]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb5898..0xb5920
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0xb5920..0xb5990]
@@ -405,13 +396,11 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb5b25..0xb5b40
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
         - Name: m
           Type: 121 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
           Locations: [{Range: 0xb5990..0xb5b40, Pieces: []}]
-          IsParameter: false
-          IsReturn: false
+          Role: Local
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb5730..0xb57a0]
@@ -426,8 +415,7 @@ Subprograms:
               Pieces: []
             - Range: 0xb5730..0xb5750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -440,8 +428,7 @@ Subprograms:
           Locations:
             - Range: 0xb5360..0xb53a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -454,8 +441,7 @@ Subprograms:
           Locations:
             - Range: 0xb53c0..0xb53f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 126

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0xb52a0..0xb52c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb5310..0xb5390]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb5390..0xb5410]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb5410..0xb5490]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0xb5410..0xb5490
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb5490..0xb5510]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb5510..0xb5590]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0xb5510..0xb5590
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb5590..0xb55a0]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0xb5590..0xb55a0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb5660..0xb56d0]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0xb5660..0xb5698
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb56d0..0xb5790]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb5708..0xb5790
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0xb5790..0xb5800]
@@ -405,8 +396,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb59a1..0xb59c0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb55a0..0xb5610]
@@ -421,8 +411,7 @@ Subprograms:
               Pieces: []
             - Range: 0xb55a0..0xb55c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -435,8 +424,7 @@ Subprograms:
           Locations:
             - Range: 0xb51e4..0xb522c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -449,8 +437,7 @@ Subprograms:
           Locations:
             - Range: 0xb5244..0xb5274
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 124

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -270,8 +270,7 @@ Subprograms:
           Locations:
             - Range: 0xb7e20..0xb7e40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 2
       Name: main.stringArg
       OutOfLinePCRanges: [0xb7e90..0xb7f00]
@@ -286,8 +285,7 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 3
       Name: main.intSliceArg
       OutOfLinePCRanges: [0xb7f00..0xb7f80]
@@ -304,8 +302,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 4
       Name: main.intArrayArg
       OutOfLinePCRanges: [0xb7f80..0xb7ff0]
@@ -316,8 +313,7 @@ Subprograms:
           Locations:
             - Range: 0xb7f80..0xb7ff0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
       OutOfLinePCRanges: [0xb7ff0..0xb8070]
@@ -334,8 +330,7 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
       OutOfLinePCRanges: [0xb8070..0xb80e0]
@@ -346,8 +341,7 @@ Subprograms:
           Locations:
             - Range: 0xb8070..0xb80e0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
       OutOfLinePCRanges: [0xb80e0..0xb80f0]
@@ -358,8 +352,7 @@ Subprograms:
           Locations:
             - Range: 0xb80e0..0xb80f0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 8
       Name: main.mapArg
       OutOfLinePCRanges: [0xb81b0..0xb8220]
@@ -370,8 +363,7 @@ Subprograms:
           Locations:
             - Range: 0xb81b0..0xb81e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 9
       Name: main.bigMapArg
       OutOfLinePCRanges: [0xb8220..0xb82d0]
@@ -384,8 +376,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb8258..0xb82d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 10
       Name: main.noArgs
       OutOfLinePCRanges: [0xb82d0..0xb8340]
@@ -405,8 +396,7 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
             - Range: 0xb84d9..0xb84f0
               Pieces: []
-          IsParameter: true
-          IsReturn: true
+          Role: Return
     - ID: 12
       Name: main.inlined
       OutOfLinePCRanges: [0xb80f0..0xb8160]
@@ -421,8 +411,7 @@ Subprograms:
               Pieces: []
             - Range: 0xb80f0..0xb8110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 13
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
@@ -435,8 +424,7 @@ Subprograms:
           Locations:
             - Range: 0xb7d78..0xb7dbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
     - ID: 14
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
@@ -449,8 +437,7 @@ Subprograms:
           Locations:
             - Range: 0xb7dd4..0xb7e00
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
+          Role: Parameter
 Types:
     - __kind: PointerType
       ID: 126

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -99,6 +99,9 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 		json.MarshalToFunc(func(enc *jsontext.Encoder, v ir.EventKind) error {
 			return enc.WriteToken(jsontext.String(v.String()))
 		}),
+		json.MarshalToFunc(func(enc *jsontext.Encoder, v ir.VariableRole) error {
+			return enc.WriteToken(jsontext.String(v.String()))
+		}),
 	)
 	probeMarshalers := json.JoinMarshalers(
 		basicMarshalers,

--- a/pkg/dyninst/rcscrape/ir_generator.go
+++ b/pkg/dyninst/rcscrape/ir_generator.go
@@ -173,7 +173,7 @@ func addRcProbe(
 						{Size: 8, Op: ir.Register{RegNo: abiRegs[1]}},
 					},
 				}},
-				IsParameter: true,
+				Role: ir.VariableRoleParameter,
 			},
 			{
 				Name: "configPath",
@@ -185,7 +185,7 @@ func addRcProbe(
 						{Size: 8, Op: ir.Register{RegNo: abiRegs[3]}},
 					},
 				}},
-				IsParameter: true,
+				Role: ir.VariableRoleParameter,
 			},
 			{
 				Name: "configContent",
@@ -197,7 +197,7 @@ func addRcProbe(
 						{Size: 8, Op: ir.Register{RegNo: abiRegs[5]}},
 					},
 				}},
-				IsParameter: true,
+				Role: ir.VariableRoleParameter,
 			},
 		},
 	}
@@ -267,7 +267,7 @@ func addSymdbProbe(
 						{Size: 8, Op: ir.Register{RegNo: abiRegs[1]}},
 					},
 				}},
-				IsParameter: true,
+				Role: ir.VariableRoleParameter,
 			},
 			{
 				Name: "enabled",
@@ -278,7 +278,7 @@ func addSymdbProbe(
 						{Size: 1, Op: ir.Register{RegNo: abiRegs[2]}},
 					},
 				}},
-				IsParameter: true,
+				Role: ir.VariableRoleParameter,
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

There's an issue with the way we check if variables are returns in DWARF. Parameters and return values are both entries with `DW_TAG_formal_parameter`.  Go populates a field with attribute `DW_AT_variable_parameter` under return entries with value set to true.

For example:

```
0x000462cf:     DW_TAG_formal_parameter
                  DW_AT_name    ("i")
                  DW_AT_variable_parameter      (0x00)
                  DW_AT_decl_line       (14)
                  DW_AT_type    (0x00000000000ffa4f "int")
                  DW_AT_location        (0x0008b8fe:
                     [0x000000000084d8c0, 0x000000000084d8dc): DW_OP_reg0 W0)

0x000462dc:     DW_TAG_formal_parameter
                  DW_AT_name    ("~r0")
                  DW_AT_variable_parameter      (0x01)
                  DW_AT_decl_line       (14)
                  DW_AT_type    (0x00000000000ffa4f "int")
                  DW_AT_location        (<empty>)
```  

### Motivation

Correctly identifying return values.

### Describe how you validated your changes

Added tests

### Additional Notes
