### PR TITLE
update inv devcontainer task and add claude code support

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -309,9 +309,16 @@ build_tags = {
         "loader": LOADER_TAGS,
         "full-host-profiler": FULL_HOST_PROFILER_TAGS,
         # Test setups
-        "test": AGENT_TEST_TAGS.union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
-        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS).union(UNIT_TEST_TAGS).difference(UNIT_TEST_EXCLUDE_TAGS),
+        "test": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
+        .union(CLUSTER_AGENT_TAGS)
+        .union(UNIT_TEST_TAGS)
+        .difference(UNIT_TEST_EXCLUDE_TAGS),
+        "lint": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
+        .union(CLUSTER_AGENT_TAGS)
+        .union(UNIT_TEST_TAGS)
+        .difference(UNIT_TEST_EXCLUDE_TAGS),
         "unit-tests": AGENT_TEST_TAGS.union(PROCESS_AGENT_TAGS)
+        .union(CLUSTER_AGENT_TAGS)
         .union(UNIT_TEST_TAGS)
         .difference(UNIT_TEST_EXCLUDE_TAGS),
     },

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -41,6 +41,7 @@ def setup(
     skaffoldProfile=None,
     flavor=AgentFlavor.base.name,
     image='',
+    claude_code=False,
 ):
     """
     Generate or Modify devcontainer settings file for this project.
@@ -95,8 +96,8 @@ def setup(
     devcontainer["features"] = {}
     devcontainer["remoteUser"] = "datadog"
     devcontainer["mounts"] = [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+        "source=${localEnv:HOME}/.ssh,target=/home/datadog/.ssh,type=bind",
     ]
     devcontainer["customizations"] = {
         "vscode": {
@@ -133,6 +134,7 @@ def setup(
     }
 
     configure_skaffold(devcontainer, SkaffoldProfile(skaffoldProfile))
+    configure_claude_code(devcontainer, claude_code)
 
     # Add per user configuration
     user_config_path = Path.home() / ".devcontainer" / "agent_overrides.json"
@@ -148,6 +150,19 @@ def setup(
 
     with open(fullpath, "w") as sf:
         json.dump(devcontainer, sf, indent=4, sort_keys=False, separators=(',', ': '))
+
+
+def configure_claude_code(devcontainer: dict, claude_code: bool):
+    if claude_code:
+        # create folder .devcontainer/claude-data/.claude if not exists
+        claude_data_path = Path.home() / ".devcontainer" / "claude-data"
+        Path(claude_data_path).mkdir(parents=True, exist_ok=True)
+        devcontainer["mounts"].append(
+            "source=${localWorkspaceFolder}/.devcontainer/claude-data/,target=/home/datadog/.claude,type=bind"
+        )
+
+        devcontainer["features"]["ghcr.io/devcontainers/features/node:1"] = {}
+        devcontainer["features"]["ghcr.io/anthropics/devcontainer-features/claude-code:1.0"] = {}
 
 
 def configure_skaffold(devcontainer: dict, profile: SkaffoldProfile):


### PR DESCRIPTION
### What does this PR do?

Adds optional Claude Code integration support to the devcontainer setup,
enabling AI-assisted development within the Datadog Agent development environment.

Changes:
  - Added --claude-code flag to inv devcontainer.setup command
  - Automatically provisions Claude Code by:
    - Creating a persistent .devcontainer/claude-data/ directory for session data
    - Mounting it to /home/datadog/.claude in the container
    - Installing required Node.js and Claude Code devcontainer features
  -  fix tags sets generation in `build_tags.py` to also cover `cluster-agent` specific tags in test and linter.
Usage:
- Enable Claude Code in your devcontainer:
  `dda inv devcontainer.setup --claude-code`

### Motivation

### Describe how you validated your changes

### Additional Notes
