### PR TITLE
[USM] HTTP2: Use SetStatusCode for static table

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -277,29 +277,33 @@ func (ew *EventWrapper) Method() http.Method {
 // Otherwise, f the status code is huffman encoded, then we decode it and convert it from string to int.
 // Otherwise, we convert the status code from byte array to int.
 func (ew *EventWrapper) StatusCode() uint16 {
+	if ew.statusCodeSet {
+		return ew.statusCode
+	}
+
 	if ew.Stream.Status_code.Static_table_entry != 0 {
+		statusCode := uint16(0)
 		switch ew.Stream.Status_code.Static_table_entry {
 		case K200Value:
-			return 200
+			statusCode = 200
 		case K204Value:
-			return 204
+			statusCode = 204
 		case K206Value:
-			return 206
+			statusCode = 206
 		case K304Value:
-			return 304
+			statusCode = 304
 		case K400Value:
-			return 400
+			statusCode = 400
 		case K404Value:
-			return 404
+			statusCode = 404
 		case K500Value:
-			return 500
+			statusCode = 500
 		default:
 			return 0
 		}
-	}
 
-	if ew.statusCodeSet {
-		return ew.statusCode
+		ew.SetStatusCode(statusCode)
+		return statusCode
 	}
 
 	if ew.Stream.Status_code.Is_huffman_encoded {


### PR DESCRIPTION
## What does this PR do?

Uses SetStatusCode function for handling HTTP2 static table status codes.

## Motivation

Ensures consistent status code handling for HTTP2 static table entries.

## Description of the changes

- Updated HTTP2 static table code to use SetStatusCode
- Ensures proper status code setting for HTTP2 responses
- Improves consistency in HTTP2 status code handling

## Additional Notes

Part of USMON-658 work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)