### PR TITLE
[clusteragent/admission] Decouple default label selectors from APM opts

### DIFF
--- a/pkg/clusteragent/admission/common/label_selectors.go
+++ b/pkg/clusteragent/admission/common/label_selectors.go
@@ -21,6 +21,14 @@ type LabelSelectorsConfig struct {
 	// IncludeNamespaces lists namespaces to explicitly include (mutually exclusive with ExcludeNamespaces)
 	// If set, only these namespaces will be targeted
 	IncludeNamespaces []string
+
+	// ShouldAcceptAllFunc the condition to accept all pods except the ones explicitly
+	// excluded. If empty, defaultShouldAcceptAllFunc is used.
+	ShouldAcceptAllFunc func() bool
+}
+
+var defaultShouldAcceptAllFunc = func() bool {
+	return pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled")
 }
 
 // DefaultLabelSelectors returns namespace and object selectors for admission webhooks.
@@ -30,10 +38,10 @@ type LabelSelectorsConfig struct {
 func DefaultLabelSelectors(useNamespaceSelector bool, config LabelSelectorsConfig) (nsSelector *metav1.LabelSelector, objSelector *metav1.LabelSelector) {
 	nsSelector = &metav1.LabelSelector{}
 	if useNamespaceSelector {
-		applyAdmissionEnabledSelectors(nsSelector)
+		applyAdmissionEnabledSelectors(nsSelector, config)
 	} else {
 		objSelector = &metav1.LabelSelector{}
-		applyAdmissionEnabledSelectors(objSelector)
+		applyAdmissionEnabledSelectors(objSelector, config)
 	}
 
 	applySelectorConfig(nsSelector, config)
@@ -67,10 +75,13 @@ func applySelectorConfig(nsSelector *metav1.LabelSelector, config LabelSelectors
 	}
 }
 
-func applyAdmissionEnabledSelectors(selector *metav1.LabelSelector) {
-	if pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") ||
-		pkgconfigsetup.Datadog().GetBool("apm_config.instrumentation.enabled") ||
-		len(pkgconfigsetup.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")) > 0 {
+func applyAdmissionEnabledSelectors(selector *metav1.LabelSelector, config LabelSelectorsConfig) {
+	shouldAcceptAllFunc := config.ShouldAcceptAllFunc
+	if shouldAcceptAllFunc == nil {
+		shouldAcceptAllFunc = defaultShouldAcceptAllFunc
+	}
+
+	if shouldAcceptAllFunc() {
 		// Accept all, ignore pods explicitly filtered-out
 		selector.MatchExpressions = []metav1.LabelSelectorRequirement{
 			{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -26,6 +26,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -111,6 +112,11 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (*metav1.LabelSelector, *metav1.LabelSelector) {
 	return common.DefaultLabelSelectors(useNamespaceSelector, common.LabelSelectorsConfig{
 		ExcludeNamespaces: mutatecommon.DefaultDisabledNamespaces(),
+		ShouldAcceptAllFunc: func() bool {
+			return pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") ||
+				pkgconfigsetup.Datadog().GetBool("apm_config.instrumentation.enabled") ||
+				len(pkgconfigsetup.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")) > 0
+		},
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR moves APM-specific config options out of the default label selectors used in the DCA admission controller.

The default label selectors are used by 4 webhooks: APM, config, tags-from-labels, and kubernetes-admission-events. In the past, the config and tags-from-labels webhooks needed to run when APM was enabled. They're now decoupled, so this is no longer needed. The kubernetes-admission-events webhook was tied to APM by accident because it has nothing to do with APM.

This PR moves the current default label selectors to the APM webhook without changes and modifies the default ones used by the other 3 webhooks to avoid depending on APM config options.

Not sure if kubernetes-admission-events should check `mutate_unlabelled` since it validates rather than mutates. I'll keep the existing behavior for now.

The APM label selector logic is unchanged. There may be other optimization opportunities, but I'm leaving those for injection-platform.

### Describe how you validated your changes

CI and manual tests to verify that basic injection scenarios work as expected.
