### PR TITLE
Use 7z to expand datadog-agent zip in windows docker builds

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -16,12 +16,10 @@
     - cp ${OMNIBUS_PACKAGE_DIR}/pipeline-${CI_PIPELINE_ID}/${AGENT_ZIP} ${BUILD_CONTEXT}/datadog-agent-latest.amd64.zip
     - cp entrypoint.exe ${BUILD_CONTEXT}/entrypoint.exe
 
-    # Much faster but doesn't exist in build container
-    # - & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
     - pushd ${BUILD_CONTEXT}
-    - Expand-Archive datadog-agent-latest.amd64.zip
+    - |
+      & 'C:\Program Files\7-Zip\7z.exe' x .\datadog-agent-latest.amd64.zip -o"Datadog Agent"
     - Remove-Item datadog-agent-latest.amd64.zip
-    - Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
     # Omnibus uses a slightly different path than the actual install
     # TODO: This overwrites an extra agent.exe, we should also remove it from the zip
     - mv "Datadog Agent\bin\agent\agent.exe" "Datadog Agent\bin\agent.exe" -Force


### PR DESCRIPTION
### What does this PR do?

It switches to 7z for unzipping the datadog-agent zip build on windows docker build jobs.

### Motivation

As part of doing research for mitigating #incident-42947, we found that this `Expand-Archive` command is one of the places where windows jobs are getting stuck. I then found a comment on the job's code mentioning how 7z would be much faster than the native `Expand-Archive` powershell command, the limitation being that 7z was not installed in the runner (these jobs don't run inside docker, but directly on the CI runner).

I also found that windows docker builds spend 5+ minutes (often more than half of the build time) doing this unzip operation. In some bad cases ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1171882969)) this also takes 30+ minutes.

### Describe how you validated your changes

CI. This [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1179627504#L37) took 7 minutes (compared to typical times above 10 minutes), unzipping took 21 seconds.

### Additional Notes

- To make this possible, I added 7z to our Windows AMI images here: https://github.com/DataDog/ci-platform-machine-images/pull/478
- Upstream issue reporting on Expand-Archive slowness: https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/32
