### PR TITLE
Add malicious matches to junit

### DIFF
--- a/.gitlab/scan/windows.yml
+++ b/.gitlab/scan/windows.yml
@@ -6,6 +6,7 @@
     - !reference [.on_deploy]
     - !reference [.on_main]
     - !reference [.except_mergequeue]
+    - when: manual  # Manual on all other branches
   variables:
     SCAN_ARTIFACT_PATTERN: "datadog-agent-7*.msi"
     OMNIBUS_PIPELINE_DIR: $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID

--- a/tasks/virustotal.py
+++ b/tasks/virustotal.py
@@ -199,6 +199,8 @@ def _write_junit_xml(
     )
     add_tag("vt.malicious", str(malicious))
     add_tag("vt.suspicious", str(suspicious))
+    add_tag("vt.malicious_matches", json.dumps(malicious_matches))
+    add_tag("vt.suspicious_matches", json.dumps(suspicious_matches))
     add_tag("vt.api_call_count", str(_vt_api_call_count))
     add_tag("vt.url", f"https://www.virustotal.com/gui/file/{file_sha256}")
     # Include GitLab CI metadata as tags


### PR DESCRIPTION
### What does this PR do?
Adds list of suspicious and malicious matches to junit output. This helps us better not match on old matches.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1919

### Describe how you validated your changes
Runs in CI. 

### Additional Notes
