### PR TITLE
Make `buildifier` faster on Windows

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,9 +25,9 @@ http_archive(
     name = "com_github_bazelbuild_buildtools",
     patch_strip = 1,
     patches = [
-        "//bazel/patches:buildifier-build.patch",  # https://github.com/bazelbuild/buildtools/pull/1398
-        "//bazel/patches:buildifier-internal-factory.patch",  # https://github.com/bazelbuild/buildtools/pull/1399
-        "//bazel/patches:buildifier-runner-bat-template.patch",  # ^ https://github.com/bazelbuild/buildtools/pull/1400
+        "//bazel/patches:buildifier-build.patch",  # bazelbuild/buildtools#1398
+        "//bazel/patches:buildifier-internal-factory.patch",  # bazelbuild/buildtools#1399
+        "//bazel/patches:buildifier-runner-bat-template.patch",  # bazelbuild/buildtools#1400 bazelbuild/buildtools#1404
     ],
     sha256 = "53119397bbce1cd7e4c590e117dcda343c2086199de62932106c80733526c261",
     strip_prefix = "buildtools-8.2.1",

--- a/bazel/patches/buildifier-runner-bat-template.patch
+++ b/bazel/patches/buildifier-runner-bat-template.patch
@@ -1,8 +1,8 @@
 diff --git a/buildifier/runner.bat.template b/buildifier/runner.bat.template
-index 13ca3fa..d8ccac9 100644
+index 13ca3fa..3c8882f 100644
 --- a/buildifier/runner.bat.template
 +++ b/buildifier/runner.bat.template
-@@ -11,9 +11,34 @@ set stripped_args=%stripped_args:'=%
+@@ -11,9 +11,28 @@ set stripped_args=%stripped_args:'=%
  rem Get the absolute path to the buildifier executable
 -for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" MANIFEST') do (set buildifier_abs_path=%%i)
 +if exist MANIFEST (
@@ -16,8 +16,11 @@ index 13ca3fa..d8ccac9 100644
 +for /f "tokens=2" %%i in ('findstr /r "\<buildifier\.exe\>" "%manifest_file%"') do (set buildifier_abs_path=%%i)
  
  powershell ^
+-function Buildify($Root)^
 +function Should-Exclude($Path)^
-+{^
+ {^
+-    $Folder = (New-Object -Com Scripting.FileSystemObject).GetFolder($Root);^
+-    $Files = $Folder.Files ^| Where-Object {^
 +    $relPath = '.' + $Path.Substring('%BUILD_WORKSPACE_DIRECTORY%'.Length);^
 +    foreach ($pattern in @(@@EXCLUDE_PATTERNS@@))^
 +    {^
@@ -28,21 +31,32 @@ index 13ca3fa..d8ccac9 100644
 +    };^
 +    return $false;^
 +};^
- function Buildify($Root)^
- {^
-+    if (Should-Exclude $Root)^
-+    {^
-+        return;^
-+    };^
-     $Folder = (New-Object -Com Scripting.FileSystemObject).GetFolder($Root);^
-     $Files = $Folder.Files ^| Where-Object {^
++$Files = Get-ChildItem -LiteralPath '%BUILD_WORKSPACE_DIRECTORY:/=\%' -Recurse -File -ErrorAction SilentlyContinue ^|^
++    Where-Object {^
 +        (^
          $_.Name -eq 'BUILD.bazel' `^
-@@ -30,2 +55,3 @@ function Buildify($Root)^
+@@ -30,16 +49,10 @@ function Buildify($Root)^
          -or $_.Name -clike 'WORKSPACE.*.oss'^
-+        ) -and -not (Should-Exclude $_.Path)^
++        ) -and -not (Should-Exclude $_.FullName)^
      };^
-@@ -44,2 +70,2 @@ function Buildify($Root)^
- };^
+-    foreach ($File in $Files)^
+-    {^
+-        ^& '%buildifier_abs_path%' %stripped_args% $File.Path;^
+-    };^
+-    foreach ($SubFolder in $Folder.Subfolders)^
+-    {^
+-        $CurrentItem = Get-Item $SubFolder.Path -ErrorAction SilentlyContinue;^
+-        if ($CurrentItem -and !$CurrentItem.Attributes.ToString().Contains('ReparsePoint'))^
+-        {^
+-            Buildify($SubFolder.Path);^
+-        };^
+-    };^
+-};^
 -Buildify('%BUILD_WORKSPACE_DIRECTORY%');
-+Buildify('%BUILD_WORKSPACE_DIRECTORY:/=\%');
++$i = 0;^
++while ($i -lt $Files.Count)^
++{^
++    $Batch = $Files[$i..($i + 99)];^
++    ^& '%buildifier_abs_path%' %stripped_args% $Batch.FullName;^
++    $i += $Batch.Count;^
++};


### PR DESCRIPTION
### What does this PR do?
Apply a last path on `buildifier`'s runner script template on Windows:
- bazelbuild/buildtools#1404

### Motivation
Decrease execution time from [~2 minutes](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1177131952#L77) to [~2 seconds](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1180039154#L99).

### Describe how you validated your changes
Locally (Windows VM) and in CI (1985f7fb75a32e955475d27b723155e030c68512).

### Additional Notes
Closes [ABLD-174](https://datadoghq.atlassian.net/browse/ABLD-174).

[ABLD-174]: https://datadoghq.atlassian.net/browse/ABLD-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ