### PR TITLE
Add new tags, improve error handling, add func as unique key

### DIFF
--- a/tasks/fuzz_infra.py
+++ b/tasks/fuzz_infra.py
@@ -90,7 +90,7 @@ def build_and_upload_fuzz(ctx, team="chaos-platform", core_count=2, duration=360
             try:
                 ctx.run(fuzz_build_cmd)
             except Exception as e:
-                print(f'❌ Failed to build {pkgname}/{func}: {e}... Skipping this fuzz target')
+                print(f'❌ Failed to build {pkgname}: {e}... Skipping this fuzz target')
                 continue
 
             build_full_path = directory + "/" + build_file

--- a/tasks/fuzz_infra.py
+++ b/tasks/fuzz_infra.py
@@ -86,7 +86,7 @@ def build_and_upload_fuzz(ctx, team="chaos-platform", core_count=2, duration=360
             build_file = "fuzz.test"
 
             print(f'Building {pkgname}/{func} for {git_sha}...')
-            fuzz_build_cmd = f'go test . -c -fuzz={func}$ -o {build_file} -cover -tags=test,linux_bpf,nvml'
+            fuzz_build_cmd = f'go test . -c -fuzz={func}$ -o {build_file} -cover -tags=test,linux_bpf,nvml,amd64'
             try:
                 ctx.run(fuzz_build_cmd)
             except Exception as e:

--- a/tasks/fuzz_infra.py
+++ b/tasks/fuzz_infra.py
@@ -77,14 +77,22 @@ def build_and_upload_fuzz(ctx, team="chaos-platform", core_count=2, duration=360
         with ctx.cd(directory):
             # eg: convert "/path/to/fuzz/target" to "datadog-agent-path-to-fuzz-target".
             # It's a unique identifier for the fuzz target.
+            # We also append the function name to the package name to make sure that every function inside the same package
+            # has a unique target name. This allows us to have different inputs for different functions in the same package.
             rel = directory.removeprefix("/go/src/github.com/DataDog/datadog-agent/")
             pkgname = "datadog-agent-"
             pkgname += "-".join(rel.split('/'))[:max_pkg_name_length]
+            pkgname += f"-{func}"
             build_file = "fuzz.test"
 
             print(f'Building {pkgname}/{func} for {git_sha}...')
-            fuzz_build_cmd = f'go test . -c -fuzz={func}$ -o {build_file} -cover -tags=test,linux_bpf'
-            ctx.run(fuzz_build_cmd)
+            fuzz_build_cmd = f'go test . -c -fuzz={func}$ -o {build_file} -cover -tags=test,linux_bpf,nvml'
+            try:
+                ctx.run(fuzz_build_cmd)
+            except Exception as e:
+                print(f'❌ Failed to build {pkgname}/{func}: {e}... Skipping this fuzz target')
+                continue
+
             build_full_path = directory + "/" + build_file
             if not os.path.exists(build_full_path):
                 print(

--- a/tasks/fuzz_infra.py
+++ b/tasks/fuzz_infra.py
@@ -47,7 +47,7 @@ def get_slack_channel_for_directory(directory_path: str) -> str:
         first_owner = owners[0].lower()
 
         # Map the owner to a slack channel
-        return GITHUB_SLACK_MAP.get(first_owner, DEFAULT_FUZZING_SLACK_CHANNEL)
+        return GITHUB_SLACK_MAP.get(first_owner, DEFAULT_FUZZING_SLACK_CHANNEL).replace("#", "")
 
     except Exception as e:
         print(


### PR DESCRIPTION
### What does this PR do?

This improve the `fuzz_infra.py` script to handle ctx.run throws that we encountered in this job:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1175663441

That made the list of fuzzer to be started truncated to the first crashing build.

This also adds the `nvml` tag to build some new targets. (TODO: how can we automate the list of tags to include "everything" ? Now that we can fail a build safely, should we "add them all" ?)

And finally, there's a small improvements on the naming scheme for Go fuzzer: the function name is now part of the package. This creates duplicate binaries, but if a package has  multiple fuzzers, we can now run them properly (i.e: with their own inputs/crash/coverage)

### Motivation
Improve the fuzzing infrastructure error handling and improve coverage

### Describe how you validated your changes
Gitlab run with the build failure not blocking the remaining fuzzers: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1175824522

### Additional Notes
N/A