### PR TITLE
[EBPF-851] chore(corechecks/gpu): log device uuid on failed collector creation

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -103,6 +103,10 @@ func BuildCollectors(devices []ddnvml.Device, deps *CollectorDependencies) ([]Co
 }
 
 func buildCollectors(devices []ddnvml.Device, deps *CollectorDependencies, builders map[CollectorName]subsystemBuilder) ([]Collector, error) {
+	if len(devices) == 0 {
+		return nil, nil
+	}
+
 	var collectors []Collector
 
 	// Step 1: Build NVML collectors for physical devices only,
@@ -114,7 +118,7 @@ func buildCollectors(devices []ddnvml.Device, deps *CollectorDependencies, build
 				log.Warnf("device %s does not support collector %s", dev.GetDeviceInfo().UUID, name)
 				continue
 			} else if err != nil {
-				log.Warnf("failed to create collector %s: %s", name, err)
+				log.Warnf("failed to create collector %s for device %s: %s", name, dev.GetDeviceInfo().UUID, err)
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?

Enriches a warning log line with the GPU device uuid in case of failed collector creation.

### Motivation

Helps troubleshooting issues with specific device types.

### Describe how you validated your changes

### Additional Notes
