### PR TITLE
updating check to link to troubleshooting doc

### DIFF
--- a/pkg/logs/status/utils/status.go
+++ b/pkg/logs/status/utils/status.go
@@ -46,7 +46,11 @@ func (s *LogStatus) Error(err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.status = isError
-	s.err = fmt.Sprintf("Error: %s", err.Error())
+	if strings.Contains(err.Error(), "permission denied"){
+        s.err = fmt.Sprintf("Error: %s. See https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/?tab=linux#permission-issues-tailing-log-files for details on how to troubleshoot this issue", err.Error())
+    } else {
+      s.err = fmt.Sprintf("Error: %s", err.Error())
+    }
 }
 
 // IsPending returns whether the current status is not yet determined.


### PR DESCRIPTION
### What does this PR do?
Adding troubleshooting doc link to Agent status log when permissions error for log tailing is triggered
### Motivation
Inproved Agent Error logging
### Describe how you validated your changes
Tested locally with Agent build, recreated the error and displayed the doc link within the status log
### Additional Notes
Straightforward if statement when the permission denied error populates

Something similar was opened below, but closed due to incorrect permissions
https://github.com/DataDog/datadog-agent/pull/40061