### PR TITLE
[USM] Support a PRIORITY flag

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -13,10 +13,10 @@
 #define HTTP2_MAX_FRAMES_FOR_EOS_PARSER (HTTP2_MAX_FRAMES_FOR_EOS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_EOS_PARSER)
 
 // Represents the maximum number of frames we'll process in a single tail call in `handle_headers_frames` program.
-#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 16
+#define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL 15
 // Represents the maximum number of tail calls to process headers frames.
-// Currently we have up to 240 frames in a packet, thus 15 (15*16 = 240) tail calls is enough.
-#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 15
+// Currently we have up to 240 frames in a packet, thus 16 (15*16 = 240) tail calls is enough.
+#define HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER 16
 #define HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER (HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL * HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER)
 // Maximum number of frames to be processed in a single tail call.
 #define HTTP2_MAX_FRAMES_ITERATIONS 240
@@ -69,6 +69,12 @@
 
 // The flag which will be sent in the data/header frame that indicates end of stream.
 #define HTTP2_END_OF_STREAM 0x1
+
+// The flag which will be sent in the PRIORITY field.
+#define HTTP2_PRIORITY_FLAG 0x20
+
+// 5-byte priority section at the start of a HEADERS frame when the PRIORITY flag is set.
+#define HTTP2_PRIORITY_BUFFER_LEN 5
 
 // Http2 max batch size.
 #define HTTP2_BATCH_SIZE (MAX_BATCH_SIZE(http2_event_t))

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -930,6 +930,17 @@ static __always_inline void headers_parser(pktbuf_t pkt, void *map_key, conn_tup
         }
         current_stream->tags = tags;
         pktbuf_set_offset(pkt, current_frame.offset);
+        
+         // If PRIORITY flag (0x20) set, skip 5-byte priority fields.
+                // See: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2
+        if (current_frame.frame.flags & HTTP2_PRIORITY_FLAG) {
+            pktbuf_advance(pkt, HTTP2_PRIORITY_BUFFER_LEN);
+            if (current_frame.frame.length > HTTP2_PRIORITY_BUFFER_LEN) {
+                current_frame.frame.length -= HTTP2_PRIORITY_BUFFER_LEN;
+            } else {
+                continue;
+            }
+        }
 
         interesting_headers = pktbuf_filter_relevant_headers(pkt, global_dynamic_counter, &http2_ctx->dynamic_index, headers_to_process, current_frame.frame.length, http2_tel);
         pktbuf_process_headers(pkt, &http2_ctx->dynamic_index, current_stream, headers_to_process, interesting_headers, http2_tel);

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -662,7 +662,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate max interesting frames limit with PRIORITY",
-			// PRIORITY frames should not be supported and cause failure
+			// PRIORITY frames are supported - validate with maximum frame limit
 			messageBuilder: func() [][]byte {
 				const iterations = 119
 				framer := newFramer()
@@ -674,7 +674,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}
 				return [][]byte{framer.bytes()}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 119,
+			},
 		},
 		{
 			name: "validate literal header field without indexing",
@@ -703,7 +708,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate literal header field without indexing with PRIORITY",
-			// PRIORITY affects HEADERS frame size changing HPACK boundary calculations
+			// PRIORITY is supported - validate with literal header field without indexing
 			messageBuilder: func() [][]byte {
 				const iterations = 5
 				framer := newFramer()
@@ -717,7 +722,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}
 				return [][]byte{framer.bytes()}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/" + strings.Repeat("a", defaultDynamicTableSize))},
+					Method: usmhttp.MethodPost,
+				}: 5,
+			},
 		},
 		{
 			name: "validate literal header field never indexed",
@@ -745,7 +755,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate literal header field never indexed with PRIORITY",
-			// PRIORITY impacts frame structure for literal header processing
+			// PRIORITY is supported - validate with literal header field never indexed
 			messageBuilder: func() [][]byte {
 				const iterations = 5
 				framer := newFramer()
@@ -758,7 +768,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}
 				return [][]byte{framer.bytes()}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 5,
+			},
 		},
 		{
 			name: "validate path with index 4",
@@ -1134,19 +1149,23 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "Interesting frame header sent separately from frame payload with PRIORITY",
-			// PRIORITY adds 5 bytes to HEADERS frame - changes frame splitting calculations
+			// Testing the scenario in which the frame header with priority (of an interesting type) is sent separately from the frame payload.
 			messageBuilder: func() [][]byte {
 				headersFrame := newFramer().writeHeaders(t, withStream(1), withFrameOptions(t, usmhttp2.HeadersFrameOptions{Headers: testHeaders()}), withPriority(true)).bytes()
 				dataFrame := newFramer().writeData(t, 1, endStream, emptyBody).bytes()
-				// Split after HTTP/2 frame header (9 bytes) + PRIORITY section (5 bytes) = 14 bytes
-				headersFrameHeader := headersFrame[:14]
-				secondMessage := append(headersFrame[14:], dataFrame...)
+				headersFrameHeader := headersFrame[:9]
+				secondMessage := append(headersFrame[9:], dataFrame...)
 				return [][]byte{
 					headersFrameHeader,
 					secondMessage,
 				}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 1,
+			},
 		},
 		{
 			name: "Not interesting frame header sent separately from frame payload",
@@ -1195,7 +1214,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "validate dynamic table update with indexed header field with PRIORITY",
-			// PRIORITY impacts dynamic table operations
+			// PRIORITY is supported - validate with dynamic table update
 			messageBuilder: func() [][]byte {
 				const iterations = 5
 				framer := newFramer()
@@ -1209,7 +1228,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 				}
 				return [][]byte{framer.bytes()}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/")},
+					Method: usmhttp.MethodPost,
+				}: 5,
+			},
 		},
 		{
 			name: "validate dynamic table update with high value and indexed header field",
@@ -1265,7 +1289,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "Data frame header sent separately from frame payload with PRIORITY",
-			// PRIORITY affects frame boundaries in multi-frame messages
+			// PRIORITY is supported - validate frame boundaries in multi-frame messages with PRIORITY
 			messageBuilder: func() [][]byte {
 				payload := []byte("test")
 				headersFrame := newFramer().writeHeaders(t, withStream(1), withFrameOptions(t, usmhttp2.HeadersFrameOptions{Headers: testHeaders()}), withPriority(true)).bytes()
@@ -1283,7 +1307,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 					secondMessage,
 				}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 2,
+			},
 		},
 		{
 			name: "Data frame header sent separately from frame payload with PING between them",
@@ -1343,7 +1372,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "Payload data frame header sent separately with PRIORITY",
-			// PRIORITY changes HEADERS frame size affecting frame splitting calculations
+			// PRIORITY is supported - validate payload frame splitting with PRIORITY
 			messageBuilder: func() [][]byte {
 				payload := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
 				headersFrame := newFramer().writeHeaders(t, withStream(1), withFrameOptions(t, usmhttp2.HeadersFrameOptions{
@@ -1362,7 +1391,12 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 					secondMessage,
 				}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 2,
+			},
 		},
 		{
 			name: "validate CONTINUATION frame support",
@@ -1439,7 +1473,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 		},
 		{
 			name: "remainder + header remainder with PRIORITY",
-			// PRIORITY changes frame sizes affecting remainder calculations
+			// PRIORITY is supported - validate remainder handling with PRIORITY
 			messageBuilder: func() [][]byte {
 				data := []byte("testcontent")
 				request1 := newFramer().
@@ -1457,7 +1491,16 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 					request2[5:],
 				}
 			},
-			expectedEndpoints: nil, // PRIORITY not supported
+			expectedEndpoints: map[usmhttp.Key]int{
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString(http2DefaultTestPath)},
+					Method: usmhttp.MethodPost,
+				}: 1,
+				{
+					Path:   usmhttp.Path{Content: usmhttp.Interner.GetString("/bbb")},
+					Method: usmhttp.MethodPost,
+				}: 1,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1606,7 +1649,7 @@ func (s *usmHTTP2Suite) TestIncompleteFrameTable() {
 		},
 		{
 			name: "validate clean with remainder and header zero with PRIORITY",
-			// PRIORITY changes HEADERS frame size affecting remainder calculations
+			// PRIORITY is supported - validate remainder cleanup with PRIORITY (HEADERS frame size changes)
 			messageBuilder: func() [][]byte {
 				data := []byte("test12345")
 				a := newFramer().
@@ -1619,7 +1662,7 @@ func (s *usmHTTP2Suite) TestIncompleteFrameTable() {
 					b[11:],
 				}
 			},
-			mapSize: 0, // PRIORITY not supported, so map should be empty
+			mapSize: 0,
 		},
 		{
 			name: "validate remainder in map",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* This PR adds support for HTTP/2 priority flag.
* Change `HTTP2_MAX_FRAMES_FOR_HEADERS_PARSER_PER_TAIL_CALL` from 16 to 15.
* Change `HTTP2_MAX_TAIL_CALLS_FOR_HEADERS_PARSER` from 15 to 16. 

### Motivation

When priority flag is set, the frame includes 5 additional bytes: 4 bytes for the stream dependency field and 1 byte for the weight. Since we weren’t accounting for these extra bytes in our parser, we were misinterpreting the frame structure, which caused the capture logic to fail.

> The HEADERS frame defines the following flags:
> PRIORITY (0x20): When set, the PRIORITY flag indicates that the Exclusive, Stream Dependency, and Weight fields are present.

link to the HTTP/2 RFC that contains documentation about the issue: https://datatracker.ietf.org/doc/html/rfc7540#section-6.2

I reached the instruction count limit, which explains the changes to the constants we use to iterate over the frames. I increased one and decreased another to maintain the same total number of iterations as before.

### Describe how you validated your changes

- [x] Support all UTs related to the PRIORY introduced in this PR: https://github.com/DataDog/datadog-agent/pull/40354
- [x] Load test scenarios:
 * [HTTP/2 plain](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-http2-plain-base&tpl_var_client-service%5B0%5D=golang-k6-client-http2&tpl_var_compare_agent-env%5B0%5D=priorty-http2-plain-new&tpl_var_http.version%5B0%5D=http%2F2&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-httpbin-http2&from_ts=1760517045850&to_ts=1760603445850&live=true)
 * [HTTP/2 openssl](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-http2-openssl-base&tpl_var_client-service%5B0%5D=python-k6-client-http2-tls&tpl_var_compare_agent-env%5B0%5D=priorty-http2-openssl-new&tpl_var_http.version%5B0%5D=http%2F2&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=python-httpbin-http2-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1760517085970&to_ts=1760603485970&live=true)
 * [HTTP/2 gotls](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-http2-go-tls-base&tpl_var_client-service%5B0%5D=golang-k6-client-http2-tls&tpl_var_compare_agent-env%5B0%5D=priorty-http2-go-tls-new&tpl_var_http.version%5B0%5D=http%2F2&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-httpbin-http2-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1760517122658&to_ts=1760603522658&live=true)
 * [gRPC plain](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-grpc-plain-base&tpl_var_client-service%5B0%5D=golang-k6-client-grpc&tpl_var_compare_agent-env%5B0%5D=priorty-grpc-plain-new&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-grpcbin&from_ts=1760517006981&to_ts=1760603406981&live=true)
 * [gRPC openssl](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-grpc-openssl-base&tpl_var_client-service%5B0%5D=python-k6-client-grpc-tls&tpl_var_compare_agent-env%5B0%5D=priorty-grpc-openssl-new&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=python-grpcbin-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1760516941602&to_ts=1760603341602&live=true)
 * [gRPC openssl](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=sliding&tpl_var_base_agent-env%5B0%5D=priorty-grpc-gotls-base&tpl_var_client-service%5B0%5D=golang-k6-client-grpc-tls&tpl_var_compare_agent-env%5B0%5D=priorty-grpc-gotls-new&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=golang-grpcbin-tls&tpl_var_tls.library%5B0%5D=go&from_ts=1760516971102&to_ts=1760603371102&live=true)

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->