### PR TITLE
[APM] Mark test as flaky on macOS

### DIFF
--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"runtime"
 	"sync"
 	"testing"
@@ -50,6 +51,10 @@ func (s MockSampler) GetTargetTPS() float64 {
 var mockSampler = MockSampler{TargetTPS: 5, Enabled: true}
 
 func TestTraceWriter(t *testing.T) {
+	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" {
+		t.Skip("TestTraceWriter is known to fail on the macOS Gitlab runners.")
+	}
+
 	testCases := []struct {
 		compressor compression.Component
 	}{


### PR DESCRIPTION
### What does this PR do?

This test is known to be [flaky on macos](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1177133499), due to network resource exhaustion.

### Motivation

### Describe how you validated your changes

### Additional Notes
