### PR TITLE
[APM] Mark test as flaky on macOS

### DIFF
--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"math"
 	"net/url"
+	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -332,6 +333,10 @@ func TestStatsResetBuffer(t *testing.T) {
 }
 
 func TestStatsSyncWriter(t *testing.T) {
+	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" {
+		t.Skip("TestStatsSyncWriter is known to fail on the macOS Gitlab runners.")
+	}
+
 	t.Run("ok", func(t *testing.T) {
 		assert := assert.New(t)
 		sw, srv := testStatsSyncWriter()


### PR DESCRIPTION
### What does this PR do?

Mark tests as flaky. This is a known issue on macos Gitlab runners.

### Motivation

### Describe how you validated your changes

### Additional Notes
