### PR TITLE
Bump minimum supported macOS ABI as advertised (ABLD-28 follow-up)

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -269,9 +269,8 @@ build do
     app_temp_dir = "#{install_dir}/Datadog Agent.app/Contents"
     mkdir "#{app_temp_dir}/MacOS"
     systray_build_dir = "#{project_dir}/comp/core/gui/guiimpl/systray"
-    # Target OSX 10.10 (it brings significant changes to Cocoa and Foundation APIs, and older versions of OSX are EOL'ed)
     # Add @executable_path/../Frameworks to rpath to find the swift libs in the Frameworks folder.
-    target = arm_target? ? 'arm64-apple-macos11.0' : 'x86_64-apple-macosx10.10'
+    target = "#{arm_target? ? 'arm64' : 'x86_64'}-apple-macos11.0" # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
     command "swiftc -O -swift-version \"5\" -target \"#{target}\" -Xlinker '-rpath' -Xlinker '@executable_path/../Frameworks' Sources/*.swift -o gui", cwd: systray_build_dir
     copy "#{systray_build_dir}/gui", "#{app_temp_dir}/MacOS/"
     copy "#{systray_build_dir}/agent.png", "#{app_temp_dir}/MacOS/"

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -139,7 +139,7 @@ def get_omnibus_env(
             env[key] = sha1
 
     if sys.platform == 'darwin':
-        env['MACOSX_DEPLOYMENT_TARGET'] = '11.0' if os.uname().machine == "arm64" else '10.12'
+        env['MACOSX_DEPLOYMENT_TARGET'] = '11.0'  # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'


### PR DESCRIPTION
### What does this PR do?
This aligns (up) the minimum supported macOS ABI to 11.0, as otherwise [documented](https://docs.datadoghq.com/agent/supported_platforms/?tab=macos).

### Motivation
1. establish a baseline for binary sizes (static quality gates) with a single ABI version so that we'd get the same with Bazel builds,
2. macOS ABI 10.x is no longer officially supported since Agent [7.62.0](https://github.com/DataDog/datadog-agent/releases/tag/7.62.0) (Jan 29, 2025) according to:
<img width="621" height="471" alt="image" src="https://github.com/user-attachments/assets/1affd02f-bdf0-478d-8a1b-0e66d7ddbd57" />

Some bundled dependencies are anyway already depending on a greater ABI, for instance:
- [snowflake_connector_python-3.17.2-cp312-cp312-macosx_11_0_x86_64.whl](https://github.com/DataDog/integrations-core/blob/d3f7387a09725bd2e30b7466c0edfc34b2fb6f45/.deps/resolved/macos-x86_64_3.12.txt#L111) (11.0)
- [ddtrace-3.12.5-cp312-cp312-macosx_12_0_x86_64.whl](https://github.com/DataDog/integrations-core/blob/d3f7387a09725bd2e30b7466c0edfc34b2fb6f45/.deps/resolved/macos-x86_64_3.12.txt#L21) (**12.0**)

### Additional Notes
There are multiple points of maintenance we'll centralize in the frame of the ongoing migration to Bazel.
See also:
- DataDog/integrations-core#21652