### PR TITLE
Add info about agent version + disable cache

### DIFF
--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -15,10 +15,14 @@ setup_agent_version:
         echo "Failed to upload agent version cache"
         exit 1
       fi
+    - echo "Agent version:"
+    - cat agent-version.cache
   needs: []
   artifacts:
     reports:
       dotenv: build.env
+  variables:
+    DISABLE_GIT_CACHE: true
 
 github_rate_limit_info:
   stage: .pre


### PR DESCRIPTION
### What does this PR do?

Make sure git cache is disabled on the setup_agent job. Otherwise it can cause issues when a tag is deleted from upstream, but still present in the cache. And the computed agent version can be wrong
Also display the content of the cache file to make it easier to debug

### Motivation

### Describe how you validated your changes

### Additional Notes
