### PR TITLE
feat(ask_review): Remove duplicated messages

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -67,11 +67,16 @@ def ask_reviews(_, pr_id):
         client = WebClient(os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
         emojis = client.emoji_list()
         waves = [emoji for emoji in emojis.data['emoji'] if 'wave' in emoji and 'microwave' not in emoji]
+
+        channels = set()
         for reviewer in reviewers:
             channel = next(
                 (chan for team, chan in GITHUB_SLACK_REVIEW_MAP.items() if team.casefold() == reviewer.casefold()),
                 DEFAULT_SLACK_CHANNEL,
             )
+            channels.add(channel)
+
+        for channel in channels:
             stop_updating = ""
             if (pr.user.login == "renovate[bot]" or pr.user.login == "mend[bot]") and pr.title.startswith(
                 "chore(deps): update integrations-core"


### PR DESCRIPTION
### What does this PR do?
We sometimes receive duplicated messages when the same slack channel is used for different teams (agent-devx and agent-e2e-framework). This tiny update prevents duplicated messages

### Motivation
Tech debt

### Describe how you validated your changes
From the PR itself
<img width="713" height="296" alt="image" src="https://github.com/user-attachments/assets/1710f299-d6aa-4c84-ba13-e67f67c47421" />


### Additional Notes
