### PR TITLE
omnibus: secret-gen-connector: ensure the output dir exists

### DIFF
--- a/omnibus/config/software/secret-generic-connector.rb
+++ b/omnibus/config/software/secret-generic-connector.rb
@@ -74,6 +74,7 @@ build do
   license_file "https://raw.githubusercontent.com/DataDog/datadog-secret-backend/master/LICENSE"
 
   if windows?
+    mkdir "#{install_dir}/bin/agent"
     # Extract the zip file
     copy "#{project_dir}/datadog-secret-backend.exe", "#{install_dir}/bin/agent/secret-generic-connector.exe"
   else


### PR DESCRIPTION
### What does this PR do?

Ensure the `secret-generic-connector` destination folder exists

### Motivation

When leveraging omnibus build cache for earlier dependencies, there is no guaranty that the folder exists, which caused a handful of build failures

### Describe how you validated your changes

### Additional Notes
