### PR TITLE
dyninst/actuator: track and report stats

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -44,6 +44,22 @@ type Actuator struct {
 	shutdownErr error
 }
 
+// Stats returns the current stats of the Actuator.
+func (a *Actuator) Stats() map[string]any {
+	metricsChan := make(chan Metrics, 1)
+	select {
+	case <-a.shuttingDown:
+		return nil
+	case a.events <- eventGetMetrics{metricsChan: metricsChan}:
+		select {
+		case <-a.shuttingDown:
+			return nil
+		case metrics := <-metricsChan:
+			return metrics.AsStats()
+		}
+	}
+}
+
 // Tenant is a tenant of the Actuator.
 type Tenant struct {
 	name    string
@@ -212,13 +228,12 @@ func (a *effects) attachToProcess(
 			return
 		}
 
-		program := &attachedProgram{
-			loadedProgram:   loaded,
-			processID:       processID,
-			attachedProgram: attached,
-		}
 		a.sendEvent(eventProgramAttached{
-			program: program,
+			program: &attachedProgram{
+				loadedProgram:   loaded,
+				processID:       processID,
+				attachedProgram: attached,
+			},
 		})
 	}()
 }

--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -191,12 +191,7 @@ func (a *effects) unloadProgram(lp *loadedProgram) {
 	go func() {
 		defer a.wg.Done()
 
-		// Close kernel program & links.
 		lp.loaded.Close()
-
-		// Dataplane/sink lifecycle is owned by loader/runtime now.
-
-		// Notify state-machine that unloading is finished.
 		a.sendEvent(eventProgramUnloaded{programID: lp.programID})
 	}()
 }

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -11,8 +11,12 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // state represents the state of an Actuator.
@@ -49,6 +53,125 @@ type state struct {
 
 	// If true, the state machine is shutting down.
 	shuttingDown bool
+
+	counters struct {
+		loaded       uint64
+		loadFailed   uint64
+		attached     uint64
+		attachFailed uint64
+		detached     uint64
+		unloaded     uint64
+	}
+}
+
+var unexpectedProgramStateLogLimiter = rate.NewLimiter(rate.Every(time.Minute), 1)
+
+func (s *state) Metrics() Metrics {
+	var numWaiting uint64
+	var numAttached uint64
+	var numAttaching uint64
+	var numLoadingFailed uint64
+	var numDetaching uint64
+	for _, p := range s.processes {
+		switch p.state {
+		case processStateAttached:
+			numAttached++
+		case processStateAttaching:
+			numAttaching++
+		case processStateWaitingForProgram:
+			numWaiting++
+		case processStateLoadingFailed:
+			numLoadingFailed++
+		case processStateDetaching:
+			numDetaching++
+		case processStateInvalid:
+			// no-op
+		default:
+			if unexpectedProgramStateLogLimiter.Allow() {
+				log.Errorf("unexpected actuator.processState: %v", p.state)
+			}
+		}
+	}
+
+	return Metrics{
+		Loaded:       s.counters.loaded,
+		LoadFailed:   s.counters.loadFailed,
+		Attached:     s.counters.attached,
+		AttachFailed: s.counters.attachFailed,
+		Detached:     s.counters.detached,
+		Unloaded:     s.counters.unloaded,
+
+		NumWaitingForProgram: uint64(numWaiting),
+		NumAttached:          numAttached,
+		NumAttaching:         numAttaching,
+		NumLoadingFailed:     numLoadingFailed,
+		NumDetaching:         numDetaching,
+
+		NumProcesses: uint64(len(s.processes)),
+		NumPrograms:  uint64(len(s.programs)),
+	}
+}
+
+// Metrics is used to report metrics about the state machine.
+type Metrics struct {
+	// Counters
+
+	// Loaded is the total number of programs that have been loaded
+	// successfully.
+	Loaded uint64
+	// LoadFailed is the total number of programs that have failed to load.
+	LoadFailed uint64
+	// Attached is the total number of programs that have been attached to a
+	// process.
+	Attached uint64
+	// AttachFailed is the total number of programs that have failed to attach
+	// to a process.
+	AttachFailed uint64
+	// Detached is the total number of programs that have been detached from a
+	// process.
+	Detached uint64
+	// Unloaded is the total number of programs that have been unloaded.
+	Unloaded uint64
+
+	// Gauges
+
+	// NumWaitingForProgram is the number of processes waiting for a program to
+	// be compiled and loaded.
+	NumWaitingForProgram uint64
+	// NumAttached is the number of processes attached to a program.
+	NumAttached uint64
+	// NumAttaching is the number of processes attaching to a program.
+	NumAttaching uint64
+	// NumLoadingFailed is the number of programs that have failed to load.
+	NumLoadingFailed uint64
+	// NumDetaching is the number of programs that are detaching.
+	NumDetaching uint64
+
+	// NumProcesses is the number of processes in the state machine.
+	NumProcesses uint64
+	// NumPrograms is the number of programs in the state machine.
+	NumPrograms uint64
+}
+
+// AsStats converts the Metrics to a map[string]any for use by the system-probe.
+func (m Metrics) AsStats() map[string]any {
+	return map[string]any{
+		"loaded":       m.Loaded,
+		"loadFailed":   m.LoadFailed,
+		"attached":     m.Attached,
+		"attachFailed": m.AttachFailed,
+		"detached":     m.Detached,
+		"unloaded":     m.Unloaded,
+
+		"numWaitingForProgram": m.NumWaitingForProgram,
+		"numAttached":          m.NumAttached,
+		"numAttaching":         m.NumAttaching,
+		"numLoadingFailed":     m.NumLoadingFailed,
+		"numDetaching":         m.NumDetaching,
+
+		"numProcesses": m.NumProcesses,
+		"numPrograms":  m.NumPrograms,
+	}
 }
 
 type processKey struct {
@@ -176,25 +299,35 @@ func handleEvent(
 
 	var err error
 	switch ev := ev.(type) {
+	case eventGetMetrics:
+		ev.metricsChan <- sm.Metrics()
+		return nil
+
 	case eventProcessesUpdated:
 		err = handleProcessesUpdated(sm, effects, ev)
 
 	case eventProgramLoaded:
+		sm.counters.loaded++
 		err = handleProgramLoaded(sm, effects, ev)
 
 	case eventProgramLoadingFailed:
+		sm.counters.loadFailed++
 		err = handleProgramLoadingFailure(sm, ev.programID, ev.err)
 
 	case eventProgramAttached:
+		sm.counters.attached++
 		err = handleProgramAttached(sm, effects, ev)
 
 	case eventProgramAttachingFailed:
+		sm.counters.attachFailed++
 		err = handleProgramAttachingFailed(sm, effects, ev)
 
 	case eventProgramDetached:
+		sm.counters.detached++
 		err = handleProgramDetached(sm, effects, ev)
 
 	case eventProgramUnloaded:
+		sm.counters.unloaded++
 		err = handleProgramUnloaded(sm, ev)
 
 	case eventShutdown:
@@ -767,11 +900,8 @@ func handleShutdown(sm *state, effects effectHandler) error {
 	}
 
 	// 3. Clear the loading queue.
-	for {
-		prog, ok := sm.queuedLoading.popFront()
-		if !ok {
-			break
-		}
+	pop := sm.queuedLoading.popFront
+	for prog, ok := pop(); ok; prog, ok = pop() {
 		proc, ok := sm.processes[prog.processKey]
 		if !ok {
 			return fmt.Errorf("process %v not found in processes", prog.processKey)

--- a/pkg/dyninst/actuator/state_events.go
+++ b/pkg/dyninst/actuator/state_events.go
@@ -118,3 +118,12 @@ type eventShutdown struct {
 func (e eventShutdown) String() string {
 	return "eventShutdown{}"
 }
+
+type eventGetMetrics struct {
+	baseEvent
+	metricsChan chan<- Metrics
+}
+
+func (e eventGetMetrics) String() string {
+	return "eventGetMetrics{}"
+}

--- a/pkg/dyninst/actuator/state_helpers_test.go
+++ b/pkg/dyninst/actuator/state_helpers_test.go
@@ -27,6 +27,7 @@ func deepCopyState(original *state) *state {
 	// Create new state with basic fields copied.
 	copied := newState()
 
+	copied.counters = original.counters
 	copied.programIDAlloc = original.programIDAlloc
 
 	// Deep copy programs map first (needed for queue and currentlyCompiling

--- a/pkg/dyninst/actuator/testdata/snapshot/aborted_program_cleanup_with_queue.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/aborted_program_cleanup_with_queue.yaml
@@ -36,6 +36,10 @@ state:
   programs:
     1: <nil> -> Loading (proc 1001)
     2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
 ---
 event: !processes-updated {removed: [1001]}
 state:
@@ -61,6 +65,8 @@ state:
   programs:
     1: LoadingAborted (proc 1001) -> Unloading (proc 1001)
     2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
 ---
 event: !loaded {program_id: 2}
 effects:
@@ -74,3 +80,7 @@ state:
   programs:
     1: Unloading (proc 1001)
     2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/attaching_failure.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/attaching_failure.yaml
@@ -25,6 +25,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -36,6 +40,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attaching-failed {program_id: 1, process_id: 1001, error: "eBPF attaching failed"}
 effects:
@@ -47,6 +55,10 @@ state:
     1001: Attaching (prog 1) -> LoadingFailed (prog 1)
   programs:
     1: Loaded (proc 1001) -> Unloading (proc 1001)
+  stats:
+    attachFailed: 0 -> 1
+    numAttaching: 1 -> 0
+    numLoadingFailed: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 state:
@@ -56,3 +68,6 @@ state:
     1001: LoadingFailed (prog 1) -> LoadingFailed
   programs:
     1: Unloading (proc 1001) -> <nil>
+  stats:
+    numPrograms: 1 -> 0
+    unloaded: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/attaching_failure_while_detaching.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/attaching_failure_while_detaching.yaml
@@ -31,6 +31,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -42,6 +46,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -56,6 +64,9 @@ state:
     1001: Attaching (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttaching: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !attaching-failed {program_id: 1, process_id: 1001, err: "boom"}
 effects:
@@ -67,6 +78,10 @@ state:
     1001: Detaching (prog 1) -> LoadingFailed (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    attachFailed: 0 -> 1
+    numDetaching: 1 -> 0
+    numLoadingFailed: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 state:
@@ -76,3 +91,6 @@ state:
     1001: LoadingFailed (prog 1) -> LoadingFailed
   programs:
     1: Unloading (proc 1001) -> <nil>
+  stats:
+    numPrograms: 1 -> 0
+    unloaded: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/failure_with_queued_programs.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/failure_with_queued_programs.yaml
@@ -35,6 +35,10 @@ state:
   programs:
     1: <nil> -> Loading (proc 1001)
     2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
 ---
 event: !loading-failed {program_id: 1, error: "boom"}
 effects:
@@ -48,6 +52,11 @@ state:
   programs:
     1: Loading (proc 1001) -> <nil>
     2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loadFailed: 0 -> 1
+    numLoadingFailed: 0 -> 1
+    numPrograms: 2 -> 1
+    numWaitingForProgram: 2 -> 1
 ---
 event: !loaded {program_id: 2}
 effects:
@@ -60,6 +69,10 @@ state:
     1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
   programs:
     2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 2, process_id: 1002}
 state:
@@ -70,3 +83,7 @@ state:
     1002: Attaching (prog 2) -> Attached (prog 2)
   programs:
     2: Loaded (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/happy_path_multiple_processes.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/happy_path_multiple_processes.yaml
@@ -36,6 +36,10 @@ state:
   programs:
     1: <nil> -> Loading (proc 1001)
     2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -50,6 +54,10 @@ state:
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
     2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -61,6 +69,10 @@ state:
   programs:
     1: Loaded (proc 1001)
     2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !loaded {program_id: 2}
 effects:
@@ -74,6 +86,10 @@ state:
   programs:
     1: Loaded (proc 1001)
     2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 2, process_id: 1002}
 state:
@@ -85,3 +101,7 @@ state:
   programs:
     1: Loaded (proc 1001)
     2: Loaded (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/happy_path_single_process.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/happy_path_single_process.yaml
@@ -24,6 +24,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -35,6 +39,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -44,3 +52,7 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/loading_failure.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/loading_failure.yaml
@@ -23,6 +23,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loading-failed {program_id: 1, error: "eBPF loading failed"}
 state:
@@ -32,3 +36,8 @@ state:
     1001: WaitingForProgram (prog 1) -> LoadingFailed
   programs:
     1: Loading (proc 1001) -> <nil>
+  stats:
+    loadFailed: 0 -> 1
+    numLoadingFailed: 0 -> 1
+    numPrograms: 1 -> 0
+    numWaitingForProgram: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/multiple_programs_queued.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/multiple_programs_queued.yaml
@@ -60,6 +60,10 @@ state:
     1: <nil> -> Loading (proc 1001)
     2: <nil> -> Queued (proc 1002)
     3: <nil> -> Queued (proc 1003)
+  stats:
+    numProcesses: 0 -> 3
+    numPrograms: 0 -> 3
+    numWaitingForProgram: 0 -> 3
 ---
 event: !processes-updated
   updated:
@@ -95,6 +99,10 @@ state:
     1: Loading (proc 1001) -> Loaded (proc 1001)
     3: Queued (proc 1003) -> Loading (proc 1003)
     4: Queued (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 3 -> 2
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -108,6 +116,10 @@ state:
     1: Loaded (proc 1001)
     3: Loading (proc 1003)
     4: Queued (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -128,6 +140,9 @@ state:
     1: Loaded (proc 1001) -> Draining (proc 1001)
     3: Loading (proc 1003)
     4: Queued (proc 1002)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -143,6 +158,8 @@ state:
     1: Draining (proc 1001) -> Unloading (proc 1001)
     3: Loading (proc 1003)
     4: Queued (proc 1002)
+  stats:
+    detached: 0 -> 1
 ---
 event: !loaded {program_id: 3}
 effects:
@@ -159,6 +176,10 @@ state:
     1: Unloading (proc 1001)
     3: Loading (proc 1003) -> Loaded (proc 1003)
     4: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
 ---
 event: !attached {program_id: 3, process_id: 1003}
 state:
@@ -172,6 +193,10 @@ state:
     1: Unloading (proc 1001)
     3: Loaded (proc 1003)
     4: Loading (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !unloaded {program_id: 1}
 state:
@@ -186,3 +211,7 @@ state:
     3: Loaded (proc 1003)
     4: Loading (proc 1002)
     5: <nil> -> Queued (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 1 -> 2
+    unloaded: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/multiple_tenants.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/multiple_tenants.yaml
@@ -31,6 +31,10 @@ state:
     t1:1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !processes-updated
   tenant_id: 2
@@ -48,3 +52,7 @@ state:
   programs:
     1: Loading (proc 1001)
     2: <nil> -> Queued (proc 1001)
+  stats:
+    numProcesses: 1 -> 2
+    numPrograms: 1 -> 2
+    numWaitingForProgram: 1 -> 2

--- a/pkg/dyninst/actuator/testdata/snapshot/probe_update_during_attaching.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/probe_update_during_attaching.yaml
@@ -34,6 +34,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -45,6 +49,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -59,6 +67,9 @@ state:
     1001: Attaching (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttaching: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !attached {program_id: 1, process_id: 1001}
 effects:
@@ -70,6 +81,8 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001)
+  stats:
+    attached: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -81,6 +94,8 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 effects:
@@ -93,6 +108,10 @@ state:
   programs:
     1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
 ---
 event: !loaded {program_id: 2}
 effects:
@@ -104,6 +123,10 @@ state:
     1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
   programs:
     2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 2, process_id: 1001}
 state:
@@ -113,3 +136,7 @@ state:
     1001: Attaching (prog 2) -> Attached (prog 2)
   programs:
     2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_attaching_failure.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_attaching_failure.yaml
@@ -25,6 +25,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -36,6 +40,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !processes-updated {removed: [1001]}
 state:
@@ -45,6 +53,9 @@ state:
     1001: Attaching (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttaching: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !attaching-failed {program_id: 1, process_id: 1001, error: "eBPF attaching failed"}
 effects:
@@ -56,3 +67,5 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    attachFailed: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_attaching_success.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_attaching_success.yaml
@@ -26,6 +26,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -37,6 +41,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !processes-updated {removed: [1001]}
 state:
@@ -46,6 +54,9 @@ state:
     1001: Attaching (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttaching: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !attached {program_id: 1, process_id: 1001}
 effects:
@@ -57,6 +68,8 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001)
+  stats:
+    attached: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -68,3 +81,5 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_loading_failed.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_loading_failed.yaml
@@ -24,6 +24,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !processes-updated {removed: [1001]}
 state:
@@ -42,3 +46,8 @@ state:
     1001: WaitingForProgram (prog 1) -> <nil>
   programs:
     1: LoadingAborted (proc 1001) -> <nil>
+  stats:
+    loadFailed: 0 -> 1
+    numProcesses: 1 -> 0
+    numPrograms: 1 -> 0
+    numWaitingForProgram: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_loading_success.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_during_loading_success.yaml
@@ -25,6 +25,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !processes-updated {removed: [1001]}
 state:
@@ -45,6 +49,8 @@ state:
     1001: WaitingForProgram (prog 1)
   programs:
     1: LoadingAborted (proc 1001) -> Unloading (proc 1001)
+  stats:
+    loaded: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 state:
@@ -54,3 +60,8 @@ state:
     1001: WaitingForProgram (prog 1) -> <nil>
   programs:
     1: Unloading (proc 1001) -> <nil>
+  stats:
+    numProcesses: 1 -> 0
+    numPrograms: 1 -> 0
+    numWaitingForProgram: 1 -> 0
+    unloaded: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_when_attached.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_when_attached.yaml
@@ -27,6 +27,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -38,6 +42,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -47,6 +55,10 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated {removed: [1001]}
 effects:
@@ -58,6 +70,9 @@ state:
     1001: Attached (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -69,6 +84,8 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 state:
@@ -78,3 +95,8 @@ state:
     1001: Detaching (prog 1) -> <nil>
   programs:
     1: Unloading (proc 1001) -> <nil>
+  stats:
+    numDetaching: 1 -> 0
+    numProcesses: 1 -> 0
+    numPrograms: 1 -> 0
+    unloaded: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/process_removed_when_queued.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_removed_when_queued.yaml
@@ -33,6 +33,10 @@ state:
   programs:
     1: <nil> -> Loading (proc 1001)
     2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
 ---
 event: !processes-updated {removed: [1002]}
 state:
@@ -44,3 +48,7 @@ state:
   programs:
     1: Loading (proc 1001)
     2: Queued (proc 1002) -> <nil>
+  stats:
+    numProcesses: 2 -> 1
+    numPrograms: 2 -> 1
+    numWaitingForProgram: 2 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/process_update_changes_probes.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_update_changes_probes.yaml
@@ -34,6 +34,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -45,6 +49,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -54,6 +62,10 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -70,6 +82,9 @@ state:
     1001: Attached (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -81,6 +96,8 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
 ---
 event: !unloaded {program_id: 1}
 effects:
@@ -93,6 +110,10 @@ state:
   programs:
     1: Unloading (proc 1001) -> <nil>
     2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
 ---
 event: !loaded {program_id: 2}
 effects:
@@ -104,6 +125,10 @@ state:
     1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
   programs:
     2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 2, process_id: 1001}
 state:
@@ -113,3 +138,7 @@ state:
     1001: Attaching (prog 2) -> Attached (prog 2)
   programs:
     2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/process_update_no_changes.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_update_no_changes.yaml
@@ -30,6 +30,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -41,6 +45,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -50,6 +58,10 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated
   updated:

--- a/pkg/dyninst/actuator/testdata/snapshot/process_update_removes_all_probes.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/process_update_removes_all_probes.yaml
@@ -31,6 +31,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -42,6 +46,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -51,6 +59,10 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -66,6 +78,9 @@ state:
     1001: Attached (prog 1) -> Detaching (prog 1)
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -77,3 +92,5 @@ state:
     1001: Detaching (prog 1)
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1

--- a/pkg/dyninst/actuator/testdata/snapshot/shutdown_with_active_programs.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/shutdown_with_active_programs.yaml
@@ -45,6 +45,10 @@ state:
     1001: <nil> -> WaitingForProgram (prog 1)
   programs:
     1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
 ---
 event: !loaded {program_id: 1}
 effects:
@@ -56,6 +60,10 @@ state:
     1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
   programs:
     1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
 ---
 event: !attached {program_id: 1, process_id: 1001}
 state:
@@ -65,6 +73,10 @@ state:
     1001: Attaching (prog 1) -> Attached (prog 1)
   programs:
     1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
 ---
 event: !processes-updated
   updated:
@@ -87,6 +99,10 @@ state:
   programs:
     1: Loaded (proc 1001)
     2: <nil> -> Loading (proc 1002)
+  stats:
+    numProcesses: 1 -> 2
+    numPrograms: 1 -> 2
+    numWaitingForProgram: 0 -> 1
 ---
 event: !shutdown {error: "test shutdown"}
 effects:
@@ -100,6 +116,9 @@ state:
   programs:
     1: Loaded (proc 1001) -> Draining (proc 1001)
     2: Loading (proc 1002) -> LoadingAborted (proc 1002)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
 ---
 event: !detached {program_id: 1, process_id: 1001}
 effects:
@@ -113,3 +132,5 @@ state:
   programs:
     1: Draining (proc 1001) -> Unloading (proc 1001)
     2: LoadingAborted (proc 1002)
+  stats:
+    detached: 0 -> 1

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -287,10 +287,14 @@ func (m *Module) run(ctx context.Context, interval time.Duration) {
 
 // GetStats returns the stats of the module
 func (m *Module) GetStats() map[string]any {
-	// m.controller.mu.Lock()
-	// defer m.controller.mu.Unlock()
-
-	return map[string]any{}
+	stats := map[string]any{}
+	if m.shutdown.realDependencies.actuator != nil {
+		actuatorStats := m.shutdown.realDependencies.actuator.Stats()
+		if actuatorStats != nil {
+			stats["actuator"] = actuatorStats
+		}
+	}
+	return stats
 }
 
 // Register registers the module to the router


### PR DESCRIPTION
### What does this PR do?

This adds some stats reporting to the Actuator structure. It might be better to make this
per-tenant, but this is still useful for a first pass.

### Motivation

We don't have enough visibility into the internal state of the agent and the DI subsystem.

### Describe how you validated your changes

There's automated testing.

### Additional Notes

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4201
