### PR TITLE
[USM] HTTP2: Do not keep pointer to a pooled object

### DIFF
--- a/pkg/network/protocols/http2/incomplete_stats.go
+++ b/pkg/network/protocols/http2/incomplete_stats.go
@@ -56,8 +56,12 @@ func (b *incompleteBuffer) Add(tx http.Transaction) {
 		return
 	}
 
+	ebpfTxCopy := new(EbpfTx)
+	*ebpfTxCopy = *eventWrapper.EbpfTx
+
 	eventWrapperCopy := new(EventWrapper)
 	*eventWrapperCopy = *eventWrapper
+	eventWrapperCopy.EbpfTx = ebpfTxCopy
 
 	b.data = append(b.data, eventWrapperCopy)
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where HTTP2 code was keeping a pointer to a pooled object, leading to incorrect caching behavior.

## Motivation

Pooled objects get reused, so keeping pointers to them can lead to data corruption or incorrect behavior when the object is returned to the pool and reused.

## Description of the changes

- Removed pointer references to pooled objects in HTTP2 incomplete buffer
- Ensures proper object lifecycle management with pooled objects
- Fixes potential data corruption issues from pointer aliasing

## Additional Notes

Part of USMON-658 work. This is a critical fix for correct HTTP2 data handling when using object pools.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)