### PR TITLE
Increase timeout when getting ec2 metadata in e2e tests

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/ec2_metadata.go
+++ b/test/new-e2e/pkg/utils/e2e/client/ec2_metadata.go
@@ -67,6 +67,6 @@ func runWithRetry(t *testing.T, h *Host, cmd string) string {
 		var err error
 		output, err = h.Execute(cmd)
 		require.NoError(c, err)
-	}, time.Second*10, time.Second*1)
+	}, time.Second*30, time.Second*1)
 	return output
 }


### PR DESCRIPTION
### What does this PR do?
Increase the max timeout to get EC2 metadata in e2e tests.

### Motivation
Fix reported flakiness.

### Describe how you validated your changes
CI.

### Additional Notes
