### PR TITLE
[USM] HTTP2: tests: Prevent panic if status code does not exist

### DIFF
--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1798,11 +1798,16 @@ func validateStats(t *testing.T, usmMonitor *Monitor, res, expectedEndpoints map
 			if statusCode == 0 {
 				statusCode = 200
 			}
-			hasTag := stat.Data[statusCode].StaticTags == ebpftls.ConnTagGo
+			statusCodeStats, ok := stat.Data[statusCode]
+			if !ok {
+				t.Logf("Bug was found; Path: %q; Status Code: %d; data: %#v", key.Path.Content.Get(), statusCode, stat.Data)
+				return false
+			}
+			hasTag := statusCodeStats.StaticTags == ebpftls.ConnTagGo
 			if hasTag != isTLS {
 				continue
 			}
-			count := stat.Data[statusCode].Count
+			count := statusCodeStats.Count
 			newKey := usmhttp.Key{
 				Path:   usmhttp.Path{Content: key.Path.Content},
 				Method: key.Method,


### PR DESCRIPTION
## What does this PR do?

Prevents panic in HTTP2 tests when a status code does not exist in the response data.

## Motivation

Improves test stability by handling missing status codes gracefully instead of panicking.

## Description of the changes

- Added nil/existence checks for status codes in HTTP2 test code
- Prevents test panics when expected status code is not present
- Improves test error reporting for missing status codes

## Additional Notes

This change makes HTTP2 tests more robust when dealing with incomplete or unexpected response data.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)