### PR TITLE
conntracker: do not require confirmed for insert

### DIFF
--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -31,7 +31,7 @@ SEC("kprobe/__nf_conntrack_hash_insert")
 int BPF_BYPASSABLE_KPROBE(kprobe___nf_conntrack_hash_insert, struct nf_conn *ct) {
     u32 status = 0;
     BPF_CORE_READ_INTO(&status, ct, status);
-    if (!(status&IPS_CONFIRMED) || !(status&IPS_NAT_MASK)) {
+    if (!(status&IPS_NAT_MASK)) {
         return 0;
     }
 


### PR DESCRIPTION
### What does this PR do?

Removes `IPS_CONFIRMED` as a requirement for the `nf_conn->status` field within `__nf_conntrack_hash_insert`.

### Motivation

`IPS_CONFIRMED` is now set after `__nf_conntrack_hash_insert`, so we cannot require it as a condition at the beginning of the function. See https://github.com/torvalds/linux/commit/a47ef874189d47f934d0809ae738886307c0ea22 for the behavior change in the kernel.

### Describe how you validated your changes

Conntracker related tests were failing on newer Debian 12 versions. Those tests pass with this fix.

### Additional Notes

This is the non-backported commit: https://github.com/torvalds/linux/commit/2d72afb340657f03f7261e9243b44457a9228ac7

Affects:
6.16+
6.15.8+
6.12.40+
6.6.100+
6.1.147+
