### PR TITLE
security/activity_tree: use maps instead of smaps

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -10,11 +10,13 @@ package activitytree
 
 import (
 	"bufio"
+	"bytes"
 	"math/rand"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -199,67 +201,56 @@ func (pn *ProcessNode) addFiles(files []string, stats *Stats, newEvent func() *m
 const MaxMmapedFiles = 128
 
 func getMemoryMappedFiles(pid int32, processEventPath string) (files []string, _ error) {
-	smapsPath := kernel.HostProc(strconv.Itoa(int(pid)), "smaps")
-	smapsFile, err := os.Open(smapsPath)
+	mapsPath := kernel.HostProc(strconv.Itoa(int(pid)), "maps")
+	mapsFile, err := os.Open(mapsPath)
 	if err != nil {
 		return nil, err
 	}
-	defer smapsFile.Close()
+	defer mapsFile.Close()
 
 	files = make([]string, 0, MaxMmapedFiles)
-	scanner := bufio.NewScanner(smapsFile)
+	scanner := bufio.NewScanner(mapsFile)
 
 	for scanner.Scan() && len(files) < MaxMmapedFiles {
-		line := scanner.Bytes()
-
-		path, ok := extractPathFromSmapsLine(line)
-		if !ok {
+		pathBytes, ok := extractPathFromMapsLine(scanner.Bytes())
+		if !ok ||
+			len(pathBytes) == 0 ||
+			// skip [vdso], [stack], [heap] and similar mappings
+			bytes.HasPrefix(pathBytes, []byte("[")) ||
+			bytes.Equal(pathBytes, []byte(processEventPath)) {
 			continue
 		}
-
-		if len(path) == 0 {
-			continue
-		}
-
-		if path == processEventPath {
-			continue
-		}
-
-		// skip [vdso], [stack], [heap] and similar mappings
-		if strings.HasPrefix(path, "[") {
-			continue
-		}
-
-		files = append(files, path)
+		files = append(files, string(pathBytes))
 	}
 
 	return files, scanner.Err()
 }
 
-func extractPathFromSmapsLine(line []byte) (string, bool) {
-	inSpace := false
-	spaceCount := 0
-	for i, c := range line {
-		if c == ' ' || c == '\t' {
-			// check for fields separator
-			if !inSpace && spaceCount == 0 && i > 0 {
-				if line[i-1] == ':' {
-					return "", false
-				}
-			}
-
-			if !inSpace {
-				inSpace = true
-				spaceCount++
-			}
-		} else if spaceCount == 5 {
-			return string(line[i:]), true
-		} else {
-			inSpace = false
-		}
+func extractPathFromMapsLine(line []byte) ([]byte, bool) {
+	m := mapsLineParserRegex.FindSubmatchIndex(line)
+	if len(m) == 0 || m[pathnameIdx*2] == -1 {
+		return nil, false
 	}
-	return "", false
+	return line[m[pathnameIdx*2]:m[pathnameIdx*2+1]], true
 }
+
+var (
+	// From `man procfs`: The format of the file is:
+	//
+	//    address           perms offset  dev   inode       pathname
+	//    00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dbus-daemon
+	//    00651000-00652000 r--p 00051000 08:02 173521      /usr/bin/dbus-daemon
+	//    00652000-00655000 rw-p 00052000 08:02 173521      /usr/bin/dbus-daemon
+	mapsLineParserRegex = regexp.MustCompile(`^` +
+		`(?:\S+)` + // address
+		`\s+(?:\S+)` + // perms
+		`\s+(?:\S+)` + // offset
+		`\s+(?:\S+)` + // dev
+		`\s+(?:\S+)` + // inode
+		`(?:\s+(?P<pathname>.+))?` +
+		`$`)
+	pathnameIdx = mapsLineParserRegex.SubexpIndex("pathname")
+)
 
 func (pn *ProcessNode) snapshotBoundSockets(p *process.Process, stats *Stats, newEvent func() *model.Event) {
 	boundSockets, err := procfs.NewBoundSocketSnapshotter().GetBoundSockets(p)

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -52,7 +52,7 @@ func TestSnapshotMemoryMappedFiles(t *testing.T) {
 	assert.Equal(t, gopsutilFiles, ownImplemFiles)
 }
 
-func TestExtractPathFromSmapsLine(t *testing.T) {
+func TestExtractPathFromMapsLine(t *testing.T) {
 	entries := []struct {
 		name string
 		line string
@@ -78,24 +78,8 @@ func TestExtractPathFromSmapsLine(t *testing.T) {
 			ok:   true,
 		},
 		{
-			name: "field",
-			line: "KernelPageSize:        4 kB",
-			path: "",
-			ok:   false,
-		},
-		{
-			name: "vmflags",
-			line: "VmFlags: rd wr mr mw me ac",
-			path: "",
-			ok:   false,
-		},
-		// this one is not found today in actual smaps but
-		// if for some reason a new flags is added then the
-		// number of spaces matches the number of spaces in
-		// a file line, so it's best to test it
-		{
-			name: "vmflags future",
-			line: "VmFlags: rd wr mr mw me ac abc",
+			name: "anonymous",
+			line: "7398749de000-739874a00000 rw-p 00000000 00:00 0",
 			path: "",
 			ok:   false,
 		},
@@ -103,11 +87,11 @@ func TestExtractPathFromSmapsLine(t *testing.T) {
 
 	for _, entry := range entries {
 		t.Run(entry.name, func(t *testing.T) {
-			path, ok := extractPathFromSmapsLine([]byte(entry.line))
+			path, ok := extractPathFromMapsLine([]byte(entry.line))
 			if ok != entry.ok {
 				t.Errorf("expected ok=%t, got %t", entry.ok, ok)
 			}
-			if path != entry.path {
+			if string(path) != entry.path {
 				t.Errorf("expected %s, got %s", entry.path, path)
 			}
 		})

--- a/releasenotes/notes/security-agent-activity-tree-use-maps-26624dfa6e366f82.yaml
+++ b/releasenotes/notes/security-agent-activity-tree-use-maps-26624dfa6e366f82.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Workload Protection's activity dump functionality on Linux has been
+    improved to reduce its impact on processes that use very large amounts of
+    memory.


### PR DESCRIPTION
See [#41946](https://github.com/DataDog/datadog-agent/issues/41946).
