### PR TITLE
[SYNTH-22405]: Fix Synthetics Scheduler Flush by locking it

### DIFF
--- a/comp/syntheticstestscheduler/impl/worker.go
+++ b/comp/syntheticstestscheduler/impl/worker.go
@@ -235,7 +235,6 @@ func (s *syntheticsTestScheduler) sendSyntheticsTestResult(w *workerResult) erro
 	}
 
 	s.log.Debugf("synthetics network path test event: %s", string(payloadBytes))
-	s.log.Infof("sending result public_id:<%s> result_id:<%s>", res.Test.ID, res.Result.ID)
 
 	m := message.NewMessage(payloadBytes, nil, "", 0)
 	return s.epForwarder.SendEventPlatformEventBlocking(m, eventplatform.EventTypeSynthetics)


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the Synthetics Scheduler where we weren't locking the flush function and therefore we had race conditions when updating the nextRun value for tests.

### Motivation

The result of the race condition was that some tests wouldn't be executed when the time was due or they would be executed multiple times concurrently, breaking the expectation of a test being executed accordingly to its schedule.

### Describe how you validated your changes

Local execution of the Agent.

### Additional Notes
