### PR TITLE
[CWS] fix panic in api server when closing

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -296,11 +296,11 @@ func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID)
 func (c *CWSConsumer) Stop() {
 	c.reloader.Stop()
 
+	c.cancelFnc()
+
 	if c.apiServer != nil {
 		c.apiServer.Stop()
 	}
-
-	c.cancelFnc()
 
 	c.ruleEngine.Stop()
 

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -114,6 +114,7 @@ func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create direct reported endpoints: %w", err)
 	}
+	stopper.Add(destinationsCtx)
 
 	for _, status := range endpoints.GetStatus() {
 		log.Info(status)


### PR DESCRIPTION
### What does this PR do?

We recently got this panic:
```
panic: send on closed channel
goroutine 934 [running]:
github.com/DataDog/datadog-agent/pkg/security/reporter.(*RuntimeReporter).ReportRaw(0xc00066ff20, {0xc003733000, 0x4d24, 0x5000}, {0xc002b24f9b, 0x18}, {0x10?, 0x22f3700?, 0x0?}, {0xc000a178c8, ...})
	github.com/DataDog/datadog-agent/pkg/security/reporter/reporter.go:40 +0x1ff
github.com/DataDog/datadog-agent/pkg/security/module.(*DirectEventMsgSender).Send(0xc002ba90c8, 0xc00478f440, 0x3a?)
	github.com/DataDog/datadog-agent/pkg/security/module/msg_sender.go:98 +0x8f
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).start.func1(0xc0071eaf00)
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:347 +0x47e
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).dequeue.func1(...)
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:229
github.com/DataDog/datadog-agent/pkg/security/module.slicesDeleteUntilFalse(...)
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:253
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).dequeue(0xc002584f00, {0xc00786ff30?, 0x68f7e6feeb2?, 0x3e58b20?}, 0xc00786ff40)
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:224 +0x182
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).start(0xc002584f00, {0x29d64b0, 0xc002ba75e0})
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:304 +0xb0
created by github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:360 +0x74
```

this caused because we dequeue an event and try to send it, when the logs context is already closed. To fix this we first close the context, exiting the dequeue loop, and then stop the api server.

In addition to that, this PR also makes sure the logs destination context is correctly stopped.

### Motivation

### Describe how you validated your changes

### Additional Notes
