### PR TITLE
[USM] HTTP/HTTP2: Consolidate and reuse method string mappings

### DIFF
--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -7,6 +7,7 @@ package http
 
 import (
 	"errors"
+	nethttp "net/http"
 
 	"github.com/DataDog/sketches-go/ddsketch"
 
@@ -44,30 +45,40 @@ const (
 	MethodPatch
 	// MethodTrace represents the TRACE request method
 	MethodTrace
+	// MethodConnect represents the CONNECT request method
+	MethodConnect
 )
+
+var (
+	// StringToMethod maps string representations of the methods to their enums.
+	StringToMethod = map[string]Method{
+		nethttp.MethodPut:     MethodPut,
+		nethttp.MethodDelete:  MethodDelete,
+		nethttp.MethodHead:    MethodHead,
+		nethttp.MethodOptions: MethodOptions,
+		nethttp.MethodPatch:   MethodPatch,
+		nethttp.MethodGet:     MethodGet,
+		nethttp.MethodPost:    MethodPost,
+		nethttp.MethodTrace:   MethodTrace,
+		nethttp.MethodConnect: MethodConnect,
+	}
+	// MethodToString maps the enums to their string representations
+	MethodToString = map[Method]string{}
+)
+
+func init() {
+	for str, method := range StringToMethod {
+		MethodToString[method] = str
+	}
+}
 
 // Method returns a string representing the HTTP method of the request
 func (m Method) String() string {
-	switch m {
-	case MethodGet:
-		return "GET"
-	case MethodPost:
-		return "POST"
-	case MethodPut:
-		return "PUT"
-	case MethodHead:
-		return "HEAD"
-	case MethodDelete:
-		return "DELETE"
-	case MethodOptions:
-		return "OPTIONS"
-	case MethodPatch:
-		return "PATCH"
-	case MethodTrace:
-		return "TRACE"
-	default:
+	value, ok := MethodToString[m]
+	if !ok {
 		return "UNKNOWN"
 	}
+	return value
 }
 
 var (

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -196,32 +196,12 @@ func (ew *EventWrapper) ConnTuple() types.ConnectionKey {
 	}
 }
 
-// stringToHTTPMethod converts a string to an HTTP method.
-func stringToHTTPMethod(method string) (http.Method, error) {
-	switch strings.ToUpper(method) {
-	case "PUT":
-		return http.MethodPut, nil
-	case "DELETE":
-		return http.MethodDelete, nil
-	case "HEAD":
-		return http.MethodHead, nil
-	case "OPTIONS":
-		return http.MethodOptions, nil
-	case "PATCH":
-		return http.MethodPatch, nil
-	case "GET":
-		return http.MethodGet, nil
-	case "POST":
-		return http.MethodPost, nil
-	// Currently unsupported methods due to lack of support in http.Method.
-	case "CONNECT":
-		return http.MethodUnknown, nil
-	case "TRACE":
-		return http.MethodUnknown, nil
-	default:
-		return 0, fmt.Errorf("unsupported HTTP method: %s", method)
+var (
+	unsupportedMethods = map[http.Method]struct{}{
+		http.MethodConnect: {},
+		http.MethodTrace:   {},
 	}
-}
+)
 
 // Method returns the HTTP method of the transaction.
 func (ew *EventWrapper) Method() http.Method {
@@ -262,8 +242,12 @@ func (ew *EventWrapper) Method() http.Method {
 	} else {
 		method = string(ew.Stream.Request_method.Raw_buffer[:ew.Stream.Request_method.Length])
 	}
-	http2Method, err := stringToHTTPMethod(method)
-	if err != nil {
+
+	http2Method, ok := http.StringToMethod[strings.ToUpper(method)]
+	if !ok {
+		return http.MethodUnknown
+	}
+	if _, exists := unsupportedMethods[http2Method]; exists {
 		return http.MethodUnknown
 	}
 


### PR DESCRIPTION
## What does this PR do?

Consolidates HTTP method string mappings and reuses them across HTTP and HTTP2 protocols.

## Motivation

Eliminates code duplication by having a single source of truth for HTTP method string mappings that can be used by both HTTP and HTTP2 monitoring.

## Description of the changes

- Consolidated mapping between method strings and method enum values in HTTP module
- Updated HTTP2 to reuse the consolidated method string mappings
- Removed duplicate method mapping code from HTTP2
- Ensures consistency in method handling across HTTP and HTTP2

## Additional Notes

This refactoring improves maintainability by having a single place to manage HTTP method mappings.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)