### PR TITLE
Correctly check packet loss percentage value

### DIFF
--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -314,7 +314,7 @@ func (s *syntheticsTestScheduler) networkPathToTestResult(w *workerResult) (*com
 }
 
 func (s *syntheticsTestScheduler) setResultStatus(w *workerResult, result *common.Result) {
-	if result.Netstats.PacketLossPercentage == 100 {
+	if result.Netstats.PacketLossPercentage == 1 {
 		if !hasAssertionOn100PacketLoss(w.assertionResult) {
 			result.Status = "failed"
 			result.Failure = common.APIError{

--- a/comp/syntheticstestscheduler/impl/worker_test.go
+++ b/comp/syntheticstestscheduler/impl/worker_test.go
@@ -251,7 +251,7 @@ func TestNetworkPathToTestResult(t *testing.T) {
 					E2eProbe: payload.E2eProbe{
 						PacketsSent:          0,
 						PacketsReceived:      0,
-						PacketLossPercentage: 100,
+						PacketLossPercentage: 1,
 						Jitter:               0,
 						RTT: payload.E2eProbeRttLatency{
 							Avg: 0, Min: 0, Max: 0,
@@ -299,7 +299,7 @@ func TestNetworkPathToTestResult(t *testing.T) {
 					E2eProbe: payload.E2eProbe{
 						PacketsSent:          0,
 						PacketsReceived:      0,
-						PacketLossPercentage: 100,
+						PacketLossPercentage: 1,
 						Jitter:               0,
 						RTT: payload.E2eProbeRttLatency{
 							Avg: 0, Min: 0, Max: 0,


### PR DESCRIPTION
### What does this PR do?

The value we get back from `datadog-traceroute` is a float and therefore packet loss percentage is represented with values between 0 and 1.

### Motivation

### Describe how you validated your changes

Local run of the Agent

### Additional Notes
