### PR TITLE
[kubernetes/kubelet] Delete pods cache

### DIFF
--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -107,7 +107,6 @@ type KubeletConfigTestSuite struct {
 
 func (suite *KubeletConfigTestSuite) SetupSuite() {
 	kubelet.ResetGlobalKubeUtil()
-	kubelet.ResetCache()
 	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 	mockConfig := configmock.New(suite.T())
 	mockConfig.SetWithoutSource("cluster_agent.enabled", true)

--- a/pkg/collector/corechecks/orchestrator/pod/pod_test.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod_test.go
@@ -120,7 +120,6 @@ type PodTestSuite struct {
 
 func (suite *PodTestSuite) SetupSuite() {
 	kubelet.ResetGlobalKubeUtil()
-	kubelet.ResetCache()
 	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 
 	suite.dummyKubelet = newDummyKubelet()

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3698,12 +3698,6 @@ api_key:
 #
 # kubelet_client_key: <CLIENT_KEY_FILE_PATH>
 
-## @param kubelet_cache_pods_duration - integer - optional - default: 5
-## @env DD_KUBELET_CACHE_PODS_DURATION - integer - optional - default: 5
-## Polling frequency in seconds of the Agent to the kubelet "/pods" endpoint.
-#
-# kubelet_cache_pods_duration: 5
-
 ## @param kubernetes_pod_expiration_duration - integer - optional - default: 900
 ## @env DD_KUBERNETES_POD_EXPIRATION_DURATION - integer - optional - default: 900
 ## Set the time in second after which the Agent ignores the pods that have exited.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2008,7 +2008,6 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubelet_client_key", "")
 
 	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60) // in seconds, default 15 minutes
-	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 5)            // Polling frequency in seconds of the agent to the kubelet "/pods" endpoint
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator_test.go
@@ -28,7 +28,6 @@ func (suite *KubeletOrchestratorTestSuite) SetupTest() {
 	mockConfig := configmock.New(suite.T())
 
 	ResetGlobalKubeUtil()
-	ResetCache()
 
 	jsoniter.RegisterTypeDecoder("kubelet.PodList", nil)
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the pod list cache from the Kubelet client.

The only part of the code that lists pods from the kubelet is workloadmeta, and it already has its own storage. The frequency at which workloadmeta pulls from the kubelet isn’t just set by its own pull interval, we also have to consider the cache TTL, which is set to 5s by default.

In short, keeping another cache in the Kubelet client duplicates data, makes debugging harder, and adds delay. Removing it may increase the pull frequency, but the impact should be minimal, and having more up to date data is probably worth it.


### Describe how you validated your changes

CI