### PR TITLE
[chore][comp/forwarder/defaultforwarder] Lower level of 'successfully posted payload' messages to debug

### DIFF
--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -451,12 +451,12 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, config config.Com
 	loggingFrequency := config.GetInt64("logging_frequency")
 
 	if transactionsSuccess.Value() == 1 {
-		log.Infof("Successfully posted payload to %q (%s), the agent will only log transaction success every %d transactions", logURL, resp.Status, loggingFrequency)
+		log.Debugf("Successfully posted payload to %q (%s), the agent will only log transaction success every %d transactions", logURL, resp.Status, loggingFrequency)
 		log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
 		return resp.StatusCode, body, nil
 	}
 	if transactionsSuccess.Value()%loggingFrequency == 0 {
-		log.Infof("Successfully posted payload to %q (%s)", logURL, resp.Status)
+		log.Debugf("Successfully posted payload to %q (%s)", logURL, resp.Status)
 		log.Tracef("Url: %q, response status %s, content length %d, payload: %q", logURL, resp.Status, resp.ContentLength, truncateBodyForLog(body))
 		return resp.StatusCode, body, nil
 	}


### PR DESCRIPTION
### What does this PR do?

Lowers log level of "successfully posted payload" messages to debug level. These have been reported as spammy by OpenTelemetry Collector Datadog exporter users (see issue linked below). 

### Motivation

open-telemetry/opentelemetry-collector-contrib/issues/43594