### PR TITLE
[CONTP-1005] feat:(cluster_agent): Enable Cluster check advanced dispatching by default  

### DIFF
--- a/comp/metadata/clusteragent/README.md
+++ b/comp/metadata/clusteragent/README.md
@@ -54,7 +54,7 @@ source_local_configuration - string: the Cluster-Agent configuration synchronize
         "feature_admission_controller_validation_enabled": true,
         "feature_apm_config_instrumentation_enabled": false,
         "feature_autoscaling_workload_enabled": false,
-        "feature_cluster_checks_advanced_dispatching_enabled": false,
+        "feature_cluster_checks_advanced_dispatching_enabled": true,
         "feature_cluster_checks_enabled": true,
         "feature_cluster_checks_exclude_checks": [],
         "feature_compliance_config_enabled": false,

--- a/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_isolate_test.go
@@ -17,14 +17,49 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+// isolateTestClcRunnerClient mocks the clcRunnersClient for advanced dispatching tests in this file only
+type isolateTestClcRunnerClient struct{}
+
+func (d *isolateTestClcRunnerClient) GetVersion(string) (version.Version, error) {
+	return version.Version{}, nil
+}
+
+func (d *isolateTestClcRunnerClient) GetRunnerStats(IP string) (types.CLCRunnersStats, error) {
+	// Return dummy stats for nodes "A" and "B" to match the test setup
+	stats := map[string]types.CLCRunnersStats{
+		"A": {
+			"checkA0": {AverageExecutionTime: 50, MetricSamples: 10, IsClusterCheck: true},
+			"checkA1": {AverageExecutionTime: 20, MetricSamples: 10, IsClusterCheck: true},
+			"checkA2": {AverageExecutionTime: 100, MetricSamples: 10, IsClusterCheck: true},
+		},
+		"B": {
+			"checkB0": {AverageExecutionTime: 50, MetricSamples: 10, IsClusterCheck: true},
+			"checkB1": {AverageExecutionTime: 20, MetricSamples: 10, IsClusterCheck: true},
+			"checkB2": {AverageExecutionTime: 100, MetricSamples: 10, IsClusterCheck: true},
+		},
+	}
+	return stats[IP], nil
+}
+
+func (d *isolateTestClcRunnerClient) GetRunnerWorkers(IP string) (types.Workers, error) {
+	// Return 1 worker for node "A" and 1 worker for node "B"
+	workers := map[string]types.Workers{
+		"A": {Count: 1, Instances: map[string]types.WorkerInfo{"workerA": {Utilization: 0.1}}},
+		"B": {Count: 1, Instances: map[string]types.WorkerInfo{"workerB": {Utilization: 0.1}}},
+	}
+	return workers[IP], nil
+}
 
 func TestIsolateCheckSuccessful(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
+	testDispatcher.store.nodes["B"] = newNodeStore("B", "B")
 	testDispatcher.store.nodes["B"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{
@@ -103,9 +138,10 @@ func TestIsolateCheckSuccessful(t *testing.T) {
 func TestIsolateNonExistentCheckFails(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["B"] = newNodeStore("B", "")
+	testDispatcher.store.nodes["B"] = newNodeStore("B", "B")
 	testDispatcher.store.nodes["B"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{
@@ -182,7 +218,8 @@ func TestIsolateNonExistentCheckFails(t *testing.T) {
 func TestIsolateCheckOnlyOneRunnerFails(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
-	testDispatcher.store.nodes["A"] = newNodeStore("A", "")
+	testDispatcher.clcRunnersClient = &isolateTestClcRunnerClient{}
+	testDispatcher.store.nodes["A"] = newNodeStore("A", "A")
 	testDispatcher.store.nodes["A"].workers = pkgconfigsetup.DefaultNumWorkers
 
 	testDispatcher.store.nodes["A"].clcRunnerStats = map[string]types.CLCRunnerStats{

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -19,7 +19,32 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+// rebalanceTestClcRunnerClient mocks the clcRunnersClient for rebalance tests
+type rebalanceTestClcRunnerClient struct {
+	testStats map[string]types.CLCRunnersStats
+}
+
+func (d *rebalanceTestClcRunnerClient) GetVersion(string) (version.Version, error) {
+	return version.Version{}, nil
+}
+
+func (d *rebalanceTestClcRunnerClient) GetRunnerStats(ip string) (types.CLCRunnersStats, error) {
+	// Return the stored test stats for this IP, or empty if not found
+	if d.testStats != nil {
+		if stats, found := d.testStats[ip]; found {
+			return stats, nil
+		}
+	}
+	return types.CLCRunnersStats{}, nil
+}
+
+func (d *rebalanceTestClcRunnerClient) GetRunnerWorkers(string) (types.Workers, error) {
+	// Return default worker count
+	return types.Workers{Count: pkgconfigsetup.DefaultNumWorkers}, nil
+}
 
 func TestRebalance(t *testing.T) {
 	for i, tc := range []struct {
@@ -1381,17 +1406,27 @@ func TestRebalance(t *testing.T) {
 			fakeTagger := taggerfxmock.SetupFakeTagger(t)
 			dispatcher := newDispatcher(fakeTagger)
 
+			// Create a mock CLC runner client to avoid nil pointer errors
+			mockClient := &rebalanceTestClcRunnerClient{
+				testStats: make(map[string]types.CLCRunnersStats),
+			}
+			dispatcher.clcRunnersClient = mockClient
+
 			// prepare store
 			dispatcher.store.active = true
 			for node, store := range tc.in {
-				// init nodeStore
-				dispatcher.store.nodes[node] = newNodeStore(node, "") // no need to setup the clientIP in this test
+				// Give each node a unique IP so the mock can distinguish them
+				nodeIP := fmt.Sprintf("10.0.0.%d", len(mockClient.testStats)+1)
+				dispatcher.store.nodes[node] = newNodeStore(node, nodeIP)
 				// setup input
 				dispatcher.store.nodes[node].clcRunnerStats = store.clcRunnerStats
+				// Store the test data in the mock so it can return it
+				mockClient.testStats[nodeIP] = store.clcRunnerStats
 			}
 
-			// rebalance checks
-			dispatcher.rebalance(false)
+			// Use busyness-based rebalancing directly for these legacy tests
+			// (preserves test coverage for busyness algorithm while allowing utilization as default)
+			dispatcher.rebalanceUsingBusyness()
 
 			// assert runner stats repartition is updated correctly
 			for node, store := range tc.out {
@@ -1525,13 +1560,20 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	testDispatcher := newDispatcher(fakeTagger)
 
+	// Create a mock CLC runner client to avoid nil pointer errors
+	mockClient := &rebalanceTestClcRunnerClient{
+		testStats: make(map[string]types.CLCRunnersStats),
+	}
+	testDispatcher.clcRunnersClient = mockClient
+	testDispatcher.advancedDispatching.Store(true) // Enable advanced dispatching for utilization tests
+
 	testDispatcher.store.active = true
-	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "")
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "10.0.0.1")
 	testDispatcher.store.nodes["node1"].workers = pkgconfigsetup.DefaultNumWorkers
-	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "")
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "10.0.0.2")
 	testDispatcher.store.nodes["node2"].workers = pkgconfigsetup.DefaultNumWorkers
 
-	testDispatcher.store.nodes["node1"].clcRunnerStats = map[string]types.CLCRunnerStats{
+	node1Stats := map[string]types.CLCRunnerStats{
 		// This is the check with the highest utilization. The code will try to
 		// place this one first, but it'll give precedence to the node where the
 		// check is already running, so the check won't move.
@@ -1550,6 +1592,11 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 			IsClusterCheck:       false,
 		},
 	}
+
+	// Assign the stats to node1 and store in mock
+	testDispatcher.store.nodes["node1"].clcRunnerStats = node1Stats
+	mockClient.testStats["10.0.0.1"] = node1Stats
+	mockClient.testStats["10.0.0.2"] = types.CLCRunnersStats{} // node2 has no initial stats
 
 	// check3 not included because it's a cluster check.
 	testDispatcher.store.idToDigest = map[checkid.ID]string{

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3143,18 +3143,18 @@ api_key:
 #   extra_tags:
 #     - <TAG_KEY>:<TAG_VALUE>
 
-#   # @param advanced_dispatching_enabled - boolean - optional - default: false
-#   # @env DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED - boolean - optional - default: false
+#   # @param advanced_dispatching_enabled - boolean - optional - default: true
+#   # @env DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED - boolean - optional - default: true
 #   # If advanced_dispatching_enabled is true the leader cluster-agent collects stats
 #   # from the cluster level check runners to optimize the check dispatching logic.
 #
-#   advanced_dispatching_enabled: false
+#   advanced_dispatching_enabled: true
 
-#   # @param rebalance_with_utilization - boolean - optional - default: false
-#   # @env DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION - boolean - optional - default: false
+#   # @param rebalance_with_utilization - boolean - optional - default: true
+#   # @env DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION - boolean - optional - default: true
 #   # If rebalance_with_utilization is true, the cluster-agent will rebalance cluster checks using node utilization.
 #
-#   rebalance_with_utilization: false
+#   rebalance_with_utilization: true
 
 #   # @param clc_runners_port - integer - optional - default: 5005
 #   # @env DD_CLUSTER_CHECKS_CLC_RUNNERS_PORT - integer - optional - default: 5005

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -786,8 +786,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.unscheduled_check_threshold", 60) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
-	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", false)
+	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", true)
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", true)
 	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1092,6 +1092,12 @@ func TestLogDefaults(t *testing.T) {
 	require.False(t, SystemProbe.GetBool("log_format_json"))
 }
 
+func TestClusterCheckDefaults(t *testing.T) {
+	conf := newTestConf(t)
+	require.True(t, conf.GetBool("cluster_checks.advanced_dispatching_enabled"))
+	require.True(t, conf.GetBool("cluster_checks.rebalance_with_utilization"))
+}
+
 func TestProxyNotLoaded(t *testing.T) {
 	conf := newTestConf(t)
 	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "TestFunction")

--- a/releasenotes/notes/enable-clusterchecks-advanced-dispatching-628b3468069f225e.yaml
+++ b/releasenotes/notes/enable-clusterchecks-advanced-dispatching-628b3468069f225e.yaml
@@ -1,0 +1,12 @@
+---
+enhancements:
+  - |
+    The Cluster Agent now enables both `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
+    and `DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default.
+    These options are now set to `true` in both the configuration template and the code,
+    improving cluster check dispatching and balancing based on node utilization out-of-the-box.
+    To disable these features, a user must now explicitly set them to `false` with the following config options:
+      - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
+        value: "false"
+      - name: DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION
+        value: "false"

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -442,6 +442,18 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 		}
 	})
 
+	suite.Run("cluster-agent config", func() {
+		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"datadog-cluster-agent", "config"})
+		suite.Require().NoError(err)
+		suite.Empty(stderr, "Standard error of `datadog-cluster-agent config` should be empty")
+		//advanced dispatching and rebalance with utilization are enabled by default
+		suite.Contains(stdout, "advanced_dispatching_enabled: true", "Advanced dispatching should be enabled in config")
+		suite.Contains(stdout, "rebalance_with_utilization: true", "Rebalance with utilization should be enabled in config")
+		if suite.T().Failed() {
+			suite.T().Log(stdout)
+		}
+	})
+
 	suite.Run("cluster-agent clusterchecks", func() {
 		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"datadog-cluster-agent", "clusterchecks"})
 		suite.Require().NoError(err)
@@ -452,6 +464,18 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 		suite.Contains(stdout, "=== kubernetes_state_core check ===")
 		if suite.T().Failed() {
 			suite.T().Log(stdout)
+		}
+	})
+
+	suite.Run("cluster-agent clusterchecks force rebalance", func() {
+		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"datadog-cluster-agent", "clusterchecks", "rebalance", "--force"})
+		suite.Require().NoError(err)
+		suite.NotContains(stdout+stderr, "advanced dispatching is not enabled", "Advanced dispatching must be enabled for force rebalance")
+		matched := regexp.MustCompile(`\d+\s+cluster checks rebalanced successfully`).MatchString(stdout)
+		suite.True(matched, "Expected 'X cluster checks rebalanced successfully' in output")
+		if suite.T().Failed() {
+			suite.T().Log(stdout)
+			suite.T().Log(stderr)
 		}
 	})
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -442,18 +442,6 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 		}
 	})
 
-	suite.Run("cluster-agent config", func() {
-		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"datadog-cluster-agent", "config"})
-		suite.Require().NoError(err)
-		suite.Empty(stderr, "Standard error of `datadog-cluster-agent config` should be empty")
-		//advanced dispatching and rebalance with utilization are enabled by default
-		suite.Contains(stdout, "advanced_dispatching_enabled: true", "Advanced dispatching should be enabled in config")
-		suite.Contains(stdout, "rebalance_with_utilization: true", "Rebalance with utilization should be enabled in config")
-		if suite.T().Failed() {
-			suite.T().Log(stdout)
-		}
-	})
-
 	suite.Run("cluster-agent clusterchecks", func() {
 		stdout, stderr, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", leaderDcaPodName, "cluster-agent", []string{"datadog-cluster-agent", "clusterchecks"})
 		suite.Require().NoError(err)


### PR DESCRIPTION
### What does this PR do?

The PR enables `CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` and `CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION` by default.

Adds unit and e2e tests to validate cluster check advanced dispatching is enabled and runs as expected.

### Motivation

This is the second attempt to enable both configs (first being https://github.com/DataDog/datadog-agent/pull/39211) in an effort to improve dispatching and cluster check utilization. The initial merged PR was [reverted](https://github.com/DataDog/datadog-agent/pull/39859) because of an issue when cluster checks ran on node agents instead of CLC runners. PR https://github.com/DataDog/datadog-agent/pull/40682 fixed this issue in 7.72 so we can now proceed with re-enabling the config for 7.73.

### Describe how you validated your changes

#### Added unit & e2e tests that pass ✅ 

#### Run agent and confirm config is enabled

```yaml
clusterChecks:
   enabled: true
kubeStateMetricsCore:
   enabled: true
clusterChecksRunner:
   enabled: true
```

<img width="470" height="293" alt="image" src="https://github.com/user-attachments/assets/ed24d596-55dd-4f22-a5ea-c04ab949bf16" />


### Additional Notes

This change should only be added following this 7.72 [PR](https://github.com/DataDog/datadog-agent/pull/40682) which introduces dynamic disabling of advanced dispatching if only node agents are available for cluster checks.
