### PR TITLE
[EBPF-851] fix(corechecks/gpu): lazily init gpu device events collector with registration retry logic

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/device_events.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device_events.go
@@ -24,24 +24,28 @@ import (
 )
 
 const (
-	eventSetMask                = uint64(nvml.EventTypeXidCriticalError)
-	eventSetWaitTimeout         = 1000 * time.Millisecond
-	devicePendingEventQueueSize = 1000
-	xidOriginDriver             = "driver"
-	xidOriginHardware           = "hardware"
-	xidOriginUnknown            = "unknown"
+	eventSetMask                  = uint64(nvml.EventTypeXidCriticalError)
+	eventSetWaitTimeout           = 1000 * time.Millisecond
+	devicePendingEventQueueSize   = 1000
+	deviceMaxRegistrationAttempts = 5
+	xidOriginDriver               = "driver"
+	xidOriginHardware             = "hardware"
+	xidOriginUnknown              = "unknown"
 )
 
 // helps mocking an actual events gatherer in tests
 type deviceEventsCollectorCache interface {
 	GetEvents(deviceUUID string) ([]ddnvml.DeviceEventData, error)
 	RegisterDevice(device ddnvml.Device) error
+	SupportsDevice(device ddnvml.Device) (bool, error)
 }
 
 type deviceEventsCollector struct {
-	device           ddnvml.Device
-	eventsCache      deviceEventsCollectorCache
-	metricsByXidCode map[uint64]*Metric
+	registered           bool
+	registrationAttempts int
+	device               ddnvml.Device
+	eventsCache          deviceEventsCollectorCache
+	metricsByXidCode     map[uint64]*Metric
 }
 
 func newDeviceEventsCollector(device ddnvml.Device, deps *CollectorDependencies) (c Collector, err error) {
@@ -53,8 +57,11 @@ func newDeviceEventsCollectorWithCache(device ddnvml.Device, cache deviceEventsC
 	if cache == nil {
 		return nil, fmt.Errorf("device events gatherer cannot be nil")
 	}
-	if err := cache.RegisterDevice(device); err != nil {
+
+	if supported, err := cache.SupportsDevice(device); err != nil {
 		return nil, err
+	} else if !supported {
+		return nil, errUnsupportedDevice
 	}
 
 	return &deviceEventsCollector{
@@ -73,6 +80,10 @@ func (c *deviceEventsCollector) Name() CollectorName {
 }
 
 func (c *deviceEventsCollector) Collect() ([]Metric, error) {
+	if !c.ensureDeviceRegistered() {
+		return nil, nil
+	}
+
 	events, err := c.eventsCache.GetEvents(c.DeviceUUID())
 	if err != nil {
 		return nil, fmt.Errorf("failed collecting device events: %w", err)
@@ -108,6 +119,34 @@ func (c *deviceEventsCollector) Collect() ([]Metric, error) {
 		metrics = append(metrics, *m)
 	}
 	return metrics, nil
+}
+
+// note: watching device events seems to require specific permission/status with the NVIDIA driver,
+// which leads to data races at initialization/node-setup time that give us error when registering
+// devices. As such, this collector performs a lazy registration of the device to the events gatherer,
+// with a retry logic with a max number of attempts. This makes sure we attempt registration multiple
+// times at subsequent runs of the GPU check, and eventually give up if errors are persistent
+func (c *deviceEventsCollector) ensureDeviceRegistered() bool {
+	if c.registered {
+		return true
+	}
+
+	if c.registrationAttempts >= deviceMaxRegistrationAttempts {
+		return false
+	}
+
+	c.registrationAttempts++
+	if err := c.eventsCache.RegisterDevice(c.device); err != nil {
+		if c.registrationAttempts == 1 {
+			log.Warnf("could not register %s to device events gatherer, will retry up to %d times: %v", c.DeviceUUID(), deviceMaxRegistrationAttempts, err)
+		} else if c.registrationAttempts >= deviceMaxRegistrationAttempts {
+			log.Warnf("could not register %s to device events gatherer after %d attempts, skipping collection: %v", c.DeviceUUID(), deviceMaxRegistrationAttempts, err)
+		}
+		return false
+	}
+
+	c.registered = true
+	return true
 }
 
 // NewDeviceEventsGatherer creates a new cache that gathers NVML device events
@@ -238,6 +277,15 @@ func (c *DeviceEventsGatherer) GetEvents(deviceUUID string) ([]ddnvml.DeviceEven
 	}
 	log.Debugf("event set gatherer: could not find cache for %s while getting events", deviceUUID)
 	return nil, nil
+}
+
+// SupportsDevice returns true if the gatherer supports the given device
+func (c *DeviceEventsGatherer) SupportsDevice(device ddnvml.Device) (bool, error) {
+	evtTypes, err := device.GetSupportedEventTypes()
+	if err != nil {
+		return false, fmt.Errorf("failed to query supported device event types for %s: %w", device.GetDeviceInfo().UUID, err)
+	}
+	return (evtTypes & eventSetMask) != 0, nil
 }
 
 // RegisterDevice registers a device for event collection


### PR DESCRIPTION
### What does this PR do?

Introduces a lazy initialization approach for registering devices for event watching in the respective GPU check collectors. Registration is moved at metric collection time, and reattempted up to a max number of times. After the limit is reached, a warning is logged and metric production is skipped for that collector, which however is properly created and never skipped at construction time.

### Motivation

We're hitting sporadic failures when registering a GPU device for events watching (just XID errors so far). The current hypothesis is that this could happen due to a setup/init race when a node is provisioned in autoscaling, and the Nvidia driver is not yet "ready" for registering devices for event watching. This alternative proposal adds resiliency through controlled reattempts at subsequent check runs.

### Describe how you validated your changes

### Additional Notes
