### PR TITLE
Fix otel config with nodetreemodel implementation

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/serializer.go
@@ -122,6 +122,8 @@ func InitSerializer(logger *zap.Logger, cfg *ExporterConfig, sourceProvider sour
 		fxutil.FxAgentBase(),
 		fx.Provide(func() config.Component {
 			pkgconfig := create.NewConfig("DD")
+			pkgconfigsetup.InitConfig(pkgconfig)
+			pkgconfig.BuildSchema()
 
 			// Set the API Key
 			pkgconfig.Set("api_key", string(cfg.API.Key), pkgconfigmodel.SourceFile)


### PR DESCRIPTION
### What does this PR do?

Not using the default config means doing the init steps manually

### Describe how you validated your changes

`opentelemetry-agent` need to validate the change with manual QA.