### PR TITLE
docs: fix format in contributing guideline

### DIFF
--- a/docs/public/guidelines/contributing.md
+++ b/docs/public/guidelines/contributing.md
@@ -49,7 +49,7 @@ Adding GitHub labels is only possible for contributors with write access.
 We have safety measures to protect our repository. As an external contributor, you are required to:
 
 1. Sign our [Contributor License Agreement](https://cla.datadoghq.com/DataDog/datadog-agent) (CLA). You will receive a message once your PR is opened to sign the agreement.
-1. Provide signed commits before merging. To learn how to sign your commits, follow [this procedure from Github](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+1. Provide signed commits before merging. To learn how to sign your commits, follow [this procedure from GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ### Keep it small, focused
 
@@ -182,8 +182,8 @@ The main thing to keep in mind is that the CHANGELOG is written for the agent's 
         collection, `kube_service` tagging) is not implemented
     ```
 
-- `upgrade`: List actions to take or limitations that could arise upon upgrading the Agent. Notes here must include steps that users can follow to
-    1. know if they're affected and
+- `upgrade`: List actions to take or limitations that could arise upon upgrading the Agent. Notes here must include steps that users can follow to:
+    1. know if they're affected, and
     1. handle the change gracefully on their end.
 
     example:

--- a/docs/public/guidelines/contributing.md
+++ b/docs/public/guidelines/contributing.md
@@ -49,7 +49,7 @@ Adding GitHub labels is only possible for contributors with write access.
 We have safety measures to protect our repository. As an external contributor, you are required to:
 
 1. Sign our [Contributor License Agreement](https://cla.datadoghq.com/DataDog/datadog-agent) (CLA). You will receive a message once your PR is opened to sign the agreement.
-2. Provide signed commits before merging. To learn how to sign your commits, follow [this procedure from Github](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+1. Provide signed commits before merging. To learn how to sign your commits, follow [this procedure from Github](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ### Keep it small, focused
 
@@ -94,15 +94,15 @@ You must open the PR when the code is reviewable or you must set the PR as draft
 
 #### Write a good PR description
 
-Reviewers and future maintainers only see the PR description, not your individual commit history, so the description should incorporate everything that they will need. The merge commit may include PR descriptions from multiple PRs, so the description should tie back to the changed code in some way. For example `run mdformat on iot-agent team docs` rather than just `mdformat the docs`.```
+Reviewers and future maintainers only see the PR description, not your individual commit history, so the description should incorporate everything that they will need. The merge commit may include PR descriptions from multiple PRs, so the description should tie back to the changed code in some way. For example `run mdformat on iot-agent team docs` rather than just `mdformat the docs`.
 
 - A description of what is changed.
 - A reason why the change is made. Pointing to an issue is usually a good reason.
 - When testing had to include work not covered by test suites, a description of how you validated your change.
 - Any relevant benchmarks.
 - Additional notes that make code understanding easier.
-  - If this is part of a chain of PRs, point to the predecessors.
-  - If there are drawbacks or tradeoffs to consider, raise them here.
+- If this is part of a chain of PRs, point to the predecessors.
+- If there are drawbacks or tradeoffs to consider, raise them here.
 
 #### Before the first PR review
 
@@ -182,7 +182,9 @@ The main thing to keep in mind is that the CHANGELOG is written for the agent's 
         collection, `kube_service` tagging) is not implemented
     ```
 
-- `upgrade`: List actions to take or limitations that could arise upon upgrading the Agent. Notes here must include steps that users can follow to 1. know if they're affected and 2. handle the change gracefully on their end.
+- `upgrade`: List actions to take or limitations that could arise upon upgrading the Agent. Notes here must include steps that users can follow to
+    1. know if they're affected and
+    1. handle the change gracefully on their end.
 
     example:
     ```yaml

--- a/docs/public/guidelines/conventions/logging.md
+++ b/docs/public/guidelines/conventions/logging.md
@@ -19,27 +19,27 @@ They also avoid the performance overhead of excess logging, even if the logs are
 
 - **TRACE**: Typically contains a high level of detail for deep/rich debugging.
 
-  Trace logging is typically used when instrumenting algorithms and core pieces of logic.
-  Avoid adding trace logging to tight loops or commonly used codepaths.
-  Even when the logs are disabled, logging an event can incur overheads.
+    Trace logging is typically used when instrumenting algorithms and core pieces of logic.
+    Avoid adding trace logging to tight loops or commonly used codepaths.
+    Even when the logs are disabled, logging an event can incur overheads.
 
 - **DEBUG**: Basic information that can be helpful for initially debugging issues.
 
-  Do not use debug logging for things that happen per-event or that scale with event throughput.
-  You can safely use debug logging for uncommon cases, for example, something that happens every 1000th event.
+    Do not use debug logging for things that happen per-event or that scale with event throughput.
+    You can safely use debug logging for uncommon cases, for example, something that happens every 1000th event.
 
 - **INFO**: Common information about normal processes.
 
-  Info logging is appropriate for logical or temporal events.
-  Examples include notifications when components are stopped and started, or other high-level events that do not require operator attention.
+    Info logging is appropriate for logical or temporal events.
+    Examples include notifications when components are stopped and started, or other high-level events that do not require operator attention.
 
-  **INFO** is primarily used for information that tells an operator that a notable action completed successfully.
+    **INFO** is primarily used for information that tells an operator that a notable action completed successfully.
 
 - **WARN** should be used for potentially problematic but non-critical events where the software can continue operating,
-  potentially in a degraded state and/or recover from the problem. Do not use **WARN** for events that require user's immediate attention.
+    potentially in a degraded state and/or recover from the problem. Do not use **WARN** for events that require user's immediate attention.
 
 - **ERROR** level should be used for events indicating severely problematic issues that require immediate user visibility and remediation.
 
-  This includes logging related to events that may lead to data loss, unrecoverable states, and any other situation where a required component is faulty,
-  causing the software to be unable to remediate the problem on its own.
-  Error logs should be extremely rare in normally operating software to ensure high signal-to-noise ratio in observability tooling.
+    This includes logging related to events that may lead to data loss, unrecoverable states, and any other situation where a required component is faulty,
+    causing the software to be unable to remediate the problem on its own.
+    Error logs should be extremely rare in normally operating software to ensure high signal-to-noise ratio in observability tooling.

--- a/docs/public/guidelines/testing/test-categories.md
+++ b/docs/public/guidelines/testing/test-categories.md
@@ -7,6 +7,7 @@ The Datadog Agent employs a comprehensive testing strategy with four distinct ca
 **Purpose**: Validate individual functions, methods, or small code units in isolation.
 
 **When to Use Unit Tests**:
+
 - Testing pure functions with predictable inputs/outputs.
 - Validating business logic without external dependencies.
 - Testing error handling and edge cases.
@@ -14,6 +15,7 @@ The Datadog Agent employs a comprehensive testing strategy with four distinct ca
 - When you can mock all external dependencies effectively.
 
 **Criteria**:
+
 - **Speed**: Must execute in milliseconds (< 100ms per test).
 - **Isolation**: No network calls, file system access, or external services.
 - **Deterministic**: Same input always produces same output.
@@ -39,6 +41,7 @@ func TestConfig_ParseYAML(t *testing.T) {
 ```
 
 **Common Patterns**:
+
 - Mock external dependencies using interfaces.
 - Test both happy path and error conditions.
 - Use table-driven tests for multiple input scenarios.
@@ -51,6 +54,7 @@ func TestConfig_ParseYAML(t *testing.T) {
 **Purpose**: Test the interaction between multiple components or validate functionality that requires external services.
 
 **When to Use Integration Tests**:
+
 - Testing database interactions and queries.
 - Validating API client implementations.
 - Testing component interactions within the same service.
@@ -58,6 +62,7 @@ func TestConfig_ParseYAML(t *testing.T) {
 - When external services are required but controllable.
 
 **Criteria**:
+
 - **Moderate Speed**: Should complete within seconds (< 30s per test).
 - **Controlled Dependencies**: Use real services but in test environments.
 - **CI Compatible**: Must work in both local and CI environments.
@@ -98,6 +103,7 @@ func TestDatadogClient_SubmitMetrics(t *testing.T) {
 ```
 
 **Requirements**:
+
 - Use test containers or in-memory databases when possible.
 - Implement proper setup/teardown procedures.
 - Handle network timeouts and retries gracefully.
@@ -110,6 +116,7 @@ func TestDatadogClient_SubmitMetrics(t *testing.T) {
 **Purpose**: Validate how multiple Agent components work together as a cohesive system, testing inter-component communication and workflows.
 
 **When to Use System Tests**:
+
 - Testing complete data pipelines (collection → processing → forwarding).
 - Validating component startup and shutdown sequences.
 - Testing configuration changes and reloads.
@@ -117,6 +124,7 @@ func TestDatadogClient_SubmitMetrics(t *testing.T) {
 - Testing cross-component communication (e.g., DogStatsD → Forwarder).
 
 **Criteria**:
+
 - **Realistic Environment**: Uses actual Agent binaries and configurations.
 - **Component Integration**: Tests multiple Agent components together.
 - **Moderate Isolation**: May use real system resources but in controlled manner.
@@ -168,6 +176,7 @@ func TestAgentConfigReload(t *testing.T) {
 ```
 
 **Characteristics**:
+
 - May spawn actual Agent processes.
 - Tests real configuration files and command-line arguments.
 - Validates inter-process communication.
@@ -181,6 +190,7 @@ func TestAgentConfigReload(t *testing.T) {
 Pulumi, and external services.
 
 **When to Use E2E Tests**:
+
 - Testing complete deployment scenarios.
 - Validating Agent behavior in different operating systems.
 - Testing Kubernetes integration and autodiscovery.
@@ -189,6 +199,7 @@ Pulumi, and external services.
 - Validating security configurations and compliance.
 
 **Criteria**:
+
 - **Production-Like Environment**: Uses real infrastructure (VMs, containers, cloud services).
 - **Complete Workflows**: Tests entire user journeys from installation to data delivery.
 - **Extended Duration**: May run for hours to test long-running scenarios.
@@ -196,6 +207,7 @@ Pulumi, and external services.
 - **Comprehensive Coverage**: Tests all supported platforms and configurations.
 
 **Example**:
+
 More examples can be found in the [examples](https://github.com/DataDog/datadog-agent/tree/main/test/new-e2e/examples) directory.
 ```go
 package examples
@@ -229,12 +241,14 @@ func (v *vmSuite) TestExecute() {
 ```
 
 **Infrastructure Examples**:
+
 - **Container Orchestration**: Testing in Kubernetes, Docker Swarm, ECS.
 - **Operating Systems**: Validating on Ubuntu, CentOS, Windows Server, macOS.
 - **Cloud Integrations**: Testing AWS EC2, Azure VMs, GCP Compute Engine.
 - **Network Configurations**: Testing with firewalls, load balancers, service meshes.
 
 **Test Scenarios**:
+
 - Fresh installation and first-time setup.
 - Agent updates and version migrations.
 - High-availability and failover scenarios.
@@ -248,17 +262,19 @@ func (v *vmSuite) TestExecute() {
 Use this decision tree to determine the appropriate test category:
 
 1. **Can you test it with mocked dependencies?** → **Unit Test**
-2. **Does it require external services but limited scope?** → **Integration Test**
-3. **Does it test multiple Agent components together?** → **System Test**
-4. **Does it require production-like infrastructure?** → **E2E Test**
+1. **Does it require external services but limited scope?** → **Integration Test**
+1. **Does it test multiple Agent components together?** → **System Test**
+1. **Does it require production-like infrastructure?** → **E2E Test**
 
 **Speed vs Coverage Trade-off**:
+
 - **Unit Tests**: Maximum speed, narrow coverage.
 - **Integration Tests**: Fast execution, moderate coverage.
 - **System Tests**: Moderate speed, broad coverage.
 - **E2E Tests**: Slower execution, maximum coverage.
 
 **Execution Context**:
+
 - **Unit + Integration**: Run on every commit (CI/CD pipeline).
 - **System**: Run on pull requests and nightly builds.
 - **E2E**: Run on releases and scheduled intervals.

--- a/docs/public/how-to/build/standalone.md
+++ b/docs/public/how-to/build/standalone.md
@@ -104,7 +104,7 @@ dda inv agent.build --bundle process-agent --bundle security-agent
 ```
 ///
 
-// details | Under the hood
+/// details | Under the hood
     open: False
     type: info
 


### PR DESCRIPTION
Just documentation format update
1. Improve how docs are rendered
2. Enforce guideline compliance of numbered list
3. Fix a few delimiters

### Describe how you validated your changes

```shell
dda run docs build
dda run docs serve
```