### PR TITLE
[EBPF] gpu: clean up logs for vGPU devices

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -125,7 +125,7 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 			gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 		}
 	} else {
-		if _, ok := c.seenUUIDs[gpuDeviceInfo.EntityID.ID]; !ok {
+		if _, ok := c.seenUUIDs[gpuDeviceInfo.EntityID.ID]; !ok && logLimiter.ShouldLog() {
 			// only report the warning once for each device
 			log.Infof("vGPU device %s does not support queries for max clock info", gpuDeviceInfo.EntityID.ID)
 		}

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -125,7 +125,10 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 			gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 		}
 	} else {
-		log.Infof("vGPU device %d does not support queries for max clock info", gpuDeviceInfo.Index)
+		if _, ok := c.seenUUIDs[gpuDeviceInfo.EntityID.ID]; !ok {
+			// only report the warning once for each device
+			log.Infof("vGPU device %s does not support queries for max clock info", gpuDeviceInfo.EntityID.ID)
+		}
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -87,6 +87,15 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 		gpuDeviceInfo.Architecture = gpuArchToString(arch)
 	}
 
+	virtMode, err := device.GetVirtualizationMode()
+	if err != nil {
+		if logLimiter.ShouldLog() {
+			log.Warnf("cannot get virtualization mode: %v for %d", err, gpuDeviceInfo.Index)
+		}
+	} else {
+		gpuDeviceInfo.VirtualizationMode = gpuVirtModeToString(virtMode)
+	}
+
 	memBusWidth, err := device.GetMemoryBusWidth()
 	if err != nil {
 		if logLimiter.ShouldLog() {
@@ -96,31 +105,25 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 		gpuDeviceInfo.MemoryBusWidth = memBusWidth
 	}
 
-	maxSMClock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
-	if err != nil {
-		if logLimiter.ShouldLog() {
-			log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
+	// Do not generate errors for vGPU devices, we already know that they don't support max clock info
+	if virtMode != nvml.GPU_VIRTUALIZATION_MODE_VGPU {
+		maxSMClock, err := device.GetMaxClockInfo(nvml.CLOCK_SM)
+		if err != nil {
+			if logLimiter.ShouldLog() {
+				log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
+			}
+		} else {
+			gpuDeviceInfo.MaxClockRates[workloadmeta.GPUSM] = maxSMClock
 		}
-	} else {
-		gpuDeviceInfo.MaxClockRates[workloadmeta.GPUSM] = maxSMClock
-	}
 
-	maxMemoryClock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
-	if err != nil {
-		if logLimiter.ShouldLog() {
-			log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
+		maxMemoryClock, err := device.GetMaxClockInfo(nvml.CLOCK_MEM)
+		if err != nil {
+			if logLimiter.ShouldLog() {
+				log.Warnf("%v for %d", err, gpuDeviceInfo.Index)
+			}
+		} else {
+			gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 		}
-	} else {
-		gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
-	}
-
-	virtMode, err := device.GetVirtualizationMode()
-	if err != nil {
-		if logLimiter.ShouldLog() {
-			log.Warnf("cannot get virtualization mode: %v for %d", err, gpuDeviceInfo.Index)
-		}
-	} else {
-		gpuDeviceInfo.VirtualizationMode = gpuVirtModeToString(virtMode)
 	}
 }
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -124,6 +124,8 @@ func (c *collector) fillNVMLAttributes(gpuDeviceInfo *workloadmeta.GPU, device d
 		} else {
 			gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 		}
+	} else {
+		log.Infof("vGPU device %d does not support queries for max clock info", gpuDeviceInfo.Index)
 	}
 }
 

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -12,10 +12,11 @@ import (
 	"fmt"
 	"time"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
-	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/hashicorp/go-multierror"
+
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 // processSample handles the complex time-weighted averaging logic for NVML sample types
@@ -27,6 +28,13 @@ func processSample(device ddnvml.Device, metricName string, samplingType nvml.Sa
 	// we need to average them.
 	valueType, samples, err := device.GetSamples(samplingType, lastTimestamp)
 	if err != nil {
+		var nvmlErr *ddnvml.NvmlAPIError
+		if errors.As(err, &nvmlErr) && errors.Is(nvmlErr.NvmlErrorCode, nvml.ERROR_NOT_FOUND) {
+			// NOT_FOUND is a valid scenario when no samples are available, such as vGPU. Ignore it and treat it the same way as
+			// if there were no samples returned.
+			return nil, lastTimestamp, nil
+		}
+
 		return nil, 0, fmt.Errorf("failed to get samples for %s: %w", metricName, err)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Cleans up some logging that was generated too frequently with vGPU nodes

### Motivation

Reduce log noise

Related: https://datadoghq.atlassian.net/browse/EBPF-849

### Describe how you validated your changes

Validated in a vGPU node that the logs are reduced

### Additional Notes
