### PR TITLE
Mark the agent command runner as ready if waitForReady succeeded in init

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -43,6 +43,7 @@ func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, wa
 
 	if params.ShouldWaitForReady {
 		if err := waitForReadyTimeout(commandRunner, agentReadyTimeout); err != nil {
+			commandRunner.isReady = true
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

We call `waitForReady` in the Agent client initialization, but never mark it as ready when it succeeds so next time we call a command the `agent status` command is executed again to check if the agent is ready. This should not be required, let's mark is as ready if the agent is ready during the client initialization

### Motivation

### Describe how you validated your changes

### Additional Notes
