### PR TITLE
[CWS] apply to proper delay in selftest

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -212,13 +212,14 @@ func (c *CWSConsumer) Start() error {
 			c.selfTestPassed = true
 
 			c.reportSelfTest(success, fails)
+			delay = selftestPassedDelay
 		}
+
+		time.Sleep(delay)
 
 		if _, err := c.RunSelfTest(false); err != nil {
 			seclog.Errorf("self-test error: %s", err)
 		}
-
-		time.Sleep(delay)
 	}
 	if c.selfTester != nil {
 		go c.selfTester.WaitForResult(cb)


### PR DESCRIPTION
### What does this PR do?

Apply the success delay after the first success and not the 15s causing 2 sefltest event to be generated.

### Motivation

### Describe how you validated your changes

### Additional Notes
