### PR TITLE
[tasks] deprecate GITHUB_TOKEN

### DIFF
--- a/tasks/auth.py
+++ b/tasks/auth.py
@@ -7,6 +7,7 @@ from invoke import Exit, task
 from tasks.libs.ciproviders.github_api import generate_local_github_token
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_token
 from tasks.libs.common.auth import datadog_infra_token
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.utils import running_in_ci
 
 
@@ -40,6 +41,5 @@ def github(ctx):
         raise Exit(message='This task is meant to be run locally, not in CI', code=1)
 
     if "GITHUB_TOKEN" in os.environ:
-        print(os.environ["GITHUB_TOKEN"])
-    else:
-        print(generate_local_github_token(ctx))
+        print(color_message('GITHUB_TOKEN is deprecated. Please remove it from your environment.', Color.RED))
+    print(generate_local_github_token(ctx))

--- a/tasks/auth.py
+++ b/tasks/auth.py
@@ -7,7 +7,6 @@ from invoke import Exit, task
 from tasks.libs.ciproviders.github_api import generate_local_github_token
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_token
 from tasks.libs.common.auth import datadog_infra_token
-from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.utils import running_in_ci
 
 
@@ -40,6 +39,4 @@ def github(ctx):
     if running_in_ci():
         raise Exit(message='This task is meant to be run locally, not in CI', code=1)
 
-    if "GITHUB_TOKEN" in os.environ:
-        print(color_message('GITHUB_TOKEN is deprecated. Please remove it from your environment.', Color.RED))
     print(generate_local_github_token(ctx))

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -529,9 +529,6 @@ class GithubAPI:
         from tasks.libs.common.utils import running_in_ci
 
         if not running_in_ci():
-            if "GITHUB_TOKEN" in os.environ:
-                msg = "GITHUB_TOKEN is deprecated locally, please remove it from your environment."
-                print(color_message(msg, Color.ORANGE))
             return Auth.Token(generate_local_github_token(Context()))
         if "GITHUB_TOKEN" in os.environ:
             return Auth.Token(os.environ["GITHUB_TOKEN"])

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -4,7 +4,6 @@ Helpers for setting up your environment
 
 from __future__ import annotations
 
-import os
 import re
 import sys
 import traceback
@@ -185,11 +184,6 @@ def pre_commit(ctx, interactive=True):
 
     if running_in_pyapp():
         import shutil
-
-        # TODO Remove in a couple of weeks
-        # Remove the old devagent file if it exists
-        if os.path.isfile(".pre-commit-config-devagent.yaml"):
-            os.remove(".pre-commit-config-devagent.yaml")
 
         # We use a custom version that use deva instead of dda inv directly, that requires the venv to be loaded
         from pre_commit import update_pyapp_file

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -36,6 +36,7 @@ def setup(ctx, vscode=False):
         check_git_repo,
         check_python_version,
         check_go_version,
+        update_ddtool,
         install_go_tools,
         install_protoc,
         enable_pre_commit,
@@ -237,6 +238,17 @@ def setup_vscode(ctx) -> SetupResult:
         status = Status.FAIL
 
     return SetupResult("Setup vscode", status, message)
+
+
+def update_ddtool(ctx) -> SetupResult:
+    """Update ddtool."""
+    print(color_message("Updating ddtool...", Color.BLUE))
+    status = Status.OK
+    message = ""
+
+    ctx.run('brew update && brew upgrade ddtool', hide=True)
+
+    return SetupResult("Update ddtool", status, message)
 
 
 def install_go_tools(ctx) -> SetupResult:

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -85,6 +85,7 @@ def setup(ctx, vscode=False):
 
 
 def check_git_repo(ctx) -> SetupResult:
+    """Check if the git repository is up to date."""
     print(color_message("Fetching git repository...", Color.BLUE))
     ctx.run("git fetch", hide=True)
 
@@ -103,6 +104,7 @@ def check_git_repo(ctx) -> SetupResult:
 
 
 def check_go_version(ctx) -> SetupResult:
+    """Check if the Go version is up to date."""
     print(color_message("Checking Go version...", Color.BLUE))
 
     with open(".go-version") as f:
@@ -129,6 +131,7 @@ def check_go_version(ctx) -> SetupResult:
 
 
 def check_python_version(_ctx) -> SetupResult:
+    """Check if the Python version is up to date."""
     print(color_message("Checking Python version...", Color.BLUE))
 
     with open(".python-version") as f:
@@ -220,12 +223,14 @@ def pre_commit(ctx, interactive=True):
 
 
 def enable_pre_commit(ctx) -> SetupResult:
+    """Enable pre-commit hooks."""
     status, message = pre_commit(ctx, interactive=False)
 
     return SetupResult("Enable pre-commit", status, message)
 
 
 def setup_vscode(ctx) -> SetupResult:
+    """Set up VS Code."""
     print(color_message("Setting up VS Code...", Color.BLUE))
 
     try:
@@ -241,6 +246,7 @@ def setup_vscode(ctx) -> SetupResult:
 
 
 def install_go_tools(ctx) -> SetupResult:
+    """Install go tools."""
     print(color_message("Installing go tools...", Color.BLUE))
     status = Status.OK
     message = ""
@@ -257,6 +263,7 @@ def install_go_tools(ctx) -> SetupResult:
 
 
 def install_protoc(ctx) -> SetupResult:
+    """Install protoc."""
     print(color_message("Installing protoc...", Color.BLUE))
     status = Status.OK
     message = ""


### PR DESCRIPTION
### What does this PR do?

Deprecate `GITHUB_TOKEN` local usage, warning local users to remove it from their environment

### Motivation

`GITHUB_TOKEN` is deprecated now, our script support OAuth. Let's default to OAuth and avoid getting a 403 when reaching to github through a deprecated token.

### Describe how you validated your changes

I executed the script locally

### Additional Notes

I kept the behaviour as is for the CI
