### PR TITLE
Also bump timeout of `bazel` jobs on Windows to 1h

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -25,7 +25,7 @@
 
 .bazel:ext:windows:
   extends: .windows_docker_default
-  timeout: 30m # pulling images alone takes between 10m and 20m
+  timeout: 60m # pulling images alone can take more than 30m
   allow_failure: true
   retry: 0
   variables:


### PR DESCRIPTION
### Motivation
Despite all earliers tweaks (#41023, #41262, #41300), `bazel` jobs on Windows sometimes still time out when pulling fresh container images, for instance:
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1175807538

### What does this PR do?
The present change consists in bumping the timeout to 1 hour, using the following reference PR:
- #40925