### PR TITLE
[AGENTRUN-769] Add configurable timeout for azure metadata endpoint

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -512,6 +512,12 @@ api_key:
 #
 # collect_gpu_tags: false
 
+## @param azure_metadata_timeout - integer - optional - default: 300
+## @env DD_AZURE_METADATA_TIMEOUT - integer - optional - default: 300
+## Timeout in milliseconds on calls to the Azure metadata endpoints.
+#
+# azure_metadata_timeout: 300
+
 ## @param azure_hostname_style - string - optional - default: "os"
 ## @env DD_AZURE_HOSTNAME_STYLE - string - optional - default: "os"
 ## Changes how agent hostname is set on Azure virtual machines.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -693,6 +693,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Azure
 	config.BindEnvAndSetDefault("azure_hostname_style", "os")
+	config.BindEnvAndSetDefault("azure_metadata_timeout", 300)
 
 	// IBM cloud
 	// We use a long timeout here since the metadata and token API can be very slow sometimes.

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -23,7 +23,6 @@ import (
 // declare these as vars not const to ease testing
 var (
 	metadataURL = "http://169.254.169.254"
-	timeout     = 300 * time.Millisecond
 
 	// CloudProviderName contains the inventory name of for EC2
 	CloudProviderName = "Azure"
@@ -111,6 +110,7 @@ func getResponse(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("cloud provider is disabled by configuration")
 	}
 
+	timeout := time.Duration(pkgconfigsetup.Datadog().GetInt("azure_metadata_timeout")) * time.Millisecond
 	return httputils.Get(ctx, url, map[string]string{"Metadata": "true"}, timeout, pkgconfigsetup.Datadog())
 }
 


### PR DESCRIPTION
### What does this PR do?
Add configurable timeout for azure metadata endpoint, similar to what we have for EC2 or GCE.

### Motivation
We sometimes hit timeout in e2e tests, having a configuration flag would help in case users also do, or if we want to increase it.

### Describe how you validated your changes
CI

### Additional Notes
No functional changes expected as the default timeout is still the same.