### PR TITLE
[SYNTH-22340]: Improves Assertion computation for Synthetics Tests

### DIFF
--- a/comp/syntheticstestscheduler/common/result.go
+++ b/comp/syntheticstestscheduler/common/result.go
@@ -21,7 +21,6 @@ type AssertionResult struct {
 	Expected interface{}      `json:"expected"`
 	Actual   interface{}      `json:"actual"`
 	Valid    bool             `json:"valid"`
-	Failure  APIFailure       `json:"failure"`
 }
 
 // Compare evaluates the assertion result by comparing the actual and expected values.

--- a/comp/syntheticstestscheduler/impl/assertions.go
+++ b/comp/syntheticstestscheduler/impl/assertions.go
@@ -6,8 +6,6 @@
 package syntheticstestschedulerimpl
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/comp/syntheticstestscheduler/common"
 )
 
@@ -46,10 +44,7 @@ func runAssertion(assertion common.Assertion, stats common.NetStats) common.Asse
 				Type:     assertion.Type,
 				Property: assertion.Property,
 				Expected: assertion.Target,
-				Failure: common.APIFailure{
-					Code:    invalidTest,
-					Message: fmt.Sprintf("unsupported field: %s.%s", assertion.Type, assertion.Property),
-				},
+				Valid:    false,
 			}
 		}
 	case common.AssertionTypeNetworkHops:
@@ -66,10 +61,7 @@ func runAssertion(assertion common.Assertion, stats common.NetStats) common.Asse
 				Type:     assertion.Type,
 				Property: assertion.Property,
 				Expected: assertion.Target,
-				Failure: common.APIFailure{
-					Code:    invalidTest,
-					Message: fmt.Sprintf("unsupported field: %s.%s", assertion.Type, assertion.Property),
-				},
+				Valid:    false,
 			}
 		}
 	default:
@@ -78,10 +70,7 @@ func runAssertion(assertion common.Assertion, stats common.NetStats) common.Asse
 			Type:     assertion.Type,
 			Property: assertion.Property,
 			Expected: assertion.Target,
-			Failure: common.APIFailure{
-				Code:    invalidTest,
-				Message: fmt.Sprintf("unsupported field: %s", assertion.Type),
-			},
+			Valid:    false,
 		}
 	}
 
@@ -93,10 +82,7 @@ func runAssertion(assertion common.Assertion, stats common.NetStats) common.Asse
 		Actual:   actual,
 	}
 	if err := assertionResult.Compare(); err != nil {
-		assertionResult.Failure = common.APIFailure{
-			Code:    incorrectAssertion,
-			Message: err.Error(),
-		}
+		assertionResult.Valid = false
 		return assertionResult
 	}
 	return assertionResult

--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -332,11 +332,17 @@ func (s *syntheticsTestScheduler) setResultStatus(w *workerResult, result *commo
 	}
 	if result.Status != "failed" {
 		for _, res := range w.assertionResult {
-			if !res.Valid || res.Failure.Code != "" {
+			if !res.Valid {
 				result.Status = "failed"
+				assertionResultJSON, err := json.Marshal(w.assertionResult)
+				message := "Assertions failed"
+				if err == nil {
+					message = string(assertionResultJSON)
+				}
+
 				result.Failure = common.APIError{
 					Code:    incorrectAssertion,
-					Message: w.tracerouteError.Error(),
+					Message: message,
 				}
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a few issues with our assertions computation
1. If there was no error from `datadog-traceroute` it would cause a `panic` and break the Agent
2. We don't need a `failure` property on each assertion on `assertionResults`

### Motivation

When doing local testing on Synthetics Tests, I got some panic crashes and when solving it, found some other issues around Assertions computation.

### Describe how you validated your changes

Local run of the Agent

### Additional Notes
