### PR TITLE
Add cmourot and dd-ddamien to CODEOWNERS for SQG

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@
 /.gitlab/binary_build/include.yml                    @DataDog/agent-devx
 /.gitlab/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-build
 /.gitlab/functional_test/include.yml                 @DataDog/agent-devx
-/.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-build
+/.gitlab/functional_test/static_quality_gate.yml     @DataDog/agent-build @cmourot @dd-ddamien 
 /.gitlab/install_script_testing/install_script_testing.yml          @DataDog/agent-build @DataDog/agent-onboarding
 /.gitlab/integration_test/dogstatsd.yml              @DataDog/agent-devx @DataDog/agent-metric-pipelines
 /.gitlab/integration_test/include.yml                @DataDog/agent-devx


### PR DESCRIPTION
### What does this PR do?
It introduces new code owners for for SQG configuration to formalize the exception process. From now on if a developer requests an exception to increase a threshold it should be approved by either of @cmourot and @dd-ddamien.
