### PR TITLE
[CNM-4711] Validate that destination IP addresses are valid in network path results and that static path hostname isn't empty string.

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -366,6 +366,13 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 		s.logger.Errorf("%s", err)
 		return
 	}
+
+	err = payload.ValidateNetworkPath(&path)
+	if err != nil {
+		s.logger.Errorf("failed to validate network path: %s", err)
+		return
+	}
+
 	path.Source.ContainerID = ptest.Pathtest.SourceContainerID
 	path.Namespace = s.networkDevicesNamespace
 	path.Origin = payload.PathOriginNetworkTraffic

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -101,6 +101,11 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, fmt.Errorf("invalid instance config: %s", err)
 	}
 
+	// hostname validation is done by the datadog-traceroute library but an empty hostname results in querying system-probe with an invalid URL
+	if instance.DestHostname == "" {
+		return nil, fmt.Errorf("invalid instance config, hostname must be provided")
+	}
+
 	c := &CheckConfig{}
 
 	c.DestHostname = instance.DestHostname

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -72,6 +72,12 @@ func (c *Check) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to trace path: %w", err)
 	}
+
+	err = payload.ValidateNetworkPath(&path)
+	if err != nil {
+		return fmt.Errorf("failed to validate network path: %w", err)
+	}
+
 	path.Namespace = c.config.Namespace
 	path.Origin = payload.PathOriginNetworkPathIntegration
 

--- a/pkg/networkpath/payload/payload_test.go
+++ b/pkg/networkpath/payload/payload_test.go
@@ -6,6 +6,7 @@
 package payload
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,4 +27,154 @@ func TestICMPMode(t *testing.T) {
 	require.False(t, ICMPModeTCP.ShouldUseICMP(ProtocolUDP))
 	require.True(t, ICMPModeUDP.ShouldUseICMP(ProtocolUDP))
 	require.True(t, ICMPModeAll.ShouldUseICMP(ProtocolUDP))
+}
+
+func TestValidateNetworkPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        *NetworkPath
+		expectError bool
+		errorText   string
+	}{
+		{
+			name: "all valid IP addresses",
+			path: &NetworkPath{
+				Destination: NetworkPathDestination{
+					Hostname: "destination.com",
+					Port:     443,
+				},
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{
+						{
+							RunID: "runid0",
+							Destination: TracerouteDestination{
+								IPAddress: net.ParseIP("1.2.3.4"),
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid1",
+							Destination: TracerouteDestination{
+								IPAddress: net.ParseIP("1.2.3.4"),
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid2",
+							Destination: TracerouteDestination{
+								IPAddress: net.ParseIP("1.2.3.4"),
+								Port:      443,
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "all invalid IP addresses",
+			path: &NetworkPath{
+				Destination: NetworkPathDestination{
+					Hostname: "destination.com",
+					Port:     443,
+				},
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{
+						{
+							RunID: "runid0",
+							Destination: TracerouteDestination{
+								IPAddress: net.IP{},
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid1",
+							Destination: TracerouteDestination{
+								IPAddress: net.IP{},
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid2",
+							Destination: TracerouteDestination{
+								IPAddress: net.IP{},
+								Port:      443,
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorText:   "invalid destination IP address for destination.com:443",
+		},
+		{
+			name: "one invalid IP address",
+			path: &NetworkPath{
+				Destination: NetworkPathDestination{
+					Hostname: "destination.com",
+					Port:     443,
+				},
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{
+						{
+							RunID: "runid0",
+							Destination: TracerouteDestination{
+								IPAddress: net.ParseIP("1.2.3.4"),
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid1",
+							Destination: TracerouteDestination{
+								IPAddress: net.IP{},
+								Port:      443,
+							},
+						},
+						{
+							RunID: "runid2",
+							Destination: TracerouteDestination{
+								IPAddress: net.ParseIP("1.2.3.4"),
+								Port:      443,
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorText:   "invalid destination IP address for destination.com:443",
+		},
+		{
+			name:        "nil path",
+			path:        nil,
+			expectError: true,
+			errorText:   "invalid nil path",
+		},
+		{
+			name: "empty runs",
+			path: &NetworkPath{
+				Destination: NetworkPathDestination{
+					Hostname: "destination.com",
+				},
+				Traceroute: Traceroute{
+					Runs: []TracerouteRun{},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNetworkPath(tt.path)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorText != "" {
+					require.Contains(t, err.Error(), tt.errorText)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/networkpath/payload/utils.go
+++ b/pkg/networkpath/payload/utils.go
@@ -5,9 +5,35 @@
 
 package payload
 
-import "github.com/google/uuid"
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 // NewPathtraceID creates a new pathtrace id
 func NewPathtraceID() string {
 	return uuid.New().String()
+}
+
+// ValidateNetworkPath validates a NetworkPath payload.
+// Returns an error if any run does not have a valid destination IP address.
+func ValidateNetworkPath(path *NetworkPath) error {
+	if path == nil {
+		return fmt.Errorf("invalid nil path")
+	}
+
+	if len(path.Traceroute.Runs) == 0 {
+		return nil
+	}
+
+	for i, run := range path.Traceroute.Runs {
+		// IP address will be nil if json.Unmarshal fails to parse an invalid IP address
+		// from the traceroute results returned by system-probe
+		if len(run.Destination.IPAddress) == 0 {
+			return fmt.Errorf("traceroute run %d (%s) has invalid destination IP address for %s:%d", i, run.RunID, path.Destination.Hostname, path.Destination.Port)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION

### What does this PR do?
Validate that destination IP addresses are valid in network path results and that static path hostname isn't empty string.

### Motivation
Avoid sending invalid events to the backend, to avoid potential problems that were seen in a previous incident.

### Describe how you validated your changes
Built and tested agent with a version of datadog-traceroute that returned an invalid destination IP address.

### Additional Notes
