### PR TITLE
[BARX-1164] [Release] The update-changelog task should open backport PRs to ongoing agent releases

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -761,7 +761,7 @@ Make sure that milestone is open before trying again.""",
     return updated_pr.html_url
 
 
-def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None):
+def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None, labels=None):
     if milestone:
         milestone_name = milestone
     else:
@@ -769,7 +769,7 @@ def create_release_pr(title, base_branch, target_branch, version, changelog_pr=F
 
         milestone_name = get_current_milestone()
 
-    labels = [
+    labels = (labels or []) + [
         "team/agent-delivery",
     ]
     if changelog_pr:

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -761,7 +761,7 @@ Make sure that milestone is open before trying again.""",
     return updated_pr.html_url
 
 
-def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None, labels=None):
+def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None, labels=()):
     if milestone:
         milestone_name = milestone
     else:
@@ -769,8 +769,9 @@ def create_release_pr(title, base_branch, target_branch, version, changelog_pr=F
 
         milestone_name = get_current_milestone()
 
-    labels = (labels or []) + [
+    labels = [
         "team/agent-delivery",
+        *labels,
     ]
     if changelog_pr:
         labels.append(f"backport/{get_default_branch()}")

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -1,5 +1,5 @@
-import sys
 import re
+import sys
 from datetime import date
 
 from invoke import Failure, task

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -134,16 +134,16 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
                 code=1,
             )
 
-        # awk script that formats git output and retrieves branches
-        # from later releases (i.e. if we are on 7.67.2, and releases
-        # are being cut for 7.68.x and 7.69.x they would be retrieved)
+        # formats git output and retrieves branches from later
+        # releases (i.e. if we are on 7.67.2, and releases
+        # are being cut for 7.68.x and 7.69.x, they would be retrieved)
         awk_script = (
             f"awk -v min={new_version_int[1]} " + "{"
             "sub(\"refs/heads/\", \"\", $2); "
-                "if ($2 ~ /^7\\.[0-9]+\\.[xX]$/) {"
-                    "split($2, parts, \".\"); "
-                    "if (parts[2] > min) print $2;"
-                "}"
+            "if ($2 ~ /^7\\.[0-9]+\\.[xX]$/) {"
+            "split($2, parts, \".\"); "
+            "if (parts[2] > min) print $2;"
+            "}"
             "}'"
         )
         res = ctx.run(f"git ls-remote --heads origin | {awk_script}")

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -135,7 +135,7 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
                 code=1,
             )
 
-        res = ctx.run(f"git ls-remote --heads origin")
+        res = ctx.run("git ls-remote --heads origin")
         backport_labels = []
         for line in res.splitlines():
             sections = line.strip().split()


### PR DESCRIPTION
### What does this PR do?

In the update-changelog task, we now check for ongoing releases and, if any, add backport labels to the release pr.

### Motivation

https://datadoghq.atlassian.net/browse/BARX-1164

### Describe how you validated your changes

Ran python snippet locally, will have to test fully during the release process.

### Additional Notes
