### PR TITLE
[CWS] some eBPF maps usage/size cleanup

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -56,10 +56,10 @@ __attribute__((always_inline)) bool is_cgroup_mount_id_filter_valid(u32 cgroup_f
 // cleanup_expired_dump removes all kernel space entries for an expired dump
 // If pid is non-zero, also removes that specific PID from traced_pids
 // Note: complete traced_pids cleanup requires userspace intervention since we can't iterate the map efficiently
-__attribute__((always_inline)) void cleanup_expired_dump(struct path_key_t *cgroup_file, u64 cookie, u32 pid) {
+__attribute__((always_inline)) void cleanup_expired_dump(u64 *cgroup_inode, u64 cookie, u32 pid) {
     bpf_map_delete_elem(&activity_dumps_config, &cookie);
-    if (cgroup_file != NULL && (cgroup_file->ino != 0 || cgroup_file->mount_id != 0)) {
-        bpf_map_delete_elem(&traced_cgroups, cgroup_file);
+    if (cgroup_inode != NULL && *cgroup_inode != 0) {
+        bpf_map_delete_elem(&traced_cgroups, cgroup_inode);
     }
     if (pid != 0) {
         bpf_map_delete_elem(&traced_pids, &pid);
@@ -111,9 +111,8 @@ __attribute__((always_inline)) bool reserve_traced_cgroup_spot(struct cgroup_con
         return false;
     }
 
-    struct path_key_t path_key;
-    path_key = cgroup->cgroup_file;
-    int ret = bpf_map_update_elem(&traced_cgroups, &path_key, &cookie, BPF_NOEXIST);
+    u64 cgroup_inode = cgroup->cgroup_file.ino;
+    int ret = bpf_map_update_elem(&traced_cgroups, &cgroup_inode, &cookie, BPF_NOEXIST);
     if (ret < 0) {
         // we didn't get a lock, skip this cgroup for now and go back to it later
         return false;
@@ -126,12 +125,12 @@ __attribute__((always_inline)) bool reserve_traced_cgroup_spot(struct cgroup_con
     ret = bpf_map_update_elem(&activity_dumps_config, &cookie, config, BPF_ANY);
     if (ret < 0) {
         // should never happen, ignore
-        bpf_map_delete_elem(&traced_cgroups, &path_key);
+        bpf_map_delete_elem(&traced_cgroups, &cgroup_inode);
         return false;
     }
 
     // we're tracing a new cgroup, update its wait list timeout
-    bpf_map_update_elem(&cgroup_wait_list, &path_key, &config->wait_list_timestamp, BPF_ANY);
+    bpf_map_update_elem(&cgroup_wait_list, &cgroup_inode, &config->wait_list_timestamp, BPF_ANY);
     return true;
 }
 
@@ -175,21 +174,23 @@ __attribute__((always_inline)) u64 should_trace_new_process_cgroup(void *ctx, u6
 
     if (is_cgroup_activity_dumps_enabled()) {
 
+        u64 cgroup_inode = cgroup_context.cgroup_file.ino;
+
         // is this cgroup discarded ?
-        u8 *discarded = bpf_map_lookup_elem(&traced_cgroups_discarded, &cgroup_context.cgroup_file);
+        u8 *discarded = bpf_map_lookup_elem(&traced_cgroups_discarded, &cgroup_inode);
         if (discarded != NULL) {
             return 0;
         }
 
         // is this cgroup traced ?
-        u64 *cookie = bpf_map_lookup_elem(&traced_cgroups, &cgroup_context.cgroup_file);
+        u64 *cookie = bpf_map_lookup_elem(&traced_cgroups, &cgroup_inode);
 
         if (cookie) {
             u64 cookie_val = *cookie;
             struct activity_dump_config *config = bpf_map_lookup_elem(&activity_dumps_config, &cookie_val);
             if (config == NULL) {
                 // delete expired cgroup entry
-                bpf_map_delete_elem(&traced_cgroups, &cgroup_context.cgroup_file);
+                bpf_map_delete_elem(&traced_cgroups, &cgroup_inode);
                 return 0;
             }
 
@@ -205,7 +206,7 @@ __attribute__((always_inline)) u64 should_trace_new_process_cgroup(void *ctx, u6
 
             if (now > config->end_timestamp) {
                 // delete expired dump (no specific pid to clean here)
-                cleanup_expired_dump(&cgroup_context.cgroup_file, cookie_val, 0);
+                cleanup_expired_dump(&cgroup_inode, cookie_val, 0);
                 return 0;
             }
 
@@ -215,11 +216,11 @@ __attribute__((always_inline)) u64 should_trace_new_process_cgroup(void *ctx, u6
 
         } else {
             // have we seen this cgroup before ?
-            u64 *wait_timeout = bpf_map_lookup_elem(&cgroup_wait_list, &cgroup_context.cgroup_file);
+            u64 *wait_timeout = bpf_map_lookup_elem(&cgroup_wait_list, &cgroup_inode);
             if (wait_timeout) {
                 if (now > *wait_timeout) {
                     // delete expired wait_list entry
-                    bpf_map_delete_elem(&cgroup_wait_list, &cgroup_context.cgroup_file);
+                    bpf_map_delete_elem(&cgroup_wait_list, &cgroup_inode);
                 }
 
                 // this cgroup is on the wait list, do not start tracing it

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -40,10 +40,8 @@ BPF_ARRAY_MAP(global_rate_limiters, struct rate_limiter_ctx, 2)
 BPF_ARRAY_MAP(filtered_dns_rcodes, u16, 1)
 BPF_ARRAY_MAP(in_upper_layer_approvers, struct event_mask_filter_t, 1)
 
-BPF_HASH_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime
-BPF_HASH_MAP(activity_dump_config_defaults, u32, struct activity_dump_config, 5)
+BPF_HASH_MAP(activity_dump_config_defaults, u32, struct activity_dump_config, 1)
 BPF_HASH_MAP(traced_cgroups, struct path_key_t, u64, 1) // max entries will be overridden at runtime
-BPF_HASH_MAP(cgroup_wait_list, struct path_key_t, u64, 1) // max entries will be overridden at runtime
 BPF_HASH_MAP(traced_pids, u32, u64, 8192) // max entries will be overridden at runtime
 BPF_HASH_MAP(basename_approvers, struct basename_t, struct event_mask_filter_t, 255)
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
@@ -60,6 +58,8 @@ BPF_HASH_MAP(cgroup_mount_id, u32, u32, 1)
 BPF_HASH_MAP_FLAGS(active_flows, u32, struct active_flows_t, 1, BPF_F_NO_PREALLOC) // max entry will be overridden at runtime
 BPF_HASH_MAP_FLAGS(inet_bind_args, u64, struct inet_bind_args_t, 1, BPF_F_NO_PREALLOC) // max entries will be overridden at runtime
 
+BPF_LRU_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(cgroup_wait_list, struct path_key_t, u64, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(traced_cgroups_discarded, struct path_key_t, u8, 512)
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -41,7 +41,7 @@ BPF_ARRAY_MAP(filtered_dns_rcodes, u16, 1)
 BPF_ARRAY_MAP(in_upper_layer_approvers, struct event_mask_filter_t, 1)
 
 BPF_HASH_MAP(activity_dump_config_defaults, u32, struct activity_dump_config, 1)
-BPF_HASH_MAP(traced_cgroups, struct path_key_t, u64, 1) // max entries will be overridden at runtime
+BPF_HASH_MAP(traced_cgroups, u64, u64, 1) // max entries will be overridden at runtime
 BPF_HASH_MAP(traced_pids, u32, u64, 8192) // max entries will be overridden at runtime
 BPF_HASH_MAP(basename_approvers, struct basename_t, struct event_mask_filter_t, 255)
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
@@ -59,8 +59,8 @@ BPF_HASH_MAP_FLAGS(active_flows, u32, struct active_flows_t, 1, BPF_F_NO_PREALLO
 BPF_HASH_MAP_FLAGS(inet_bind_args, u64, struct inet_bind_args_t, 1, BPF_F_NO_PREALLOC) // max entries will be overridden at runtime
 
 BPF_LRU_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(cgroup_wait_list, struct path_key_t, u64, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(traced_cgroups_discarded, struct path_key_t, u8, 512)
+BPF_LRU_MAP(cgroup_wait_list, u64, u64, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(traced_cgroups_discarded, u64, u8, 512)
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -60,7 +60,7 @@ BPF_HASH_MAP(cgroup_mount_id, u32, u32, 1)
 BPF_HASH_MAP_FLAGS(active_flows, u32, struct active_flows_t, 1, BPF_F_NO_PREALLOC) // max entry will be overridden at runtime
 BPF_HASH_MAP_FLAGS(inet_bind_args, u64, struct inet_bind_args_t, 1, BPF_F_NO_PREALLOC) // max entries will be overridden at runtime
 
-BPF_LRU_MAP(traced_cgroups_discarded, struct path_key_t, u8, 256)
+BPF_LRU_MAP(traced_cgroups_discarded, struct path_key_t, u8, 512)
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -302,11 +302,11 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			EditorFlag: manager.EditMaxEntries,
 		}
 		editors["activity_dumps_config"] = manager.MapSpecEditor{
-			MaxEntries: uint32(opts.TracedCgroupSize),
+			MaxEntries: uint32(opts.TracedCgroupSize * 2),
 			EditorFlag: manager.EditMaxEntries,
 		}
 		editors["activity_dump_rate_limiters"] = manager.MapSpecEditor{
-			MaxEntries: uint32(opts.TracedCgroupSize),
+			MaxEntries: uint32(opts.TracedCgroupSize * 2),
 			EditorFlag: manager.EditMaxEntries,
 		}
 		editors["cgroup_wait_list"] = manager.MapSpecEditor{

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -205,6 +205,7 @@ type MapSpecEditorOpts struct {
 	SpanTrackMaxCount             int
 	CapabilitiesMonitoringEnabled bool
 	CgroupSocketEnabled           bool
+	SecurityProfileSyscallAnomaly bool
 }
 
 // AllMapSpecEditors returns the list of map editors
@@ -275,10 +276,6 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: model.MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		},
-		"security_profiles": {
-			MaxEntries: uint32(opts.SecurityProfileMaxCount),
-			EditorFlag: manager.EditMaxEntries,
-		},
 		"secprofs_syscalls": {
 			MaxEntries: uint32(opts.SecurityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
@@ -295,6 +292,13 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: capabilitiesContextsMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
+	}
+
+	if opts.SecurityProfileSyscallAnomaly {
+		editors["security_profiles"] = manager.MapSpecEditor{
+			MaxEntries: uint32(opts.SecurityProfileMaxCount),
+			EditorFlag: manager.EditMaxEntries,
+		}
 	}
 
 	if opts.PathResolutionEnabled {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -264,18 +264,6 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: nsFlowToNetworkStats,
 			EditorFlag: manager.EditMaxEntries,
 		},
-		"activity_dumps_config": {
-			MaxEntries: model.MaxTracedCgroupsCount,
-			EditorFlag: manager.EditMaxEntries,
-		},
-		"activity_dump_rate_limiters": {
-			MaxEntries: model.MaxTracedCgroupsCount,
-			EditorFlag: manager.EditMaxEntries,
-		},
-		"cgroup_wait_list": {
-			MaxEntries: model.MaxTracedCgroupsCount,
-			EditorFlag: manager.EditMaxEntries,
-		},
 		"secprofs_syscalls": {
 			MaxEntries: uint32(opts.SecurityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
@@ -311,6 +299,18 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 	if opts.TracedCgroupSize > 0 {
 		editors["traced_cgroups"] = manager.MapSpecEditor{
 			MaxEntries: uint32(opts.TracedCgroupSize),
+			EditorFlag: manager.EditMaxEntries,
+		}
+		editors["activity_dumps_config"] = manager.MapSpecEditor{
+			MaxEntries: uint32(opts.TracedCgroupSize),
+			EditorFlag: manager.EditMaxEntries,
+		}
+		editors["activity_dump_rate_limiters"] = manager.MapSpecEditor{
+			MaxEntries: uint32(opts.TracedCgroupSize),
+			EditorFlag: manager.EditMaxEntries,
+		}
+		editors["cgroup_wait_list"] = manager.MapSpecEditor{
+			MaxEntries: model.MaxTracedCgroupsCount,
 			EditorFlag: manager.EditMaxEntries,
 		}
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2698,6 +2698,7 @@ func (p *EBPFProbe) initManagerOptionsMapSpecEditors() {
 		SpanTrackMaxCount:             1,
 		CapabilitiesMonitoringEnabled: p.config.Probe.CapabilitiesMonitoringEnabled,
 		CgroupSocketEnabled:           p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket(),
+		SecurityProfileSyscallAnomaly: slices.Contains(p.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType),
 	}
 
 	if p.config.Probe.SpanTrackingEnabled {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1004,7 +1004,7 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 func (p *EBPFProbe) onEventLost(_ string, perEvent map[string]uint64) {
 	// snapshot traced cgroups if a CgroupTracing event was lost
 	if p.probe.IsActivityDumpEnabled() && perEvent[model.CgroupTracingEventType.String()] > 0 {
-		p.profileManager.SnapshotTracedCgroups()
+		p.profileManager.SyncTracedCgroups()
 	}
 }
 

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -49,6 +49,7 @@ type ResolverInterface interface {
 	AddPID(*model.ProcessCacheEntry)
 	DelPID(uint32)
 	GetWorkload(containerutils.ContainerID) (*cgroupModel.CacheEntry, bool)
+	GetWorkloadByCGroupID(containerutils.CGroupID) (*cgroupModel.CacheEntry, bool)
 	Len() int
 	RegisterListener(Event, utils.Listener[*cgroupModel.CacheEntry]) error
 }
@@ -344,6 +345,18 @@ func (cr *Resolver) GetWorkload(id containerutils.ContainerID) (*cgroupModel.Cac
 	defer cr.Unlock()
 
 	return cr.containerWorkloads.Get(id)
+}
+
+// GetWorkloadByCGroupID returns the workload referenced by the provided cgroup ID
+func (cr *Resolver) GetWorkloadByCGroupID(cgroupID containerutils.CGroupID) (*cgroupModel.CacheEntry, bool) {
+	if cgroupID == "" {
+		return nil, false
+	}
+
+	cr.Lock()
+	defer cr.Unlock()
+
+	return cr.hostWorkloads.Get(cgroupID)
 }
 
 // DelPID removes a PID from the cgroup resolver

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -513,7 +513,7 @@ workloadLoop:
 		}
 
 		if err := m.startDumpWithConfig(workloads[0].ContainerID, workloads[0].CGroupContext, utils.NewCookie(), *defaultConfig); err != nil {
-			if !errors.Is(err, unix.E2BIG) {
+			if errors.Is(err, unix.E2BIG) {
 				seclog.Debugf("%v", err)
 				break
 			}
@@ -589,7 +589,10 @@ func (m *Manager) HandleCGroupTracingEvent(event *model.CgroupTracingEvent) {
 	defer m.m.Unlock()
 
 	if err := m.startDumpWithConfig(event.ContainerContext.ContainerID, event.CGroupContext, event.ConfigCookie, event.Config); err != nil {
-		seclog.Warnf("%v", err)
+		if errors.Is(err, unix.E2BIG) {
+			seclog.Debugf("%v", err)
+		}
+		seclog.Errorf("%v", err)
 	}
 }
 

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -167,6 +167,11 @@ func (m *Manager) insertActivityDump(newDump *dump.ActivityDump) error {
 		}
 	}
 
+	// check if we're at capacity
+	if len(m.activeDumps) >= m.config.RuntimeSecurity.ActivityDumpTracedCgroupsCount {
+		return fmt.Errorf("activity dump capacity reached (%d/%d)", len(m.activeDumps), m.config.RuntimeSecurity.ActivityDumpTracedCgroupsCount)
+	}
+
 	// loop through the process cache entry tree and push traced pids if necessary
 	pces := m.newProcessCacheEntrySearcher(newDump)
 	m.resolvers.ProcessResolver.Walk(func(entry *model.ProcessCacheEntry) {

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -610,6 +610,8 @@ func (m *Manager) SnapshotTracedCgroups() {
 	for iterator.Next(&cgroupFile, &event.ConfigCookie) {
 		m.m.Lock()
 		if m.ignoreFromSnapshot[cgroupFile] {
+			// remove from traced_cgroups since it should be ignored
+			_ = m.tracedCgroupsMap.Delete(cgroupFile)
 			m.m.Unlock()
 			continue
 		}

--- a/pkg/security/security_profile/grpc.go
+++ b/pkg/security/security_profile/grpc.go
@@ -136,6 +136,8 @@ func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 			(params.GetContainerID() != "" && ad.Profile.Metadata.ContainerID == containerutils.ContainerID(params.GetContainerID())) ||
 			(params.GetCGroupID() != "" && ad.Profile.Metadata.CGroupContext.CGroupID == containerutils.CGroupID(params.GetCGroupID())) {
 			m.finalizeKernelEventCollection(ad, true)
+			// mark the cgroup to ignore from snapshot to prevent re-creation
+			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupFile] = true
 			seclog.Infof("tracing stopped for [%s]", ad.GetSelectorStr())
 			toDelete = i
 

--- a/pkg/security/security_profile/grpc.go
+++ b/pkg/security/security_profile/grpc.go
@@ -137,7 +137,7 @@ func (m *Manager) StopActivityDump(params *api.ActivityDumpStopParams) (*api.Act
 			(params.GetCGroupID() != "" && ad.Profile.Metadata.CGroupContext.CGroupID == containerutils.CGroupID(params.GetCGroupID())) {
 			m.finalizeKernelEventCollection(ad, true)
 			// mark the cgroup to ignore from snapshot to prevent re-creation
-			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupFile] = true
+			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupFile.Inode] = true
 			seclog.Infof("tracing stopped for [%s]", ad.GetSelectorStr())
 			toDelete = i
 

--- a/pkg/security/security_profile/load_controller.go
+++ b/pkg/security/security_profile/load_controller.go
@@ -139,7 +139,7 @@ func (m *Manager) getOverweightDumps() []*dump.ActivityDump {
 		if dumpSize >= int64(m.config.RuntimeSecurity.ActivityDumpMaxDumpSize()) {
 			toDelete = append([]int{i}, toDelete...)
 			dumps = append(dumps, ad)
-			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupFile] = true
+			m.ignoreFromSnapshot[ad.Profile.Metadata.CGroupContext.CGroupFile.Inode] = true
 		}
 	}
 	for _, i := range toDelete {
@@ -182,6 +182,6 @@ func (m *Manager) triggerLoadController() {
 		}
 
 		// remove container ID from the map of ignored container IDs for the snapshot
-		delete(m.ignoreFromSnapshot, ad.Profile.Metadata.CGroupContext.CGroupFile)
+		delete(m.ignoreFromSnapshot, ad.Profile.Metadata.CGroupContext.CGroupFile.Inode)
 	}
 }

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -99,7 +99,7 @@ type Manager struct {
 	activityDumpConfigDefaults  *ebpf.Map
 	activityDumpRateLimitersMap *ebpf.Map
 
-	ignoreFromSnapshot   map[model.PathKey]bool
+	ignoreFromSnapshot   map[uint64]bool
 	dumpLimiter          *lru.Cache[cgroupModel.WorkloadSelector, *atomic.Uint64]
 	workloadDenyList     []cgroupModel.WorkloadSelector
 	workloadDenyListHits *atomic.Uint64
@@ -302,7 +302,7 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 		activityDumpConfigDefaults:  activityDumpConfigDefaultsMap,
 		activityDumpRateLimitersMap: activityDumpRateLimitersMap,
 
-		ignoreFromSnapshot:   make(map[model.PathKey]bool),
+		ignoreFromSnapshot:   make(map[uint64]bool),
 		dumpLimiter:          dumpLimiter,
 		workloadDenyList:     workloadDenyList,
 		workloadDenyListHits: atomic.NewUint64(0),

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -126,7 +126,8 @@ type Manager struct {
 
 	// fields from SecurityProfileManager
 
-	secProfEventTypes []model.EventType
+	secProfEventTypes       []model.EventType
+	isSyscallAnomalyEnabled bool
 
 	// ebpf maps
 	securityProfileMap         *ebpf.Map
@@ -321,7 +322,8 @@ func NewManager(cfg *config.Config, statsdClient statsd.ClientInterface, ebpf *e
 		emptyDropped:       atomic.NewUint64(0),
 		dropMaxDumpReached: atomic.NewUint64(0),
 
-		secProfEventTypes: secProfEventTypes,
+		secProfEventTypes:       secProfEventTypes,
+		isSyscallAnomalyEnabled: slices.Contains(cfg.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType),
 
 		securityProfileMap:         securityProfileMap,
 		securityProfileSyscallsMap: securityProfileSyscallsMap,

--- a/pkg/security/security_profile/manager_test.go
+++ b/pkg/security/security_profile/manager_test.go
@@ -479,7 +479,7 @@ func TestActivityDumpManager_getExpiredDumps(t *testing.T) {
 
 			adm := &Manager{
 				activeDumps:        tt.fields.activeDumps,
-				ignoreFromSnapshot: make(map[model.PathKey]bool),
+				ignoreFromSnapshot: make(map[uint64]bool),
 			}
 
 			expiredDumps := adm.getExpiredDumps()
@@ -964,7 +964,7 @@ func TestActivityDumpManager_getOverweightDumps(t *testing.T) {
 					},
 				},
 				statsdClient:       &statsd.NoOpClient{},
-				ignoreFromSnapshot: make(map[model.PathKey]bool),
+				ignoreFromSnapshot: make(map[uint64]bool),
 			}
 
 			compareListOfDumps(t, adm.getOverweightDumps(), tt.overweightDumps)

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -347,7 +347,7 @@ func (m *Manager) linkProfile(profile *profile.Profile, workload *tags.Workload)
 	profile.Instances = append(profile.Instances, workload)
 
 	// can we apply the profile or is it not ready yet ?
-	if profile.LoadedInKernel.Load() && slices.Contains(m.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
+	if profile.LoadedInKernel.Load() && m.isSyscallAnomalyEnabled {
 		m.linkProfileMap(profile, workload)
 	}
 }
@@ -378,7 +378,7 @@ func (m *Manager) unlinkProfile(profile *profile.Profile, workload *tags.Workloa
 	}
 
 	// remove link between the profile and the workload
-	if slices.Contains(m.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
+	if m.isSyscallAnomalyEnabled {
 		m.unlinkProfileMap(profile, workload)
 	}
 }

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -342,7 +342,7 @@ func (m *Manager) linkProfile(profile *profile.Profile, workload *tags.Workload)
 	profile.Instances = append(profile.Instances, workload)
 
 	// can we apply the profile or is it not ready yet ?
-	if profile.LoadedInKernel.Load() {
+	if profile.LoadedInKernel.Load() && slices.Contains(m.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
 		m.linkProfileMap(profile, workload)
 	}
 }
@@ -373,7 +373,9 @@ func (m *Manager) unlinkProfile(profile *profile.Profile, workload *tags.Workloa
 	}
 
 	// remove link between the profile and the workload
-	m.unlinkProfileMap(profile, workload)
+	if slices.Contains(m.config.RuntimeSecurity.AnomalyDetectionEventTypes, model.SyscallsEventType) {
+		m.unlinkProfileMap(profile, workload)
+	}
 }
 
 func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -9,6 +9,7 @@
 package securityprofile
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -21,6 +22,7 @@ import (
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"golang.org/x/sys/unix"
 )
 
 // fetchSilentWorkloads returns the list of workloads for which we haven't received any profile
@@ -318,11 +320,14 @@ func (m *Manager) unloadProfileMap(profile *profile.Profile) {
 // linkProfile (thread unsafe) updates the kernel space mapping between a workload and its profile
 func (m *Manager) linkProfileMap(profile *profile.Profile, workload *tags.Workload) {
 	if err := m.securityProfileMap.Put(workload.CGroupFile.Inode, profile.GetProfileCookie()); err != nil {
-		seclog.Errorf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
+		if errors.Is(err, unix.E2BIG) {
+			seclog.Debugf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
+		} else {
+			seclog.Errorf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
+		}
 		return
 	}
 	seclog.Infof("%s %s (selector: %s) successfully linked to profile %s", workload.Type(), workload.GetWorkloadID(), workload.Selector.String(), profile.Metadata.Name)
-
 }
 
 // linkProfile applies a profile to the provided workload


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix some issues related to ebpf maps usage:
* allocate/use `security_profiles` map only if we need it (when `syscalls` being present int the security profile anomaly detection event types)
* increase the size of the `traced_cgroups_discarded` map (which should not reach max size) after seeing it at max on staging.
* add cleanup of `traced_pids` map when AD ends
* add some other missing cleanups kernel side when a dump ends
* allocate activity dump maps (`activity_dumps_config`, `activity_dump_rate_limiters` and `cgroup_wait_list`) only when enabled
* make `activity_dumps_config` and `activity_dump_rate_limiters` double size of `traced_cgroups` and an LRU (not ideal, but it will ~deal with races).
* reduce log level of map E2BIG errors to debug
* when evicting a cgroup from traced_cgroups maps we now also cleanup the two other related maps (config and rate limiter)
* rework a bit the logic around the `ignoreFromSnapshot` map (when stopping a dump)
* rework a bit the logic of `SnapshotTracedCgroups`, renaming it `SyncTracedCgroups` because it no longer create new dumps (to avoid a race), now it only cleans and sync the `traced_cgroups` maps with the active dumps
* add new helpers (`EvictAllTracedCgroups` and `ClearTracedCgroups`) for the functional tests to, when stopping all dumps we also put current cgroups into the discarders/ignore maps to avoid races of cgroup being traced between the "stop all" and the test itself.
* update the maps `traced_cgroups`, `cgroup_wait_list` and `traced_cgroups_discarded` to use only the inode as key (and not the whole pathkey, as a same cgroup can have different pathkeys/mountid depending how it's accessed).
* add a sync on traced cgroup map before inserting anew dump userspace side

### Motivation

I've investigate why we got so much E2BIG errors when pushing values to some eBPF maps, and here's my report:
* `security_profiles`: we should not use it at all as the feature is disabled by default. and if enabled, a size of 400 looks plenty enough. To be double check if/when we want to enable it (I'm not even sure we'll keep it on the on going rework)
* `activity_dumps_config`: was sized to 128 instead of the same size of traced cgroups (5) and still was reaching max capacity. I've added missing cleanups but it might not be enough (cause, races).
* Same for the `activity_dump_rate_limiters` one
* I saw also `traced_cgroups_discarded` being at max; which is not so critic as it's an LRU and we have cleanup fallback but it's better to increase its size

### Describe how you validated your changes

### Additional Notes

A more broader maps usage review/cleanup should be done once the security profiles rework will be done
