### PR TITLE
[nodetreemodel] Add missing 'provided' source in AllSettingsBySource function

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -900,6 +900,7 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 		model.SourceLocalConfigProcess: c.localConfigProcess.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceRC:                 c.remoteConfig.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceCLI:                c.cli.DumpSettings(func(model.Source) bool { return true }),
+		model.SourceProvided:           c.root.DumpSettings(func(src model.Source) bool { return src != model.SourceDefault }),
 	}
 }
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -315,6 +315,7 @@ func TestAllSettingsBySource(t *testing.T) {
 	cfg.SetDefault("a", 0)
 	cfg.SetDefault("b.c", 0)
 	cfg.SetDefault("b.d", 0)
+	cfg.SetDefault("x", 123)
 	cfg.BuildSchema()
 
 	cfg.ReadConfig(strings.NewReader("a: 987"))
@@ -327,6 +328,7 @@ func TestAllSettingsBySource(t *testing.T) {
 				"c": 0,
 				"d": 0,
 			},
+			"x": 123,
 		},
 		model.SourceUnknown: map[string]interface{}{},
 		model.SourceFile: map[string]interface{}{
@@ -342,6 +344,12 @@ func TestAllSettingsBySource(t *testing.T) {
 		model.SourceLocalConfigProcess: map[string]interface{}{},
 		model.SourceRC:                 map[string]interface{}{},
 		model.SourceCLI:                map[string]interface{}{},
+		model.SourceProvided: map[string]interface{}{
+			"a": 987,
+			"b": map[string]interface{}{
+				"c": 123,
+			},
+		},
 	}
 	assert.Equal(t, expected, cfg.AllSettingsBySource())
 }


### PR DESCRIPTION
### What does this PR do?

Add missing 'provided' source in `AllSettingsBySource` function. This fixes the inventoryagent test when running with nodetreemodel.

### Describe how you validated your changes

Running CI is enough.

### Additional Notes
