### PR TITLE
(fleet) fix cleanup of OCI package during DEB uninstalls

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -8,7 +8,7 @@
 ##########################################################################
 
 INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
-INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer
 
 # Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
 if [ -f ${INSTALLER_DEB} ] && [ "$1" = "remove" ]; then

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -8,7 +8,7 @@
 ##########################################################################
 
 INSTALLER_DEB=/opt/datadog-agent/embedded/bin/installer
-INSTALLER_OCI=/opt/datadog-package/datadog-agent/stable/embedded/bin/installer
+INSTALLER_OCI=/opt/datadog-packages/datadog-agent/stable/embedded/bin/installer
 
 # Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 # Note: the upgrade prerm is handled in the preinst script of the new package on rpm.

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -75,6 +75,7 @@ func (h *Host) setSystemdVersion() {
 	h.systemdVersion = version
 }
 
+// RemovePackage removes a package from the host.
 func (h *Host) RemovePackage(pkg string) {
 	switch h.pkgManager {
 	case "apt":

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -75,6 +75,15 @@ func (h *Host) setSystemdVersion() {
 	h.systemdVersion = version
 }
 
+func (h *Host) RemovePackage(pkg string) {
+	switch h.pkgManager {
+	case "apt":
+		h.remote.MustExecute("sudo dpkg -r " + pkg)
+	case "yum", "zypper":
+		h.remote.MustExecute("sudo rpm -e " + pkg)
+	}
+}
+
 // InstallDocker installs Docker on the host if it is not already installed.
 func (h *Host) InstallDocker() {
 	defer func() {

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -152,6 +152,10 @@ func (s *upgradeScenarioSuite) TestUpgradeSuccessfulFromDebRPM() {
 	s.assertSuccessfulAgentPromoteExperiment(timestamp, s.pipelineAgentVersion)
 	state = s.host.State()
 	state.AssertPathDoesNotExist("/opt/datadog-agent")
+
+	s.host.RemovePackage("datadog-agent")
+	state = s.host.State()
+	state.AssertPathDoesNotExist("/opt/datadog-packages/datadog-agent")
 }
 
 func (s *upgradeScenarioSuite) TestBackendFailure() {


### PR DESCRIPTION
This PR fixes the removal of the OCI install during a DEB uninstall. This left a version of the agent on disk if customers did:
- install deb
- remotely upgrade
- uninstall