### PR TITLE
[USM] HTTP2: Change field type to allow copying in user mode

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -110,7 +110,7 @@ typedef enum {
 } __attribute__((packed)) static_table_value_t;
 
 typedef struct {
-    char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
+    __u8 buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
     __u32 original_index;
     __u8 string_len;
     bool is_huffman_encoded;

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -32,7 +32,7 @@ type HTTP2DynamicTableIndex struct {
 	Tup   ConnTuple
 }
 type HTTP2DynamicTableEntry struct {
-	Buffer             [160]int8
+	Buffer             [160]uint8
 	Original_index     uint32
 	String_len         uint8
 	Is_huffman_encoded bool


### PR DESCRIPTION
## What does this PR do?

Changes the HTTP2 field type to allow proper copying in user mode.

## Motivation

Fixes issues with HTTP2 data handling in user space.

## Description of the changes

- Changed field types in HTTP2 structures to support user mode copying
- Ensures proper memory handling for HTTP2 events

## Additional Notes

Part of USMON-658 work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)