### PR TITLE
Fix windows event log check integration tests

### DIFF
--- a/comp/checks/windowseventlog/windowseventlogimpl/check/check_test.go
+++ b/comp/checks/windowseventlog/windowseventlogimpl/check/check_test.go
@@ -19,6 +19,7 @@ import (
 	agentConfigmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	agentEvent "github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/publishermetadatacache"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	evtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
 	evtreporter "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/reporter"
@@ -124,6 +125,7 @@ func newCheck(api evtapi.API, sender *mocksender.MockSender, instanceConfig []by
 	initConfig := []byte(`legacy_mode: false`)
 	check := new(Check)
 	check.evtapi = api
+	check.publisherMetadataCache = publishermetadatacache.New(api)
 
 	// Have to call BuildID() separately here so we can register our mock sender with the aggregator
 	// for the ID for the check we're about to make so when the check calls GetSender()

--- a/comp/checks/windowseventlog/windowseventlogimpl/check/check_test.go
+++ b/comp/checks/windowseventlog/windowseventlogimpl/check/check_test.go
@@ -19,9 +19,9 @@ import (
 	agentConfigmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	agentEvent "github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/publishermetadatacache"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	evtapi "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/publishermetadatacache"
 	evtreporter "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/reporter"
 	eventlog_test "github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/test"
 


### PR DESCRIPTION
### What does this PR do?
Fixed the integration tests failing by instantiating the publisher metadata cache in the `newCheck` function.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1927

### Describe how you validated your changes
`go test ./comp/checks/windowseventlog/windowseventlogimpl/check -v -tags=test -evtapi Windows`

### Additional Notes
