### PR TITLE
Build pcre2 with bazel

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -17,6 +17,7 @@ filegroup(
         "@platforms//os:linux": [
             "@libsepol//:sepol",
             "@nghttp2",
+            "@pcre2",
         ],
         "//conditions:default": [],
     }),

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -1,0 +1,262 @@
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:native_binary.bzl", "native_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+copy_file(
+    name = "config_h_generic",
+    src = "src/config.h.generic",
+    out = "src/config.h",
+)
+
+copy_file(
+    name = "pcre2_h_generic",
+    src = "src/pcre2.h.generic",
+    out = "src/pcre2.h",
+)
+
+copy_file(
+    name = "pcre2_chartables_c",
+    src = "src/pcre2_chartables.c.dist",
+    out = "src/pcre2_chartables.c",
+)
+
+# Removed src/pcre2_ucptables.c below because it is #included in
+# src/pcre2_tables.c. Also fixed typo: ckdint should be chkdint.
+# PH, 22-March-2023.
+cc_library(
+    name = "pcre2",
+    srcs = [
+        "src/pcre2_auto_possess.c",
+        "src/pcre2_chkdint.c",
+        "src/pcre2_compile.c",
+        "src/pcre2_compile_class.c",
+        "src/pcre2_config.c",
+        "src/pcre2_context.c",
+        "src/pcre2_convert.c",
+        "src/pcre2_dfa_match.c",
+        "src/pcre2_error.c",
+        "src/pcre2_extuni.c",
+        "src/pcre2_find_bracket.c",
+        "src/pcre2_jit_compile.c",
+        "src/pcre2_maketables.c",
+        "src/pcre2_match.c",
+        "src/pcre2_match_data.c",
+        "src/pcre2_newline.c",
+        "src/pcre2_ord2utf.c",
+        "src/pcre2_pattern_info.c",
+        "src/pcre2_script_run.c",
+        "src/pcre2_serialize.c",
+        "src/pcre2_string_utils.c",
+        "src/pcre2_study.c",
+        "src/pcre2_substitute.c",
+        "src/pcre2_substring.c",
+        "src/pcre2_tables.c",
+        "src/pcre2_ucd.c",
+        "src/pcre2_valid_utf.c",
+        "src/pcre2_xclass.c",
+        ":pcre2_chartables_c",
+        "src/pcre2_compile.h",
+        "src/pcre2_internal.h",
+        "src/pcre2_intmodedep.h",
+        "src/pcre2_ucp.h",
+        "src/pcre2_util.h",
+        ":config_h_generic",
+    ],
+    textual_hdrs = [
+        "src/pcre2_jit_match.c",
+        "src/pcre2_jit_misc.c",
+        "src/pcre2_ucptables.c",
+    ],
+    hdrs = [
+        ":pcre2_h_generic",
+    ],
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
+        "PCRE2_CODE_UNIT_WIDTH=8",
+        "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
+    ],
+    includes = ["src"],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "pcre2-posix",
+    srcs = [
+        "src/pcre2posix.c",
+        ":config_h_generic",
+    ],
+    hdrs = [
+        "src/pcre2posix.h",
+    ],
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
+        "PCRE2_CODE_UNIT_WIDTH=8",
+        "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
+    ],
+    includes = ["src"],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [":pcre2"],
+)
+
+# Totally weird issue in Bazel. It won't let you #include any files unless they
+# are declared to the build system. OK, fair enough. But - for a cc_binary it
+# uses the file extension to determine whether it's a header or a compilation
+# unit. But... we have several .c files which are #included, rather than treated
+# as a compilation unit.
+#
+# For cc_library() above, we can overcome this with textual_hdrs. But that
+# doesn't work for cc_binary(). Here's our workaround.
+#
+# https://github.com/bazelbuild/bazel/issues/680
+cc_library(
+    name = "pcre2test_dotc_headers",
+    hdrs = [
+        "src/pcre2_chkdint.c",
+        "src/pcre2_printint.c",
+        "src/pcre2_tables.c",
+        "src/pcre2_ucd.c",
+        "src/pcre2_valid_utf.c",
+    ],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "pcre2test",
+    srcs = [
+        "src/pcre2test.c",
+        ":config_h_generic",
+    ],
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "HAVE_MEMMOVE",
+        "HAVE_STRERROR",
+        "PCRE2_STATIC",
+        "SUPPORT_UNICODE",
+        "SUPPORT_PCRE2_8",
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["HAVE_UNISTD_H"],
+    }),
+    linkopts = select({
+        "@platforms//os:windows": ["-STACK:2500000"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
+)
+
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/*"]),
+)
+
+native_test(
+    name = "pcre2_test",
+    src = select({
+        "@platforms//os:windows": "RunTest.bat",
+        "//conditions:default": "RunTest",
+    }),
+    out = select({
+        "@platforms//os:windows": "RunTest.bat",
+        "//conditions:default": "RunTest",
+    }),
+    data = [":pcre2test", ":testdata"],
+    size = "small",
+)
+
+expand_template(
+    name = "gen_pkgconfig",
+    template = "//:libpcre2-8.pc.in",
+    out = "libpcre2-8.pc",
+    substitutions = {
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@PACKAGE_VERSION@": "10.46",
+        "@LIB_POSTFIX@": "",
+        "@PTHREAD_CFLAGS@": "",
+        "@PTHREAD_LIBS@": "",
+        "@PCRE2_STATIC_CFLAG@": "",
+    },
+)
+
+expand_template(
+    name = "gen_pkgconfig_posix",
+    template = "//:libpcre2-posix.pc.in",
+    out = "libpcre2-posix.pc",
+    substitutions = {
+        "@prefix@": "##PREFIX##",
+        "@exec_prefix@": "${prefix}",
+        "@libdir@": "${prefix}/lib",
+        "@includedir@": "${prefix}/include",
+        "@PACKAGE_VERSION@": "10.46",
+        "@LIB_POSTFIX@": "",
+        "@PTHREAD_CFLAGS@": "",
+        "@PTHREAD_LIBS@": "",
+        "@PCRE2POSIX_STATIC_CFLAG@": "",
+    },
+)
+
+pkg_files(
+    name = "pkgconfig",
+    srcs = [
+        ":gen_pkgconfig",
+        ":gen_pkgconfig_posix",
+    ],
+    prefix = "lib/pkgconfig",
+)
+
+cc_shared_library(
+    name = "pcre2_so",
+    deps = [":pcre2"],
+)
+
+cc_shared_library(
+    name = "pcre2posix_so",
+    deps = [":pcre2-posix"],
+)
+
+so_symlink(
+    name = "pcre2_libfiles",
+    src = ":pcre2_so",
+    libname = "libpcre2-8",
+    version = "0.11.2",
+)
+
+so_symlink(
+    name = "pcre2posix_libfiles",
+    src = ":pcre2posix_so",
+    libname = "libpcre2-posix",
+    version = "3.0.4",
+)
+
+pkg_files(
+    name = "headers",
+    srcs = [
+        ":pcre2_h_generic",
+        ":src/pcre2posix.h",
+    ],
+    prefix = "include",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":headers",
+        ":pkgconfig",
+        ":pcre2_libfiles",
+        ":pcre2posix_libfiles",
+    ],
+)

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -59,6 +59,19 @@ http_archive(
     url = "https://github.com/SELinuxProject/selinux/releases/download/3.5/libsepol-3.5.tar.gz",
 )
 
+# PCRE2 has native bazel support.
+# They expose a :pcre2 label for the main library
+http_archive(
+    name = "pcre2",
+    sha256 = "15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f",
+    strip_prefix = "pcre2-10.46",
+    url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.bz2",
+    files = {
+        # We still need to vendor the build file as long as we need .pc files & the :install rule
+        "BUILD.bazel": "//deps:pcre2.BUILD.bazel",
+    },
+)
+
 http_archive(
     name = "patchelf",
     build_file = "//deps:patchelf.BUILD.bazel",

--- a/omnibus/config/software/pcre2.rb
+++ b/omnibus/config/software/pcre2.rb
@@ -28,15 +28,9 @@ source url: "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-#{ver
 relative_path "pcre2-#{version}"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  configure_options = [
-    "--disable-static",
-    "--enable-shared",
-  ]
-
-  configure(*configure_options, env: env)
-
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  command_on_repo_root "bazelisk run -- @pcre2//:install --destdir=#{install_dir}/embedded"
+  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix " \
+    "--prefix #{install_dir}/embedded " \
+    "#{install_dir}/embedded/lib/pkgconfig/libpcre2*.pc " \
+    "#{install_dir}/embedded/lib/libpcre2*.so"
 end


### PR DESCRIPTION
### What does this PR do?

Build pcre2 with bazel from omnibus

### Motivation

Migrating to bazel for our native dependencies

### Describe how you validated your changes

CI & local build

### Additional Notes

I was hoping to be able to only slightly extend the upstream `BUILD.bazel` with the `.pc` config and our `pkg_install` machinery, but we require a few targets/files to be reachable from a different package, which would require us to patch the upstream build file on top of adding our own.

Since we only have a couple dependencies that need `pcre2` (openscap & libselinux), vendoring the `BUILD.bazel` file with our modifications & dropping it in place of theirs seems like a simpler and cleaner approach that we can easily revert once we don't need the pkgconfig & install bits.