### PR TITLE
irgen: relax bound on memory usage testing

### DIFF
--- a/pkg/dyninst/irgen/irgen_memory_use_test.go
+++ b/pkg/dyninst/irgen/irgen_memory_use_test.go
@@ -77,7 +77,7 @@ func TestIrgenMemoryUse(t *testing.T) {
 		}
 		maxMem = max(maxMem, metric.Value.Uint64())
 	}
-	const maxMemLimit = 9 * 1024 * 1024 // 9 MiB
+	const maxMemLimit = 10 * 1024 * 1024 // 10 MiB
 	require.Less(t, maxMem, uint64(maxMemLimit),
 		"%s > %s", humanize.IBytes(maxMem), humanize.IBytes(maxMemLimit))
 	t.Logf("maxMem: %s", humanize.IBytes(maxMem))


### PR DESCRIPTION
### What does this PR do?
Deflakes a test.

### Motivation
I had run it 1000 times to determine the bound, but my computer is not CI. Let's make it substantially more conservative because we saw flakes.

### Describe how you validated your changes
I ran it, and well, the flake was pretty clear.
