### PR TITLE
Update api version used in Azure e2e test and make one case clearer

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/hostname/hostname_azure_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/hostname/hostname_azure_nix_test.go
@@ -43,16 +43,13 @@ func (v *linuxAzureHostnameSuite) TestAgentHostnameStyle() {
 	hostname := v.Env().RemoteHost.MustExecute("hostname")
 	hostname = strings.TrimSpace(hostname)
 
-	metadataStr := v.Env().RemoteHost.MustExecute(`curl -s -H "Metadata: true" http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01`)
+	metadataStr := v.Env().RemoteHost.MustExecute(`curl -s -H "Metadata: true" http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01`)
 
 	var metadata struct {
 		VMID              string
 		Name              string
 		ResourceGroupName string
 		SubscriptionID    string
-		OsProfile         struct {
-			ComputerName string
-		}
 	}
 
 	err := json.Unmarshal([]byte(metadataStr), &metadata)
@@ -65,7 +62,8 @@ func (v *linuxAzureHostnameSuite) TestAgentHostnameStyle() {
 		"name":                    metadata.Name,
 		"name_and_resource_group": fmt.Sprintf("%s.%s", metadata.Name, metadata.ResourceGroupName),
 		"full":                    fmt.Sprintf("%s.%s.%s", metadata.Name, metadata.ResourceGroupName, metadata.SubscriptionID),
-		"os_computer_name":        strings.ToLower(metadata.OsProfile.ComputerName),
+		// the machine hostname will be used if the style is invalid
+		"some_invalid_value": hostname,
 	}
 
 	for hostnameStyle, expected := range hostnameStyles {


### PR DESCRIPTION
### What does this PR do?
Update the Azure metadata API version used in the Azure hostname e2e test to match the one used by the agent.
Also rename one test case to make it clear that it tests the case where the config value is not valid, and just use the already computed result of the `hostname` command in the assertion.

### Motivation
Clean the test and make it more correct.

### Describe how you validated your changes
CI.

### Additional Notes
`os_computer_name` was handled when the test was written but the PR was reverted shortly after, we're just lucky it kept working because `metadata.OsProfile.ComputerName` is the computer hostname, which we fallback to if the config key is not known.