### PR TITLE
[CWS] Properly propagate new custom exit code for kmt tests

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -282,7 +282,9 @@
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}" -send-env-vars CI_COMMIT_SHA,DD_API_KEY || CONNECTOR_EXIT_CODE=$? # Allow DD_API_KEY to be passed to the metal instance, so we can use it to send metrics from the connector.
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'" || true
     - "[ ! -f $CI_PROJECT_DIR/daemon-${ARCH}.log ] && ${CI_PROJECT_DIR}/tools/ci/retry.sh scp metal_instance:/home/ubuntu/daemon.log $CI_PROJECT_DIR/vm-metrics-daemon-${ARCH}.log || true"
-    - exit ${CONNECTOR_EXIT_CODE:-0}
+    - |
+      echo "Connector exit code: ${CONNECTOR_EXIT_CODE:-0}"
+      exit ${CONNECTOR_EXIT_CODE:-0}
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -279,9 +279,10 @@
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh scp "$DD_AGENT_TESTING_DIR/job_env.txt" "metal_instance:/home/ubuntu/job_env-${ARCH}-${TAG}-${TEST_SET}.txt"
     - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "scp /home/ubuntu/job_env-${ARCH}-${TAG}-${TEST_SET}.txt ${MICRO_VM_IP}:/job_env.txt"
     - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'mount -o remount,size=5G /opt/kmt-ramfs && CI=true /root/fetch_dependencies.sh ${ARCH} && COLLECT_COMPLEXITY=${COLLECT_COMPLEXITY} /opt/micro-vm-init.sh -test-tools /opt/testing-tools -retry ${RETRY} -test-root /opt/${TEST_COMPONENT}-tests -packages-run-config /opt/${TEST_SET}.json'"
-    - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}" -send-env-vars CI_COMMIT_SHA,DD_API_KEY # Allow DD_API_KEY to be passed to the metal instance, so we can use it to send metrics from the connector.
-    - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'"
-    - "[ ! -f $CI_PROJECT_DIR/daemon-${ARCH}.log ] && ${CI_PROJECT_DIR}/tools/ci/retry.sh scp metal_instance:/home/ubuntu/daemon.log $CI_PROJECT_DIR/vm-metrics-daemon-${ARCH}.log"
+    - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}" -send-env-vars CI_COMMIT_SHA,DD_API_KEY || CONNECTOR_EXIT_CODE=$? # Allow DD_API_KEY to be passed to the metal instance, so we can use it to send metrics from the connector.
+    - ${CI_PROJECT_DIR}/tools/ci/retry.sh ssh metal_instance "ssh ${MICRO_VM_IP} '/opt/testing-tools/test-json-review -flakes /opt/testing-tools/flakes.yaml -codeowners /opt/testing-tools/CODEOWNERS -test-root /opt/${TEST_COMPONENT}-tests'" || true
+    - "[ ! -f $CI_PROJECT_DIR/daemon-${ARCH}.log ] && ${CI_PROJECT_DIR}/tools/ci/retry.sh scp metal_instance:/home/ubuntu/daemon.log $CI_PROJECT_DIR/vm-metrics-daemon-${ARCH}.log || true"
+    - exit ${CONNECTOR_EXIT_CODE:-0}
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -103,7 +103,8 @@ upload_secagent_tests_arm64:
 
 .kmt_run_secagent_tests_base:
   extends: .kmt_run_tests
-  allow_failure: true
+  allow_failure: 
+    exit_codes: 44
   stage: kernel_matrix_testing_security_agent
   rules: !reference [.on_security_agent_changes_or_manual]
   timeout: 1h 30m
@@ -112,7 +113,8 @@ upload_secagent_tests_arm64:
 
 .kmt_run_secagent_tests:
   extends: .kmt_run_secagent_tests_base
-  allow_failure: true
+  allow_failure:
+    exit_codes: 44
 
 .kmt_run_secagent_tests_required:
   extends: .kmt_run_secagent_tests_base

--- a/pkg/security/tests/main_test.go
+++ b/pkg/security/tests/main_test.go
@@ -74,8 +74,13 @@ func TestMain(m *testing.M) {
 	if commonCfgDir != "" {
 		_ = os.RemoveAll(commonCfgDir)
 	}
-	// Write special marker to stdout for test-runner to parse (gotestsum passes stdout through)
-	fmt.Printf("\n###TEST_EXIT_CODE:%d###\n", retCode)
+
+	// Write exit code to file if requested (for test-runner)
+	if exitCodeFile != "" {
+		if err := os.WriteFile(exitCodeFile, []byte(fmt.Sprintf("%d", retCode)), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to write exit code to file %s: %v\n", exitCodeFile, err)
+		}
+	}
 
 	os.Exit(retCode)
 }
@@ -97,10 +102,12 @@ var (
 	logPatterns     stringSlice
 	logTags         stringSlice
 	ebpfLessEnabled bool
+	exitCodeFile    string
 )
 
 func init() {
 	flag.StringVar(&logLevelStr, "loglevel", log.WarnStr, "log level")
 	flag.Var(&logPatterns, "logpattern", "List of log pattern")
 	flag.Var(&logTags, "logtag", "List of log tag")
+	flag.StringVar(&exitCodeFile, "exit-code-file", "", "file to write exit code to")
 }

--- a/test/new-e2e/system-probe/connector/sshtools/cmd.go
+++ b/test/new-e2e/system-probe/connector/sshtools/cmd.go
@@ -94,3 +94,14 @@ func (e *ExitError) Error() string {
 	}
 	return fmt.Sprintf("%q exit status: %d", e.Command, e.ExitStatus)
 }
+
+// ExitCode returns the exit code of the command. This makes ExitError compatible
+// with code that checks for exit codes via the ExitCode() method.
+func (e *ExitError) ExitCode() int {
+	return e.ExitStatus
+}
+
+// Exited returns true if the program has exited.
+func (e *ExitError) Exited() bool {
+	return true
+}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -48,8 +48,13 @@ func (e *testsuiteError) Unwrap() error {
 // readExitCodeFromFile reads the exit code from the specified file
 // Returns -1 if the file doesn't exist or can't be read
 func readExitCodeFromFile(path string) int {
+	fmt.Printf("Reading exit code from file: %s\n", path)
+	if path == "" {
+		return -1
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		fmt.Printf("Error reading file: %s\n", err)
 		return -1
 	}
 	code := -1
@@ -335,6 +340,7 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 			fmt.Fprintf(os.Stderr, "\n>>> cmd run %s: %s\n", testsuite, err)
 			if firstTestError == nil {
 				// Read exit code from file (written by testsuite)
+				fmt.Printf("exitCodeFile: %s\n", exitCodeFile)
 				exitCode := readExitCodeFromFile(exitCodeFile)
 				var exitErr *exec.ExitError
 				if errors.As(err, &exitErr) {
@@ -529,9 +535,12 @@ func main() {
 		// For other errors, use exit code 1
 		var tsErr *testsuiteError
 		if errors.As(err, &tsErr) {
+			fmt.Fprintf("It's a testsuite error: %s\n", err.Error())
+			fmt.Fprintf("Exit code: %d\n", tsErr.exitCode)
 			os.Exit(tsErr.exitCode)
 		}
 		// Not a testsuite error
+		fmt.Printf("It's not a testsuite error: %s\n", err.Error())
 		fmt.Fprintf(os.Stderr, "%s\n", color.RedString(err.Error()))
 		os.Exit(1)
 	}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -330,11 +330,9 @@ func testPass(testConfig *testConfig, props map[string]string) error {
 			// log error and capture the first one to preserve exit code
 			fmt.Fprintf(os.Stderr, "\n>>> cmd run %s: %s\n", testsuite, err)
 			if firstTestError == nil {
-				exitCode := -1
-
 				// Try to extract exit code from stdout marker (reliable with gotestsum)
 				stdoutContent := stdoutBuf.String()
-				exitCode = extractExitCodeFromOutput(stdoutContent)
+				exitCode := extractExitCodeFromOutput(stdoutContent)
 				var exitErr *exec.ExitError
 				if errors.As(err, &exitErr) {
 					// Store the custom exit code if found, otherwise use the one from exitErr


### PR DESCRIPTION
### What does this PR do?
This PR updates the behavior of the KMT tests by introducing and properly propagating a custom exit code that is the only one allowed to fail.

If a test exits with code 1, it will now be considered a Failure instead of a Warning.
Additionally, when this custom exit code is triggered, it is now correctly propagated as the overall job exit code., when this specific exit code is present, the PR ensures it is properly propagated as the overall job exit code.

The list of **tests that are now not allowed to fail** was added and **will be edited in future PRs**.
### Motivation
Previously, because of flakiness in some KMT tests, all tests in the KMT matrix were allowed to fail.
This sometimes led to PRs being merged even though they broke valid tests.

To mitigate this, a past initiative introduced a _non allowed to fail new job_ with a dedicated non-flaky test to ensure that a broken agent would at least cause a failure.

This PR is the first step in a new effort to make the KMT test suite stricter:

- Only identified flaky tests will remain allowed to fail.

- All other tests will be made mandatory in a future PR.

### Describe how you validated your changes
When a test is added to the _not allowed to fail_ list, the job now fails if that test fails.

When only tests that are still allowed to fail (flaky ones) fail, the job continues to warn as before.

### How did you validate your changes?

When a test is added to the “not allowed to fail” list and fails, the entire job fails.

When only tests that are still allowed to fail (flaky ones) fail, the job reports a Warning, as before.