### PR TITLE
Adding error messages to sgc e2e tests

### DIFF
--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_nix_test.go
@@ -34,5 +34,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "embedded_secret_key")
-	}, 30*time.Second, 2*time.Second)
+	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'embedded_secret_key' within the allotted time")
 }

--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_aws_win_test.go
@@ -39,5 +39,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "embedded_secret_key")
-	}, 30*time.Second, 2*time.Second)
+	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'embedded_key' within the allotted time")
 }

--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_nix_test.go
@@ -50,5 +50,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "fake_yaml_key")
-	}, 30*time.Second, 2*time.Second)
+	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'fake_yaml_key' within the allotted time")
 }

--- a/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/secret-backend-embedded/secret_backend_win_test.go
@@ -58,5 +58,5 @@ secret_backend_config:
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
 		secretOutput := v.Env().Agent.Client.Secret()
 		require.Contains(t, secretOutput, "fake_yaml_key")
-	}, 30*time.Second, 2*time.Second)
+	}, 30*time.Second, 2*time.Second, "could not check if secretOutput contains 'fake_yaml_key' within the allotted time")
 }


### PR DESCRIPTION
### What does this PR do?

Our team is getting a number of flaky tests from the secretbackend package indicating that it cannot find the checked-for secret in the allotted time. These test failures don't clearly show this, so we want to add explicit error messages to make the cause of the test failures more clear.

### Motivation

### Describe how you validated your changes

### Additional Notes
