### PR TITLE
[Backport 7.72.x] [CWS] fix windows event category

### DIFF
--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -128,6 +128,7 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 
 	// FIM
 	case
+		// linux
 		FileChmodEventType.String(),
 		FileChownEventType.String(),
 		FileOpenEventType.String(),
@@ -148,7 +149,17 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 		StatEventType.String(),
 		FileFsmountEventType.String(),
 		FileMoveMountEventType.String(),
-		FileOpenTreeEventType.String():
+		FileOpenTreeEventType.String(),
+		// windows
+		CreateNewFileEventType.String(),
+		DeleteFileEventType.String(),
+		WriteFileEventType.String(),
+		CreateRegistryKeyEventType.String(),
+		OpenRegistryKeyEventType.String(),
+		SetRegistryKeyValueEventType.String(),
+		DeleteRegistryKeyEventType.String(),
+		ChangePermissionEventType.String():
+
 		return FIMCategory
 	}
 

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -159,7 +159,7 @@ const (
 	CustomEventType EventType = iota
 
 	// CreateNewFileEventType event
-	CreateNewFileEventType
+	CreateNewFileEventType EventType = iota
 	// DeleteFileEventType event
 	DeleteFileEventType
 	// WriteFileEventType event
@@ -174,6 +174,11 @@ const (
 	DeleteRegistryKeyEventType
 	// ChangePermissionEventType event
 	ChangePermissionEventType
+
+	// FirstWindowsEventType is the first Windows event type
+	FirstWindowsEventType = CreateNewFileEventType
+	// LastWindowsEventType is the last Windows event type
+	LastWindowsEventType = ChangePermissionEventType
 
 	// MaxAllEventType is used internally to get the maximum number of events.
 	MaxAllEventType

--- a/pkg/security/secl/model/events_test.go
+++ b/pkg/security/secl/model/events_test.go
@@ -26,6 +26,17 @@ func TestEventTypesHaveValidCategories(t *testing.T) {
 		}
 	}
 
+	// Iterate through all event types between FirstWindowsEventType and LastWindowsEventType
+	for eventType := FirstWindowsEventType; eventType <= LastWindowsEventType; eventType++ {
+		// Get the category for this event type
+		category := GetEventTypeCategory(eventType.String())
+
+		// Check if the category is unknown (invalid)
+		if category == UnknownCategory {
+			eventTypesWithoutCategory = append(eventTypesWithoutCategory, eventType)
+		}
+	}
+
 	// If there are event types without valid categories, fail the test with the list
 	if len(eventTypesWithoutCategory) > 0 {
 		t.Errorf("The following event types do not have a valid category defined:\n")

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -159,7 +159,7 @@ const (
 	CustomEventType EventType = iota
 
 	// CreateNewFileEventType event
-	CreateNewFileEventType
+	CreateNewFileEventType EventType = iota
 	// DeleteFileEventType event
 	DeleteFileEventType
 	// WriteFileEventType event
@@ -174,6 +174,11 @@ const (
 	DeleteRegistryKeyEventType
 	// ChangePermissionEventType event
 	ChangePermissionEventType
+
+	// FirstWindowsEventType is the first Windows event type
+	FirstWindowsEventType = CreateNewFileEventType
+	// LastWindowsEventType is the last Windows event type
+	LastWindowsEventType = ChangePermissionEventType
 
 	// MaxAllEventType is used internally to get the maximum number of events.
 	MaxAllEventType


### PR DESCRIPTION
Backport d8507099b11e7331d1a2af6006d380acf26ecec2 from #42040.
___

### What does this PR do?

Fix & improve the category test for Windows.

### Motivation

Fix bug preventing system-probe from loading FIM security rules on Windows.

### Describe how you validated your changes

### Additional Notes
