### PR TITLE
fix(upgrade): Restore upgrade tests

### DIFF
--- a/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
+++ b/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -62,7 +61,6 @@ func TestUpgradeScript(t *testing.T) {
 		osDesc := osDesc
 
 		t.Run(fmt.Sprintf("test upgrade on %s", platforms.PrettifyOsDescriptor(osDesc)), func(tt *testing.T) {
-			flake.Mark(tt)
 			tt.Parallel()
 			tt.Logf("Testing %s", platforms.PrettifyOsDescriptor(osDesc))
 


### PR DESCRIPTION
### What does this PR do?
- Pass the osDescriptors to the testSuite
- Install the required test public keys
- TBD remove the flake mark

### Motivation
- The upgrade tests are currently [silently failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1179953871) on the `main` branch as their are marked as flaky

### Describe how you validated your changes
Full CI execution is [~green](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/79592565)

### Additional Notes
