### PR TITLE
Document that long lines from log tailers are split

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1178,9 +1178,12 @@ api_key:
 
 #   # @param max_message_size_bytes - integer - optional - default: 900000
 #   # @env DD_LOGS_CONFIG_MAX_MESSAGE_SIZE_BYTES - integer - optional - default : 900000
-#   # The maximum size of single log message in bytes. If maxMessageSizeBytes exceeds
-#   # the documented API limit of 1MB - any payloads larger than 1MB will be dropped by the intake.
-#   # https://docs.datadoghq.com/api/latest/logs/
+#   # The maximum size of single log message in bytes. Lines that are longer than this limit
+#   # are split into multiple lines -- each lower than the limit -- with split lines having
+#   # `...TRUNCATED...` added as a suffix.
+#   #
+#   # Note: Datadog's ingest API will truncate any logs greater than 1 MB by discarding the
+#   # remainder. See https://docs.datadoghq.com/api/latest/logs/ for details.
 #
 #   max_message_size_bytes: 900000
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1182,7 +1182,7 @@ api_key:
 #   # are split into multiple lines -- each lower than the limit -- with split lines having
 #   # `...TRUNCATED...` added as a suffix.
 #   #
-#   # Note: Datadog's ingest API will truncate any logs greater than 1 MB by discarding the
+#   # Note: Datadog's ingest API truncates any logs greater than 1 MB by discarding the
 #   # remainder. See https://docs.datadoghq.com/api/latest/logs/ for details.
 #
 #   max_message_size_bytes: 900000

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1178,9 +1178,10 @@ api_key:
 
 #   # @param max_message_size_bytes - integer - optional - default: 900000
 #   # @env DD_LOGS_CONFIG_MAX_MESSAGE_SIZE_BYTES - integer - optional - default : 900000
-#   # The maximum size of single log message in bytes. Lines that are longer than this limit
-#   # are split into multiple lines -- each lower than the limit -- with split lines having
-#   # `...TRUNCATED...` added as a suffix.
+#   # The maximum size of single log message in bytes. Lines that are longer
+#   # than this limit are split into multiple line where each long line that is
+#   # split has `...TRUNCATED...` added as a suffix and each line that was created
+#   # from a split of a previous line has `...TRUNCATED...` added as a prefix.
 #   #
 #   # Note: Datadog's ingest API truncates any logs greater than 1 MB by discarding the
 #   # remainder. See https://docs.datadoghq.com/api/latest/logs/ for details.


### PR DESCRIPTION
### What does this PR do?

Updates the documentation for the `max_message_size_bytes` option to mention that lines that exceed it are split.

### Motivation

This splitting behavior wasn't previously documented in the configuration template.

### Describe how you validated your changes

Only docs changes, nothing to validate.

### Additional Notes
