### PR TITLE
[CWS] check compatibility of set action field/expr

### DIFF
--- a/pkg/security/secl/compiler/eval/event.go
+++ b/pkg/security/secl/compiler/eval/event.go
@@ -29,7 +29,8 @@ type Event interface {
 	GetTags() []string
 }
 
-func eventTypeFromFields(model Model, state *State) (EventType, error) {
+// EventTypeFromState return the event type from state
+func EventTypeFromState(model Model, state *State) (EventType, error) {
 	var eventType EventType
 
 	// if there are no fields, we can't determine the event type

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -113,7 +113,7 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 		return nil, err
 	}
 
-	eventType, err := eventTypeFromFields(model, state)
+	eventType, err := EventTypeFromState(model, state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -214,7 +214,7 @@ func NewRuleEvaluator(rule *ast.Rule, model Model, opts *Opts) (*RuleEvaluator, 
 		return nil, NewTypeError(rule.Pos, reflect.Bool)
 	}
 
-	eventType, err := eventTypeFromFields(model, state)
+	eventType, err := EventTypeFromState(model, state)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Avoid panic when the field/expression is the set action is not compatible with the rule expression. i.e

rule : open.file.path == "/tmp/test"
action: exec.file.path

### Motivation

### Describe how you validated your changes

### Additional Notes
